### PR TITLE
Add SDL sync toggle for CMS data lake export control

### DIFF
--- a/src/components/SdlSyncToggle/SdlSyncToggle.tsx
+++ b/src/components/SdlSyncToggle/SdlSyncToggle.tsx
@@ -1,0 +1,41 @@
+import { Box, FormControlLabel, Switch, Typography } from '@mui/material'
+import {
+  SDL_SYNC_DESCRIPTION_ON,
+  SDL_SYNC_DESCRIPTION_OFF,
+  SDL_SYNC_SWITCH_SX,
+} from '@/constants'
+
+interface SdlSyncToggleProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+}
+
+export default function SdlSyncToggle({
+  checked,
+  onChange,
+}: SdlSyncToggleProps) {
+  return (
+    <Box>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={checked}
+            onChange={(e) => onChange(e.target.checked)}
+            sx={SDL_SYNC_SWITCH_SX}
+          />
+        }
+        label={
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Sync to SDL (Snowflake)
+          </Typography>
+        }
+      />
+      <Typography
+        variant="caption"
+        sx={{ display: 'block', ml: 4, color: 'text.secondary' }}
+      >
+        {checked ? SDL_SYNC_DESCRIPTION_ON : SDL_SYNC_DESCRIPTION_OFF}
+      </Typography>
+    </Box>
+  )
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,6 +93,18 @@ export const PILLAR_FUNCTION_MAP: { [key: string]: string[] } = {
     'Cross-VisibilityAnalytics',
   ],
 }
