### PR TITLE
feat: adding modal to edit fismasystems

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -53,7 +53,7 @@ jobs:
         run: yarn build:${{ inputs.environment }}
 
       - name: Get AWS Creds
-        if: github.actor != 'dependabot[bot]'
+        # if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
@@ -61,5 +61,5 @@ jobs:
           aws-region: us-east-1
 
       - name: AWS Sync
-        if: github.actor != 'dependabot[bot]'
+        # if: github.actor != 'dependabot[bot]'
         run: aws s3 sync ./dist s3://${{ secrets.BUCKET_NAME }}/ --delete

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -53,7 +53,6 @@ jobs:
         run: yarn build:${{ inputs.environment }}
 
       - name: Get AWS Creds
-        # if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLEARN }}
@@ -61,5 +60,4 @@ jobs:
           aws-region: us-east-1
 
       - name: AWS Sync
-        # if: github.actor != 'dependabot[bot]'
         run: aws s3 sync ./dist s3://${{ secrets.BUCKET_NAME }}/ --delete

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,0 +1,46 @@
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import { Box, IconButton, Typography, Button } from '@mui/material'
+import { CONFIRMATION_MESSAGE } from '@/constants'
+import { Button as CmsButton } from '@cmsgov/design-system'
+
+import CloseIcon from '@mui/icons-material/Close'
+type ConfirmDialogTypes = {
+  open: boolean
+  onClose: () => void
+  confirmClick: (confirm: boolean) => void
+}
+
+const ConfirmDialog = ({ open, onClose, confirmClick }: ConfirmDialogTypes) => {
+  const handleConfirm = () => {
+    confirmClick(true)
+    onClose()
+  }
+  const handleClose = () => {
+    confirmClick(false)
+    onClose()
+  }
+  return (
+    <Dialog open={open} maxWidth="sm" fullWidth>
+      <DialogTitle>Unsaved Changes</DialogTitle>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton onClick={handleClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent>
+        <Typography>{CONFIRMATION_MESSAGE}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <CmsButton variation="solid" onClick={handleConfirm}>
+          Confirm
+        </CmsButton>
+        <CmsButton onClick={handleClose}>Cancel</CmsButton>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmDialog

--- a/src/components/DialogTitle/CustomDialogTitle.tsx
+++ b/src/components/DialogTitle/CustomDialogTitle.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import DialogTitle from '@mui/material/DialogTitle'
+import Typography from '@mui/material/Typography'
+/**
+ * Component that renders the title of the dialog.
+ * @param {string} title - The title to be displayed.
+ * @returns {JSX.Element} Component that renders the title of the dialog.
+ */
+type CustomDialogTitleProps = {
+  title: string
+}
+export default function CustomDialogTitle({ title }: CustomDialogTitleProps) {
+  return (
+    <DialogTitle align="center">
+      <div>
+        <Typography variant="h3">{title}</Typography>
+      </div>
+    </DialogTitle>
+  )
+}

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -28,27 +28,6 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-// test('renders auth session error and navigate to logout after 5 seconds', () => {
-//   const navigateMock = jest.fn().mockImplementation(() => ({}))
-//   useNavigateMock.mockReturnValue(navigateMock)
-//   isRouteErrorResponseMock.mockReturnValue(true)
-//   routeErrorMock.mockReturnValue({
-//     status: 401,
-//     statusText: 'Unauthorized',
-//     data: 'Unauthorized',
-//   })
-
-//   render(<ErrorBoundary />)
-
-//   expect(
-//     screen.getByText(/Your session has expired. Please login again./i)
-//   ).toBeInTheDocument()
-
-//   jest.advanceTimersByTime(5000)
-
-//   expect(navigateMock).toHaveBeenCalledWith(Routes.AUTH_LOGOUT)
-// })
-
 test('renders generic error message', () => {
   routeErrorMock.mockReturnValue(new Error('Something went wrong'))
   render(<ErrorBoundary />)

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -28,26 +28,26 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-test('renders auth session error and navigate to logout after 5 seconds', () => {
-  const navigateMock = jest.fn().mockImplementation(() => ({}))
-  useNavigateMock.mockReturnValue(navigateMock)
-  isRouteErrorResponseMock.mockReturnValue(true)
-  routeErrorMock.mockReturnValue({
-    status: 401,
-    statusText: 'Unauthorized',
-    data: 'Unauthorized',
-  })
+// test('renders auth session error and navigate to logout after 5 seconds', () => {
+//   const navigateMock = jest.fn().mockImplementation(() => ({}))
+//   useNavigateMock.mockReturnValue(navigateMock)
+//   isRouteErrorResponseMock.mockReturnValue(true)
+//   routeErrorMock.mockReturnValue({
+//     status: 401,
+//     statusText: 'Unauthorized',
+//     data: 'Unauthorized',
+//   })
 
-  render(<ErrorBoundary />)
+//   render(<ErrorBoundary />)
 
-  expect(
-    screen.getByText(/Your session has expired. Please login again./i)
-  ).toBeInTheDocument()
+//   expect(
+//     screen.getByText(/Your session has expired. Please login again./i)
+//   ).toBeInTheDocument()
 
-  jest.advanceTimersByTime(5000)
+//   jest.advanceTimersByTime(5000)
 
-  expect(navigateMock).toHaveBeenCalledWith(Routes.AUTH_LOGOUT)
-})
+//   expect(navigateMock).toHaveBeenCalledWith(Routes.AUTH_LOGOUT)
+// })
 
 test('renders generic error message', () => {
   routeErrorMock.mockReturnValue(new Error('Something went wrong'))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@
  * Application-wide constants
  * @module constants
  */
+import { userData } from './types'
 
 //* Application Strings
 export const ORG_NAME = 'CMS'
@@ -20,4 +21,11 @@ export const ERROR_MESSAGES = {
     'Your changes were not saved. Your session may have expired. Please log in again.',
   error:
     'An error occurred. Please log in and try again. If the error persists, please contact support.',
+}
+export const EMPTY_USER: userData = {
+  userid: '',
+  email: '',
+  fullname: '',
+  role: '',
+  assignedfismasystems: [],
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,3 +29,5 @@ export const EMPTY_USER: userData = {
   role: '',
   assignedfismasystems: [],
 }
+export const CONFIRMATION_MESSAGE =
+  'Your changes will not be saved! Are you sure you want to close out of editing a Fisma system before saving your changes?'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,3 +86,7 @@ export const PILLAR_FUNCTION_MAP: { [key: string]: string[] } = {
     'Cross-VisibilityAnalytics',
   ],
 }
+export const TEXTFIELD_HELPER_TEXT = 'This field is required'
+
+export const INVALID_INPUT_TEXT = (key: string) =>
+  `Please provide a valid ${key}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,3 +31,58 @@ export const EMPTY_USER: userData = {
 }
 export const CONFIRMATION_MESSAGE =
   'Your changes will not be saved! Are you sure you want to close out of editing a Fisma system before saving your changes?'
+
+export const PILLAR_FUNCTION_MAP: { [key: string]: string[] } = {
+  Identity: [
+    'AccessManagement',
+    'Identity-AutomationOrchestration',
+    'Identity-Governance',
+    'IdentityStores-Users',
+    'RiskAssessment',
+    'Authentication-Users',
+    'Identity-VisibilityAnalytics',
+  ],
+  Devices: [
+    'AssetRiskManagement',
+    'Device-AutomationOrchestration',
+    'Device-Governance',
+    'DeviceThreatProtection',
+    'PolicyEnforcement',
+    'Device-VisibilityAnalytics',
+    'ResourceAccess',
+  ],
+  Networks: [
+    'Network-AutomationOrchestration',
+    'Network-Encryption',
+    'Network-Governance',
+    'NetworkResilience',
+    'NetworkSegmentation',
+    'NetworkTrafficManagement',
+    'Network-VisibilityAnalytics',
+  ],
+  Applications: [
+    'AccessibleApplications',
+    'AccessAuthorization-Users',
+    'Application-AutomationOrchestration',
+    'Application-Governance',
+    'SecureDevDeployWorkflow',
+    'ApplicationSecurityTesting',
+    'AppThreatProtection',
+    'Application-VisibilityAnalytics',
+  ],
+  Data: [
+    'DataAccess',
+    'Data-AutomationOrchestration',
+    'DataAvailability',
+    'DataCategorization',
+    'DataEncryption',
+    'Data-Governance',
+    'DataInventoryManagement',
+    'Data-VisibilityAnalytics',
+  ],
+  CrossCutting: [
+    'Cross-AutomationOrchestration',
+    'Cross-Governance',
+    'Cross-VisibilityAnalytics',
+  ],
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,10 @@ export type FismaSystemType = {
   fismaimpactlevel: string
   issoemail: string
   datacenterenvironment: string
+  datacallcontact?: string
+  groupacronym?: string
+  groupname?: string
+  divisionname?: string
 }
 export type FismaSystems = {
   fismaSystems: FismaSystemType[]
@@ -89,6 +93,12 @@ export type SystemDetailsModalProps = {
   onClose: () => void
   system: FismaSystemType | null
 }
+export type editSystemModalProps = {
+  open: boolean
+  onClose: (data: FismaSystemType) => void
+  system: FismaSystemType | null
+}
+
 export type ScoreData = {
   datacallid: number
   fismasystemid: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,11 @@ export type FormValidHelperText = {
   [key: string]: string
 }
 
+export type FismaTableProps = {
+  scores: Record<number, number>
+  latestDataCallId: number
+}
+
 export type ThemeColor =
   | 'primary'
   | 'secondary'

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type RequestOptions = {
 }
 export type FismaSystemType = {
   fismasystemid: number
-  fismauid: string | number
+  fismauid: string
   fismaacronym: string
   fismaname: string
   fismasubsystem: string
@@ -94,9 +94,11 @@ export type SystemDetailsModalProps = {
   system: FismaSystemType | null
 }
 export type editSystemModalProps = {
+  title: string
   open: boolean
   onClose: (data: FismaSystemType) => void
   system: FismaSystemType | null
+  mode: string
 }
 
 export type ScoreData = {
@@ -119,6 +121,14 @@ export type datacall = {
   datacall: string
   datecreated: number
   deadline: number
+}
+
+export type FormValidType = {
+  [key: string]: boolean
+}
+
+export type FormValidHelperText = {
+  [key: string]: string
 }
 
 export type ThemeColor =

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,13 @@ export type users = {
   isNew?: boolean
 }
 
+export type datacall = {
+  datacallid: number
+  datacall: string
+  datecreated: number
+  deadline: number
+}
+
 export type ThemeColor =
   | 'primary'
   | 'secondary'

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -19,6 +19,7 @@ import axiosInstance from '@/axiosConfig'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
+import { useSnackbar } from 'notistack'
 /**
  * Component that renders a modal to edit fisma systems.
  * @param {boolean, function, FismaSystemType} editSystemModalProps - props to get populate dialog and function .
@@ -32,6 +33,7 @@ export default function EditSystemModal({
 }: editSystemModalProps) {
   const formValid = React.useRef({ issoemail: false, datacallcontact: false })
   const navigate = useNavigate()
+  const { enqueueSnackbar } = useSnackbar()
   const [loading, setLoading] = React.useState<boolean>(true)
   const [openAlert, setOpenAlert] = React.useState<boolean>(false)
   // const [confirmChanges, setConfirmChanges] = React.useState<boolean>(false)
@@ -82,6 +84,14 @@ export default function EditSystemModal({
             },
           })
         }
+        enqueueSnackbar(`Saved`, {
+          variant: 'success',
+          anchorOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+          autoHideDuration: 1000,
+        })
       })
       .catch((error) => {
         console.error('Error fetching data:', error)

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -1,0 +1,326 @@
+import * as React from 'react'
+import TextField from '@mui/material/TextField'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import CustomDialogTitle from '../../components/DialogTitle/CustomDialogTitle'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import { Box, Grid } from '@mui/material'
+import { editSystemModalProps, FismaSystemType } from '@/types'
+import MenuItem from '@mui/material/MenuItem'
+import ValidatedTextField from './ValidatedTextField'
+import { emailValidator } from './validators'
+import { EMPTY_SYSTEM } from './emptySystem'
+import { datacenterenvironment } from './dataEnvironment'
+import CircularProgress from '@mui/material/CircularProgress'
+import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
+import _ from 'lodash'
+import axiosInstance from '@/axiosConfig'
+import { useNavigate } from 'react-router-dom'
+import { Routes } from '@/router/constants'
+import { ERROR_MESSAGES } from '@/constants'
+/**
+ * Component that renders a modal to edit fisma systems.
+ * @param {boolean, function, FismaSystemType} editSystemModalProps - props to get populate dialog and function .
+ * @returns {JSX.Element} Component that renders a dialog to edit details of a fisma systems.
+ */
+
+export default function EditSystemModal({
+  open,
+  onClose,
+  system,
+}: editSystemModalProps) {
+  const formValid = React.useRef({ issoemail: false, datacallcontact: false })
+  const navigate = useNavigate()
+  const [loading, setLoading] = React.useState<boolean>(true)
+  const [openAlert, setOpenAlert] = React.useState<boolean>(false)
+  // const [confirmChanges, setConfirmChanges] = React.useState<boolean>(false)
+  const handleConfirmReturn = (confirm: boolean) => {
+    if (confirm) {
+      onClose(EMPTY_SYSTEM)
+    }
+  }
+  const [editedFismaSystem, setEditedFismaSystem] =
+    React.useState<FismaSystemType>(EMPTY_SYSTEM)
+  React.useEffect(() => {
+    if (system && open) {
+      setEditedFismaSystem(system)
+      setLoading(false)
+    }
+  }, [system, open])
+  const handleClose = () => {
+    setEditedFismaSystem(EMPTY_SYSTEM)
+    if (_.isEqual(system, editedFismaSystem)) {
+      onClose(editedFismaSystem)
+    } else {
+      setOpenAlert(true)
+    }
+    return
+  }
+  const handleSave = async () => {
+    // TODO: Set this axiosInstance to update into the database with the latest changes
+    await axiosInstance
+      .put(`fismasystems/${editedFismaSystem.fismasystemid}`, {
+        fismauid: editedFismaSystem.fismauid,
+        fismaacronym: editedFismaSystem.fismaacronym,
+        fismaname: editedFismaSystem.fismaname,
+        fismasubsystem: editedFismaSystem.fismasubsystem,
+        component: editedFismaSystem.component,
+        groupacronym: editedFismaSystem.groupacronym,
+        groupname: editedFismaSystem.groupname,
+        divisionname: editedFismaSystem.divisionname,
+        datacenterenvironment: editedFismaSystem.datacenterenvironment,
+        datacallcontact: editedFismaSystem.datacallcontact,
+        issoemail: editedFismaSystem.issoemail,
+      })
+      .then((res) => {
+        if (res.status !== 200 && res.status.toString()[0] === '4') {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: {
+              message: ERROR_MESSAGES.expired,
+            },
+          })
+        }
+      })
+      .catch((error) => {
+        console.error('Error fetching data:', error)
+        navigate(Routes.SIGNIN, {
+          replace: true,
+          state: {
+            message: ERROR_MESSAGES.error,
+          },
+        })
+      })
+    onClose(editedFismaSystem)
+  }
+  if (open && system) {
+    if (loading) {
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            maxHeight: '100%',
+          }}
+        >
+          <CircularProgress size={80} />
+        </Box>
+      )
+    }
+    return (
+      <>
+        <Dialog open={open} onClose={handleClose} maxWidth="lg" fullWidth>
+          <CustomDialogTitle title="Edit Fisma System" />
+          <DialogContent>
+            <Box sx={{ flexGrow: 1 }} component="form">
+              <Grid container spacing={2}>
+                <Grid item xs={6}>
+                  <TextField
+                    id="fismaname"
+                    label="Fisma Name"
+                    fullWidth
+                    margin="normal"
+                    variant="standard"
+                    defaultValue={system?.fismaname}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        fismaname: e.target.value,
+                      }))
+                    }}
+                  />
+                  <TextField
+                    id="fismaacronym"
+                    label="Fisma Acronym"
+                    variant="standard"
+                    margin="normal"
+                    defaultValue={system?.fismaacronym}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                  />
+                  <TextField
+                    id="groupacronym"
+                    label="Group Acronym"
+                    variant="standard"
+                    margin="normal"
+                    defaultValue={system?.groupacronym}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    sx={{ ml: 2 }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        groupacronym: e.target.value,
+                      }))
+                    }}
+                  />
+                  <TextField
+                    id="component"
+                    label="Component"
+                    variant="standard"
+                    margin="normal"
+                    defaultValue={system?.component}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    sx={{ ml: 2 }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        component: e.target.value,
+                      }))
+                    }}
+                  />
+                  <TextField
+                    id="groupname"
+                    label="Group Name"
+                    variant="standard"
+                    margin="normal"
+                    fullWidth
+                    defaultValue={system?.groupname}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        groupname: e.target.value,
+                      }))
+                    }}
+                  />
+
+                  <TextField
+                    id="divisionname"
+                    label="Division Name"
+                    variant="standard"
+                    margin="normal"
+                    fullWidth
+                    defaultValue={system?.divisionname}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        divisionname: e.target.value,
+                      }))
+                    }}
+                  />
+                  <TextField
+                    id="fismasubsystem"
+                    label="Fisma Subsystem"
+                    variant="standard"
+                    margin="normal"
+                    fullWidth
+                    defaultValue={system?.fismasubsystem}
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        fismasubsystem: e.target.value,
+                      }))
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={6}>
+                  <ValidatedTextField
+                    label="Data Call Contact"
+                    validator={emailValidator}
+                    dfValue={system?.datacallcontact}
+                    isFullWidth={true}
+                    onChange={(isValid, newValue) => {
+                      formValid.current.datacallcontact = isValid
+                      if (isValid) {
+                        setEditedFismaSystem((prevState) => ({
+                          ...prevState,
+                          datacallcontact: newValue,
+                        }))
+                      }
+                    }}
+                  />
+                  <ValidatedTextField
+                    label="ISSO Email"
+                    validator={emailValidator}
+                    dfValue={system?.issoemail}
+                    isFullWidth={true}
+                    onChange={(isValid, newValue) => {
+                      formValid.current.issoemail = isValid
+                      if (isValid) {
+                        setEditedFismaSystem((prevState) => ({
+                          ...prevState,
+                          issoemail: newValue,
+                        }))
+                      }
+                    }}
+                  />
+                  <TextField
+                    id="outlined-select-datacenterenvironment"
+                    select
+                    label="Datacenter Environment"
+                    defaultValue={system?.datacenterenvironment}
+                    fullWidth
+                    InputLabelProps={{
+                      sx: {
+                        marginTop: 0,
+                      },
+                    }}
+                    sx={{ mt: 2 }}
+                    onChange={(e) => {
+                      setEditedFismaSystem((prevState) => ({
+                        ...prevState,
+                        datacenterenvironment: e.target.value,
+                      }))
+                    }}
+                  >
+                    {datacenterenvironment.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Grid>
+              </Grid>
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <CmsButton variation="solid" onClick={handleSave}>
+              Save
+            </CmsButton>
+            <CmsButton onClick={handleClose} color="primary">
+              Close
+            </CmsButton>
+          </DialogActions>
+        </Dialog>
+        <ConfirmDialog
+          open={openAlert}
+          onClose={() => setOpenAlert(false)}
+          confirmClick={handleConfirmReturn}
+        />
+      </>
+    )
+  }
+  return <></>
+}

--- a/src/views/EditSystemModal/ValidatedTextField.tsx
+++ b/src/views/EditSystemModal/ValidatedTextField.tsx
@@ -1,0 +1,47 @@
+import { useState, ChangeEvent } from 'react'
+import { TextField } from '@mui/material'
+
+type ValidatedTextFieldProps = {
+  label: string
+  dfValue?: string
+  isFullWidth?: boolean
+  validator: (value: string) => string | false
+  onChange: (isValid: boolean, value: string) => void
+}
+const ValidatedTextField: React.FC<ValidatedTextFieldProps> = ({
+  label,
+  validator,
+  isFullWidth,
+  dfValue,
+  onChange,
+}) => {
+  const [value, setValue] = useState<string>(dfValue || '')
+  const [error, setError] = useState<string | false>(false)
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    const errorMessage = validator(newValue)
+    setValue(newValue)
+    setError(errorMessage)
+    onChange(!errorMessage, newValue)
+  }
+
+  return (
+    <TextField
+      label={label}
+      value={value}
+      variant="standard"
+      fullWidth={isFullWidth}
+      margin="normal"
+      onChange={handleChange}
+      InputLabelProps={{
+        sx: {
+          marginTop: 0,
+        },
+      }}
+      error={!!error}
+      helperText={error || ''}
+    />
+  )
+}
+export default ValidatedTextField

--- a/src/views/EditSystemModal/ValidatedTextField.tsx
+++ b/src/views/EditSystemModal/ValidatedTextField.tsx
@@ -1,6 +1,6 @@
 import { useState, ChangeEvent } from 'react'
 import { TextField } from '@mui/material'
-
+import { useEffect, useRef } from 'react'
 type ValidatedTextFieldProps = {
   label: string
   dfValue?: string
@@ -17,7 +17,16 @@ const ValidatedTextField: React.FC<ValidatedTextFieldProps> = ({
 }) => {
   const [value, setValue] = useState<string>(dfValue || '')
   const [error, setError] = useState<string | false>(false)
+  const isInitialMount = useRef(true)
 
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      const errorMessage = validator(dfValue || '')
+      setError(errorMessage)
+      onChange(!errorMessage, dfValue || '')
+    }
+  }, [dfValue, validator, onChange])
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     const errorMessage = validator(newValue)
@@ -34,6 +43,7 @@ const ValidatedTextField: React.FC<ValidatedTextFieldProps> = ({
       fullWidth={isFullWidth}
       margin="normal"
       onChange={handleChange}
+      required
       InputLabelProps={{
         sx: {
           marginTop: 0,

--- a/src/views/EditSystemModal/dataEnvironment.ts
+++ b/src/views/EditSystemModal/dataEnvironment.ts
@@ -1,0 +1,39 @@
+/**
+ * datacenterenvironment values for the select dropdown
+ * to edit a system
+ */
+
+export const datacenterenvironment = [
+  {
+    value: 'AWS',
+    label: 'AWS',
+  },
+  {
+    value: 'CMS-Cloud-AWS',
+    label: 'CMS-Cloud-AWS',
+  },
+  {
+    value: 'CMSDC',
+    label: 'CMSDC',
+  },
+  {
+    value: 'CMS-Cloud-MAG',
+    label: 'CMS-Cloud-MAG',
+  },
+  {
+    value: 'DECOMMISSIONED',
+    label: 'DECOMMISSIONED',
+  },
+  {
+    value: 'OPDC',
+    label: 'OPDC',
+  },
+  {
+    value: 'Other',
+    label: 'Other',
+  },
+  {
+    value: 'SaaS',
+    label: 'SaaS',
+  },
+]

--- a/src/views/EditSystemModal/emptySystem.ts
+++ b/src/views/EditSystemModal/emptySystem.ts
@@ -1,0 +1,16 @@
+export const EMPTY_SYSTEM = {
+  fismauid: '',
+  fismaacronym: '',
+  fismaname: '',
+  fismasubsystem: '',
+  fismaimpactlevel: '',
+  mission: '',
+  fismasystemid: 0,
+  component: '',
+  groupacronym: '',
+  groupname: '',
+  divisionname: '',
+  datacenterenvironment: '',
+  datacallcontact: '',
+  issoemail: '',
+}

--- a/src/views/EditSystemModal/validators.ts
+++ b/src/views/EditSystemModal/validators.ts
@@ -1,0 +1,5 @@
+export const emailValidator = (value: string): string | false => {
+  if (!/^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/.test(value))
+    return 'Invalid email address'
+  return false
+}

--- a/src/views/EditSystemModal/validators.ts
+++ b/src/views/EditSystemModal/validators.ts
@@ -1,4 +1,7 @@
 export const emailValidator = (value: string): string | false => {
+  if (value.length === 0) {
+    return 'This field is required'
+  }
   if (!/^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/.test(value))
     return 'Invalid email address'
   return false

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -25,10 +25,7 @@ import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '../../constants'
 import EditIcon from '@mui/icons-material/Edit'
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined'
-type FismaTableProps = {
-  scores: Record<number, number>
-  latestDataCallId: number
-}
+import { FismaTableProps } from '@/types'
 
 type selectedRowsType = GridRowId[]
 declare module '@mui/x-data-grid' {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -26,7 +26,6 @@ import { ERROR_MESSAGES } from '../../constants'
 import EditIcon from '@mui/icons-material/Edit'
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined'
 type FismaTableProps = {
-  fismaSystems: FismaSystemType[]
   scores: Record<number, number>
   latestDataCallId: number
 }
@@ -136,11 +135,11 @@ export function CustomFooterSaveComponent(
   )
 }
 export default function FismaTable({
-  fismaSystems,
   scores,
   latestDataCallId,
 }: FismaTableProps) {
   const apiRef = useGridApiRef()
+  const { fismaSystems } = useContextProp()
   const [open, setOpen] = useState<boolean>(false)
   const { userInfo } = useContextProp() || EMPTY_USER
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
@@ -154,7 +153,11 @@ export default function FismaTable({
     setOpen(false)
     setSelectedRow(null)
   }
-  const handleEditOpenModal = (row: FismaSystemType) => {
+  const handleEditOpenModal = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    row: FismaSystemType
+  ) => {
+    event.stopPropagation()
     setSelectedRow(row)
     setOpenEditModal(true)
   }
@@ -162,12 +165,6 @@ export default function FismaTable({
     if (selectedRow) {
       const row = apiRef.current.getRow(selectedRow?.fismasystemid)
       if (row) {
-        // const updatedRow = {
-        //   ...row,
-        //   fismaname: newRowData.fismaname,
-        //   issoemail: newRowData.issoemail,
-        //   datacenterenvironment: newRowData.datacenterenvironment,
-        // }
         apiRef.current.updateRows([newRowData])
       }
     }
@@ -196,8 +193,12 @@ export default function FismaTable({
       renderCell: (params) => {
         const name = params.row.issoemail.split('@')
         const fullName = name[0].replace(/[0-9]/g, '').split('.')
-        const firstName = fullName[0][0].toUpperCase() + fullName[0].slice(1)
-        const lastName = fullName[1][0].toUpperCase() + fullName[1].slice(1)
+        let firstName = ''
+        let lastName = ''
+        if (fullName.length > 1) {
+          firstName = fullName[0][0].toUpperCase() + fullName[0].slice(1)
+          lastName = fullName[1][0].toUpperCase() + fullName[1].slice(1)
+        }
         return fullName.length > 1 ? `${firstName} ${lastName}` : fullName[0]
       },
     },
@@ -278,7 +279,9 @@ export default function FismaTable({
               key={`edit-${params.row.fismasystemid}`}
               label="Edit"
               className="textPrimary"
-              onClick={() => handleEditOpenModal(params.row as FismaSystemType)}
+              onClick={(event) =>
+                handleEditOpenModal(event, params.row as FismaSystemType)
+              }
               color="inherit"
             />
           )}
@@ -347,9 +350,11 @@ export default function FismaTable({
         system={selectedRow}
       />
       <EditSystemModal
+        title={'Edit'}
         open={openEditModal}
         onClose={handleCloseEditModal}
         system={selectedRow}
+        mode={'edit'}
       />
     </div>
   )

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -4,6 +4,8 @@ import {
   GridColDef,
   GridFooterContainer,
   GridSlotsComponentsProps,
+  GridRenderCellParams,
+  GridActionsCellItem,
   GridFooter,
   GridRowId,
 } from '@mui/x-data-grid'
@@ -11,11 +13,13 @@ import Tooltip from '@mui/material/Tooltip'
 import { Box, IconButton } from '@mui/material'
 import { useState } from 'react'
 import FileDownloadSharpIcon from '@mui/icons-material/FileDownloadSharp'
-import Link from '@mui/material/Link'
 import QuestionnareModal from '../QuestionnareModal/QuestionnareModal'
 import CustomSnackbar from '../Snackbar/Snackbar'
 import axiosInstance from '@/axiosConfig'
-
+import { useContextProp } from '../Title/Context'
+import { EMPTY_USER } from '../../constants'
+import EditIcon from '@mui/icons-material/Edit'
+import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined'
 type FismaTable2Props = {
   fismaSystems: FismaSystemType[]
   scores: Record<number, number>
@@ -114,6 +118,7 @@ export function CustomFooterSaveComponent(
 }
 export default function FismaTable({ fismaSystems, scores }: FismaTable2Props) {
   const [open, setOpen] = useState<boolean>(false)
+  const { userInfo } = useContextProp() || EMPTY_USER
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
   const [selectedRows, setSelectedRows] = useState<GridRowId[]>([])
   const handleOpenModal = (row: FismaSystemType) => {
@@ -206,18 +211,40 @@ export default function FismaTable({ fismaSystems, scores }: FismaTable2Props) {
       headerName: 'Actions',
       headerAlign: 'center',
       align: 'center',
-      flex: 1,
+      flex: 0.5,
       hideable: false,
       sortable: false,
       disableColumnMenu: true,
-      renderCell: (params) => (
-        <Link
-          component="button"
-          variant="body2"
-          onClick={() => handleOpenModal(params.row as FismaSystemType)}
-        >
-          View Questionnare
-        </Link>
+      renderCell: (params: GridRenderCellParams) => (
+        <>
+          {/* <Link
+            component="button"
+            variant="body2"
+            onClick={() => handleOpenModal(params.row as FismaSystemType)}
+          >
+            View Questionnare
+          </Link> */}
+          <Tooltip title="View Questionnare">
+            <GridActionsCellItem
+              icon={<QuestionAnswerOutlinedIcon />}
+              key={`question-${params.row.fismasystemid}`}
+              label="View Questionnare"
+              className="textPrimary"
+              onClick={() => handleOpenModal(params.row as FismaSystemType)}
+              color="inherit"
+            />
+          </Tooltip>
+          {userInfo.role === 'ADMIN' && (
+            <GridActionsCellItem
+              icon={<EditIcon />}
+              key={`edit-${params.row.fismasystemid}`}
+              label="Edit"
+              className="textPrimary"
+              // onClick={}
+              color="inherit"
+            />
+          )}
+        </>
       ),
     },
   ]

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -114,7 +114,7 @@ export default function HomePageContainer() {
   return (
     <>
       <div>
-        <StatisticsBlocks fismaSystems={fismaSystems} scores={scoreMap} />
+        <StatisticsBlocks scores={scoreMap} />
         <FismaTable scores={scoreMap} latestDataCallId={latestDataCallId} />
       </div>
     </>

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
 import { FismaSystemType } from '@/types'
-import { set } from 'lodash'
 /**
  * Component that renders the contents of the Home view.
  * @returns {JSX.Element} Component that renders the home contents.
@@ -116,11 +115,7 @@ export default function HomePageContainer() {
     <>
       <div>
         <StatisticsBlocks fismaSystems={fismaSystems} scores={scoreMap} />
-        <FismaTable
-          fismaSystems={fismaSystems}
-          scores={scoreMap}
-          latestDataCallId={latestDataCallId}
-        />
+        <FismaTable scores={scoreMap} latestDataCallId={latestDataCallId} />
       </div>
     </>
   )

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -265,13 +265,7 @@ export default function QuestionnareModal({
             }
             return res.data.data
           })
-          let latestDataCallId = -Infinity
-          for (let i = 0; i < datacall.length; i++) {
-            latestDataCallId = Math.max(
-              latestDataCallId,
-              datacall[i].datacallid
-            )
-          }
+          const latestDataCallId = datacall[0].datacallid
           setDatacallID(latestDataCallId)
           await axiosInstance
             .get(`/fismasystems/${system.fismasystemid}/questions`)

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -30,7 +30,7 @@ import { Routes } from '@/router/constants'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
-import { ERROR_MESSAGES } from '@/constants'
+import { ERROR_MESSAGES, PILLAR_FUNCTION_MAP } from '@/constants'
 const CssTextField = styled(TextField)({
   '& label.Mui-focused': {
     color: 'rgb(13, 36, 153)',
@@ -294,13 +294,31 @@ export default function QuestionnareModal({
               const sortedPillars = Object.keys(organizedData).sort(
                 (a, b) => pillarOrder[a] - pillarOrder[b]
               )
+              const sortSteps = (
+                steps: FismaQuestion[],
+                order: string[]
+              ): FismaQuestion[] => {
+                return steps.sort(
+                  (a, b) =>
+                    order.indexOf(a.function.function) -
+                    order.indexOf(b.function.function)
+                )
+              }
               const categoriesData: Category[] = sortedPillars.map(
                 (pillar) => ({
                   name: pillar,
-                  steps: organizedData[pillar],
+                  steps: sortSteps(
+                    organizedData[pillar],
+                    PILLAR_FUNCTION_MAP[pillar]
+                  ),
                 })
               )
-
+              // const categoriesData: Category[] = sortedPillars.map(
+              //   (pillar) => ({
+              //     name: pillar,
+              //     steps: organizedData[pillar],
+              //   })
+              // )
               setCategories(categoriesData)
               if (data.length > 0) {
                 setQuestionId(categoriesData[0]['steps'][0].function.functionid)

--- a/src/views/QuestionnareModal/__test__/QuestionnareModal.test.tsx
+++ b/src/views/QuestionnareModal/__test__/QuestionnareModal.test.tsx
@@ -1,0 +1,26 @@
+import mockAxios from 'axios'
+jest.mock('axios')
+const mAxios = mockAxios as jest.Mocked<typeof mockAxios>
+
+const mockResponse = [
+  {
+    function: {
+      datacenterenvironment: 'test-center-environment',
+      description: 'test description',
+      function: 'test function',
+      functiondid: 1,
+    },
+    pillar: {
+      order: 1,
+      pillar: 'test pillar',
+      pillarid: 1,
+    },
+    noteprompt: 'test note prompt',
+    order: 'test-order none',
+    question: 'test question',
+    questionid: 'test-question-id',
+  },
+]
+it('test axios fetch', async () => {
+  mAxios.get.mockResolvedValueOnce({ data: mockResponse })
+})

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { FismaSystemType } from '@/types'
+import { useContextProp } from '../Title/Context'
 const StatisticsPaper = styled(Paper)(({ theme }) => ({
   width: 120,
   height: 120,
@@ -14,12 +14,11 @@ const StatisticsPaper = styled(Paper)(({ theme }) => ({
   elevation: 3,
 }))
 export default function StatisticsBlocks({
-  fismaSystems,
   scores,
 }: {
-  fismaSystems: FismaSystemType[]
   scores: Record<number, number>
 }) {
+  const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
   const [avgSystemScore, setAvgSystemScore] = useState<number>(0)
   const [maxSystemAcronym, setMaxSystemAcronym] = useState<string>('')

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -49,11 +49,17 @@ export default function StatisticsBlocks({
         }
       }
     }
+    if (totalCount === 0) {
+      setAvgSystemScore(0)
+      setMinSystemScore(0)
+    } else {
+      setAvgSystemScore(Number((totalScores / totalCount).toFixed(2)))
+      setMinSystemScore(minScore)
+    }
     setTotalSystems(totalCount)
-    setAvgSystemScore(Number((totalScores / totalCount).toFixed(2)))
     setMaxSystemScore(maxScore)
     setMaxSystemAcronym(maxScoreSystem || '')
-    setMinSystemScore(minScore)
+
     setMinSystemAcronym(minScoreSystem || '')
     setLoading(false)
   }, [fismaSystems, scores])

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -1,8 +1,11 @@
 import { useOutletContext } from 'react-router-dom'
-import { FismaSystemType } from '@/types'
+import { FismaSystemType, userData } from '@/types'
 
-type ContextType = { fismaSystems: FismaSystemType[] | [] }
+type ContextType = {
+  fismaSystems: FismaSystemType[] | []
+  userInfo: userData
+}
 
-export function useFismaSystems() {
+export function useContextProp() {
   return useOutletContext<ContextType>()
 }

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -45,6 +45,7 @@ export default function Title() {
     async function fetchFismaSystems() {
       try {
         const fismaSystems = await axiosInstance.get('/fismasystems')
+        // TODO: use ERROR_MESSAGES to handle errors
         if (fismaSystems.status !== 200) {
           navigate(Routes.SIGNIN, {
             replace: true,
@@ -164,7 +165,7 @@ export default function Title() {
         {loaderData.status !== 200 ? (
           <LoginPage />
         ) : (
-          <Outlet context={{ fismaSystems }} />
+          <Outlet context={{ fismaSystems, userInfo }} />
         )}
       </Container>
     </>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -17,6 +17,7 @@ import { FismaSystemType } from '@/types'
 import { Routes } from '@/router/constants'
 import axiosInstance from '@/axiosConfig'
 import LoginPage from '../LoginPage/LoginPage'
+import { ERROR_MESSAGES } from '@/constants'
 /**
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
@@ -45,11 +46,10 @@ export default function Title() {
     async function fetchFismaSystems() {
       try {
         const fismaSystems = await axiosInstance.get('/fismasystems')
-        // TODO: use ERROR_MESSAGES to handle errors
         if (fismaSystems.status !== 200) {
           navigate(Routes.SIGNIN, {
             replace: true,
-            state: { message: 'Please log in' },
+            state: ERROR_MESSAGES.expired,
           })
         }
         setFismaSystems(fismaSystems.data.data)

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -18,6 +18,9 @@ import { Routes } from '@/router/constants'
 import axiosInstance from '@/axiosConfig'
 import LoginPage from '../LoginPage/LoginPage'
 import { ERROR_MESSAGES } from '@/constants'
+import EditSystemModal from '../EditSystemModal/EditSystemModal'
+import { EMPTY_SYSTEM } from '../EditSystemModal/emptySystem'
+import _ from 'lodash'
 /**
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
@@ -42,6 +45,7 @@ export default function Title() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [titlePage, setTitlePage] = useState<string>('Dashboard')
+  const [openModal, setOpenModal] = useState<boolean>(false)
   useEffect(() => {
     async function fetchFismaSystems() {
       try {
@@ -70,6 +74,13 @@ export default function Title() {
   }
   const handleClose = () => {
     setAnchorEl(null)
+  }
+  const handleCloseModal = (newRowData: FismaSystemType) => {
+    if (!_.isEqual(EMPTY_SYSTEM, newRowData)) {
+      setFismaSystems((prevFismSystems) => [...prevFismSystems, newRowData])
+    }
+    setOpenModal(false)
+    handleClose()
   }
   return (
     <>
@@ -144,6 +155,9 @@ export default function Title() {
                               Edit Users
                             </MenuItem>
                           </Link>
+                          <MenuItem onClick={() => setOpenModal(true)}>
+                            Add Fisma System
+                          </MenuItem>
                         </Menu>
                       </>
                     ) : (
@@ -167,6 +181,13 @@ export default function Title() {
         ) : (
           <Outlet context={{ fismaSystems, userInfo }} />
         )}
+        <EditSystemModal
+          title={'Add'}
+          open={openModal}
+          onClose={handleCloseModal}
+          system={EMPTY_SYSTEM}
+          mode={'create'}
+        />
       </Container>
     </>
   )

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -25,6 +25,7 @@ import _ from 'lodash'
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
  */
+
 const emptyUser: userData = {
   userid: '',
   email: '',

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -32,7 +32,7 @@ import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
 import axiosInstance from '@/axiosConfig'
 import { users } from '@/types'
-import { useFismaSystems } from '../Title/Context'
+import { useContextProp } from '../Title/Context'
 import Box from '@mui/material/Box'
 import CustomSnackbar from '../Snackbar/Snackbar'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
@@ -95,7 +95,7 @@ export default function UserTable() {
   }
   const [rows, setRows] = useState<users[]>([])
   const [userId, setUserId] = useState<GridRowId>('')
-  const { fismaSystems } = useFismaSystems()
+  const { fismaSystems } = useContextProp()
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({})
   const [open, setOpen] = useState<boolean>(false)
   const [openModal, setOpenModal] = useState<boolean>(false)

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -135,7 +135,7 @@ export default function UserTable() {
       apiRef.current.setEditCellValue({
         id: selectedRow.userid,
         field: 'role',
-        value: selectedRow.role, // Replace with the desired value
+        value: selectedRow.role,
       })
     }
     setOpenAlert(false)


### PR DESCRIPTION
### Summary

Adding a modal that allows admins to edit fisma systems

Ordered the pillar functions in questionnaire modal

removed `dependabot` from imbedded ui workflow

closes #90
closes #105 

### Added

Modal to edit fisma system

Modal to confirm changes if a user does not save their changes of editing a fisma system. 

### Changes

Fisma Table to update the row data if edits to fisma system were made.

### Test

(ADMIN) click on the icon in fisma table to edit a fisma system. Make changes and click 'save' to save changes.

if changes are made and admin closes the modal before saving the change, a confirmation modal will appear.

Changes that are made which are invalid to the endpoint will prompt user to enter a valid input.

- to test this remove characters from the `fismauid` OR when adding a new system to have an invalid `fismauid`

To add a new fisma system, please click on the kebab icon next to your name (admin). There is a menu to add a fisma system.

For the ordered pillar functions in questionnaire modal
- Open questionnaire modal to check order of functions


