### PR TITLE
feat: email modal and email sent modal

### DIFF
--- a/src/components/EmailModal/EmailModal.css
+++ b/src/components/EmailModal/EmailModal.css
@@ -1,0 +1,22 @@
+.group-label {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+
+.subject-label-text {
+  margin-top: 0;
+  margin-bottom: 24px; /* Default for all browsers */
+}
+
+@-moz-document url-prefix() {
+  .subject-label-text {
+    margin-top: 0;
+    margin-bottom: 0px; /* Default for all browsers */
+  }
+  .required-label-text {
+    /* margin-top: 24px; */
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}

--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -1,0 +1,264 @@
+import React from 'react'
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  IconButton,
+} from '@mui/material'
+import {
+  TextField as CMSTextField,
+  Dropdown,
+  InlineError,
+  Button as CMSButton,
+  Label,
+} from '@cmsgov/design-system'
+import SentEmailsModal from './SentEmailsModal'
+import { useSnackbar } from 'notistack'
+import TextField from '@mui/material/TextField'
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
+import { EmailModalProps } from '@/types'
+import './EmailModal.css'
+import { styled } from '@mui/material'
+import axiosInstance from '@/axiosConfig'
+const CssTextField = styled(TextField)({
+  '& .MuiOutlinedInput-root': {
+    '& fieldset': {
+      borderColor: '#000000',
+      borderWidth: '2px',
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: '#000000',
+      borderWidth: '2px',
+      boxShadow: '0px 0px 0px 3px #FFFFFF, 0px 0px 3px 6px #bd13b8',
+    },
+
+    '&.Mui-error fieldset': {
+      borderColor: 'rgb(227, 28, 61)',
+      borderWidth: '3px',
+    },
+    '@supports (-moz-appearance:none)': {
+      '& .MuiInputBase-inputMultiline': {
+        paddingTop: '15px',
+        height: '100%',
+        width: '100%',
+        scrollbarWidth: 'none',
+      },
+    },
+    '& .MuiInputBase-inputMultiline': {
+      msOverflowStyle: 'none', // Hide scrollbar in IE/Edge
+      '&::-webkit-scrollbar': { display: 'none' },
+    },
+  },
+})
+
+export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
+  const { enqueueSnackbar } = useSnackbar()
+  const [sentToEmails, setSentToEmails] = React.useState<string[]>([])
+  const [openSentEmailsDialog, setOpenSentEmailsDialog] =
+    React.useState<boolean>(false)
+  const closeSentEmailsDialog = () => {
+    setOpenSentEmailsDialog(false)
+  }
+  const [groupValue, setGroupValue] = React.useState<string>('')
+  const [subject, setSubject] = React.useState<string>('')
+  const [body, setBody] = React.useState<string>('')
+  const [sentGroup, setSentGroup] = React.useState<string>('')
+  const submitEmail = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    await axiosInstance
+      .post('/massemails', {
+        group: formData.get('email_group'),
+        subject: formData.get('email_subject'),
+        body: formData.get('email_body'),
+      })
+      .then((res) => {
+        console.log(res.data.data)
+        setSentGroup(groupValue)
+        enqueueSnackbar(`Emails have successfully been sent`, {
+          variant: 'success',
+          anchorOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+          autoHideDuration: 2500,
+        })
+        setSentToEmails(res.data.data)
+      })
+      .catch((error) => {
+        if (error.response.status === 403) {
+          enqueueSnackbar(`You don't have permission to send emails`, {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 1500,
+          })
+        } else {
+          enqueueSnackbar(
+            `You there has been a problem sending the emails to ${groupValue}`,
+            {
+              variant: 'error',
+              anchorOrigin: {
+                vertical: 'top',
+                horizontal: 'left',
+              },
+              autoHideDuration: 1500,
+            }
+          )
+        }
+        console.log(error)
+      })
+  }
+
+  const handleChange = (value: string) => {
+    setGroupValue(value)
+  }
+  const handleSubjectChange = (value: string) => {
+    setSubject(value)
+  }
+  const handleBodyChange = (value: string) => {
+    setBody(value)
+  }
+  console.log(subject.length)
+  return (
+    <>
+      <Dialog
+        open={openModal}
+        onClose={closeModal}
+        maxWidth="md"
+        fullWidth
+        sx={{
+          '& .MuiDialog-paper': {
+            borderRadius: 0,
+            boxShadow: '3px 3px 5px',
+            // height: 725,
+            minHeight: '95vh',
+            maxHeight: '95vh',
+          },
+        }}
+      >
+        <DialogTitle id="email-dialog-title">
+          <Box
+            sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}
+            className={'ds-u-font-size--2xl ds-u-font-weight--bold'}
+          >
+            {'Email Users'}
+            <IconButton
+              size="large"
+              sx={{
+                p: 0,
+                borderRadius: 0,
+                '&:hover': {
+                  backgroundColor: 'white',
+                },
+              }}
+              onClick={closeModal}
+            >
+              <CloseRoundedIcon
+                fontSize="large"
+                sx={{ color: 'rgb(90, 90, 90)' }}
+              />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <form onSubmit={submitEmail}>
+          <DialogContent sx={{ pt: 0, ml: 1 }}>
+            <Dropdown
+              label="Select the group to email"
+              name="email_group"
+              errorMessage={
+                groupValue.length === 0 ? 'This field is required' : ''
+              }
+              // errorMessage={'This field is required'}
+              labelClassName="group-label"
+              onChange={(e) => handleChange(e.target.value)}
+              options={[
+                {
+                  label: '- Select an option -',
+                  value: '',
+                },
+                {
+                  label: 'ISSO',
+                  value: 'ISSO',
+                },
+                {
+                  label: 'ISSM',
+                  value: 'ISSM',
+                },
+                {
+                  label: 'ADMIN',
+                  value: 'ADMIN',
+                },
+                {
+                  label: 'DCC',
+                  value: 'DCC',
+                },
+                {
+                  label: 'ALL',
+                  value: 'ALL',
+                },
+              ]}
+            />
+            <CMSTextField
+              label="Subject"
+              maxLength={100}
+              name="email_subject"
+              onChange={(e) => handleSubjectChange(e.target.value)}
+              className="subject-label-text"
+              errorMessage={
+                subject.length === 0 ? 'This field is required' : ''
+              }
+            />
+            <Label>Body</Label>
+            {!body && <InlineError>This field is required</InlineError>}
+            <CssTextField
+              multiline
+              rows={13}
+              fullWidth
+              name="email_body"
+              margin="none"
+              inputProps={{ maxLength: 2000 }}
+              error={!body}
+              onChange={(e) => handleBodyChange(e.target.value)}
+            />
+          </DialogContent>
+          <DialogActions
+            sx={{
+              justifyContent: 'flex-start',
+              ml: 3,
+              mb: 1,
+            }}
+          >
+            <CMSButton
+              variation="solid"
+              type="submit"
+              disabled={subject && groupValue && body ? false : true}
+            >
+              Send
+            </CMSButton>
+            {sentToEmails.length !== 0 ? (
+              <CMSButton
+                variation="solid"
+                onClick={() => setOpenSentEmailsDialog(true)}
+              >
+                Emails sent to ...
+              </CMSButton>
+            ) : (
+              <></>
+            )}
+          </DialogActions>
+        </form>
+      </Dialog>
+      <SentEmailsModal
+        openModal={openSentEmailsDialog}
+        closeModal={closeSentEmailsDialog}
+        emails={sentToEmails}
+        group={sentGroup}
+      />
+    </>
+  )
+}