+export const SDL_SYNC_DESCRIPTION_ON =
+  'This system and its scores will be exported to the CMS data lake.'
+export const SDL_SYNC_DESCRIPTION_OFF =
+  'This system is excluded from CMS data lake exports.'
+
+export const SDL_SYNC_SWITCH_SX = {
+  '& .MuiSwitch-switchBase.Mui-checked': { color: '#004297' },
+  '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+    backgroundColor: '#004297',
+  },
+} as const
+
 export const TEXTFIELD_HELPER_TEXT = 'This field is required'
 
 export const INVALID_INPUT_TEXT = (key: string) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type FismaSystemType = {
   mission: string
   fismaimpactlevel: string
   issoemail: string
+  sdl_sync_enabled: boolean | null
   datacenterenvironment: string
   datacallcontact?: string
   groupacronym?: string

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/types'
 import MenuItem from '@mui/material/MenuItem'
 import { CONFIRMATION_MESSAGE } from '@/constants'
+import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 
 import ValidatedTextField from './ValidatedTextField'
 import { emailValidator } from './validators'
@@ -200,6 +201,7 @@ export default function EditSystemModal({
           datacenterenvironment: editedFismaSystem.datacenterenvironment,
           datacallcontact: editedFismaSystem.datacallcontact,
           issoemail: editedFismaSystem.issoemail,
+          sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then((res) => {
           if (res.status !== 200 && res.status.toString()[0] === '4') {
@@ -265,6 +267,7 @@ export default function EditSystemModal({
           datacenterenvironment: editedFismaSystem.datacenterenvironment,
           datacallcontact: editedFismaSystem.datacallcontact,
           issoemail: editedFismaSystem.issoemail,
+          sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then((res) => {
           if (res.status !== 200 && res.status.toString()[0] === '4') {
@@ -680,6 +683,25 @@ export default function EditSystemModal({
                       </MenuItem>
                     ))}
                   </TextField>
+                  <Box
+                    sx={{
+                      mt: 3,
+                      p: 2,
+                      border: 1,
+                      borderColor: 'divider',
+                      borderRadius: 1,
+                    }}
+                  >
+                    <SdlSyncToggle
+                      checked={editedFismaSystem.sdl_sync_enabled ?? false}
+                      onChange={(checked) =>
+                        setEditedFismaSystem((prev) => ({
+                          ...prev,
+                          sdl_sync_enabled: checked,
+                        }))
+                      }
+                    />
+                  </Box>
                   {mode === 'edit' && (
                     <Box
                       sx={{

--- a/src/views/EditSystemModal/emptySystem.ts
+++ b/src/views/EditSystemModal/emptySystem.ts
@@ -13,6 +13,7 @@ export const EMPTY_SYSTEM = {
   datacenterenvironment: '',
   datacallcontact: '',
   issoemail: '',
+  sdl_sync_enabled: false,
   decommissioned: false,
   decommissioned_date: null,
   decommissioned_by: null,

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -26,7 +26,7 @@ import { useContextProp } from '../Title/Context'
 import { useNavigate, Link } from 'react-router-dom'
 import { RouteNames, Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '../../constants'
-import EditIcon from '@mui/icons-material/Edit'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 import QuestionAnswerOutlinedIcon from '@mui/icons-material/QuestionAnswerOutlined'
 import BarChartIcon from '@mui/icons-material/BarChart'
 import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresModal'
@@ -435,13 +435,13 @@ export default function FismaTable({ scores }: FismaTableProps) {
           </Tooltip>
           {isAdmin && (
             <GridActionsCellItem
-              icon={<EditIcon />}
-              key={`edit-${params.row.fismasystemid}`}
-              label="Edit"
+              icon={<VisibilityIcon />}
+              key={`view-${params.row.fismasystemid}`}
+              label="View"
               className="textPrimary"
               onClick={(event) => {
                 event.stopPropagation()
-                navigate(`/systems/${params.row.fismasystemid}?edit=true`)
+                navigate(`/systems/${params.row.fismasystemid}`)
               }}
               color="inherit"
             />

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -18,6 +18,7 @@ import ValidatedTextField from '@/views/EditSystemModal/ValidatedTextField'
 import { emailValidator } from '@/views/EditSystemModal/validators'
 import { datacenterenvironment } from '@/views/EditSystemModal/dataEnvironment'
 import { getTodayISO, MAX_NOTES_LENGTH } from '@/utils/decommission'
+import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 
 interface SystemDetailEditViewProps {
   system: FismaSystemType
@@ -40,6 +41,7 @@ interface SystemDetailEditViewProps {
   onShowDecommissionForm: (show: boolean) => void
   onDecommissionRequest: () => void
   validateDecommissionDate: (dateStr: string) => boolean
+  onSdlSyncToggle: (checked: boolean) => void
 }
 
 function renderEditField(field: FieldConfig, props: SystemDetailEditViewProps) {
@@ -199,12 +201,14 @@ function DecommissionDateNotesForm(props: SystemDetailEditViewProps) {
 export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
   const {
     system,
+    editedSystem,
     showDecommissionForm,
     decommissionedByName,
     decommissionDate,
     onShowDecommissionForm,
     onDecommissionRequest,
     validateDecommissionDate,
+    onSdlSyncToggle,
   } = props
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
@@ -359,6 +363,19 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             </CardContent>
           </Card>
         )}
+        <Card variant="outlined" sx={{ mb: 3 }}>
+          <CardHeader
+            title="Data Lake Export"
+            titleTypographyProps={{ variant: 'h6' }}
+            sx={{ pb: 0 }}
+          />
+          <CardContent>
+            <SdlSyncToggle
+              checked={editedSystem.sdl_sync_enabled ?? false}
+              onChange={onSdlSyncToggle}
+            />
+          </CardContent>
+        </Card>
         <Card variant="outlined">
           <CardHeader
             title="Organization"

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { useParams, useSearchParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { Box, CircularProgress, Typography } from '@mui/material'
 import { useSnackbar } from 'notistack'
 import _ from 'lodash'
@@ -24,7 +24,6 @@ import SystemDetailEditView from './SystemDetailEditView'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const { enqueueSnackbar } = useSnackbar()
   const { fismaSystems, setFismaSystems, userInfo } = useContextProp()
@@ -103,18 +102,13 @@ export default function SystemDetailPage() {
       fismauid: TEXTFIELD_HELPER_TEXT,
     })
 
-  // Auto-enter edit mode from ?edit=true query param
-  useEffect(() => {
-    if (searchParams.get('edit') === 'true' && isAdmin && system) {
-      setIsEditing(true)
-      setSearchParams({}, { replace: true })
-    }
-  }, [searchParams, isAdmin, system, setSearchParams])
-
   // Initialize editedSystem, form validity, and decommission defaults when entering edit mode
   useEffect(() => {
     if (isEditing && system) {
-      setEditedSystem({ ...system })
+      setEditedSystem({
+        ...system,
+        sdl_sync_enabled: system.sdl_sync_enabled ?? false,
+      })
       setFormValid({
         issoemail: (system.issoemail?.length ?? 0) > 0,
         datacallcontact: (system.datacallcontact?.length ?? 0) > 0,
@@ -254,6 +248,7 @@ export default function SystemDetailPage() {
         datacenterenvironment: editedSystem.datacenterenvironment,
         datacallcontact: editedSystem.datacallcontact,
         issoemail: editedSystem.issoemail,
+        sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       })
       .then(() => {
         enqueueSnackbar('Saved', {
@@ -478,6 +473,11 @@ export default function SystemDetailPage() {
           onShowDecommissionForm={setShowDecommissionForm}
           onDecommissionRequest={() => setOpenDecommissionDialog(true)}
           validateDecommissionDate={validateDecommissionDate}
+          onSdlSyncToggle={(checked) =>
+            setEditedSystem((prev) =>
+              prev ? { ...prev, sdl_sync_enabled: checked } : prev
+            )
+          }
         />
       ) : (
         <SystemDetailReadView

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -8,6 +8,7 @@ import {
   Chip,
 } from '@mui/material'
 import { FismaSystemType } from '@/types'
+import { SDL_SYNC_DESCRIPTION_ON, SDL_SYNC_DESCRIPTION_OFF } from '@/constants'
 import { getFieldsBySection, FieldConfig } from './fieldConfig'
 
 interface SystemDetailReadViewProps {
@@ -114,6 +115,52 @@ export default function SystemDetailReadView({
                 This system is active.
               </Typography>
             )}
+          </CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ mb: 3 }}>
+          <CardHeader
+            title="Data Lake Export"
+            titleTypographyProps={{ variant: 'h6' }}
+            sx={{ pb: 0 }}
+          />
+          <CardContent>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                SDL Sync
+              </Typography>
+              {system.sdl_sync_enabled === null ? (
+                <Chip
+                  label="Not configured"
+                  size="small"
+                  color="default"
+                  variant="outlined"
+                />
+              ) : system.sdl_sync_enabled ? (
+                <Chip
+                  label="On"
+                  size="small"
+                  color="primary"
+                  variant="filled"
+                />
+              ) : (
+                <Chip
+                  label="Off"
+                  size="small"
+                  color="default"
+                  variant="outlined"
+                />
+              )}
+            </Box>
+            <Typography
+              variant="caption"
+              sx={{ color: 'text.secondary', mt: 0.5, display: 'block' }}
+            >
+              {system.sdl_sync_enabled === null
+                ? 'SDL sync has not been configured for this system.'
+                : system.sdl_sync_enabled
+                  ? SDL_SYNC_DESCRIPTION_ON
+                  : SDL_SYNC_DESCRIPTION_OFF}
+            </Typography>
           </CardContent>
         </Card>
         <Card variant="outlined">


### PR DESCRIPTION
## Summary

- Adds frontend support for the `sdl_sync_enabled` field on FISMA systems, allowing admins to control whether a system's data is exported to the CMS Snowflake data lake
- Admins can toggle SDL sync on/off from both the Edit System modal and the System Detail edit view
- The System Detail read view displays the current SDL sync status as a read-only chip (On / Off / Not configured)
- New systems default to sync disabled; existing systems reflect whatever value the backend provides
- Extracts a shared `SdlSyncToggle` component and centralizes SDL-related constants to reduce duplication

## Additional changes

- Table action icon updated from edit pencil to view icon — clicking now navigates to the system detail page in read mode rather than jumping straight to edit mode
- Removed the `?edit=true` query param auto-edit flow from `SystemDetailPage` (dead code after the navigation change)

## Files changed

| File | Change |
|---|---|
| `src/types.ts` | Add `sdl_sync_enabled: boolean \| null` to `FismaSystemType` |
| `src/constants.ts` | Add SDL sync description strings and switch styling constant |
| `src/components/SdlSyncToggle/SdlSyncToggle.tsx` | New shared toggle component |
| `src/views/EditSystemModal/emptySystem.ts` | Default `sdl_sync_enabled: false` for new systems |
| `src/views/EditSystemModal/EditSystemModal.tsx` | Add toggle + include field in PUT/POST payloads |
| `src/views/FismaTable/FismaTable.tsx` | Update action icon to view, navigate to detail page |
| `src/views/SystemDetailPage/SystemDetailPage.tsx` | Include field in PUT payload, pass toggle handler, remove dead `?edit=true` effect |
| `src/views/SystemDetailPage/SystemDetailEditView.tsx` | Add Data Lake Export card with toggle |
| `src/views/SystemDetailPage/SystemDetailReadView.tsx` | Add read-only Data Lake Export card with status chip |

## Test plan

- [x] Verify FismaTable loads without the SDL Sync column (removed by design)
- [x] Open system detail page via table view icon — confirm it opens in read mode with SDL sync status displayed
- [x] Click Edit, toggle SDL sync on/off, save — confirm value persists on reload
- [x] Create a new system — confirm SDL sync defaults to Off
- [x] Verify READONLY_ADMIN users see the status chip but cannot access the toggle
- [x] Confirm no regressions on decommission flow or other system edit fields