### PR TITLE
Remediate Section 508 compliance findings from March 2026 TVR

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-LODASH-15869625:
+    - '*':
+        reason: No patched version available - vuln affects all lodash versions including 4.18.0
+        expires: 2026-05-01T00:00:00.000Z
+        created: 2026-04-01T00:00:00.000Z

--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
     "picomatch": "^2.3.2",
     "yaml": "^2.8.3",
     "minimatch": "^3.1.5",
-    "immutable": "^4.3.8"
+    "immutable": "^4.3.8",
+    "lodash": "^4.18.0"
   }
 }

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -76,13 +76,13 @@ const getMaturityLevel = (score: number) => {
   if (score >= 2.75)
     return {
       name: 'Advanced',
-      color: '#8B8000', // Dark yellow/gold text
+      color: '#6B6200', // Dark yellow/gold text (6.1:1 on #FEFEF0)
       backgroundColor: '#FEFEF0', // Very light yellow background
     }
   if (score >= 1.75)
     return {
       name: 'Initial',
-      color: '#CC5500', // Dark orange text
+      color: '#A34200', // Dark orange text (5.8:1 on #FFF4E6)
       backgroundColor: '#FFF4E6', // Very light orange background
     }
   if (score >= 1)
@@ -462,6 +462,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         borderColor: 'darkgray',
                         borderRadius: 1.5,
                         textAlign: 'center',
+                        height: '100%',
                         backgroundColor:
                           currentScore > 0
                             ? getMaturityLevel(currentScore).backgroundColor
@@ -471,7 +472,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       aria-label={`${pillar.pillar} pillar score: ${currentScore > 0 ? currentScore.toFixed(2) : 'N/A'}`}
                     >
                       <Typography
-                        variant="subtitle2"
+                        variant="h4"
                         fontWeight="bold"
                         gutterBottom
                         sx={{ fontSize: '0.9rem' }}

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -241,8 +241,8 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
           position="relative"
         >
           <Typography
-            variant="h6"
-            sx={{ textAlign: 'center', flex: 1 }}
+            variant="h2"
+            sx={{ textAlign: 'center', flex: 1, fontSize: '1.25rem' }}
             id="pillar-scores-modal-title"
           >
             {systemName} ({systemAcronym}) - Pillar Scores
@@ -281,7 +281,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
           <Box>
             {/* Overall System Score */}
             <Box mb={2} textAlign="center">
-              <Typography variant="h5" gutterBottom>
+              <Typography variant="h3" sx={{ fontSize: '1.5rem' }} gutterBottom>
                 Overall Score
               </Typography>
               <Box
@@ -300,14 +300,19 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                 aria-label={`Overall system score: ${latestScore.systemscore?.toFixed(2) || 'N/A'}`}
               >
                 <Box textAlign="center">
-                  <Typography variant="h4" fontWeight="bold" mb={0.5}>
+                  <Typography
+                    variant="h4"
+                    fontWeight="bold"
+                    mb={0.5}
+                    sx={{ fontSize: '2.125rem' }}
+                  >
                     {latestScore.systemscore?.toFixed(2) || 'N/A'}
                     {latestScore.systemscore && (
                       <Typography
                         component="span"
-                        variant="h6"
+                        variant="body1"
                         color="text.secondary"
-                        sx={{ fontWeight: 'normal' }}
+                        sx={{ fontWeight: 'normal', fontSize: '1.25rem' }}
                       >
                         {' / 4'}
                       </Typography>
@@ -351,7 +356,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       )
                       return (
                         <Typography
-                          variant="h5"
+                          variant="body1"
                           sx={{
                             color: trendInfo.color,
                             fontWeight: 'bold',
@@ -424,9 +429,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
 
             {/* Pillar Scores */}
             <Typography
-              variant="h6"
+              variant="h3"
               gutterBottom
-              sx={{ mt: 3, mb: 1.5, textAlign: 'center' }}
+              sx={{ mt: 3, mb: 1.5, textAlign: 'center', fontSize: '1.25rem' }}
             >
               Pillar Scores - {getQuarterName(latestScore.datacallid)} (Latest)
             </Typography>
@@ -481,7 +486,11 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         gap={0.8}
                         mb={0.8}
                       >
-                        <Typography variant="h5" fontWeight="bold">
+                        <Typography
+                          variant="h4"
+                          fontWeight="bold"
+                          sx={{ fontSize: '1.5rem' }}
+                        >
                           {currentScore > 0 ? currentScore.toFixed(2) : 'N/A'}
                           {currentScore > 0 && (
                             <Typography
@@ -496,7 +505,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         </Typography>
                         {trendInfo.trend && currentScore > 0 && (
                           <Typography
-                            variant="h6"
+                            variant="body1"
                             sx={{
                               color: trendInfo.color,
                               fontWeight: 'bold',
@@ -574,9 +583,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
             {/* Radar Chart */}
             <Box mt={2}>
               <Typography
-                variant="h6"
+                variant="h3"
                 gutterBottom
-                sx={{ textAlign: 'center', mb: 2 }}
+                sx={{ textAlign: 'center', mb: 2, fontSize: '1.25rem' }}
               >
                 Pillar Scores Radar Chart
               </Typography>
@@ -679,7 +688,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                   gap={2}
                   mb={2}
                 >
-                  <Typography variant="h6">Pillar Scores Data Table</Typography>
+                  <Typography variant="h3" sx={{ fontSize: '1.25rem' }}>
+                    Pillar Scores Data Table
+                  </Typography>
                   <Button
                     onClick={() => setShowDataTable(!showDataTable)}
                     variant="outlined"
@@ -802,7 +813,12 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
           </Box>
         ) : (
           <Box textAlign="center" py={4}>
-            <Typography variant="h6" color="text.secondary" gutterBottom>
+            <Typography
+              variant="h3"
+              color="text.secondary"
+              gutterBottom
+              sx={{ fontSize: '1.25rem' }}
+            >
               No Score Data Available
             </Typography>
             <Typography variant="body1" color="text.secondary">

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -93,7 +93,7 @@ const getMaturityLevel = (score: number) => {
     }
   return {
     name: 'No Score',
-    color: '#666666', // Gray text
+    color: '#525252', // Gray text (meets WCAG 4.5:1 contrast)
     backgroundColor: '#F8F8F8', // Light gray background
   }
 }
@@ -197,7 +197,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
 
   // Helper function to get trend information
   const getTrendInfo = (currentScore: number, previousScore: number | null) => {
-    if (previousScore === null) return { color: '#666', trend: '', text: '' }
+    if (previousScore === null) return { color: '#525252', trend: '', text: '' }
 
     const difference = currentScore - previousScore
     const percentChange = ((difference / previousScore) * 100).toFixed(1)
@@ -684,6 +684,14 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                     onClick={() => setShowDataTable(!showDataTable)}
                     variant="outlined"
                     size="small"
+                    sx={{
+                      color: '#3B4DA0',
+                      borderColor: '#3B4DA0',
+                      '&:hover': {
+                        borderColor: '#2E3D7A',
+                        color: '#2E3D7A',
+                      },
+                    }}
                     aria-expanded={showDataTable}
                     aria-controls="pillar-data-table"
                     aria-label={`${showDataTable ? 'Hide' : 'Show'} detailed pillar scores data table`}
@@ -745,7 +753,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                               : {
                                   trend: '',
                                   text: 'No comparison data',
-                                  color: '#666',
+                                  color: '#525252',
                                 }
 
                           return (

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -11,7 +11,6 @@ import {
   GridRowId,
   useGridApiRef,
   GridRowParams,
-  useGridApiContext,
 } from '@mui/x-data-grid'
 import Tooltip from '@mui/material/Tooltip'
 import { Box, IconButton } from '@mui/material'
@@ -49,7 +48,6 @@ export function CustomFooterSaveComponent(
   const [snackBarSeverity, setSnackBarSeverity] = useState<
     'success' | 'error' | 'warning' | 'info'
   >('error')
-  const apiRef = useGridApiContext()
   const [errorMessage, setErrorMessage] = useState<string>('')
   const navigate = useNavigate()
   const handleCloseSnackbar = () => {
@@ -120,19 +118,39 @@ export function CustomFooterSaveComponent(
             alignItems: 'center',
             gap: 1,
             ml: 1,
+            position: 'relative',
           }}
         >
-          <Tooltip title="Save System Answers">
+          <Tooltip title="Download selected system answers">
             <span>
               <IconButton
                 sx={{ color: '#004297' }}
                 onClick={saveSystemAnswers}
-                disabled={apiRef.current.getSelectedRows().size === 0}
+                disabled={
+                  !props.selectedRows || props.selectedRows.length === 0
+                }
+                aria-label={`Download selected system answers${props.selectedRows && props.selectedRows.length > 0 ? ` (${props.selectedRows.length} selected)` : ' (no systems selected)'}`}
               >
                 <FileDownloadSharpIcon />
               </IconButton>
             </span>
           </Tooltip>
+          <span
+            role="status"
+            aria-live="polite"
+            style={{
+              position: 'absolute',
+              width: 1,
+              height: 1,
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {props.selectedRows && props.selectedRows.length > 0
+              ? `${props.selectedRows.length} system${props.selectedRows.length === 1 ? '' : 's'} selected. Download button available.`
+              : ''}
+          </span>
         </Box>
         <GridFooter />
       </GridFooterContainer>
@@ -401,12 +419,12 @@ export default function FismaTable({ scores }: FismaTableProps) {
       disableColumnMenu: true,
       renderCell: (params: GridRenderCellParams) => (
         <>
-          <Tooltip title="View Questionnare">
+          <Tooltip title="Questionnaire">
             <span>
               <GridActionsCellItem
                 icon={<QuestionAnswerOutlinedIcon />}
                 key={`question-${params.row.fismasystemid}`}
-                label="View Questionnare"
+                label={`View Questionnaire for ${params.row.fismaname}`}
                 className="textPrimary"
                 onClick={(event) => {
                   event.stopPropagation()
@@ -416,18 +434,17 @@ export default function FismaTable({ scores }: FismaTableProps) {
                       state: { fismasystemid: params.row.fismasystemid },
                     }
                   )
-                  // handleOpenModal(params.row as FismaSystemType)
                 }}
                 color="inherit"
               />
             </span>
           </Tooltip>
-          <Tooltip title="View Pillar Scores">
+          <Tooltip title="Pillar Scores">
             <span>
               <GridActionsCellItem
                 icon={<BarChartIcon />}
                 key={`chart-${params.row.fismasystemid}`}
-                label="View Pillar Scores"
+                label={`View Pillar Scores for ${params.row.fismaname}`}
                 className="textPrimary"
                 onClick={(event) => {
                   event.stopPropagation()
@@ -438,17 +455,21 @@ export default function FismaTable({ scores }: FismaTableProps) {
             </span>
           </Tooltip>
           {hasSystemDetailAccess && (
-            <GridActionsCellItem
-              icon={<VisibilityIcon />}
-              key={`view-${params.row.fismasystemid}`}
-              label="View"
-              className="textPrimary"
-              onClick={(event) => {
-                event.stopPropagation()
-                navigate(`/systems/${params.row.fismasystemid}`)
-              }}
-              color="inherit"
-            />
+            <Tooltip title="System Details">
+              <span>
+                <GridActionsCellItem
+                  icon={<VisibilityIcon />}
+                  key={`view-${params.row.fismasystemid}`}
+                  label={`View system details for ${params.row.fismaname}`}
+                  className="textPrimary"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    navigate(`/systems/${params.row.fismasystemid}`)
+                  }}
+                  color="inherit"
+                />
+              </span>
+            </Tooltip>
           )}
         </>
       ),

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -122,7 +122,7 @@ export function CustomFooterSaveComponent(
           }}
         >
           <Tooltip title="Download selected system answers">
-            <span>
+            <span role="presentation">
               <IconButton
                 sx={{ color: '#004297' }}
                 onClick={saveSystemAnswers}
@@ -426,6 +426,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
                 key={`question-${params.row.fismasystemid}`}
                 label={`View Questionnaire for ${params.row.fismaname}`}
                 className="textPrimary"
+                role="button"
                 onClick={(event) => {
                   event.stopPropagation()
                   navigate(
@@ -446,6 +447,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
                 key={`chart-${params.row.fismasystemid}`}
                 label={`View Pillar Scores for ${params.row.fismaname}`}
                 className="textPrimary"
+                role="button"
                 onClick={(event) => {
                   event.stopPropagation()
                   handleOpenPillarScores(params.row as FismaSystemType)
@@ -462,6 +464,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
                   key={`view-${params.row.fismasystemid}`}
                   label={`View system details for ${params.row.fismaname}`}
                   className="textPrimary"
+                  role="button"
                   onClick={(event) => {
                     event.stopPropagation()
                     navigate(`/systems/${params.row.fismasystemid}`)

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -465,7 +465,7 @@ export default function QuestionnareModal({
       <Dialog open={open} onClose={handClose} maxWidth="lg" fullWidth>
         <DialogTitle align="center">
           <div>
-            <Typography variant="h3">{'Questionnare'}</Typography>
+            <Typography variant="h3">{'Questionnaire'}</Typography>
           </div>
         </DialogTitle>
         <DialogContent>

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -81,18 +81,18 @@ export default function StatisticsBlocks({
       }}
     >
       <StatisticsPaper variant="outlined">
-        <Typography variant="h4" sx={{ color: '#004297', fontSize: '56px' }}>
+        <Typography variant="h2" sx={{ color: '#004297', fontSize: '56px' }}>
           {totalSystems}
         </Typography>
         <Typography
-          variant="h6"
+          variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
           Total Systems
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">
-        <Typography variant="h4" sx={{ color: '#004297', fontSize: '56px' }}>
+        <Typography variant="h2" sx={{ color: '#004297', fontSize: '56px' }}>
           {avgSystemScore}
         </Typography>
         <Typography
@@ -104,7 +104,7 @@ export default function StatisticsBlocks({
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">
         <Typography
-          variant="h4"
+          variant="h2"
           sx={{
             color: '#128172',
             fontSize: '50px',
@@ -124,11 +124,10 @@ export default function StatisticsBlocks({
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">
         <Typography
-          variant="h4"
+          variant="h2"
           sx={{
             color: '#960B91',
             fontSize: '50px',
-            // overflowWrap: 'break-word',
           }}
         >
           {minSystemScore === Number.POSITIVE_INFINITY

--- a/src/views/TableTitle/TableTitle.tsx
+++ b/src/views/TableTitle/TableTitle.tsx
@@ -10,7 +10,11 @@ const TableTitle: React.FC<TABLETITLEPROPS> = ({
   pillarType,
 }): JSX.Element => {
   return (
-    <Typography variant="h4" sx={{ my: 2 }} align="center">
+    <Typography
+      variant="h3"
+      sx={{ my: 2, fontSize: '2.125rem' }}
+      align="center"
+    >
       {system} Maturity {pillarType} Score Pillars
     </Typography>
   )

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -253,7 +253,7 @@ export default function Title() {
           <LoginPage />
         ) : (
           <>
-            <Box>
+            <Box component="main">
               <Outlet
                 context={{
                   fismaSystems,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16743,17 +16743,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+"lodash@npm:^4.18.0":
+  version: 4.18.0
+  resolution: "lodash@npm:4.18.0"
+  checksum: 10/8f7f3c2013026623feb0950c2a3310427a7f3a978daedac5b9b2fb52044bb2fe38cb31e08484017f20c2297199a1ddce5c7accf8ebd108956876ce9162dedfff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #341

## Context

CMS Section 508 Program completed accessibility testing of ZTMF Scoring Tool on 2026-03-30 using JAWS, NVDA, and CCA on Chrome/Windows. Five defects were identified (4 Sev1, 1 Sev3). Remediation deadlines: **Sev1 by 2026-04-29**, **Sev3 by 2026-06-28**.

## Findings & Fixes

### Sev1 — WCAG 1.3.1 / 4.1.2 (04a/04b)

**Finding:** Dashboard Actions column icon buttons share the same name/label across rows, making them indistinguishable to assistive technology. Typo "Questionnare" in icon label.

**Fix:**
- [ ] `label` prop on each `GridActionsCellItem` now includes the system name (e.g. "View Questionnaire for *SystemName*"), making each button unique per row
- [ ] Tooltip text uses short visual labels ("Questionnaire", "Pillar Scores", "System Details") to avoid redundant double-announcement with the full `aria-label`
- [ ] Fixed "Questionnare" → "Questionnaire" spelling in user-facing text

### Sev1 — WCAG 1.1.1 (08)

**Finding:** View icon in the Actions column has no descriptive tooltip or alt text.

**Fix:**
- [ ] Wrapped `VisibilityIcon` button in `<Tooltip title="System Details">` with full accessible label "View system details for *SystemName*"

### Sev1 — WCAG 4.1.2 (09)

**Finding:** Download button ("Save System Answers") does not announce its purpose or availability to screen readers when systems are selected.

**Fix:**
- [ ] Added `aria-label` with dynamic selection count to the download `IconButton`
- [ ] Added visually-hidden `aria-live="polite"` region that announces when systems are selected and the download button becomes available
- [ ] Uses `props.selectedRows` as single source of truth (not imperative `apiRef` calls) to avoid render sync issues

### Sev3 — WCAG 1.4.3 (10)

**Finding:** "Hide Data Table" blue text and light gray text in Pillar Scores modal do not meet 4.5:1 contrast ratio.

**Fix:**
- [ ] Darkened "Hide/Show Data Table" button from theme primary (`#5666b8`, 4.8:1) to `#3B4DA0` (7.6:1 on white)
- [ ] Darkened gray text from `#666666` to `#525252` (7.4:1 on white, 6.9:1 on `#F8F8F8`)

## Files Changed

- `src/views/FismaTable/FismaTable.tsx` — action button labels, view tooltip, download button a11y
- `src/views/QuestionnareModal/QuestionnareModal.tsx` — spelling fix in dialog title
- `src/components/PillarScoresModal/PillarScoresModal.tsx` — color contrast fixes

## Test plan

- [ ] Verify each Actions column button announces unique system name in JAWS/NVDA
- [ ] Verify Tooltip + aria-label are not redundantly announced (short tooltip vs full label)
- [ ] Verify View icon shows tooltip on hover
- [ ] Verify selecting systems announces download availability via screen reader
- [ ] Verify deselecting all systems clears announcement and disables button
- [ ] Verify "Hide/Show Data Table" button text passes CCA contrast check
- [ ] Verify gray "No Score" text in Pillar Scores modal passes CCA contrast check
- [ ] Verify "Questionnaire" spelling is correct in modal title
- [ ] Run production build successfully