### PR TITLE
revert: restore original Snyk workflow configuration

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,29 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --show-vulnerable-paths=all
+          args: test --severity-threshold=high --show-vulnerable-paths=all ./
 
   Snyk-Code-Test:
     name: snyk code test
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
       
       - name: Run Snyk Code test
         uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: code test --severity-threshold=high --show-vulnerable-paths=all
+          args: code test --severity-threshold=high --show-vulnerable-paths=all ./

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,29 +9,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Run Snyk to check for vulnerabilities
+      - name: test
         uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: test --severity-threshold=high --show-vulnerable-paths=all ./
+          command: test
+          args: --severity-threshold=high --show-vulnerable-paths=all ./
 
   Snyk-Code-Test:
     name: snyk code test
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
       
-      - name: Run Snyk Code test
+      - name: code test
         uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: code test --severity-threshold=high --show-vulnerable-paths=all ./
+          command: code test
+          args: --severity-threshold=high --show-vulnerable-paths=all ./

--- a/.github/workflows/orchestration-dev.yml
+++ b/.github/workflows/orchestration-dev.yml
@@ -13,8 +13,7 @@ jobs:
   analysis:
     name: Analysis
     uses: ./.github/workflows/analysis.yml
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    secrets: inherit
 
   ui:
     name: ui

--- a/.github/workflows/orchestration-prod.yml
+++ b/.github/workflows/orchestration-prod.yml
@@ -12,8 +12,7 @@ jobs:
     name: Analysis
     if: ${{ github.event.pull_request.merged }}
     uses: ./.github/workflows/analysis.yml
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}     
+    secrets: inherit     
   ui:
     if: ${{ github.event.pull_request.merged }}
     name: ui


### PR DESCRIPTION
## Summary
Reverts the recent Snyk workflow changes that broke the CI/CD pipeline.

## Reverted Changes
- Reverts PR #295 (secret passing changes)  
- Reverts PR #294 (syntax changes)
- Reverts PR #293 (authentication changes)

## Reason for Revert
The workflow changes caused startup failures and broke the CI/CD pipeline for all PRs. Reverting to the last known working configuration to restore repository functionality.

## Next Steps
After this revert is merged, we can properly test workflow fixes in isolation before applying them to main.