### PR TITLE
fix: Edits to User Table causes alert modal to open on all columns

### DIFF
--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -97,11 +97,13 @@ export default function UserTable() {
     }
   }
   const preProcessEditCellProps = (params: GridPreProcessEditCellProps) => {
-    const curRow = rows.find((row) => row.userid === params.id)
-    setSelectedRow(curRow)
-    if (params.props.value === 'ADMIN') {
-      setUserName(curRow?.fullname)
-      setOpenAlert(true)
+    if (params.hasChanged) {
+      const curRow = rows.find((row) => row.userid === params.id)
+      setSelectedRow(curRow)
+      if (params.props.value === 'ADMIN' && curRow?.role !== 'ADMIN') {
+        setUserName(curRow?.fullname)
+        setOpenAlert(true)
+      }
     }
     return Promise.resolve()
   }


### PR DESCRIPTION
### Summary

Bug was on editing any of the columns the alert modal for ensuring user is providing admin privileges to a user is opening. Providing a guard to check which column is being called, to ensure correct column changes are to call the alert modal.

closes #84 

### Changes

Usertable.tsx - adding a conditional to check which column has changed. If the user is going from another role to admin, ensure that the alert modal is called then.

### Test

Edit columns in user Table

