### PR TITLE
feat: Adding Buttons to download selected systems or all systems

### DIFF
--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -9,7 +9,7 @@ import {
 import { Button as CmsButton } from '@cmsgov/design-system'
 import { GridRowId } from '@mui/x-data-grid'
 import axiosInstance from '@/axiosConfig'
-import SavedSnackbar from '../Snackbar/Snackbar'
+import CustomSnackbar from '../Snackbar/Snackbar'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -135,9 +135,11 @@ export default function AssignSystemModal({
           <CmsButton onClick={handleClose}>Close</CmsButton>
         </DialogActions>
       </Dialog>
-      <SavedSnackbar
+      <CustomSnackbar
         open={openSnackBar}
         handleClose={() => setOpenSnackBar(false)}
+        severity="success"
+        text="Saved"
       />
     </>
   )

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -14,7 +14,7 @@ import SaveIcon from '@mui/icons-material/Save'
 import FileDownloadSharpIcon from '@mui/icons-material/FileDownloadSharp'
 import Link from '@mui/material/Link'
 import QuestionnareModal from '../QuestionnareModal/QuestionnareModal'
-import SavedSnackbar from '../Snackbar/Snackbar'
+import CustomSnackbar from '../Snackbar/Snackbar'
 import axiosInstance from '@/axiosConfig'
 
 type FismaTable2Props = {
@@ -117,12 +117,12 @@ export function CustomFooterSaveComponent(
         </Box>
         <GridFooter />
       </GridFooterContainer>
-      <SavedSnackbar
+      <CustomSnackbar
         open={openSnackbar}
         handleClose={handleCloseSnackbar}
         severity="error"
         text="No systems selected"
-      ></SavedSnackbar>
+      />
     </>
   )
 }

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -40,14 +40,12 @@ export function CustomFooterSaveComponent(
       setOpenSnackbar(true)
     } else {
       let exportUrl = '/datacalls/2/export'
-      let exportFileName = ''
       if (
         props.selectedRows &&
         props.fismaSystems &&
         props.selectedRows.length < props.fismaSystems.length
       ) {
         exportUrl += '?'
-        exportFileName = 'Selected_Systems_Export.xlsx'
         let idString: string = ''
         if (props.selectedRows) {
           props.selectedRows.forEach((id, index) => {
@@ -58,8 +56,6 @@ export function CustomFooterSaveComponent(
           })
         }
         exportUrl += idString
-      } else {
-        exportFileName = 'All_Systems_Export.xlsx'
       }
       return await axiosInstance
         .get(exportUrl, {
@@ -69,12 +65,14 @@ export function CustomFooterSaveComponent(
           if (response.status !== 200) {
             console.log('Error saving systems')
           } else {
+            const [, filename] =
+              response.headers['content-disposition'].split('filename=')
             const contentType = response.headers['content-type']
             const data = new Blob([response.data], { type: contentType })
             const url = window.URL.createObjectURL(data)
             const tempLink = document.createElement('a')
             tempLink.href = url
-            tempLink.setAttribute('download', exportFileName)
+            tempLink.setAttribute('download', filename)
             tempLink.setAttribute('target', '_blank')
             tempLink.click()
             window.URL.revokeObjectURL(url)

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -63,18 +63,15 @@ export function CustomFooterSaveComponent(
           if (response.status !== 200) {
             console.log('Error saving systems')
           } else {
-            const contentDisposition = response.headers[
-              'content-disposition'
-            ] as string
-            const filename =
-              getFilenameFromContentDisposition(contentDisposition)
             const contentType = response.headers['content-type']
             const data = new Blob([response.data], { type: contentType })
+            const url = window.URL.createObjectURL(data)
             const tempLink = document.createElement('a')
-            tempLink.href = window.URL.createObjectURL(data)
-            tempLink.setAttribute('download', filename)
+            tempLink.href = url
+            tempLink.setAttribute('download', 'Selected_Systems_Export.xlsx')
+            tempLink.setAttribute('target', '_blank')
             tempLink.click()
-            window.URL.revokeObjectURL(tempLink.href)
+            window.URL.revokeObjectURL(url)
           }
         })
         .catch((error) => {
@@ -91,17 +88,15 @@ export function CustomFooterSaveComponent(
         if (response.status !== 200) {
           console.log('Error saving systems')
         } else {
-          const contentDisposition = response.headers[
-            'content-disposition'
-          ] as string
-          const filename = getFilenameFromContentDisposition(contentDisposition)
           const contentType = response.headers['content-type']
           const data = new Blob([response.data], { type: contentType })
+          const url = window.URL.createObjectURL(data)
           const tempLink = document.createElement('a')
-          tempLink.href = window.URL.createObjectURL(data)
-          tempLink.setAttribute('download', filename)
+          tempLink.href = url
+          tempLink.setAttribute('download', 'All_Systems_Export.xlsx')
+          tempLink.setAttribute('target', '_blank')
           tempLink.click()
-          window.URL.revokeObjectURL(tempLink.href)
+          window.URL.revokeObjectURL(url)
         }
       })
       .catch((error) => {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -32,6 +32,13 @@ export function CustomFooterSaveComponent(
   props: NonNullable<GridSlotsComponentsProps['footer']>
 ) {
   const [openSnackbar, setOpenSnackbar] = useState<boolean>(false)
+  const getFilenameFromContentDisposition = (contentDisposition: string) => {
+    const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
+    const matches = filenameRegex.exec(contentDisposition)
+    return matches != null && matches[1]
+      ? matches[1].replace(/['"]/g, '')
+      : 'filename.xlsx'
+  }
   const handleCloseSnackbar = () => {
     setOpenSnackbar(false)
   }
@@ -56,11 +63,16 @@ export function CustomFooterSaveComponent(
           if (response.status !== 200) {
             console.log('Error saving systems')
           } else {
+            const contentDisposition = response.headers[
+              'content-disposition'
+            ] as string
+            const filename =
+              getFilenameFromContentDisposition(contentDisposition)
             const contentType = response.headers['content-type']
             const data = new Blob([response.data], { type: contentType })
             const tempLink = document.createElement('a')
             tempLink.href = window.URL.createObjectURL(data)
-            tempLink.setAttribute('download', 'ZTMF_FY2023Q4.xlsx')
+            tempLink.setAttribute('download', filename)
             tempLink.click()
             window.URL.revokeObjectURL(tempLink.href)
           }
@@ -79,11 +91,15 @@ export function CustomFooterSaveComponent(
         if (response.status !== 200) {
           console.log('Error saving systems')
         } else {
+          const contentDisposition = response.headers[
+            'content-disposition'
+          ] as string
+          const filename = getFilenameFromContentDisposition(contentDisposition)
           const contentType = response.headers['content-type']
           const data = new Blob([response.data], { type: contentType })
           const tempLink = document.createElement('a')
           tempLink.href = window.URL.createObjectURL(data)
-          tempLink.setAttribute('download', 'filename.xlsx')
+          tempLink.setAttribute('download', filename)
           tempLink.click()
           window.URL.revokeObjectURL(tempLink.href)
         }

--- a/src/views/Snackbar/Snackbar.tsx
+++ b/src/views/Snackbar/Snackbar.tsx
@@ -9,7 +9,7 @@ type SnackbarProps = {
   text: string
 }
 
-export default function SavedSnackbar({
+export default function CustomSnackbar({
   open,
   handleClose,
   severity,

--- a/src/views/Snackbar/Snackbar.tsx
+++ b/src/views/Snackbar/Snackbar.tsx
@@ -5,9 +5,16 @@ import React, { useState, useEffect } from 'react'
 type SnackbarProps = {
   open: boolean
   handleClose: () => void
+  severity?: 'success' | 'error' | 'warning' | 'info'
+  text: string
 }
 
-export default function SavedSnackbar({ open, handleClose }: SnackbarProps) {
+export default function SavedSnackbar({
+  open,
+  handleClose,
+  severity,
+  text,
+}: SnackbarProps) {
   const [localOpen, setLocalOpen] = useState(open)
 
   useEffect(() => {
@@ -32,8 +39,8 @@ export default function SavedSnackbar({ open, handleClose }: SnackbarProps) {
         autoHideDuration={2000}
         onClose={handleSnackbarClose}
       >
-        <Alert severity="success" variant="filled" sx={{ width: '100%' }}>
-          Saved
+        <Alert severity={severity} variant="filled" sx={{ width: '100%' }}>
+          {text}
         </Alert>
       </Snackbar>
     </div>

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -97,11 +97,13 @@ export default function UserTable() {
     }
   }
   const preProcessEditCellProps = (params: GridPreProcessEditCellProps) => {
-    const curRow = rows.find((row) => row.userid === params.id)
-    setSelectedRow(curRow)
-    if (params.props.value === 'ADMIN') {
-      setUserName(curRow?.fullname)
-      setOpenAlert(true)
+    if (params.hasChanged) {
+      const curRow = rows.find((row) => row.userid === params.id)
+      setSelectedRow(curRow)
+      if (params.props.value === 'ADMIN' && curRow?.role !== 'ADMIN') {
+        setUserName(curRow?.fullname)
+        setOpenAlert(true)
+      }
     }
     return Promise.resolve()
   }

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -34,7 +34,7 @@ import axiosInstance from '@/axiosConfig'
 import { users } from '@/types'
 import { useFismaSystems } from '../Title/Context'
 import Box from '@mui/material/Box'
-import SavedSnackbar from '../Snackbar/Snackbar'
+import CustomSnackbar from '../Snackbar/Snackbar'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 
 const roles = ['ISSO', 'ISSM', 'ADMIN']
@@ -364,7 +364,7 @@ export default function UserTable() {
           }}
         />
       </Box>
-      <SavedSnackbar
+      <CustomSnackbar
         open={open}
         handleClose={handleCloseSnackbar}
         severity="success"

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -364,7 +364,12 @@ export default function UserTable() {
           }}
         />
       </Box>
-      <SavedSnackbar open={open} handleClose={handleCloseSnackbar} />
+      <SavedSnackbar
+        open={open}
+        handleClose={handleCloseSnackbar}
+        severity="success"
+        text="Saved"
+      />
       <AssignSystemModal
         fismaSystemMap={fismaSystemsMap}
         open={openModal}


### PR DESCRIPTION
### Summary

Adding two buttons that allow users to download the selected systems or all systems they are assigned.

closes #69 

### Added

None

### Changes

FismaTable.jsx - adding checkboxes for users to selected. Create custom footer such that it added the two buttons. 

Snackbar.jsx - created a more generic snackbar to pass different severities and text.

UserTable.jsx - handle changes of snackbar to be used in user table

### Test

Try the buttons at the bottom of dashboard.
- Download icon is to download systems selected