### PR TITLE
Show technical difficulties page instead of login on 5xx errors

### DIFF
--- a/public/error.html
+++ b/public/error.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ZTMF - Technical Difficulties</title>
+    <link
+      rel="stylesheet"
+      href="https://design.cms.gov/cdn/ds-cms-gov/10.1.1/css/index.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://design.cms.gov/cdn/ds-cms-gov/10.1.1/css/cmsgov-theme.css"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        font-family: 'Open Sans', 'Inter', 'Roboto', 'Helvetica Neue', Arial,
+          sans-serif;
+        color: #333;
+      }
+      .error-content {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 2rem 1rem;
+      }
+      .error-box {
+        max-width: 600px;
+        text-align: center;
+      }
+      .error-box h1 {
+        font-size: 1.5rem;
+        color: #0d2499;
+        margin-bottom: 1rem;
+      }
+      .error-box p {
+        font-size: 1rem;
+        line-height: 1.6;
+        margin-bottom: 1rem;
+      }
+      .error-box .retry-btn {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.75rem 1.5rem;
+        background-color: #0d2499;
+        color: #fff;
+        text-decoration: none;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      .error-box .retry-btn:hover {
+        background-color: #081873;
+      }
+      .footer {
+        border-top: 1px solid #000;
+        background-color: #f2f2f2;
+      }
+      .footer-inner {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0 1rem;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+      }
+      .footer-logo {
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+      .footer-text {
+        padding: 0.5rem;
+        margin: 0.5rem;
+        margin-top: 0.5rem;
+        border-left: 2px solid #000;
+        font-size: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- USA Government Banner (CMS Design System) -->
+    <section
+      class="ds-c-usa-banner"
+      aria-label="An official website of the United States government"
+    >
+      <header class="ds-c-usa-banner__header ds-u-font-size--sm">
+        <svg
+          class="ds-c-usa-banner__header-icon"
+          viewBox="0 0 16 11"
+          aria-hidden="true"
+          role="img"
+        >
+          <title>U.S. Flag</title>
+          <g fill="none" fill-rule="evenodd">
+            <path fill="#FFF" d="M0 0h16v11H0z" />
+            <path fill="#DB3E1F" d="M8 0h8v1H8z" />
+            <path fill="#1E33B1" d="M0 0h8v7H0z" />
+            <path
+              fill="#DB3E1F"
+              d="M8 2h8v1H8zM8 4h8v1H8zM8 6h8v1H8zM0 8h16v1H0zM0 10h16v1H0z"
+            />
+            <path
+              fill="#FFF"
+              d="M1 1h1v1H1zM2 3h1v1H2zM1 5h1v1H1zM3 1h1v1H3zM4 3h1v1H4zM3 5h1v1H3zM5 1h1v1H5zM6 3h1v1H6zM5 5h1v1H5z"
+            />
+          </g>
+        </svg>
+        <p class="ds-c-usa-banner__header-text">
+          An official website of the United States government
+        </p>
+        <p class="ds-c-usa-banner__action ds-u-align-items--center">
+          Here's how you know
+        </p>
+      </header>
+    </section>
+
+    <!-- Main Content -->
+    <main class="error-content">
+      <div class="error-box">
+        <h1>We're experiencing technical difficulties</h1>
+        <p>
+          The Zero Trust Maturity Framework application is temporarily
+          unavailable. We are aware of the issue and working to restore service.
+        </p>
+        <p>Please try again in a few minutes.</p>
+        <a href="" class="retry-btn">Try Again</a>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="footer">
+      <div class="footer-inner">
+        <div class="footer-logo">
+          <svg
+            width="175"
+            height="75"
+            viewBox="0 0 171 41"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <g id="CMSgov-Logo">
+              <g id="Group-4" transform="translate(90,9)">
+                <path
+                  fill="#383838"
+                  d="M3.3,18.8c0.7,0,1.3,0.2,1.8,0.7s0.7,1.1,0.7,1.8c0,0.7-0.2,1.3-0.7,1.8c-0.5,0.5-1.1,0.7-1.8,0.7S2,23.6,1.5,23.1C1,22.6,0.8,22,0.8,21.3c0-0.7,0.2-1.3,0.7-1.8S2.6,18.8,3.3,18.8"
+                />
+                <path
+                  fill="#383838"
+                  d="M20.5,3.1c-1.6,0-3.1,0.4-4.5,1.2c-1.4,0.8-2.5,1.9-3.3,3.3c-0.8,1.4-1.2,2.9-1.2,4.5c0,2.4,0.8,4.5,2.5,6.1c1.6,1.6,3.8,2.4,6.4,2.4c2.6,0,4.8-0.8,6.4-2.4c1.6-1.6,2.4-3.7,2.4-6.3c0-1.7-0.4-3.2-1.1-4.5c-0.7-1.3-1.8-2.4-3.1-3.1C23.5,3.5,22,3.1,20.5,3.1z M28.9,1h2.9v17.8c0,3.1-0.3,5.4-0.8,6.9c-0.8,2.1-2.1,3.6-3.9,4.7C25.2,31.4,23,32,20.3,32c-1.9,0-3.6-0.3-5.2-0.8c-1.5-0.5-2.8-1.3-3.7-2.2s-1.8-2.2-2.6-4h3.1c0.8,1.5,1.9,2.6,3.3,3.3c1.3,0.7,3,1.1,5,1.1c2,0,3.6-0.4,5-1.1c1.3-0.7,2.3-1.6,2.9-2.7c0.6-1.1,0.9-2.9,0.9-5.3V19c-1.1,1.4-2.4,2.4-4,3.1c-1.6,0.7-3.2,1.1-5,1.1c-2.1,0-4-0.5-5.8-1.5c-1.8-1-3.2-2.4-4.2-4.1c-1-1.7-1.5-3.6-1.5-5.7c0-2.1,0.5-4,1.5-5.8c1-1.8,2.4-3.2,4.3-4.2c1.8-1,3.7-1.6,5.7-1.6c1.7,0,3.2,0.3,4.7,1c1.4,0.7,2.8,1.8,4.2,3.4V1L28.9,1z"
+                />
+              </g>
+              <path
+                fill="#383838"
+                d="M136.4,12.2c-2.4,0-4.4,0.9-6.2,2.6c-1.7,1.8-2.6,3.9-2.6,6.4c0,1.6,0.4,3.1,1.2,4.5c0.8,1.4,1.8,2.5,3.2,3.2c1.3,0.8,2.8,1.1,4.4,1.1c1.6,0,3.1-0.4,4.4-1.1c1.3-0.8,2.4-1.8,3.2-3.2c0.8-1.4,1.2-2.9,1.2-4.5c0-2.5-0.9-4.6-2.6-6.4C140.8,13.1,138.8,12.2,136.4,12.2z M136.4,9.4c3.4,0,6.3,1.2,8.5,3.7c2.1,2.3,3.1,5,3.1,8.1c0,3.1-1.1,5.8-3.3,8.2s-5,3.5-8.4,3.5c-3.4,0-6.2-1.2-8.4-3.5c-2.2-2.3-3.3-5.1-3.3-8.2c0-3.1,1-5.8,3.1-8C130.1,10.6,133,9.4,136.4,9.4L136.4,9.4z"
+              />
+              <polyline
+                fill="#383838"
+                points="149.1,10 152.2,10 159.7,26.2 167.1,10 170.2,10 159.9,32.3 159.4,32.3 149.1,10"
+              />
+              <path
+                fill="#0d2499"
+                d="M29.7,7.4l-4,3.8c-2.7-2.9-5.8-4.3-9.2-4.3c-2.9,0-5.3,1-7.3,3c-2,2-3,4.4-3,7.3c0,2,0.4,3.8,1.3,5.4c0.9,1.6,2.1,2.8,3.7,3.7c1.6,0.9,3.4,1.3,5.3,1.3c1.7,0,3.2-0.3,4.6-0.9c1.4-0.6,2.9-1.8,4.5-3.4l3.9,4.1c-2.2,2.2-4.3,3.7-6.3,4.5c-2,0.8-4.2,1.3-6.8,1.3c-4.7,0-8.5-1.5-11.5-4.5c-3-3-4.5-6.8-4.5-11.4c0-3,0.7-5.7,2-8c1.4-2.3,3.3-4.2,5.8-5.6c2.5-1.4,5.3-2.1,8.2-2.1c2.5,0,4.9,0.5,7.2,1.6S28.1,5.5,29.7,7.4"
+              />
+              <polyline
+                fill="#0d2499"
+                points="37.7,2.1 43.3,2.1 50.3,23.2 57.3,2.1 62.9,2.1 68,32.3 62.4,32.3 59.2,13.2 52.8,32.3 47.7,32.3 41.4,13.2 38,32.3 32.5,32.3 37.7,2.1"
+              />
+              <path
+                fill="#0d2499"
+                d="M88.4,6.2L84.1,10c-1.5-2.1-3-3.1-4.6-3.1c-0.8,0-1.4,0.2-1.8,0.6C77.2,7.9,77,8.3,77,8.8c0,0.5,0.2,1,0.5,1.4c0.5,0.6,1.9,1.9,4.2,3.9c2.2,1.8,3.5,3,4,3.5c1.2,1.2,2,2.3,2.5,3.4c0.5,1.1,0.7,2.2,0.7,3.5c0,2.5-0.9,4.5-2.6,6.1s-3.9,2.4-6.7,2.4c-2.1,0-4-0.5-5.6-1.6c-1.6-1.1-3-2.7-4.1-5l4.8-2.9c1.5,2.7,3.1,4,5,4c1,0,1.8-0.3,2.5-0.9c0.7-0.6,1-1.2,1-2c0-0.7-0.3-1.4-0.8-2C82,22,80.9,21,79.2,19.6c-3.3-2.7-5.4-4.7-6.4-6.2c-1-1.5-1.4-2.9-1.4-4.4c0-2.1,0.8-3.9,2.4-5.4c1.6-1.5,3.6-2.2,5.9-2.2c1.5,0,2.9,0.3,4.3,1C85.3,3.1,86.8,4.4,88.4,6.2"
+              />
+            </g>
+          </svg>
+        </div>
+        <div class="footer-text">
+          Centers for Medicare &amp; Medicaid Services
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -21,7 +21,12 @@ const authLoader = async () => {
       return { ok: false, response: emptyUser }
     }
     return { status: axiosUser.status, response: axiosUser.data.data }
-  } catch (error) {
+  } catch (error: unknown) {
+    const err = error as { response?: { status?: number }; status?: number }
+    const status = err?.response?.status || err?.status || 0
+    if (status >= 500 || status === 0) {
+      return { status, serverError: true, response: emptyUser }
+    }
     console.error('Error:', error)
   }
   return { ok: false, response: emptyUser }

--- a/src/views/ServerErrorPage/ServerErrorPage.tsx
+++ b/src/views/ServerErrorPage/ServerErrorPage.tsx
@@ -1,0 +1,41 @@
+import { Box, Typography } from '@mui/material'
+import { Button as CmsButton } from '@cmsgov/design-system'
+
+export default function ServerErrorPage() {
+  return (
+    <Box
+      flex={1}
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '50vh',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          textAlign: 'center',
+          maxWidth: 600,
+        }}
+      >
+        <Typography variant="h4" sx={{ mb: 2, color: '#0d2499' }}>
+          We&apos;re experiencing technical difficulties
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          The Zero Trust Maturity Framework application is temporarily
+          unavailable. Our team has been notified and is working to restore
+          service.
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 3 }}>
+          Please try again in a few minutes.
+        </Typography>
+        <CmsButton onClick={() => window.location.reload()}>
+          Try Again
+        </CmsButton>
+      </Box>
+    </Box>
+  )
+}

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -16,6 +16,7 @@ import { Routes } from '@/router/constants'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
 import LoginPage from '../LoginPage/LoginPage'
