### PR TITLE
fix: prompt user that the selected systems can't be exported

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,8 @@ export const COPYRIGHT_LABEL = `Copyright © ${new Date()
 // * Configuration Constants
 export const DEFAULT_ALERT_TIMEOUT = 3000
 
+export const ROLES = ['ISSO', 'ISSM', 'ADMIN']
+
 export const ERROR_MESSAGES = {
   login: 'Please log in to continue.',
   expired: 'Your session has expired. Please log in again.',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@
  * Application-wide constants
  * @module constants
  */
+import { permission } from 'process'
 import { userData } from './types'
 
 //* Application Strings
@@ -23,6 +24,7 @@ export const ERROR_MESSAGES = {
     'Your changes were not saved. Your session may have expired. Please log in again.',
   error:
     'An error occurred. Please log in and try again. If the error persists, please contact support.',
+  permission: 'You do not have permission to do this action.',
 }
 export const EMPTY_USER: userData = {
   userid: '',

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -139,6 +139,7 @@ export default function AssignSystemModal({
         open={openSnackBar}
         handleClose={() => setOpenSnackBar(false)}
         severity="success"
+        duration={2000}
         text="Saved"
       />
     </>

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -42,6 +42,9 @@ export function CustomFooterSaveComponent(
   props: NonNullable<GridSlotsComponentsProps['footer']>
 ) {
   const [openSnackbar, setOpenSnackbar] = useState<boolean>(false)
+  const [snackBarSeverity, setSnackBarSeverity] = useState<
+    'success' | 'error' | 'warning' | 'info'
+  >('error')
   const apiRef = useGridApiContext()
   const [errorMessage, setErrorMessage] = useState<string>('')
   const navigate = useNavigate()
@@ -94,6 +97,7 @@ export function CustomFooterSaveComponent(
           })
         } else if (error.status === 403) {
           setErrorMessage(ERROR_MESSAGES.permission)
+          setSnackBarSeverity('warning')
           setOpenSnackbar(true)
         }
       })
@@ -125,7 +129,7 @@ export function CustomFooterSaveComponent(
       <CustomSnackbar
         open={openSnackbar}
         handleClose={handleCloseSnackbar}
-        severity="error"
+        severity={snackBarSeverity}
         text={errorMessage}
         duration={4000}
       />

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -271,7 +271,10 @@ export default function FismaTable({
               key={`question-${params.row.fismasystemid}`}
               label="View Questionnare"
               className="textPrimary"
-              onClick={() => handleOpenModal(params.row as FismaSystemType)}
+              onClick={(event) => {
+                event.stopPropagation()
+                handleOpenModal(params.row as FismaSystemType)
+              }}
               color="inherit"
             />
           </Tooltip>
@@ -281,9 +284,10 @@ export default function FismaTable({
               key={`edit-${params.row.fismasystemid}`}
               label="Edit"
               className="textPrimary"
-              onClick={(event) =>
+              onClick={(event) => {
+                event.stopPropagation()
                 handleEditOpenModal(event, params.row as FismaSystemType)
-              }
+              }}
               color="inherit"
             />
           )}

--- a/src/views/Snackbar/Snackbar.tsx
+++ b/src/views/Snackbar/Snackbar.tsx
@@ -7,6 +7,7 @@ type SnackbarProps = {
   handleClose: () => void
   severity?: 'success' | 'error' | 'warning' | 'info'
   text: string
+  duration: number
 }
 
 export default function CustomSnackbar({
@@ -14,6 +15,7 @@ export default function CustomSnackbar({
   handleClose,
   severity,
   text,
+  duration = 2000,
 }: SnackbarProps) {
   const [localOpen, setLocalOpen] = useState(open)
 
@@ -36,7 +38,7 @@ export default function CustomSnackbar({
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
         open={localOpen}
-        autoHideDuration={2000}
+        autoHideDuration={duration}
         onClose={handleSnackbarClose}
       >
         <Alert severity={severity} variant="filled" sx={{ width: '100%' }}>

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -102,22 +102,38 @@ export default function StatisticsBlocks({
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">
-        <Typography variant="h4" sx={{ color: '#128172', fontSize: '56px' }}>
+        <Typography
+          variant="h4"
+          sx={{
+            color: '#128172',
+            fontSize: '50px',
+          }}
+        >
           {maxSystemScore}
         </Typography>
         <Typography
           variant="body1"
-          sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
+          sx={{
+            fontSize: '16px',
+          }}
         >
-          Highest System Score: {maxSystemAcronym}
+          Highest System Score:
+          <br /> {maxSystemAcronym}
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">
-        <Typography variant="h4" sx={{ color: '#960B91', fontSize: '56px' }}>
-          {minSystemScore}
+        <Typography
+          variant="h4"
+          sx={{
+            color: '#960B91',
+            fontSize: '50px',
+            // overflowWrap: 'break-word',
+          }}
+        >
+          {minSystemScore === Number.POSITIVE_INFINITY ? 0 : minSystemScore}
         </Typography>
         <Typography variant="body1" sx={{ fontSize: '16px' }}>
-          Lowest System Score: {minSystemAcronym}
+          Lowest System Score: <br /> {minSystemAcronym}
         </Typography>
       </StatisticsPaper>
     </Box>

--- a/src/views/UserTable/EditInputCell.tsx
+++ b/src/views/UserTable/EditInputCell.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid'
+import { TextField } from '@mui/material'
+
+interface CustomEditComponentProps extends GridRenderEditCellParams {
+  getErrorValue: () => boolean
+}
+
+export default function EditInputCell(props: CustomEditComponentProps) {
+  const { id, value, field, hasFocus, getErrorValue } = props
+  const apiRef = useGridApiContext()
+  const ref = React.useRef<HTMLElement>(null)
+
+  React.useLayoutEffect(() => {
+    if (hasFocus) {
+      ref.current?.focus()
+    }
+  }, [hasFocus])
+
+  const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value // The new value entered by the user
+    apiRef.current.setEditCellValue({ id, field, value: newValue })
+    // console.log(apiRef.current.getRowWithUpdatedValues(id, field))
+  }
+  return (
+    <TextField
+      fullWidth
+      inputRef={ref}
+      error={getErrorValue()}
+      label=""
+      id="fullWidth"
+      value={value}
+      onChange={handleValueChange}
+      sx={{
+        // '& .MuiOutlinedInput-root': {
+        //   '& fieldset': {
+        //     border: 'none',
+        //   },
+        // },
+        '& .MuiOutlinedInput-input': {
+          py: 1.5,
+          // pt: 2,
+        },
+      }}
+    />
+  )
+}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -5,6 +5,9 @@ import EditIcon from '@mui/icons-material/Edit'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import SaveIcon from '@mui/icons-material/Save'
 import CancelIcon from '@mui/icons-material/Close'
+import FormControl from '@mui/material/FormControl'
+import Select from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
 import {
   GridRowsProp,
   GridRowModesModel,
@@ -16,7 +19,7 @@ import {
   GridEventListener,
   GridRowId,
   GridRowModel,
-  GridPreProcessEditCellProps,
+  GridRenderEditCellParams,
   GridRowEditStopReasons,
   useGridApiRef,
 } from '@mui/x-data-grid'
@@ -38,15 +41,15 @@ import CustomSnackbar from '../Snackbar/Snackbar'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
-import { ERROR_MESSAGES } from '@/constants'
-const roles = ['ISSO', 'ISSM', 'ADMIN']
-
+import { ERROR_MESSAGES, ROLES } from '@/constants'
+import EditInputCell from './EditInputCell'
 interface EditToolbarProps {
   setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void
   setRowModesModel: (
     newModel: (oldModel: GridRowModesModel) => GridRowModesModel
   ) => void
 }
+
 function EditToolbar(props: EditToolbarProps) {
   const { setRows, setRowModesModel } = props
   const addUserRow = () => {
@@ -64,18 +67,20 @@ function EditToolbar(props: EditToolbarProps) {
   return (
     <GridToolbarContainer>
       <Button color="primary" startIcon={<AddIcon />} onClick={addUserRow}>
-        Add Users
+        Add User
       </Button>
     </GridToolbarContainer>
   )
 }
-
+function validateEmail(email: string) {
+  return /^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/.test(email)
+}
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()
   //TODO: add these to a file to be imported and used in multiple places
   const checkValidResponse = (status: number) => {
-    if (status !== 200 && status.toString()[0] === '4') {
+    if (status.toString()[0] === '401') {
       navigate(Routes.SIGNIN, {
         replace: true,
         state: {
@@ -85,19 +90,47 @@ export default function UserTable() {
     }
     return
   }
-  const routeToSignIn = () => {
-    navigate(Routes.SIGNIN, {
-      replace: true,
-      state: {
-        message: ERROR_MESSAGES.expired,
-      },
-    })
+  const renderSingleSelectEditCell = (params: GridRenderEditCellParams) => {
+    const { value } = params
+    return (
+      <FormControl sx={{ minWidth: 120 }} error={!value} fullWidth>
+        <Select
+          sx={{
+            '& .MuiOutlinedInput-input': {
+              py: 1.7,
+            },
+          }}
+          value={value || ''}
+          onChange={(event) => {
+            params.api.setEditCellValue(
+              {
+                id: params.id,
+                field: params.field,
+                value: event.target.value,
+              },
+              event
+            )
+          }}
+          renderValue={(value) => `${value}`}
+        >
+          {ROLES.map((role) => (
+            <MenuItem value={role} key={role}>
+              {role}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )
   }
   const [rows, setRows] = useState<users[]>([])
   const [userId, setUserId] = useState<GridRowId>('')
   const { fismaSystems } = useContextProp()
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({})
   const [open, setOpen] = useState<boolean>(false)
+  const [snackBarText, setSnackBarText] = useState<string>('Saved')
+  const [snackBarSeverity, setSnackBarSeverity] = useState<
+    'success' | 'error' | 'warning' | 'info'
+  >('success')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openAlert, setOpenAlert] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<users | undefined>({
@@ -119,17 +152,6 @@ export default function UserTable() {
       event.defaultMuiPrevented = true
     }
   }
-  const preProcessEditCellProps = (params: GridPreProcessEditCellProps) => {
-    if (params.hasChanged) {
-      const curRow = rows.find((row) => row.userid === params.id)
-      setSelectedRow(curRow)
-      if (params.props.value === 'ADMIN' && curRow?.role !== 'ADMIN') {
-        setUserName(curRow?.fullname)
-        setOpenAlert(true)
-      }
-    }
-    return Promise.resolve()
-  }
   const handleAlertCloseModal = (response: boolean) => {
     if (response == false && selectedRow) {
       apiRef.current.setEditCellValue({
@@ -140,12 +162,41 @@ export default function UserTable() {
     }
     setOpenAlert(false)
   }
+  const handleUnautherized = (errorStatus: number) => {
+    if (errorStatus === 403) {
+      setSnackBarSeverity('error')
+      setSnackBarText('You are not authorized to perform this action')
+      setOpen(true)
+    }
+  }
   const handleEditClick = (id: GridRowId) => () => {
+    const curRow = rows.find((row) => row.userid === id)
+    setSelectedRow(curRow)
     setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } })
   }
 
   const handleSaveClick = (id: GridRowId) => () => {
-    setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } })
+    const curRow = apiRef.current.getRowWithUpdatedValues(id, '')
+    if (
+      !curRow?.email ||
+      validateEmail(curRow?.email) === false ||
+      !curRow?.fullname ||
+      !curRow?.role
+    ) {
+      let errMessage: string = ''
+      if (!curRow?.email || !curRow?.fullname || !curRow?.role) {
+        errMessage = 'Please fill required fields'
+      } else if (validateEmail(curRow?.email) === false) {
+        errMessage = 'Please enter a valid email'
+      }
+      setSnackBarSeverity('error')
+      setSnackBarText(errMessage)
+      setOpen(true)
+      setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.Edit } })
+    } else {
+      setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } })
+    }
+    // setRowModesModel({ ...rowModesModel, [id]: { mode: GridRowModes.View } })
   }
 
   const handleCloseSnackbar = () => {
@@ -170,32 +221,33 @@ export default function UserTable() {
     }
   }
   const processRowUpdate = (newRow: GridRowModel) => {
+    const updatedRow = {
+      ...selectedRow,
+      ...newRow,
+      isNew: false,
+      role: newRow.role !== undefined ? newRow.role : selectedRow?.role ?? '',
+    } as users
     if (newRow.isNew) {
-      let newUser = {} as users
       axiosInstance
         .post('/users', {
-          email: newRow.email,
-          fullname: newRow.fullname,
-          role: newRow.role,
+          email: updatedRow.email,
+          fullname: updatedRow.fullname,
+          role: updatedRow.role,
         })
         .then((res) => {
-          newUser = res.data.data
-          checkValidResponse(res.status)
-          setRows(
-            rows.map((row) =>
-              row.userid === newRow.userid
-                ? { ...updatedRow, userid: newUser.userid }
-                : row
-            )
-          )
+          newRow = res.data.data
+          updatedRow.userid = newRow.userid
+          setSnackBarSeverity('success')
+          setSnackBarText('Saved')
           setOpen(true)
         })
         .catch((error) => {
           console.error('Error updating score:', error)
-          routeToSignIn()
+          checkValidResponse(error.response.status)
+          handleUnautherized(error.response.status)
         })
     } else {
-      const updatedRow = { ...newRow } as users
+      // const updatedRow = { ...newRow } as users
       axiosInstance
         .put(`/users/${updatedRow?.userid}`, {
           email: updatedRow?.email,
@@ -204,31 +256,38 @@ export default function UserTable() {
         })
         .then((res) => {
           checkValidResponse(res.status)
+          setSnackBarSeverity('success')
+          setSnackBarText('Saved')
           setOpen(true)
         })
         .catch((error) => {
-          console.error('Error updating score:', error)
-          routeToSignIn()
+          checkValidResponse(error.response.status)
+          handleUnautherized(error.response.status)
         })
-      setRows(
-        rows.map((row) => (row.userid === newRow.userid ? updatedRow : row))
-      )
     }
-    const updatedRow = { ...newRow, isNew: false } as users
+    setRows(
+      rows.map((row) => (row.userid === newRow.userid ? updatedRow : row))
+    )
     return updatedRow
   }
-
   const handleRowModesModelChange = (newRowModesModel: GridRowModesModel) => {
     setRowModesModel(newRowModesModel)
   }
-  const handleProcessRowUpdateError = (error: unknown) => {
-    console.error('Error updating row:', error)
+  const handleProcessRowUpdateError = () => {
+    setSnackBarSeverity('error')
+    setSnackBarText('An error occurred while saving the row')
+    setOpen(true)
   }
+
   // TODO: Custom hook for fetching data
   useEffect(() => {
     axiosInstance.get('/users').then((res) => {
       if (res.status === 200) {
-        setRows(res.data.data)
+        const data = res.data.data.map((row: users) => ({
+          ...row,
+          role: row.role.trim(),
+        }))
+        setRows(data)
         const map: Record<number, string> = {}
         for (const obj of fismaSystems) {
           map[obj.fismasystemid] = obj.fismasubsystem
@@ -247,6 +306,20 @@ export default function UserTable() {
       headerName: 'Full Name',
       flex: 1,
       hideable: false,
+      renderEditCell: (params: GridRenderEditCellParams) => (
+        <EditInputCell
+          {...params}
+          getErrorValue={() => {
+            if (params?.value) {
+              if (params.value.length === 0) {
+                return true
+              }
+              return false
+            }
+            return true
+          }}
+        />
+      ),
       editable: true,
     },
     {
@@ -254,6 +327,20 @@ export default function UserTable() {
       headerName: 'Email',
       flex: 1,
       hideable: false,
+      renderEditCell: (params: GridRenderEditCellParams) => (
+        <EditInputCell
+          {...params}
+          getErrorValue={() => {
+            if (params?.value) {
+              if (params.value.length === 0) {
+                return true
+              }
+              return validateEmail(params.value) === false
+            }
+            return true
+          }}
+        />
+      ),
       editable: true,
     },
     {
@@ -261,10 +348,7 @@ export default function UserTable() {
       headerName: 'Role',
       flex: 1,
       editable: true,
-      type: 'singleSelect',
-      valueOptions: roles,
-      preProcessEditCellProps,
-      cellClassName: 'single-select-dropdown',
+      renderEditCell: renderSingleSelectEditCell,
     },
     {
       field: 'actions',
@@ -397,8 +481,8 @@ export default function UserTable() {
         open={open}
         handleClose={handleCloseSnackbar}
         duration={2000}
-        severity="success"
-        text="Saved"
+        severity={snackBarSeverity}
+        text={snackBarText}
       />
       <AssignSystemModal
         fismaSystemMap={fismaSystemsMap}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -396,6 +396,7 @@ export default function UserTable() {
       <CustomSnackbar
         open={open}
         handleClose={handleCloseSnackbar}
+        duration={2000}
         severity="success"
         text="Saved"
       />


### PR DESCRIPTION
### Summary

Fismasystem Table -
Disabled export button if there are no selection of fismasystems. Disabled rows that have a overall score of `0.0` to export.

User Table -
Validate adding a user with required field and validate email to be a valid email

Edit system acronym to be on its separate line for statistics blocks above the fisma system table.

### Test
Fismasystem Table -
Select systems to export.

User Table - 
Add a user - requires user to fill all required fields before adding the user
edit a user - 
- test email to ensure it's validating the email
- removing full name will invalidate saving a user

closes #134 
closes #178 
closes #155 