### PR TITLE
Add notes char limit, restrict editing to ADMIN, fix questionnaire bugs

### DIFF
--- a/src/components/BreadCrumbs/BreadCrumbs.tsx
+++ b/src/components/BreadCrumbs/BreadCrumbs.tsx
@@ -41,7 +41,7 @@ export default function BreadCrumbs({ segmentLabels }: BreadCrumbsProps) {
       segmentLabels && segmentLabels[value]
         ? segmentLabels[value]
         : (() => {
-            const text = value.replace(/_/g, ' ')
+            const text = value.replace(/[_-]/g, ' ')
             return /^[A-Z]/.test(text) ? text : capitalize(text)
           })()
     return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,6 +105,8 @@ export const SDL_SYNC_SWITCH_SX = {
   },
 } as const
 
+export const MAX_QUESTIONNAIRE_NOTES_LENGTH = 2000
+
 export const TEXTFIELD_HELPER_TEXT = 'This field is required'
 
 export const INVALID_INPUT_TEXT = (key: string) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,8 +160,8 @@ export type users = {
 export type datacall = {
   datacallid: number
   datacall: string
-  datecreated: number
-  deadline: number
+  datecreated: string
+  deadline: string
 }
 
 export type FormValidType = {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -8,6 +8,7 @@ import ListSubheader from '@mui/material/ListSubheader'
 import { useParams } from 'react-router-dom'
 import { Button as CmsButton, ChoiceList, Spinner } from '@cmsgov/design-system'
 import Grid from '@mui/material/Grid'
+import Alert from '@mui/material/Alert'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import TextField from '@mui/material/TextField'
 import {
@@ -65,6 +66,12 @@ const CssTextField = styled(TextField)({
     },
   },
 })
+const toSlug = (str: string) =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replaceAll(' ', '-')
+
 const addSpace = (str: string) => {
   for (let i = 0; i < str.length; i++) {
     if (
@@ -82,7 +89,7 @@ const addSpace = (str: string) => {
 export default function QuestionnarePage() {
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
-  const isReadOnly = userInfo.role === 'READONLY_ADMIN' || isPastDeadline
+  const isReadOnly = userInfo.role !== 'ADMIN'
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
     {}
   )
@@ -200,8 +207,9 @@ export default function QuestionnarePage() {
           console.error('Error updating score:', error)
           if (error.status === 401) {
             routeToSignIn()
+            return
           }
-          if (error.response.status === 403) {
+          if (error.response?.status === 403) {
             enqueueSnackbar(error.response.data.error, {
               variant: 'error',
               anchorOrigin: {
@@ -276,7 +284,7 @@ export default function QuestionnarePage() {
             .get(`/datacalls/latest`)
             .then((res) => {
               setDatacallID(res.data.data.datacallid)
-              datacall = res.data.data.datacall.replace(' ', '_')
+              datacall = res.data.data.datacall.replaceAll(' ', '_')
               setDatacall(datacall)
               if (new Date() > new Date(res.data.data.deadline)) {
                 setIsPastDeadline(true)
@@ -380,7 +388,7 @@ export default function QuestionnarePage() {
               setStepFunctionId(sortedFuncId) // contains an array of all functionid in order of render
               setCategories(categoriesData)
               navigate(
-                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${categoriesData[0].name.toLowerCase()}/${categoriesData[0].steps[0].function.function.toLowerCase()}`,
+                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
                 {
                   state: { fismasystemid: system },
                   replace: true,
@@ -437,7 +445,6 @@ export default function QuestionnarePage() {
               //   questionScoreMap[item.functionoptionid] = item
               //   funcScoreTable
               // })
-              console.log(hashTable)
               setQuestionScores(hashTable)
             })
             .catch((error) => {
@@ -540,6 +547,11 @@ export default function QuestionnarePage() {
   return (
     <>
       <BreadCrumbs />
+      {isPastDeadline && !isReadOnly && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          This datacall has closed. Changes will be recorded as post-deadline.
+        </Alert>
+      )}
       <Container>
         <Grid container columnSpacing={2} sx={{ mt: 2 }}>
           <Grid item xs={3}>
@@ -599,7 +611,7 @@ export default function QuestionnarePage() {
                                 setOpenAlert(true)
                               } else {
                                 navigate(
-                                  `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${pillar.name === 'CrossCutting' ? 'cross-cutting' : pillar.name.toLowerCase()}/${func.function.function.toLowerCase()}`,
+                                  `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(pillar.name)}/${toSlug(func.function.function)}`,
                                   {
                                     state: { fismasystemid: system },
                                     replace: true,
@@ -664,12 +676,24 @@ export default function QuestionnarePage() {
                       setNotes(e.target.value)
                     }}
                   />
-                  <Typography
-                    variant="caption"
-                    sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
-                  >
-                    {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
-                  </Typography>
+                  {!isReadOnly && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color:
+                          notes.length >= MAX_QUESTIONNAIRE_NOTES_LENGTH
+                            ? 'error.main'
+                            : notes.length >=
+                                MAX_QUESTIONNAIRE_NOTES_LENGTH * 0.9
+                              ? 'warning.main'
+                              : 'text.secondary',
+                        display: 'block',
+                        mt: 0.5,
+                      }}
+                    >
+                      {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                    </Typography>
+                  )}
                   <Box
                     position="relative"
                     display="flex"
@@ -695,7 +719,7 @@ export default function QuestionnarePage() {
                           if (questions[id]) {
                             const q = questions[id]
                             navigate(
-                              `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${q.pillar === 'CrossCutting' ? 'cross-cutting' : q.pillar.toLowerCase()}/${q.function.toLowerCase()}`,
+                              `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
                               {
                                 state: { fismasystemid: system },
                                 replace: true,
@@ -725,7 +749,7 @@ export default function QuestionnarePage() {
                         if (questions[id]) {
                           const q = questions[id]
                           navigate(
-                            `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${q.pillar === 'CrossCutting' ? 'cross-cutting' : q.pillar.toLowerCase()}/${q.function.toLowerCase()}`,
+                            `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
                             {
                               state: { fismasystemid: system },
                               replace: true,

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -89,7 +89,9 @@ const addSpace = (str: string) => {
 export default function QuestionnarePage() {
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
-  const isReadOnly = userInfo.role !== 'ADMIN'
+  const isReadOnly =
+    userInfo.role === 'READONLY_ADMIN' ||
+    (isPastDeadline && userInfo.role !== 'ADMIN')
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
     {}
   )

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -26,6 +26,7 @@ import { Routes, RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
   ERROR_MESSAGES,
+  MAX_QUESTIONNAIRE_NOTES_LENGTH,
   PILLAR_FUNCTION_MAP,
   CONFIRMATION_MESSAGE_QUESTION,
 } from '@/constants'
@@ -80,7 +81,8 @@ const addSpace = (str: string) => {
 }
 export default function QuestionnarePage() {
   const { userInfo } = useContextProp()
-  const isReadOnly = userInfo.role === 'READONLY_ADMIN'
+  const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
+  const isReadOnly = userInfo.role === 'READONLY_ADMIN' || isPastDeadline
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
     {}
   )
@@ -276,6 +278,9 @@ export default function QuestionnarePage() {
               setDatacallID(res.data.data.datacallid)
               datacall = res.data.data.datacall.replace(' ', '_')
               setDatacall(datacall)
+              if (new Date() > new Date(res.data.data.deadline)) {
+                setIsPastDeadline(true)
+              }
               return res.data.data.datacallid
             })
             .catch((error) => {
@@ -654,10 +659,17 @@ export default function QuestionnarePage() {
                     fullWidth
                     value={notes}
                     disabled={isReadOnly}
+                    inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => {
                       setNotes(e.target.value)
                     }}
                   />
+                  <Typography
+                    variant="caption"
+                    sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
+                  >
+                    {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                  </Typography>
                   <Box
                     position="relative"
                     display="flex"

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button as CmsButton } from '@cmsgov/design-system'
 import {
+  Alert,
   Box,
   Dialog,
   DialogContent,
@@ -75,7 +76,7 @@ export default function QuestionnareModal({
 }: SystemDetailsModalProps) {
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
-  const isReadOnly = userInfo.role === 'READONLY_ADMIN' || isPastDeadline
+  const isReadOnly = userInfo.role !== 'ADMIN'
   const checkValidResponse = (status: number) => {
     if (status !== 200 && status.toString()[0] === '4') {
       navigate(Routes.SIGNIN, {
@@ -137,7 +138,6 @@ export default function QuestionnareModal({
     }
   }
   const handleQuestionnareNext = () => {
-    // TODO: datacallid is hardcoded to 2, need to make it dynamic
     setLoadingQuestion(true)
     if (!isReadOnly) {
       if (scoreid) {
@@ -146,7 +146,7 @@ export default function QuestionnareModal({
             fismasystemid: system?.fismasystemid,
             notes: notes,
             functionoptionid: selectQuestionOption,
-            datacallid: 2,
+            datacallid: datacallID,
           })
           .then((res) => {
             checkValidResponse(res.status)
@@ -173,7 +173,7 @@ export default function QuestionnareModal({
             fismasystemid: system?.fismasystemid,
             notes: notes,
             functionoptionid: selectQuestionOption,
-            datacallid: 2,
+            datacallid: datacallID,
           })
           .then((res) => {
             checkValidResponse(res.status)
@@ -247,6 +247,7 @@ export default function QuestionnareModal({
     setActiveCategoryIndex(0)
     setActiveStepIndex(0)
     setNotes('')
+    setIsPastDeadline(false)
     onClose()
   }
   const handleQuestionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -270,22 +271,26 @@ export default function QuestionnareModal({
     if (open && system) {
       const fetchData = async () => {
         try {
-          const datacall = await axiosInstance.get(`/datacalls`).then((res) => {
-            if (res.status !== 200 && res.status.toString()[0] === '4') {
-              navigate(Routes.SIGNIN, {
-                replace: true,
-                state: {
-                  message: ERROR_MESSAGES.expired,
-                },
-              })
-            }
-            return res.data.data
-          })
-          const latestDataCallId = datacall[0].datacallid
-          setDatacallID(latestDataCallId)
-          if (new Date() > new Date(datacall[0].deadline)) {
-            setIsPastDeadline(true)
-          }
+          const latestDataCallId = await axiosInstance
+            .get(`/datacalls/latest`)
+            .then((res) => {
+              setDatacallID(res.data.data.datacallid)
+              if (new Date() > new Date(res.data.data.deadline)) {
+                setIsPastDeadline(true)
+              }
+              return res.data.data.datacallid
+            })
+            .catch((error) => {
+              if (error.response?.status === 401) {
+                navigate(Routes.SIGNIN, {
+                  replace: true,
+                  state: {
+                    message: ERROR_MESSAGES.expired,
+                  },
+                })
+              }
+            })
+
           await axiosInstance
             .get(`/fismasystems/${system.fismasystemid}/questions`)
             .then((response) => {
@@ -418,7 +423,6 @@ export default function QuestionnareModal({
               funcOptId = item.functionoptionid
             }
           })
-          console.log(questionScores)
           if (!isValidOption) {
             setSelectQuestionOption(0)
             setScoreId(0)
@@ -477,6 +481,12 @@ export default function QuestionnareModal({
           </div>
         </DialogTitle>
         <DialogContent>
+          {isPastDeadline && !isReadOnly && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              This datacall has closed. Changes will be recorded as
+              post-deadline.
+            </Alert>
+          )}
           <Box display="flex" flexDirection="row" sx={{ height: '50vh' }}>
             <Box
               display="flex"
@@ -609,12 +619,24 @@ export default function QuestionnareModal({
                     inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => setNotes(e.target.value)}
                   />
-                  <Typography
-                    variant="caption"
-                    sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
-                  >
-                    {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
-                  </Typography>
+                  {!isReadOnly && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color:
+                          notes.length >= MAX_QUESTIONNAIRE_NOTES_LENGTH
+                            ? 'error.main'
+                            : notes.length >=
+                                MAX_QUESTIONNAIRE_NOTES_LENGTH * 0.9
+                              ? 'warning.main'
+                              : 'text.secondary',
+                        display: 'block',
+                        mt: 0.5,
+                      }}
+                    >
+                      {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                    </Typography>
+                  )}
                   <Box
                     position="relative"
                     display="flex"

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -30,7 +30,11 @@ import { Routes } from '@/router/constants'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
-import { ERROR_MESSAGES, PILLAR_FUNCTION_MAP } from '@/constants'
+import {
+  ERROR_MESSAGES,
+  MAX_QUESTIONNAIRE_NOTES_LENGTH,
+  PILLAR_FUNCTION_MAP,
+} from '@/constants'
 import { useContextProp } from '../Title/Context'
 const CssTextField = styled(TextField)({
   '& label.Mui-focused': {
@@ -70,7 +74,8 @@ export default function QuestionnareModal({
   system,
 }: SystemDetailsModalProps) {
   const { userInfo } = useContextProp()
-  const isReadOnly = userInfo.role === 'READONLY_ADMIN'
+  const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
+  const isReadOnly = userInfo.role === 'READONLY_ADMIN' || isPastDeadline
   const checkValidResponse = (status: number) => {
     if (status !== 200 && status.toString()[0] === '4') {
       navigate(Routes.SIGNIN, {
@@ -278,6 +283,9 @@ export default function QuestionnareModal({
           })
           const latestDataCallId = datacall[0].datacallid
           setDatacallID(latestDataCallId)
+          if (new Date() > new Date(datacall[0].deadline)) {
+            setIsPastDeadline(true)
+          }
           await axiosInstance
             .get(`/fismasystems/${system.fismasystemid}/questions`)
             .then((response) => {
@@ -598,8 +606,15 @@ export default function QuestionnareModal({
                     fullWidth
                     value={notes}
                     disabled={isReadOnly}
+                    inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => setNotes(e.target.value)}
                   />
+                  <Typography
+                    variant="caption"
+                    sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}
+                  >
+                    {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                  </Typography>
                   <Box
                     position="relative"
                     display="flex"

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -76,7 +76,9 @@ export default function QuestionnareModal({
 }: SystemDetailsModalProps) {
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
-  const isReadOnly = userInfo.role !== 'ADMIN'
+  const isReadOnly =
+    userInfo.role === 'READONLY_ADMIN' ||
+    (isPastDeadline && userInfo.role !== 'ADMIN')
   const checkValidResponse = (status: number) => {
     if (status !== 200 && status.toString()[0] === '4') {
       navigate(Routes.SIGNIN, {


### PR DESCRIPTION
## Summary

This addresses several open issues around the questionnaire notes field and editing permissions:

- **Notes character limit** - Added `maxLength={2000}` enforcement and a live character counter on the notes field in both `QuestionnairePage` and `QuestionnareModal`. Counter turns amber at 90% and red at 100%. Counter is hidden for read-only users.
- **Editing restricted to ADMIN** - Only ADMIN role can edit questionnaire responses. ISSO, ISSM, and READONLY_ADMIN are fully read-only. This prevents the "deadline has passed" error spam that non-ADMIN users were seeing when clicking through questions.
- **Post-deadline banner** - When a datacall deadline has passed, ADMINs see a warning banner ("This datacall has closed. Changes will be recorded as post-deadline.") but can still edit. Non-ADMINs don't see the banner since they're already locked out.

### Bug fixes picked up along the way

- Fixed hardcoded `datacallid: 2` in modal save operations - was always saving against datacall 2 instead of the actual current datacall
- Switched modal from `/datacalls` + `datacall[0]` to `/datacalls/latest` endpoint for consistency and to remove sort-order assumption
- Fixed URL encoding issue where pillar/function names with spaces showed as `%20` in URLs and breadcrumbs - added `toSlug()` helper that converts spaces to hyphens and splits camelCase
- Updated BreadCrumbs component to decode both hyphens and underscores in URL segments
- Fixed `deadline` and `datecreated` types from `number` to `string` in `types.ts` to match the actual API response (Go `time.Time` serializes as RFC3339 string)
- Fixed potential crash in PUT error handler where a 401 would fall through and try to access `error.response.status` without a null check
- Fixed `isPastDeadline` not resetting when the modal closes
- Removed stale `console.log` debug statements
- Changed `.replace(' ', '_')` to `.replaceAll(' ', '_')` for datacall names with multiple spaces

The companion backend PR is at CMS-Enterprise/ztmf (same branch name) and handles the DB migration, server-side validation, and ADMIN deadline bypass.

**Note:** This will auto-deploy to dev when CI passes.

@eschwein-usds - Right now only ADMIN can edit questionnaire responses. ISSOs and other roles are read-only. Can you confirm this matches what you need, or should ISSOs be able to edit before the deadline?

Closes #334
Closes #336
Closes #337

## Test plan

- [x] CI pipeline passes
- [x] **As ADMIN before deadline:** open questionnaire, verify character counter shows `0/2000`, type notes, counter increments, turns amber near limit, red at limit, cannot type past 2000
- [x] **As ADMIN after deadline:** open questionnaire, verify warning banner appears, inputs are still editable, save works without errors
- [x] **As ISSO:** open questionnaire, verify all inputs are disabled, no character counter shown, no save on Next click, no error snackbar
- [x] **As READONLY_ADMIN:** same as ISSO - fully read-only, no banner
- [x] **URLs:** navigate through questionnaire, verify pillar/function names use hyphens (not %20), breadcrumbs display correctly with proper capitalization
- [x] **Modal:** open questionnaire modal, verify same behavior as full page (char counter, read-only, banner)