+import ServerErrorPage from '../ServerErrorPage/ServerErrorPage'
 import { ERROR_MESSAGES } from '@/constants'
 import EditSystemModal from '../EditSystemModal/EditSystemModal'
 import { EMPTY_SYSTEM } from '../EditSystemModal/emptySystem'
@@ -38,6 +39,7 @@ const emptyUser: userData = {
 type PromiseType = {
   status: boolean | number
   response: userData
+  serverError?: boolean
 }
 export default function Title() {
   const navigate = useNavigate()
@@ -83,10 +85,11 @@ export default function Title() {
   )
 
   useEffect(() => {
-    fetchFismaSystems(showDecommissioned)
-  }, [showDecommissioned, fetchFismaSystems])
+    if (!loaderData.serverError) fetchFismaSystems(showDecommissioned)
+  }, [showDecommissioned, fetchFismaSystems, loaderData.serverError])
 
   useEffect(() => {
+    if (loaderData.serverError) return
     async function fetchLatestDatacall() {
       await axiosInstance
         .get('/datacalls/latest')
@@ -95,7 +98,7 @@ export default function Title() {
           setLatestDatacall(res.data.data.datacall)
         })
         .catch((error) => {
-          if (error.response.status == 401) {
+          if (error.response?.status == 401) {
             navigate(Routes.SIGNIN, {
               replace: true,
               state: {
@@ -106,7 +109,7 @@ export default function Title() {
         })
     }
     fetchLatestDatacall()
-  }, [navigate])
+  }, [navigate, loaderData.serverError])
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
@@ -244,7 +247,9 @@ export default function Title() {
         )}
       </Container>
       <Container>
-        {loaderData.status !== 200 ? (
+        {loaderData.serverError ? (
+          <ServerErrorPage />
+        ) : loaderData.status !== 200 ? (
           <LoginPage />
         ) : (
           <>


### PR DESCRIPTION
## Summary

Closes CMS-Enterprise/ztmf-ui#258

When the backend is down or returns 5xx, users previously saw the login page or a raw "Uknown Error" from the ErrorBoundary. Now they see a clear "technical difficulties" message instead.

Two layers of coverage:
- **Static error.html** — served by CloudFront custom error responses (502/503/504) when the container is completely unreachable. Self-contained HTML with CMS government banner, branded footer, and retry link. No JavaScript required.
- **ServerErrorPage React component** — renders when the app loads but the API returns 5xx or the network is unreachable (status 0). Uses CMS design system styling within the normal app shell.

## Changes

- `public/error.html` — static error page for CloudFront (deployed to S3 alongside React app)
- `src/router/authLoader.ts` — detect 5xx and network failures, return serverError flag
- `src/views/Title/Title.tsx` — check serverError before rendering LoginPage, guard useEffect hooks
- `src/views/ServerErrorPage/ServerErrorPage.tsx` — technical difficulties component

## Tested on dev

Scaled ECS backend to 0 desired tasks, confirmed the error page renders correctly with CMS government banner, messaging, retry button, and CMS.gov footer.

<!-- Paste screenshot of error page here -->

## Notes

- Companion infrastructure PR: CMS-Enterprise/ztmf#276 (CloudFront custom_error_response blocks)
- Uses `<a href="">` instead of onclick in static page for CSP compliance (script-src does not allow unsafe-inline)
- Network failures (ETIMEDOUT, ECONNREFUSED) where status is 0 also route to the error page
- Optional chaining added to error.response?.status in datacall catch to prevent TypeError on connection refused

## Test plan

- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] Manual test: stopped backend on dev, verified error page renders instead of login
- [x] Manual test: verified normal login flow still works when backend is up