### PR TITLE
fix: resolve Snyk GitHub Action authentication and syntax issues

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,31 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: test
+      - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          command: test
-          args: --severity-threshold=high --show-vulnerable-paths=all ./
+          args: test --severity-threshold=high --show-vulnerable-paths=all ./
 
   Snyk-Code-Test:
     name: snyk code test
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
       
-      - name: code test
+      - name: Run Snyk Code test
         uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          command: code test
-          args: --severity-threshold=high --show-vulnerable-paths=all ./
+          args: code test --severity-threshold=high --show-vulnerable-paths=all ./


### PR DESCRIPTION
## Summary
Fixes SNYK-0005 authentication errors in the analysis workflow that were blocking deployments.

## Changes Made
- **Remove deprecated `command` parameter** - Snyk Action no longer supports this syntax
- **Move SNYK_TOKEN to job-level** - Better token scope and accessibility for the action
- **Use proper Snyk Action syntax** - All commands now properly specified in `args` parameter
- **Maintain original strict security behavior** - Deployments still blocked on vulnerabilities

## Root Cause
The workflow was created in October 2024 with syntax that worked initially but became incompatible with updated Snyk Action requirements. The `command: test` and `command: code test` parameters are no longer supported.

## Testing
- Verified syntax follows current Snyk Action documentation
- Preserves original security enforcement (no continue-on-error)
- Minimal changes to existing workflow logic