### PR TITLE
fix: resolve Actions column overlap at high DPI settings

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -284,17 +284,22 @@ export default function FismaTable({ scores }: FismaTableProps) {
     {
       field: 'fismaname',
       headerName: 'System Name',
-      width: 430,
+      flex: 2,
+      minWidth: 300,
+      maxWidth: 450,
       hideable: false,
     },
     {
       field: 'fismaacronym',
       headerName: 'Acronym',
+      flex: 0.8,
+      minWidth: 100,
     },
     {
       field: 'issoemail',
       headerName: 'ISSO Name',
-      flex: 1,
+      flex: 1.2,
+      minWidth: 120,
       hideable: false,
       valueGetter: (value) => {
         const name = value.row.issoemail.split('@')
@@ -320,6 +325,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
       headerName: 'Zero Trust Score',
       type: 'number',
       flex: 1,
+      minWidth: 140,
       align: 'center',
       hideable: false,
       valueGetter: (value) => {
@@ -362,7 +368,8 @@ export default function FismaTable({ scores }: FismaTableProps) {
     {
       field: 'datacenterenvironment',
       headerName: 'Data Center Environment',
-      flex: 1,
+      flex: 1.5,
+      minWidth: 180,
       hideable: false,
     },
     {
@@ -370,7 +377,8 @@ export default function FismaTable({ scores }: FismaTableProps) {
       headerName: 'Actions',
       headerAlign: 'center',
       align: 'center',
-      flex: 0.5,
+      width: 140,
+      minWidth: 140,
       hideable: false,
       sortable: false,
       disableColumnMenu: true,


### PR DESCRIPTION
## Summary
- Fixes UI/UX issue where Actions column buttons (View Pillar Scores, View Questionnaire, Edit) overlap at high DPI settings
- Converts table columns from problematic fixed/flexible sizing to responsive design with minimum width constraints

## Changes Made
- **Actions Column**: Changed from `flex: 0.5` to fixed `width: 140px` with `minWidth: 140px`
  - Ensures adequate space for all 3 action buttons (View Pillar Scores, View Questionnaire, Edit)
- **System Name**: Changed from fixed `width: 430px` to responsive `flex: 2` with `minWidth: 300px, maxWidth: 450px`
- **Other Columns**: Added appropriate `minWidth` values and optimized flex ratios
  - Acronym: `flex: 0.8, minWidth: 100px`
  - ISSO Name: `flex: 1.2, minWidth: 120px` 
  - Zero Trust Score: `flex: 1, minWidth: 140px`
  - Data Center Environment: `flex: 1.5, minWidth: 180px`

## Problem Solved
At high DPI/zoom settings, the Actions column would compress too much, causing the "View Pillar Scores" button and other action icons to overlap with adjacent columns, making them inaccessible.

## Test Plan
- [x] Lint checks pass
- [x] Code compiles without errors
- [ ] Manual testing at different DPI settings (125%, 150%, 175%, 200%)
- [ ] Verify all action buttons remain clickable at various screen sizes
- [ ] Confirm responsive behavior maintains proper column proportions

## Deployment
This fix targets the dev environment for validation before production rollout.