### PR TITLE
feat: disable options and notes passed the deadline

### DIFF
--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -194,6 +194,15 @@ export default function EditSystemModal({
               },
               autoHideDuration: 1500,
             })
+          } else if (error.status === 403) {
+            enqueueSnackbar(`Not Saved`, {
+              variant: 'error',
+              anchorOrigin: {
+                vertical: 'top',
+                horizontal: 'left',
+              },
+              autoHideDuration: 1500,
+            })
           } else {
             navigate(Routes.SIGNIN, {
               replace: true,

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -5,8 +5,7 @@ import axiosInstance from '@/axiosConfig'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
-import { FismaSystemType } from '@/types'
-import { Box } from '@mui/material'
+import { Box, CircularProgress } from '@mui/material'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 /**
  * Component that renders the contents of the Home view.
@@ -16,40 +15,7 @@ import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
   const navigate = useNavigate()
-  const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [scoreMap, setScoreMap] = useState<Record<number, number>>({})
-  const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
-  useEffect(() => {
-    async function fetchFismaSystems() {
-      try {
-        const fismaSystems = await axiosInstance.get('/fismasystems')
-        if (
-          fismaSystems.status !== 200 &&
-          fismaSystems.status.toString()[0] === '4'
-        ) {
-          navigate(Routes.SIGNIN, {
-            replace: true,
-            state: {
-              message: ERROR_MESSAGES.expired,
-            },
-          })
-          return
-        }
-        setFismaSystems(fismaSystems.data.data)
-        setLoading(false)
-      } catch (error) {
-        console.log(error)
-        navigate(Routes.SIGNIN, {
-          replace: true,
-          state: {
-            message: ERROR_MESSAGES.login,
-          },
-        })
-      }
-    }
-    fetchFismaSystems()
-  }, [navigate])
-
   useEffect(() => {
     async function fetchScores() {
       try {
@@ -84,34 +50,20 @@ export default function HomePageContainer() {
     }
     fetchScores()
   }, [navigate])
-  useEffect(() => {
-    async function fetchLatestDatacall() {
-      try {
-        axiosInstance.get('/datacalls/latest').then((res) => {
-          if (res.status !== 200 && res.status.toString()[0] === '4') {
-            navigate(Routes.SIGNIN, {
-              replace: true,
-              state: {
-                message: ERROR_MESSAGES.expired,
-              },
-            })
-          }
-          setLatestDataCallId(res.data.data[0].datacallid)
-        })
-      } catch (error) {
-        console.error(error)
-        navigate(Routes.SIGNIN, {
-          replace: true,
-          state: {
-            message: ERROR_MESSAGES.error,
-          },
-        })
-      }
-    }
-    fetchLatestDatacall()
-  }, [navigate])
+
   if (loading) {
-    return <div>Loading...</div>
+    return (
+      <Box
+        sx={{
+          height: '100vh', // or any specific height
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    )
   }
   return (
     <Box>

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -6,6 +6,7 @@ type ContextType = {
   userInfo: userData
   latestDatacallId: number
   latestDatacall: string
+  datacallDeadline: string
 }
 
 export function useContextProp() {

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -48,6 +48,7 @@ export default function Title() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [latestDatacallId, setLatestDatacallId] = useState<number>(0)
+  const [datacallDeadline, setDatacallDeadline] = useState<string>('')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
   const [latestDatacall, setLatestDatacall] = useState<string>('')
@@ -74,9 +75,9 @@ export default function Title() {
       await axiosInstance
         .get('/datacalls/latest')
         .then((res) => {
-          console.log(res.data.data)
           setLatestDatacallId(res.data.data.datacallid)
           setLatestDatacall(res.data.data.datacall)
+          setDatacallDeadline(res.data.data.deadline)
         })
         .catch((error) => {
           if (error.response.status == 401) {
@@ -232,6 +233,7 @@ export default function Title() {
                   userInfo,
                   latestDatacallId,
                   latestDatacall,
+                  datacallDeadline,
                 }}
               />
             </Box>


### PR DESCRIPTION
### Summary

Disable the questionnaire options and notes when the current date is passed the deadline. In addition, pressing the next button does not trigger an update to the backend unless deadline

Refactored all the api endpoints to consider looking at error number `401`, `403`, and anything other error to be handled accordingly across the application.

### Test

Open questionnaire for a fisma system
if the deadline has been passed today, there will be a message above the function that indicates and the options and notes will be disabled