--- a/src/components/EmailModal/SentEmailsModal.tsx
+++ b/src/components/EmailModal/SentEmailsModal.tsx
@@ -1,0 +1,98 @@
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogActions,
+  IconButton,
+} from '@mui/material'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import EmailIcon from '@mui/icons-material/Email'
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
+import { Button as CMSButton } from '@cmsgov/design-system'
+import { SentEmailDialogProps } from '@/types'
+export default function SentEmailsModal({
+  openModal,
+  closeModal,
+  emails,
+  group,
+}: SentEmailDialogProps) {
+  return (
+    <Dialog
+      open={openModal}
+      onClose={closeModal}
+      maxWidth="sm"
+      fullWidth
+      sx={{
+        '& .MuiDialog-paper': {
+          borderRadius: 0,
+          boxShadow: '3px 3px 5px',
+          minHeight: '90vh',
+          maxHeight: '90vh',
+        },
+      }}
+    >
+      <DialogTitle id="email-dialog-title">
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}
+          className={'ds-u-font-size--2xl ds-u-font-weight--bold'}
+        >
+          {`Emails Sent to ${group}'s`}
+          <IconButton
+            size="large"
+            sx={{
+              p: 0,
+              borderRadius: 0,
+              '&:hover': {
+                backgroundColor: 'white',
+              },
+            }}
+            onClick={closeModal}
+          >
+            <CloseRoundedIcon
+              fontSize="large"
+              sx={{ color: 'rgb(90, 90, 90)' }}
+            />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent sx={{ overflow: 'hidden' }}>
+        <List
+          sx={{
+            width: '100%',
+            // maxWidth: 500,
+            bgcolor: 'background.paper',
+            position: 'relative',
+            overflow: 'auto',
+            overflowX: 'hidden',
+            maxHeight: 600,
+            '& ul': { padding: 0 },
+          }}
+        >
+          {emails.map((email) => (
+            <ListItem key={email}>
+              <ListItemIcon key={`${email}-icon`}>
+                <EmailIcon />
+              </ListItemIcon>
+              <ListItemText key={`email-${email}`}>{email}</ListItemText>
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions
+        sx={{
+          justifyContent: 'flex-start',
+          ml: 3,
+          mb: 3,
+        }}
+      >
+        <CMSButton variation="solid" onClick={closeModal}>
+          Close
+        </CMSButton>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,19 @@ export type SystemDetailsModalProps = {
   onClose: () => void
   system: FismaSystemType | null
 }
+
+export type EmailModalProps = {
+  openModal: boolean
+  closeModal: () => void
+}
+
+export type SentEmailDialogProps = {
+  openModal: boolean
+  closeModal: () => void
+  emails: string[]
+  group: string
+}
+
 export type editSystemModalProps = {
   title: string
   open: boolean

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -13,6 +13,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { useState, useEffect } from 'react'
 import { FismaSystemType } from '@/types'
 import { Routes } from '@/router/constants'
+import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
 import LoginPage from '../LoginPage/LoginPage'
 import { ERROR_MESSAGES } from '@/constants'
@@ -46,6 +47,7 @@ export default function Title() {
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   // const [titlePage, setTitlePage] = useState<string>('Dashboard')
   const [openModal, setOpenModal] = useState<boolean>(false)
+  const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
   useEffect(() => {
     async function fetchFismaSystems() {
       try {
@@ -81,6 +83,9 @@ export default function Title() {
     }
     setOpenModal(false)
     handleClose()
+  }
+  const handleCloseEmailModal = () => {
+    setOpenEmailModal(false)
   }
   return (
     <>
@@ -145,8 +150,21 @@ export default function Title() {
                         Edit Users
                       </MenuItem>
                     </Link>
-                    <MenuItem onClick={() => setOpenModal(true)}>
+                    <MenuItem
+                      onClick={() => {
+                        setAnchorEl(null)
+                        setOpenModal(true)
+                      }}
+                    >
                       Add Fisma System
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        setAnchorEl(null)
+                        setOpenEmailModal(true)
+                      }}
+                    >
+                      {'Email Users'}
                     </MenuItem>
                   </Menu>
                 </>
@@ -177,6 +195,10 @@ export default function Title() {
           onClose={handleCloseModal}
           system={EMPTY_SYSTEM}
           mode={'create'}
+        />
+        <EmailModal
+          openModal={openEmailModal}
+          closeModal={handleCloseEmailModal}
         />
       </Container>
       <Footer />


### PR DESCRIPTION
### Summary

email modal that allows an admin to sent out emails to groups associated with the application

When an admin sends an email, a button will show up and the admin can check the list of users the email has been sent to

### Test

Click on the kebab menu on the top right corner. Click on send email and 3 required fields must be field before submitting. After a valid email has been sent, a button will appear to allow an admin to check on the list of users the email has been sent out to.
