### PR TITLE
chore(deps): bump the npm_and_yarn group across 1 directory with 13 updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "clipboard-copy": "^4.0.1",
     "core-js": "^3.37.1",
     "jwt-decode": "^4.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "notistack": "^3.0.1",
     "react": "18.3.1",
     "react-animate-height": "^3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15694,6 +15694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -22282,7 +22289,7 @@ __metadata:
     jest-watch-typeahead: "npm:^2.2.2"
     jwt-decode: "npm:^4.0.0"
     lint-staged: "npm:^14.0.1"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.17.23"
     notistack: "npm:^3.0.1"
     npm-run-all: "npm:^4.1.5"
     prettier: "npm:^3.2.5"


### PR DESCRIPTION
Bumps the npm_and_yarn group with 10 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) | `5.4.0` | `5.4.21` |
| [braces](https://github.com/micromatch/braces) | `3.0.2` | `3.0.3` |
| [ejs](https://github.com/mde/ejs) | `3.1.9` | `3.1.10` |
| [express](https://github.com/expressjs/express) | `4.18.2` | `4.22.1` |
| [js-yaml](https://github.com/nodeca/js-yaml) | `3.14.1` | `3.14.2` |
| [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) | `7.3.2` | `7.7.17` |
| [rollup](https://github.com/rollup/rollup) | `3.28.0` | `3.29.5` |
| [store2](https://github.com/nbubna/store) | `2.14.2` | `2.14.4` |
| [tar-fs](https://github.com/mafintosh/tar-fs) | `2.1.1` | `2.1.4` |
| [ws](https://github.com/websockets/ws) | `6.2.2` | `6.2.3` |

This PR recreates the dependency updates from Dependabot PR #315 to allow CI/CD to run successfully.