### PR TITLE
fix: export datacall

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,7 @@ export type FormValidHelperText = {
 
 export type FismaTableProps = {
   scores: Record<number, number>
-  latestDataCallId: number
+  // latestDataCallId: number
 }
 
 export type ThemeColor =

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -35,7 +35,7 @@ declare module '@mui/x-data-grid' {
   interface FooterPropsOverrides {
     selectedRows: selectedRowsType
     fismaSystems: FismaSystemType[]
-    latestDataCallId: number
+    latestDatacallId: number
     scores: Record<number, number>
   }
 }
@@ -54,7 +54,7 @@ export function CustomFooterSaveComponent(
     setOpenSnackbar(false)
   }
   const saveSystemAnswers = async () => {
-    let exportUrl = `/datacalls/${props.latestDataCallId}/export`
+    let exportUrl = `/datacalls/${props.latestDatacallId}/export`
     if (
       props.selectedRows &&
       props.fismaSystems &&
@@ -173,12 +173,9 @@ function QuickSearchToolbar() {
     </Box>
   )
 }
-export default function FismaTable({
-  scores,
-  latestDataCallId,
-}: FismaTableProps) {
+export default function FismaTable({ scores }: FismaTableProps) {
   const apiRef = useGridApiRef()
-  const { fismaSystems } = useContextProp()
+  const { fismaSystems, latestDatacallId } = useContextProp()
   const [open, setOpen] = useState<boolean>(false)
   const { userInfo } = useContextProp() || EMPTY_USER
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
@@ -358,7 +355,7 @@ export default function FismaTable({
           setSelectedRows(selectedIDs)
         }}
         slotProps={{
-          footer: { selectedRows, fismaSystems, latestDataCallId, scores },
+          footer: { selectedRows, fismaSystems, latestDatacallId, scores },
           filterPanel: {
             sx: {
               '& .MuiFormLabel-root': {

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -117,7 +117,7 @@ export default function HomePageContainer() {
     <Box>
       <StatisticsBlocks scores={scoreMap} />
       <BreadCrumbs />
-      <FismaTable scores={scoreMap} latestDataCallId={latestDataCallId} />
+      <FismaTable scores={scoreMap} />
     </Box>
   )
 }

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -4,6 +4,8 @@ import { FismaSystemType, userData } from '@/types'
 type ContextType = {
   fismaSystems: FismaSystemType[] | []
   userInfo: userData
+  latestDatacallId: number
+  latestDatacall: string
 }
 
 export function useContextProp() {


### PR DESCRIPTION
### Summary

Fix for exporting datacall for a fismasystem. Providing the latest datacallid through context instead of calling the api. Added text to allow user to know which datacall they are answering to at the top left of the screen.

### Added
None

### Test
Select a fisma system with a score
Click on the download button in the footer of the table to export

