### PR TITLE
revert: remove debug code from workflow

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -13,16 +13,6 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Debug Snyk Token  
-        run: |
-          if [ -z "$SNYK_TOKEN" ]; then
-            echo "❌ SNYK_TOKEN is not available"
-          else 
-            echo "✅ SNYK_TOKEN is available (first 8 chars: ${SNYK_TOKEN:0:8}...)"
-          fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
       - name: test
         uses: snyk/actions/node@master
         env:


### PR DESCRIPTION
Removes the debug step that was added for testing. The test confirmed that SNYK_TOKEN is not available in the workflow, which is the root cause of our authentication issues.