### PR TITLE
feat: redirect users to login when endpoint throws a 4XX status

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -40,7 +40,7 @@ const ErrorBoundary: React.FC = (): JSX.Element => {
   const title = useErrorTitle(error)
   const message = useErrorMessage(error)
 
-  console.error(error)
+  // console.error(error)
 
   return (
     <Container sx={{ m: 3 }}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,12 @@ export const COPYRIGHT_LABEL = `Copyright © ${new Date()
 
 // * Configuration Constants
 export const DEFAULT_ALERT_TIMEOUT = 3000
+
+export const ERROR_MESSAGES = {
+  login: 'Please log in to continue.',
+  expired: 'Your session has expired. Please log in again.',
+  notSaved:
+    'Your changes were not saved. Your session may have expired. Please log in again.',
+  error:
+    'An error occurred. Please log in and try again. If the error persists, please contact support.',
+}

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -13,12 +13,14 @@ export enum RouteIds {
   APPLICATIONS = 'applications',
   DATA = 'data',
   USERS = 'users',
+  SIGNIN = 'signin',
 }
 
 export enum RouteNames {
   DASHBOARD = 'Dashboard',
   LOGIN = 'Login',
   LOGOUT = 'Logout',
+  SIGNIN = 'Sign In',
 }
 
 export enum Routes {
@@ -29,4 +31,5 @@ export enum Routes {
   AUTH = `/${RouteIds.AUTH}/*`,
   AUTH_LOGIN = `/${RouteIds.AUTH}/${RouteIds.LOGIN}`,
   AUTH_LOGOUT = `/${RouteIds.AUTH}/${RouteIds.LOGOUT}`,
+  SIGNIN = `/${RouteIds.SIGNIN}`,
 }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -10,6 +10,7 @@ import Title from '@/views/Title/Title'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import HomePageContainer from '@/views/Home/Home'
 import UserTable from '@/views/UserTable/UserTable'
+import LoginPage from '@/views/LoginPage/LoginPage'
 /**
  * The hash router for the application that defines routes
  *  and specifies the loaders for routes with dynamic data.
@@ -34,6 +35,12 @@ const router = createHashRouter([
         path: Routes.USERS,
         id: RouteIds.USERS,
         element: <UserTable />,
+        errorElement: <ErrorBoundary />,
+      },
+      {
+        path: Routes.SIGNIN,
+        id: RouteIds.SIGNIN,
+        element: <LoginPage />,
         errorElement: <ErrorBoundary />,
       },
     ],

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -2,6 +2,9 @@ import FismaTable from '../FismaTable/FismaTable'
 import StatisticsBlocks from '../StatisticBlocks/StatisticsBlocks'
 import { useState, useEffect } from 'react'
 import axiosInstance from '@/axiosConfig'
+import { useNavigate } from 'react-router-dom'
+import { Routes } from '@/router/constants'
+import { ERROR_MESSAGES } from '@/constants'
 import { FismaSystemType } from '@/types'
 /**
  * Component that renders the contents of the Home view.
@@ -10,6 +13,7 @@ import { FismaSystemType } from '@/types'
 
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
+  const navigate = useNavigate()
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [scoreMap, setScoreMap] = useState<Record<number, number>>({})
   useEffect(() => {
@@ -50,7 +54,14 @@ export default function HomePageContainer() {
     fetchScores()
   }, [])
   if (loading) {
-    return <div>loading...</div>
+    {
+      navigate(Routes.SIGNIN, {
+        replace: true,
+        state: {
+          message: ERROR_MESSAGES.login,
+        },
+      })
+    }
   }
   return (
     <>

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -3,9 +3,6 @@ import StatisticsBlocks from '../StatisticBlocks/StatisticsBlocks'
 import { useState, useEffect } from 'react'
 import axiosInstance from '@/axiosConfig'
 import { FismaSystemType } from '@/types'
-import CircularProgress from '@mui/material/CircularProgress'
-import { Box } from '@mui/material'
-
 /**
  * Component that renders the contents of the Home view.
  * @returns {JSX.Element} Component that renders the home contents.
@@ -53,18 +50,7 @@ export default function HomePageContainer() {
     fetchScores()
   }, [])
   if (loading) {
-    return (
-      <Box
-        flex={1}
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <CircularProgress size={100} />
-      </Box>
-    )
+    return <div>loading...</div>
   }
   return (
     <>

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -20,23 +20,46 @@ export default function HomePageContainer() {
     async function fetchFismaSystems() {
       try {
         const fismaSystems = await axiosInstance.get('/fismasystems')
-        if (fismaSystems.status !== 200) {
-          setLoading(true)
+        if (
+          fismaSystems.status !== 200 &&
+          fismaSystems.status.toString()[0] === '4'
+        ) {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: {
+              message: ERROR_MESSAGES.expired,
+            },
+          })
           return
         }
         setFismaSystems(fismaSystems.data.data)
         setLoading(false)
       } catch (error) {
         console.log(error)
+        navigate(Routes.SIGNIN, {
+          replace: true,
+          state: {
+            message: ERROR_MESSAGES.login,
+          },
+        })
       }
     }
     fetchFismaSystems()
-  }, [])
+  }, [navigate])
 
   useEffect(() => {
     async function fetchScores() {
       try {
         const scores = await axiosInstance.get('/scores/aggregate')
+        if (scores.status !== 200 && scores.status.toString()[0] === '4') {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: {
+              message: ERROR_MESSAGES.expired,
+            },
+          })
+          return
+        }
         const scoresMap: Record<number, number> = {}
         for (const obj of scores.data.data) {
           let score = 0
@@ -48,20 +71,18 @@ export default function HomePageContainer() {
         setScoreMap(scoresMap)
         setLoading(false)
       } catch (error) {
-        console.log(error)
+        navigate(Routes.SIGNIN, {
+          replace: true,
+          state: {
+            message: ERROR_MESSAGES.expired,
+          },
+        })
       }
     }
     fetchScores()
-  }, [])
+  }, [navigate])
   if (loading) {
-    {
-      navigate(Routes.SIGNIN, {
-        replace: true,
-        state: {
-          message: ERROR_MESSAGES.login,
-        },
-      })
-    }
+    return <div>Loading...</div>
   }
   return (
     <>

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -1,0 +1,32 @@
+import { Box, Typography } from '@mui/material'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import { useLocation } from 'react-router-dom'
+
+export default function LoginPage() {
+  const location = useLocation()
+  const message = location.state?.message || ''
+  return (
+    <Box
+      flex={1}
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '50vh',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="h4" sx={{ mb: 2 }}>
+          {message}
+        </Typography>
+        <CmsButton href="/login">Login</CmsButton>
+      </Box>
+    </Box>
+  )
+}

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -95,6 +95,7 @@ export default function QuestionnareModal({
   const [questionId, setQuestionId] = React.useState<number | null>(null)
   const [categories, setCategories] = React.useState<Category[]>([])
   const [options, setOptions] = React.useState<QuestionOption[]>([])
+  const [datacallID, setDatacallID] = React.useState<number>(0)
   const [loadingQuestion, setLoadingQuestion] = React.useState<boolean>(true)
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
     {}
@@ -112,7 +113,7 @@ export default function QuestionnareModal({
   ) => {
     try {
       const response = await axiosInstance.get(
-        `scores?datacallid=2&fismasystemid=${systemId}`
+        `scores?datacallid=${datacallID}&fismasystemid=${systemId}`
       )
       checkValidResponse(response.status)
       const hashTable: questionScoreMap = Object.assign(
@@ -127,24 +128,6 @@ export default function QuestionnareModal({
       routeToSignIn()
     }
   }
-  async function fetchDataCall(): Promise<number> {
-    let maxDataCallId = -1
-    axiosInstance.get('/datacalls').then((res) => {
-      if (res.status !== 200 && res.status.toString()[0] === '4') {
-        navigate(Routes.SIGNIN, {
-          replace: true,
-          state: {
-            message: ERROR_MESSAGES.expired,
-          },
-        })
-      }
-      for (let i = 0; i < res.data.data.length; i++) {
-        maxDataCallId = Math.max(maxDataCallId, res.data.data[i].datacallid)
-      }
-    })
-    return maxDataCallId
-  }
-
   const handleQuestionnareNext = () => {
     // TODO: datacallid is hardcoded to 2, need to make it dynamic
     setLoadingQuestion(true)
@@ -272,7 +255,6 @@ export default function QuestionnareModal({
       const fetchData = async () => {
         try {
           const datacall = await axiosInstance.get(`/datacalls`).then((res) => {
-            res.status = 401
             if (res.status !== 200 && res.status.toString()[0] === '4') {
               navigate(Routes.SIGNIN, {
                 replace: true,
@@ -290,6 +272,7 @@ export default function QuestionnareModal({
               datacall[i].datacallid
             )
           }
+          setDatacallID(latestDataCallId)
           await axiosInstance
             .get(`/fismasystems/${system.fismasystemid}/questions`)
             .then((response) => {

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,13 +1,12 @@
 import Typography from '@mui/material/Typography'
 import { Container } from '@mui/material'
-import { useLoaderData } from 'react-router-dom'
+import { useLoaderData, useNavigate } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
 import logo from '../../assets/icons/logo.svg'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import 'core-js/stable/atob'
 import { userData } from '@/types'
-import { Button as CmsButton } from '@cmsgov/design-system'
 import { Box } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -34,6 +33,7 @@ type PromiseType = {
   response: userData
 }
 export default function Title() {
+  const navigate = useNavigate()
   const loaderData = useLoaderData() as PromiseType
   const userInfo: userData =
     loaderData.status != 200 ? emptyUser : loaderData.response
@@ -45,7 +45,10 @@ export default function Title() {
       try {
         const fismaSystems = await axiosInstance.get('/fismasystems')
         if (fismaSystems.status !== 200) {
-          return
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: { message: 'Please log in' },
+          })
         }
         setFismaSystems(fismaSystems.data.data)
       } catch (error) {
@@ -55,7 +58,7 @@ export default function Title() {
     if (loaderData.status == 200) {
       fetchFismaSystems()
     }
-  }, [loaderData.status])
+  }, [loaderData.status, navigate])
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
@@ -157,21 +160,7 @@ export default function Title() {
         <Typography variant="h3" align="center">
           Zero Trust Maturity Score {titlePage}
         </Typography>
-        {loaderData.status !== 200 ? (
-          <Box
-            flex={1}
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              height: '50vh',
-            }}
-          >
-            <CmsButton href="/login">Login</CmsButton>
-          </Box>
-        ) : (
-          <Outlet context={{ fismaSystems }} />
-        )}
+        <Outlet context={{ fismaSystems }} />
       </Container>
     </>
   )

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -16,6 +16,7 @@ import { useState, useEffect } from 'react'
 import { FismaSystemType } from '@/types'
 import { Routes } from '@/router/constants'
 import axiosInstance from '@/axiosConfig'
+import LoginPage from '../LoginPage/LoginPage'
 /**
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
@@ -160,7 +161,11 @@ export default function Title() {
         <Typography variant="h3" align="center">
           Zero Trust Maturity Score {titlePage}
         </Typography>
-        <Outlet context={{ fismaSystems }} />
+        {loaderData.status !== 200 ? (
+          <LoginPage />
+        ) : (
+          <Outlet context={{ fismaSystems }} />
+        )}
       </Container>
     </>
   )

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -36,7 +36,8 @@ import { useFismaSystems } from '../Title/Context'
 import Box from '@mui/material/Box'
 import CustomSnackbar from '../Snackbar/Snackbar'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
-
+import { useNavigate } from 'react-router-dom'
+import { Routes } from '@/router/constants'
 const roles = ['ISSO', 'ISSM', 'ADMIN']
 
 interface EditToolbarProps {
@@ -70,6 +71,28 @@ function EditToolbar(props: EditToolbarProps) {
 
 export default function UserTable() {
   const apiRef = useGridApiRef()
+  const navigate = useNavigate()
+  //TODO: add these to a file to be imported and used in multiple places
+  const checkValidResponse = (status: number) => {
+    if (status !== 200 && status.toString()[0] === '4') {
+      navigate(Routes.SIGNIN, {
+        replace: true,
+        state: {
+          message:
+            'Your changes were not saved. Your session may have expired. Please log in again.',
+        },
+      })
+    }
+    return
+  }
+  const routeToSignIn = () => {
+    navigate(Routes.SIGNIN, {
+      replace: true,
+      state: {
+        message: 'Your session has expired. Please log in again.',
+      },
+    })
+  }
   const [rows, setRows] = useState<users[]>([])
   const [userId, setUserId] = useState<GridRowId>('')
   const { fismaSystems } = useFismaSystems()
@@ -157,6 +180,7 @@ export default function UserTable() {
         })
         .then((res) => {
           newUser = res.data.data
+          checkValidResponse(res.status)
           setRows(
             rows.map((row) =>
               row.userid === newRow.userid
@@ -165,6 +189,10 @@ export default function UserTable() {
             )
           )
           setOpen(true)
+        })
+        .catch((error) => {
+          console.error('Error updating score:', error)
+          routeToSignIn()
         })
     } else {
       const updatedRow = { ...newRow } as users
@@ -175,13 +203,12 @@ export default function UserTable() {
           role: updatedRow?.role,
         })
         .then((res) => {
-          if (res.status != 204) {
-            return console.error('Error updating score')
-          }
+          checkValidResponse(res.status)
           setOpen(true)
         })
         .catch((error) => {
           console.error('Error updating score:', error)
+          routeToSignIn()
         })
       setRows(
         rows.map((row) => (row.userid === newRow.userid ? updatedRow : row))

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -38,6 +38,7 @@ import CustomSnackbar from '../Snackbar/Snackbar'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
+import { ERROR_MESSAGES } from '@/constants'
 const roles = ['ISSO', 'ISSM', 'ADMIN']
 
 interface EditToolbarProps {
@@ -78,8 +79,7 @@ export default function UserTable() {
       navigate(Routes.SIGNIN, {
         replace: true,
         state: {
-          message:
-            'Your changes were not saved. Your session may have expired. Please log in again.',
+          message: ERROR_MESSAGES.notSaved,
         },
       })
     }
@@ -89,7 +89,7 @@ export default function UserTable() {
     navigate(Routes.SIGNIN, {
       replace: true,
       state: {
-        message: 'Your session has expired. Please log in again.',
+        message: ERROR_MESSAGES.expired,
       },
     })
   }


### PR DESCRIPTION
### Summary

Refactoring code to redirect users to sign in on all api calls such that if status is a 4XX number to a sign in page.
Added function description for each function in pillar with a info icon that users can hover.

closes: #97 
closes: #81 

### Added

Login.tsx - a component that contains a reference to login endpoint. Moved previous sign in to a reusable 

### Changes

Files that call an endpoint


### Test

Open questionnare modal to see the info icon. Hover to see description of function.

