### PR TITLE
508 compliance: confirm dialogs and restore/reactivate UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@mui/material": "^5.16.2",
     "@mui/x-data-grid": "^6.19.4",
     "@popperjs/core": "^2.11.8",
-    "axios": "^1.15.0",
+    "axios": "^1.15.2",
     "classnames": "^2.5.1",
     "clipboard-copy": "^4.0.1",
     "core-js": "^3.37.1",
@@ -256,6 +256,7 @@
     "lodash-es": "^4.17.21",
     "tar": "^7.5.13",
     "brace-expansion": "^1.1.13",
-    "@tootallnate/once": "^3.0.1"
+    "@tootallnate/once": "^3.0.1",
+    "follow-redirects": "^1.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -257,6 +257,7 @@
     "tar": "^7.5.13",
     "brace-expansion": "^1.1.13",
     "@tootallnate/once": "^3.0.1",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "ws": "^8.20.0"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,9 @@ export type FismaSystemType = {
   decommissioned_date: string | null
   decommissioned_by: string | null
   decommissioned_notes: string | null
+  reactivated_by: string | null
+  reactivated_date: string | null
+  reactivation_notes: string | null
 }
 export type FismaSystems = {
   fismaSystems: FismaSystemType[]
@@ -154,6 +157,7 @@ export type users = {
   fullname: string
   role: string
   userid: string
+  deleted?: boolean
   isNew?: boolean
 }
 

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -19,6 +19,7 @@ import { useSnackbar } from 'notistack'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
+import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
 const checkedIcon = <CheckBoxIcon fontSize="small" />
 
@@ -27,6 +28,7 @@ type Props = {
   open: boolean
   handleClose: () => void
   userid: GridRowId
+  userName: string
 }
 
 export default function AssignSystemModal({
@@ -34,10 +36,15 @@ export default function AssignSystemModal({
   open,
   handleClose,
   userid,
+  userName,
 }: Props) {
   const [assignedSystems, setAssignedSystems] = React.useState<number[]>([])
   const [fismaSystems, setFismaSystems] = React.useState<number[]>([])
   const [openSnackBar, setOpenSnackBar] = React.useState<boolean>(false)
+  const [pendingUnassign, setPendingUnassign] = React.useState<{
+    systemid: number
+    nextValue: number[]
+  } | null>(null)
   const { enqueueSnackbar } = useSnackbar()
   const navigate = useNavigate()
   React.useEffect(() => {
@@ -51,6 +58,51 @@ export default function AssignSystemModal({
       })
     }
   }, [open, userid, fismaSystemMap])
+  const handleConfirmUnassign = (confirm: boolean) => {
+    const target = pendingUnassign
+    setPendingUnassign(null)
+    if (!confirm || !target) return
+    axiosInstance
+      .delete(`/users/${userid}/assignedfismasystems/${target.systemid}`)
+      .then(() => {
+        setAssignedSystems(target.nextValue)
+        enqueueSnackbar(`Saved - unassigned system`, {
+          variant: 'success',
+          anchorOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+        })
+      })
+      .catch((error) => {
+        if (error.response?.status === 401) {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: {
+              message: ERROR_MESSAGES.error,
+            },
+          })
+        } else if (error.response?.status === 403) {
+          enqueueSnackbar(ERROR_MESSAGES.permission, {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 1500,
+          })
+        } else {
+          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 1500,
+          })
+        }
+      })
+  }
 
   return (
     <>
@@ -107,6 +159,7 @@ export default function AssignSystemModal({
                     fismasystemid: added[0],
                   })
                   .then(() => {
+                    setAssignedSystems(newValue)
                     enqueueSnackbar(`Saved - assign system`, {
                       variant: 'success',
                       anchorOrigin: {
@@ -116,14 +169,14 @@ export default function AssignSystemModal({
                     })
                   })
                   .catch((error) => {
-                    if (error.response.status === 401) {
+                    if (error.response?.status === 401) {
                       navigate(Routes.SIGNIN, {
                         replace: true,
                         state: {
                           message: ERROR_MESSAGES.error,
                         },
                       })
-                    } else if (error.response.status === 403) {
+                    } else if (error.response?.status === 403) {
                       enqueueSnackbar(ERROR_MESSAGES.permission, {
                         variant: 'error',
                         anchorOrigin: {
@@ -144,48 +197,11 @@ export default function AssignSystemModal({
                     }
                   })
               } else if (removed.length) {
-                axiosInstance
-                  .delete(`/users/${userid}/assignedfismasystems/${removed[0]}`)
-                  .then(() => {
-                    enqueueSnackbar(`Saved - unassigned system`, {
-                      variant: 'success',
-                      anchorOrigin: {
-                        vertical: 'top',
-                        horizontal: 'left',
-                      },
-                    })
-                  })
-                  .catch((error) => {
-                    if (error.response.status === 401) {
-                      navigate(Routes.SIGNIN, {
-                        replace: true,
-                        state: {
-                          message: ERROR_MESSAGES.error,
-                        },
-                      })
-                    } else if (error.response.status === 403) {
-                      enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                        variant: 'error',
-                        anchorOrigin: {
-                          vertical: 'top',
-                          horizontal: 'left',
-                        },
-                        autoHideDuration: 1500,
-                      })
-                    } else {
-                      enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                        variant: 'error',
-                        anchorOrigin: {
-                          vertical: 'top',
-                          horizontal: 'left',
-                        },
-                        autoHideDuration: 1500,
-                      })
-                    }
-                  })
+                setPendingUnassign({
+                  systemid: removed[0],
+                  nextValue: newValue,
+                })
               }
-
-              setAssignedSystems(newValue)
             }}
             renderInput={(params) => (
               <TextField
@@ -212,6 +228,24 @@ export default function AssignSystemModal({
         severity="success"
         duration={2000}
         text="Saved"
+      />
+      <ConfirmDialog
+        title="Confirm Unassign System"
+        confirmationText={
+          pendingUnassign
+            ? `Are you sure you want to unassign ${
+                fismaSystemMap[pendingUnassign.systemid]?.acronym ??
+                'this system'
+              }${
+                fismaSystemMap[pendingUnassign.systemid]
+                  ? ` - ${fismaSystemMap[pendingUnassign.systemid].name}`
+                  : ''
+              } from ${userName || 'this user'}?`
+            : ''
+        }
+        open={pendingUnassign !== null}
+        onClose={() => setPendingUnassign(null)}
+        confirmClick={handleConfirmUnassign}
       />
     </>
   )

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -74,6 +74,12 @@ export default function EditSystemModal({
     React.useState<boolean>(false)
   const [decommissionedByName, setDecommissionedByName] =
     React.useState<string>('')
+  const [reactivatedByName, setReactivatedByName] = React.useState<string>('')
+  const [showReactivateForm, setShowReactivateForm] =
+    React.useState<boolean>(false)
+  const [reactivationNotes, setReactivationNotes] = React.useState<string>('')
+  const [openReactivateAlert, setOpenReactivateAlert] =
+    React.useState<boolean>(false)
   const [formValidErrorText, setFormValidErrorText] =
     React.useState<FormValidHelperText>({
       issoemail: TEXTFIELD_HELPER_TEXT,
@@ -148,6 +154,8 @@ export default function EditSystemModal({
       setDecommissionDateError('')
       setDecommissionNotes('')
       setShowDecommissionForm(false)
+      setReactivationNotes('')
+      setShowReactivateForm(false)
       setLoading(false)
     }
   }, [system, open])
@@ -173,6 +181,33 @@ export default function EditSystemModal({
         })
     } else {
       setDecommissionedByName('')
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [system, open])
+  React.useEffect(() => {
+    let cancelled = false
+    if (open && system?.reactivated_by) {
+      const userId = system.reactivated_by
+      axiosInstance
+        .get(`users/${userId}`)
+        .then((res) => {
+          if (!cancelled && system?.reactivated_by === userId) {
+            if (res.data?.data?.fullname) {
+              setReactivatedByName(res.data.data.fullname)
+            } else {
+              setReactivatedByName(userId)
+            }
+          }
+        })
+        .catch(() => {
+          if (!cancelled && system?.reactivated_by === userId) {
+            setReactivatedByName(userId)
+          }
+        })
+    } else {
+      setReactivatedByName('')
     }
     return () => {
       cancelled = true
@@ -389,6 +424,74 @@ export default function EditSystemModal({
       .catch((error) => {
         console.error(
           'Decommission error:',
+          error.response?.status,
+          error.response?.data
+        )
+        if (error.response?.status === 403) {
+          enqueueSnackbar('Permission denied. Admin access required.', {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 2000,
+          })
+        } else if (error.response?.status === 404) {
+          enqueueSnackbar('System not found', {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 2000,
+          })
+        } else if (error.response?.status === 400) {
+          const errorMsg = error.response?.data?.error || 'Invalid request'
+          enqueueSnackbar(`Error: ${errorMsg}`, {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 3000,
+          })
+        } else {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: {
+              message: ERROR_MESSAGES.error,
+            },
+          })
+        }
+      })
+  }
+  const handleReactivate = async () => {
+    setOpenReactivateAlert(false)
+    const trimmedNotes = reactivationNotes.trim()
+    const body = trimmedNotes ? { notes: trimmedNotes } : undefined
+    await axiosInstance
+      .put(`fismasystems/${editedFismaSystem.fismasystemid}/reactivate`, body)
+      .then((res) => {
+        if (res.status === 200) {
+          enqueueSnackbar('System reactivated successfully', {
+            variant: 'success',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 2000,
+          })
+          const updatedSystem: FismaSystemType = res.data?.data || {
+            ...editedFismaSystem,
+            decommissioned: false,
+            reactivation_notes: trimmedNotes || null,
+          }
+          onClose(updatedSystem)
+        }
+      })
+      .catch((error) => {
+        console.error(
+          'Reactivate error:',
           error.response?.status,
           error.response?.data
         )
@@ -720,7 +823,7 @@ export default function EditSystemModal({
                           >
                             System Decommissioned
                           </Typography>
-                          {!showDecommissionForm && (
+                          {!showDecommissionForm && !showReactivateForm && (
                             <>
                               {system?.decommissioned_date && (
                                 <Typography
@@ -764,33 +867,120 @@ export default function EditSystemModal({
                                   Notes: {system.decommissioned_notes}
                                 </Typography>
                               )}
-                              <CmsButton
-                                size="small"
-                                onClick={() => {
-                                  if (system?.decommissioned_date) {
-                                    const d = new Date(
-                                      system.decommissioned_date
+                              {system?.reactivated_date && (
+                                <Box sx={{ mt: 1 }}>
+                                  <Typography
+                                    variant="caption"
+                                    sx={{
+                                      display: 'block',
+                                      fontStyle: 'italic',
+                                      color: 'text.secondary',
+                                    }}
+                                  >
+                                    Previously reactivated on{' '}
+                                    {new Date(
+                                      system.reactivated_date
+                                    ).toLocaleDateString()}
+                                    {system?.reactivated_by &&
+                                      ` by ${reactivatedByName || system.reactivated_by}`}
+                                    {system?.reactivation_notes
+                                      ? ` (notes: ${system.reactivation_notes})`
+                                      : ''}
+                                  </Typography>
+                                </Box>
+                              )}
+                              <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                                <CmsButton
+                                  size="small"
+                                  onClick={() => {
+                                    if (system?.decommissioned_date) {
+                                      const d = new Date(
+                                        system.decommissioned_date
+                                      )
+                                      const yyyy = d.getFullYear()
+                                      const mm = String(
+                                        d.getMonth() + 1
+                                      ).padStart(2, '0')
+                                      const dd = String(d.getDate()).padStart(
+                                        2,
+                                        '0'
+                                      )
+                                      setDecommissionDate(`${yyyy}-${mm}-${dd}`)
+                                    }
+                                    setDecommissionNotes(
+                                      system?.decommissioned_notes || ''
                                     )
-                                    const yyyy = d.getFullYear()
-                                    const mm = String(
-                                      d.getMonth() + 1
-                                    ).padStart(2, '0')
-                                    const dd = String(d.getDate()).padStart(
-                                      2,
-                                      '0'
-                                    )
-                                    setDecommissionDate(`${yyyy}-${mm}-${dd}`)
-                                  }
-                                  setDecommissionNotes(
-                                    system?.decommissioned_notes || ''
-                                  )
-                                  setShowDecommissionForm(true)
-                                }}
-                                style={{ marginTop: '8px' }}
-                              >
-                                Edit Decommission Details
-                              </CmsButton>
+                                    setShowDecommissionForm(true)
+                                  }}
+                                >
+                                  Edit Decommission Details
+                                </CmsButton>
+                                <CmsButton
+                                  variation="solid"
+                                  size="small"
+                                  onClick={() => {
+                                    setReactivationNotes('')
+                                    setShowReactivateForm(true)
+                                  }}
+                                >
+                                  Reactivate System
+                                </CmsButton>
+                              </Box>
                             </>
+                          )}
+                          {showReactivateForm && (
+                            <Box sx={{ ml: 2, mt: 2 }}>
+                              <Typography
+                                variant="body2"
+                                sx={{ mt: 0, mb: 0.5, fontWeight: 500 }}
+                              >
+                                Reactivation Notes (optional)
+                              </Typography>
+                              <textarea
+                                value={reactivationNotes}
+                                maxLength={500}
+                                rows={3}
+                                onChange={(e) =>
+                                  setReactivationNotes(e.target.value)
+                                }
+                                placeholder="Reason for reactivation..."
+                                style={{
+                                  width: '100%',
+                                  padding: '8px',
+                                  fontSize: '14px',
+                                  border: '1px solid #ccc',
+                                  borderRadius: '4px',
+                                  boxSizing: 'border-box',
+                                  fontFamily: 'inherit',
+                                  resize: 'vertical',
+                                }}
+                              />
+                              <Typography
+                                variant="caption"
+                                sx={{
+                                  color: 'text.secondary',
+                                  display: 'block',
+                                  mb: 1,
+                                }}
+                              >
+                                {reactivationNotes.length}/500
+                              </Typography>
+                              <Box sx={{ display: 'flex', gap: 1 }}>
+                                <CmsButton
+                                  variation="solid"
+                                  size="small"
+                                  onClick={() => setOpenReactivateAlert(true)}
+                                >
+                                  Reactivate
+                                </CmsButton>
+                                <CmsButton
+                                  size="small"
+                                  onClick={() => setShowReactivateForm(false)}
+                                >
+                                  Cancel
+                                </CmsButton>
+                              </Box>
+                            </Box>
                           )}
                           {showDecommissionForm && (
                             <Box sx={{ ml: 2, mt: 1 }}>
@@ -1058,7 +1248,7 @@ export default function EditSystemModal({
           confirmationText={
             system?.decommissioned
               ? `Update decommission details for "${system?.fismaname}" to ${new Date(decommissionDate + 'T00:00:00.000Z').toLocaleDateString()}?${decommissionNotes.trim() ? ` Notes: "${decommissionNotes.trim().length > 100 ? decommissionNotes.trim().substring(0, 100) + '...' : decommissionNotes.trim()}"` : ''}`
-              : `Are you sure you want to decommission "${system?.fismaname}" on ${new Date(decommissionDate + 'T00:00:00.000Z').toLocaleDateString()}?${decommissionNotes.trim() ? ` Notes: "${decommissionNotes.trim().length > 100 ? decommissionNotes.trim().substring(0, 100) + '...' : decommissionNotes.trim()}"` : ''} This will hide the system from the active systems list. This action cannot be undone through the UI.`
+              : `Are you sure you want to decommission "${system?.fismaname}" on ${new Date(decommissionDate + 'T00:00:00.000Z').toLocaleDateString()}?${decommissionNotes.trim() ? ` Notes: "${decommissionNotes.trim().length > 100 ? decommissionNotes.trim().substring(0, 100) + '...' : decommissionNotes.trim()}"` : ''} This will hide the system from the active systems list. An admin can later reactivate the system if needed.`
           }
           open={openDecommissionAlert}
           onClose={() => setOpenDecommissionAlert(false)}
@@ -1067,6 +1257,23 @@ export default function EditSystemModal({
               handleDecommission()
             } else {
               setOpenDecommissionAlert(false)
+            }
+          }}
+        />
+        <ConfirmDialog
+          title="Confirm Reactivate System"
+          confirmationText={`Reactivate "${system?.fismaname}"? This will move the system back to the active systems list.${
+            reactivationNotes.trim()
+              ? ` Notes: "${reactivationNotes.trim().length > 100 ? reactivationNotes.trim().substring(0, 100) + '...' : reactivationNotes.trim()}"`
+              : ''
+          }`}
+          open={openReactivateAlert}
+          onClose={() => setOpenReactivateAlert(false)}
+          confirmClick={(confirm: boolean) => {
+            if (confirm) {
+              handleReactivate()
+            } else {
+              setOpenReactivateAlert(false)
             }
           }}
         />

--- a/src/views/EditSystemModal/emptySystem.ts
+++ b/src/views/EditSystemModal/emptySystem.ts
@@ -18,4 +18,7 @@ export const EMPTY_SYSTEM = {
   decommissioned_date: null,
   decommissioned_by: null,
   decommissioned_notes: null,
+  reactivated_by: null,
+  reactivated_date: null,
+  reactivation_notes: null,
 }

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -80,7 +80,9 @@ export function CustomFooterSaveComponent(
         const [, filename] =
           response.headers['content-disposition'].split('filename=')
         const contentType = response.headers['content-type']
-        const data = new Blob([response.data], { type: contentType })
+        const data = new Blob([response.data], {
+          type: typeof contentType === 'string' ? contentType : undefined,
+        })
         const url = window.URL.createObjectURL(data)
         const tempLink = document.createElement('a')
         tempLink.href = url

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -30,6 +30,9 @@ interface SystemDetailEditViewProps {
   decommissionNotes: string
   showDecommissionForm: boolean
   decommissionedByName: string
+  reactivationNotes: string
+  showReactivateForm: boolean
+  reactivatedByName: string
   onInputChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     key: string
@@ -40,6 +43,9 @@ interface SystemDetailEditViewProps {
   onDecommissionNotesChange: (value: string) => void
   onShowDecommissionForm: (show: boolean) => void
   onDecommissionRequest: () => void
+  onReactivationNotesChange: (value: string) => void
+  onShowReactivateForm: (show: boolean) => void
+  onReactivateRequest: () => void
   validateDecommissionDate: (dateStr: string) => boolean
   onSdlSyncToggle: (checked: boolean) => void
 }
@@ -198,6 +204,40 @@ function DecommissionDateNotesForm(props: SystemDetailEditViewProps) {
   )
 }
 
+function ReactivateNotesForm(props: SystemDetailEditViewProps) {
+  const { reactivationNotes, onReactivationNotesChange } = props
+  return (
+    <>
+      <Typography variant="body2" sx={{ mb: 0.5, fontWeight: 500 }}>
+        Reactivation Notes (optional)
+      </Typography>
+      <textarea
+        value={reactivationNotes}
+        maxLength={MAX_NOTES_LENGTH}
+        rows={3}
+        onChange={(e) => onReactivationNotesChange(e.target.value)}
+        placeholder="Reason for reactivation..."
+        style={{
+          width: '100%',
+          padding: '8px',
+          fontSize: '14px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxSizing: 'border-box',
+          fontFamily: 'inherit',
+          resize: 'vertical',
+        }}
+      />
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', display: 'block', mb: 1 }}
+      >
+        {reactivationNotes.length}/{MAX_NOTES_LENGTH}
+      </Typography>
+    </>
+  )
+}
+
 export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
   const {
     system,
@@ -207,6 +247,10 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
     decommissionDate,
     onShowDecommissionForm,
     onDecommissionRequest,
+    showReactivateForm,
+    reactivatedByName,
+    onShowReactivateForm,
+    onReactivateRequest,
     validateDecommissionDate,
     onSdlSyncToggle,
   } = props
@@ -252,7 +296,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
               sx={{ pb: 0 }}
             />
             <CardContent>
-              {!showDecommissionForm && (
+              {!showDecommissionForm && !showReactivateForm && (
                 <>
                   {system.decommissioned_date && (
                     <Box sx={{ mb: 2 }}>
@@ -286,13 +330,41 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
                       </Typography>
                     </Box>
                   )}
-                  <CmsButton
-                    size="small"
-                    onClick={() => onShowDecommissionForm(true)}
-                    style={{ marginTop: '4px' }}
-                  >
-                    Edit Decommission Details
-                  </CmsButton>
+                  {system.reactivated_date && (
+                    <Box sx={{ mb: 2 }}>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          display: 'block',
+                          fontStyle: 'italic',
+                          color: 'text.secondary',
+                        }}
+                      >
+                        Previously reactivated on{' '}
+                        {new Date(system.reactivated_date).toLocaleDateString()}
+                        {system.reactivated_by &&
+                          ` by ${reactivatedByName || system.reactivated_by}`}
+                        {system.reactivation_notes
+                          ? ` (notes: ${system.reactivation_notes})`
+                          : ''}
+                      </Typography>
+                    </Box>
+                  )}
+                  <Box sx={{ display: 'flex', gap: 1, mt: '4px' }}>
+                    <CmsButton
+                      size="small"
+                      onClick={() => onShowDecommissionForm(true)}
+                    >
+                      Edit Decommission Details
+                    </CmsButton>
+                    <CmsButton
+                      variation="solid"
+                      size="small"
+                      onClick={() => onShowReactivateForm(true)}
+                    >
+                      Reactivate System
+                    </CmsButton>
+                  </Box>
                 </>
               )}
               {showDecommissionForm && (
@@ -313,6 +385,26 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
                     <CmsButton
                       size="small"
                       onClick={() => onShowDecommissionForm(false)}
+                    >
+                      Cancel
+                    </CmsButton>
+                  </Box>
+                </Box>
+              )}
+              {showReactivateForm && (
+                <Box sx={{ mt: 1 }}>
+                  <ReactivateNotesForm {...props} />
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <CmsButton
+                      variation="solid"
+                      size="small"
+                      onClick={onReactivateRequest}
+                    >
+                      Reactivate
+                    </CmsButton>
+                    <CmsButton
+                      size="small"
+                      onClick={() => onShowReactivateForm(false)}
                     >
                       Cancel
                     </CmsButton>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -391,7 +391,7 @@ export default function SystemDetailPage() {
     if (system?.decommissioned) {
       return `Update decommission details for "${system?.fismaname}" to ${dateDisplay}?${notesSuffix}`
     }
-    return `Are you sure you want to decommission "${system?.fismaname}" on ${dateDisplay}?${notesSuffix} This will hide the system from the active systems list. This action cannot be undone through the UI.`
+    return `Are you sure you want to decommission "${system?.fismaname}" on ${dateDisplay}?${notesSuffix} This will hide the system from the active systems list. An admin can later reactivate the system if needed.`
   }
 
   // Invalid system ID in URL

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -74,6 +74,7 @@ export default function SystemDetailPage() {
   const [isSaving, setIsSaving] = useState(false)
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
   const [openDecommissionDialog, setOpenDecommissionDialog] = useState(false)
+  const [openReactivateDialog, setOpenReactivateDialog] = useState(false)
 
   // Decommission-specific state
   const [decommissionDate, setDecommissionDate] = useState('')
@@ -81,6 +82,11 @@ export default function SystemDetailPage() {
   const [decommissionNotes, setDecommissionNotes] = useState('')
   const [showDecommissionForm, setShowDecommissionForm] = useState(false)
   const [decommissionedByName, setDecommissionedByName] = useState('')
+
+  // Reactivate-specific state
+  const [reactivationNotes, setReactivationNotes] = useState('')
+  const [showReactivateForm, setShowReactivateForm] = useState(false)
+  const [reactivatedByName, setReactivatedByName] = useState('')
 
   const [formValid, setFormValid] = useState<FormValidType>({
     issoemail: false,
@@ -123,6 +129,8 @@ export default function SystemDetailPage() {
       setDecommissionDateError('')
       setDecommissionNotes('')
       setShowDecommissionForm(false)
+      setReactivationNotes('')
+      setShowReactivateForm(false)
     }
   }, [isEditing, system])
 
@@ -146,6 +154,31 @@ export default function SystemDetailPage() {
         })
     } else {
       setDecommissionedByName('')
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [system])
+
+  // Resolve reactivated_by UUID to a human-readable name
+  useEffect(() => {
+    let cancelled = false
+    if (system?.reactivated_by) {
+      const userId = system.reactivated_by
+      axiosInstance
+        .get(`users/${userId}`)
+        .then((res) => {
+          if (!cancelled) {
+            setReactivatedByName(res.data?.data?.fullname || userId)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setReactivatedByName(userId)
+          }
+        })
+    } else {
+      setReactivatedByName('')
     }
     return () => {
       cancelled = true
@@ -380,6 +413,75 @@ export default function SystemDetailPage() {
       })
   }
 
+  const handleReactivate = async () => {
+    if (!editedSystem) return
+    setOpenReactivateDialog(false)
+
+    const trimmedNotes = reactivationNotes.trim()
+    const body = trimmedNotes ? { notes: trimmedNotes } : undefined
+
+    await axiosInstance
+      .put(`fismasystems/${editedSystem.fismasystemid}/reactivate`, body)
+      .then((res) => {
+        if (res.status === 200) {
+          enqueueSnackbar('System reactivated successfully', {
+            variant: 'success',
+            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+            autoHideDuration: 2000,
+          })
+          const updatedSystem: FismaSystemType = res.data?.data || {
+            ...editedSystem,
+            decommissioned: false,
+            reactivated_by: userInfo.userid,
+            reactivated_date: new Date().toISOString(),
+            reactivation_notes: trimmedNotes || null,
+          }
+          setFismaSystems((prev) =>
+            prev.map((s) =>
+              s.fismasystemid === updatedSystem.fismasystemid
+                ? updatedSystem
+                : s
+            )
+          )
+          setReactivatedByName(userInfo.fullname || userInfo.userid)
+          setIsEditing(false)
+          setEditedSystem(null)
+        }
+      })
+      .catch((error) => {
+        console.error(
+          'Reactivate error:',
+          error.response?.status,
+          error.response?.data
+        )
+        if (error.response?.status === 403) {
+          enqueueSnackbar('Permission denied. Admin access required.', {
+            variant: 'error',
+            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+            autoHideDuration: 2000,
+          })
+        } else if (error.response?.status === 404) {
+          enqueueSnackbar('System not found', {
+            variant: 'error',
+            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+            autoHideDuration: 2000,
+          })
+        } else if (error.response?.status === 400) {
+          const errorMsg = error.response?.data?.error || 'Invalid request'
+          enqueueSnackbar(`Error: ${errorMsg}`, {
+            variant: 'error',
+            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+            autoHideDuration: 3000,
+          })
+        } else {
+          navigate(Routes.SIGNIN, {
+            replace: true,
+            state: { message: ERROR_MESSAGES.error },
+          })
+        }
+      })
+  }
+
   // Build decommission confirmation text
   const getDecommissionConfirmText = (): string => {
     const dateDisplay = new Date(
@@ -392,6 +494,12 @@ export default function SystemDetailPage() {
       return `Update decommission details for "${system?.fismaname}" to ${dateDisplay}?${notesSuffix}`
     }
     return `Are you sure you want to decommission "${system?.fismaname}" on ${dateDisplay}?${notesSuffix} This will hide the system from the active systems list. An admin can later reactivate the system if needed.`
+  }
+
+  const getReactivateConfirmText = (): string => {
+    const truncated = truncateNotes(reactivationNotes)
+    const notesSuffix = truncated ? ` Notes: "${truncated}"` : ''
+    return `Reactivate "${system?.fismaname}"? This will move the system back to the active systems list.${notesSuffix}`
   }
 
   // Invalid system ID in URL
@@ -466,6 +574,9 @@ export default function SystemDetailPage() {
           decommissionNotes={decommissionNotes}
           showDecommissionForm={showDecommissionForm}
           decommissionedByName={decommissionedByName}
+          reactivationNotes={reactivationNotes}
+          showReactivateForm={showReactivateForm}
+          reactivatedByName={reactivatedByName}
           onInputChange={handleInputChange}
           onFieldChange={handleFieldChange}
           onValidatedFieldChange={handleValidatedFieldChange}
@@ -473,6 +584,9 @@ export default function SystemDetailPage() {
           onDecommissionNotesChange={setDecommissionNotes}
           onShowDecommissionForm={setShowDecommissionForm}
           onDecommissionRequest={() => setOpenDecommissionDialog(true)}
+          onReactivationNotesChange={setReactivationNotes}
+          onShowReactivateForm={setShowReactivateForm}
+          onReactivateRequest={() => setOpenReactivateDialog(true)}
           validateDecommissionDate={validateDecommissionDate}
           onSdlSyncToggle={(checked) =>
             setEditedSystem((prev) =>
@@ -517,6 +631,19 @@ export default function SystemDetailPage() {
             handleDecommission()
           } else {
             setOpenDecommissionDialog(false)
+          }
+        }}
+      />
+      <ConfirmDialog
+        title="Confirm Reactivate System"
+        confirmationText={getReactivateConfirmText()}
+        open={openReactivateDialog}
+        onClose={() => setOpenReactivateDialog(false)}
+        confirmClick={(confirm: boolean) => {
+          if (confirm) {
+            handleReactivate()
+          } else {
+            setOpenReactivateDialog(false)
           }
         }}
       />

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -9,6 +9,7 @@ import FormControl from '@mui/material/FormControl'
 import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import DeleteIcon from '@mui/icons-material/DeleteOutlined'
+import RestoreIcon from '@mui/icons-material/RestoreFromTrash'
 import {
   GridRowsProp,
   GridRowModesModel,
@@ -30,8 +31,11 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControlLabel,
+  Switch,
   Typography,
 } from '@mui/material'
+import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { Button as CmsButton } from '@cmsgov/design-system'
 import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
@@ -53,10 +57,13 @@ interface EditToolbarProps {
     newModel: (oldModel: GridRowModesModel) => GridRowModesModel
   ) => void
   isAdmin?: boolean
+  showDeleted: boolean
+  setShowDeleted: (value: boolean) => void
 }
 
 function EditToolbar(props: EditToolbarProps) {
-  const { setRows, setRowModesModel, isAdmin } = props
+  const { setRows, setRowModesModel, isAdmin, showDeleted, setShowDeleted } =
+    props
   const addUserRow = () => {
     const userid = Math.floor(Math.random() * 1000) + 1
     setRows((oldRows) => [
@@ -73,32 +80,47 @@ function EditToolbar(props: EditToolbarProps) {
       <GridToolbarQuickFilter
         debounceMs={250}
         sx={{
-          // '& .MuiInputBase-root:before': {
-          //   borderBottomColor: '#5666b8',
-          //   borderBottomWidth: 2,
-          // },
           '& .MuiInputBase-input::placeholder': {
-            color: '#404040', // Change placeholder color to red
-            opacity: 0.8, // Ensure it is fully visible (MUI reduces opacity by default)
+            color: '#404040',
+            opacity: 0.8,
           },
           '& .MuiInputBase-root:after': {
-            borderBottomColor: '#5666b8', // Changes the underline color when active
+            borderBottomColor: '#5666b8',
           },
           '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
-            borderBottomColor: '#5666b8', // Changes the underline color on hover
+            borderBottomColor: '#5666b8',
           },
         }}
       />
-      {isAdmin && (
-        <Button
-          color="primary"
-          startIcon={<AddIcon />}
-          onClick={addUserRow}
-          sx={{ color: '#5666b8' }}
-        >
-          Add User
-        </Button>
-      )}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={showDeleted}
+              onChange={(e) => setShowDeleted(e.target.checked)}
+              sx={{
+                '& .MuiSwitch-switchBase.Mui-checked': {
+                  color: '#004297',
+                },
+                '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                  backgroundColor: '#004297',
+                },
+              }}
+            />
+          }
+          label="Show Deleted"
+        />
+        {isAdmin && !showDeleted && (
+          <Button
+            color="primary"
+            startIcon={<AddIcon />}
+            onClick={addUserRow}
+            sx={{ color: '#5666b8' }}
+          >
+            Add User
+          </Button>
+        )}
+      </Box>
     </GridToolbarContainer>
   )
 }
@@ -200,6 +222,10 @@ export default function UserTable() {
   const [fismaSystemsMap, setFismaSystemsMap] = useState<
     Record<number, { name: string; acronym: string }>
   >({})
+  const [showDeleted, setShowDeleted] = useState<boolean>(false)
+  const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
+  const [pendingRestoreRow, setPendingRestoreRow] = useState<users | null>(null)
+  const [assignModalUserName, setAssignModalUserName] = useState<string>('')
   const handleRowEditStop: GridEventListener<'rowEditStop'> = (
     params,
     event
@@ -263,6 +289,8 @@ export default function UserTable() {
   }
   const handleOpenModal = (id: GridRowId) => {
     setUserId(id)
+    const row = rows.find((r) => r.userid === id)
+    setAssignModalUserName(row?.fullname ?? '')
     setOpenModal(true)
   }
   const handleCloseModal = () => {
@@ -355,12 +383,19 @@ export default function UserTable() {
     setOpen(true)
   }
   const handleDeleteClick = (id: GridRowId) => () => {
-    const curRow = apiRef.current.getRow(id)
-    setRows(rows.filter((row) => row.userid !== id))
+    const curRow = apiRef.current.getRow(id) as users | undefined
+    if (!curRow) return
+    setPendingDeleteRow(curRow)
+  }
+  const handleConfirmDelete = (confirm: boolean) => {
+    const target = pendingDeleteRow
+    setPendingDeleteRow(null)
+    if (!confirm || !target) return
     axiosInstance
-      .delete(`/users/${id}`)
+      .delete(`/users/${target.userid}`)
       .then(() => {
-        enqueueSnackbar(`Saved - Delete User ${curRow.fullname}`, {
+        setRows((prev) => prev.filter((row) => row.userid !== target.userid))
+        enqueueSnackbar(`Saved - Delete User ${target.fullname}`, {
           variant: 'success',
           anchorOrigin: {
             vertical: 'top',
@@ -370,13 +405,52 @@ export default function UserTable() {
         })
       })
       .catch((error) => {
-        if (error.response.status === 401) {
+        if (error.response?.status === 401) {
           checkValidResponse(error.response.status)
-        } else if (error.response.status === 403) {
+        } else if (error.response?.status === 403) {
           handleUnautherized(error.response.status)
         } else {
-          enqueueSnackbar(`An error occurred, please try again later`, {
-            variant: 'success',
+          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
+            variant: 'error',
+            anchorOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            autoHideDuration: 2000,
+          })
+        }
+      })
+  }
+  const handleRestoreClick = (id: GridRowId) => () => {
+    const curRow = apiRef.current.getRow(id) as users | undefined
+    if (!curRow) return
+    setPendingRestoreRow(curRow)
+  }
+  const handleConfirmRestore = (confirm: boolean) => {
+    const target = pendingRestoreRow
+    setPendingRestoreRow(null)
+    if (!confirm || !target) return
+    axiosInstance
+      .put(`/users/${target.userid}/restore`)
+      .then(() => {
+        setRows((prev) => prev.filter((row) => row.userid !== target.userid))
+        enqueueSnackbar(`Saved - Restore User ${target.fullname}`, {
+          variant: 'success',
+          anchorOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+          autoHideDuration: 2000,
+        })
+      })
+      .catch((error) => {
+        if (error.response?.status === 401) {
+          checkValidResponse(error.response.status)
+        } else if (error.response?.status === 403) {
+          handleUnautherized(error.response.status)
+        } else {
+          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
+            variant: 'error',
             anchorOrigin: {
               vertical: 'top',
               horizontal: 'left',
@@ -390,7 +464,7 @@ export default function UserTable() {
   useEffect(() => {
     if (!isAdmin) return
     axiosInstance
-      .get('/users')
+      .get('/users', { params: { deleted: showDeleted } })
       .then((res) => {
         if (res.status === 200) {
           const data = res.data.data.map((row: users) => ({
@@ -439,7 +513,7 @@ export default function UserTable() {
           })
         }
       })
-  }, [isAdmin, fismaSystems, navigate, enqueueSnackbar])
+  }, [isAdmin, fismaSystems, navigate, enqueueSnackbar, showDeleted])
   const columns: GridColDef[] = [
     {
       field: 'fullname',
@@ -521,6 +595,24 @@ export default function UserTable() {
           ]
         }
 
+        if (params.row.deleted) {
+          return [
+            <Tooltip
+              title="Restore User"
+              key={`tooltip-restore-${params.id}`}
+              placement="right-start"
+            >
+              <GridActionsCellItem
+                icon={<RestoreIcon sx={{ color: 'black' }} />}
+                key={`restore-${params.id}`}
+                label="Restore"
+                onClick={handleRestoreClick(params.id)}
+                color="inherit"
+              />
+            </Tooltip>,
+          ]
+        }
+
         return [
           <GridActionsCellItem
             icon={<EditIcon />}
@@ -591,7 +683,13 @@ export default function UserTable() {
             toolbar: EditToolbar,
           }}
           slotProps={{
-            toolbar: { setRows, setRowModesModel, isAdmin },
+            toolbar: {
+              setRows,
+              setRowModesModel,
+              isAdmin,
+              showDeleted,
+              setShowDeleted,
+            },
             filterPanel: {
               sx: {
                 '& .MuiFormLabel-root': {
@@ -639,6 +737,29 @@ export default function UserTable() {
         open={openModal}
         handleClose={handleCloseModal}
         userid={userId}
+        userName={assignModalUserName}
+      />
+      <ConfirmDialog
+        title="Confirm User Deletion"
+        confirmationText={
+          pendingDeleteRow
+            ? `Are you sure you want to delete ${pendingDeleteRow.fullname}? This will remove their access to ZTMF. The user can be restored later from the "Show Deleted" view.`
+            : ''
+        }
+        open={pendingDeleteRow !== null}
+        onClose={() => setPendingDeleteRow(null)}
+        confirmClick={handleConfirmDelete}
+      />
+      <ConfirmDialog
+        title="Confirm User Restore"
+        confirmationText={
+          pendingRestoreRow
+            ? `Restore ${pendingRestoreRow.fullname}? This will re-enable their access to ZTMF.`
+            : ''
+        }
+        open={pendingRestoreRow !== null}
+        onClose={() => setPendingRestoreRow(null)}
+        confirmClick={handleConfirmRestore}
       />
       <Dialog
         open={openAlert}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,14 +7268,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
   languageName: node
   linkType: hard
 
@@ -10123,13 +10123,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 
@@ -18709,7 +18709,7 @@ __metadata:
     "@types/react-is": "npm:^19"
     "@types/uuid": "npm:^9.0.8"
     "@vitejs/plugin-react-swc": "npm:^4.3.0"
-    axios: "npm:^1.15.0"
+    axios: "npm:^1.15.2"
     babel-plugin-transform-import-meta: "npm:^2.2.1"
     camelcase: "npm:^6.3.0"
     classnames: "npm:^2.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18507,9 +18507,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.2.3":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
+"ws@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -18518,7 +18518,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/1769532b6fdab9ff659f0b17810e7501831d34ecca23fd179ee64091dd93a51f42c59f6c7bb4c7a384b6c229aca8076fb312aa35626257c18081511ef62a161d
+  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stage 2 of CMS-Enterprise/ztmf-ui#339 (frontend half of CMS-Enterprise/ztmf#281). Pairs with backend PR CMS-Enterprise/ztmf#297.

## ⚠️ Merge order

**Do NOT merge this PR until CMS-Enterprise/ztmf#297 is squashed and merged to ztmf `main`.** This branch calls two endpoints that only exist on the backend `feature/508-restore-reactivate-281` branch:

- `PUT /api/v1/users/{userid}/restore`
- `PUT /api/v1/fismasystems/{fismasystemid}/reactivate`

If this merges first, dev will 404 on the restore/reactivate buttons until backend dev catches up.

## Summary

Closes the four UI work items called out in the 508 audit so destructive actions are confirmable and soft-deleted/decommissioned records can be recovered without database access.

- **UserTable** — `ConfirmDialog` before deleting a user; **Show Deleted** toggle in the toolbar that fetches with `?deleted=true`; **Restore** action button on deleted rows calling `PUT /users/{id}/restore`. Also fixes a pre-existing bug where rows were dropped from local state *before* the DELETE resolved, so a 403 hid a row that still existed on the server.
- **AssignSystemModal** — `ConfirmDialog` before unassigning a FISMA system. The Autocomplete value is left untouched until the DELETE resolves so canceling snaps the chip back. New `userName` prop carries the row's full name into the prompt copy.
- **SystemDetailPage / SystemDetailEditView** — **Reactivate System** button surfaced alongside **Edit Decommission Details** on a decommissioned system's edit view. Optional 500-char reactivation-notes textarea mirrors the decommission notes UI. Calls `PUT /fismasystems/{id}/reactivate`. Renders prior reactivation history when present so audit context survives a re-decommission.
- **Decommission copy** — drops "This action cannot be undone through the UI." from both `SystemDetailPage` and `EditSystemModal` since reactivation now exists.
- **Types** — `FismaSystemType` gains `reactivated_by` / `reactivated_date` / `reactivation_notes`; `users` gains `deleted?`. Defaults added to `EMPTY_SYSTEM`.

## Test plan (dev environment, after backend ztmf#297 is merged and dev redeployed)

Sign in as **ADMIN**.

### 1. Delete user — confirmation dialog

- [ ] On the Users page, click the trash icon on a normal user row. A "Confirm User Deletion" dialog appears with the user's full name in the prompt.
- [ ] Click **Cancel** — row stays, no DELETE request fires (verify in Network tab).
- [ ] Click the trash icon again, then **Confirm** — DELETE `/users/{id}` fires, the row disappears, success snackbar shows "Saved - Delete User …".

### 2. Show Deleted toggle + Restore user

- [ ] Toggle **Show Deleted** in the toolbar — request fires to `/users?deleted=true` (Network tab), the table now shows only deleted users, and the **Add User** button is hidden in this mode.
- [ ] On the user just deleted in step 1, click the Restore icon. A "Confirm User Restore" dialog appears.
- [ ] Click **Confirm** — `PUT /users/{id}/restore` fires, row disappears from the deleted view, success snackbar.
- [ ] Toggle **Show Deleted** off — the user is back in the active list with normal Edit / Assign / Delete actions.

### 3. Unassign system — confirmation dialog

- [ ] On a user row, click the assign-systems icon to open `AssignSystemModal`.
- [ ] Click the X on a chip for an assigned FISMA system. A "Confirm Unassign System" dialog appears naming both the system (acronym + name) and the user.
- [ ] Click **Cancel** — chip snaps back, no DELETE in Network tab.
- [ ] Repeat, click **Confirm** — DELETE fires, chip is removed, success snackbar.

### 4. Decommission a system (regression check)

- [ ] Open a system's detail page → Edit. Decommission flow still works as before.
- [ ] On the confirmation dialog, verify the copy no longer contains "This action cannot be undone through the UI." It should read "An admin can later reactivate the system if needed."

### 5. Reactivate a system

- [ ] Toggle **Show Decommissioned** on the systems list, click into a decommissioned system, then **Edit**.
- [ ] In the System Status card you should see both **Edit Decommission Details** and **Reactivate System** buttons (admin only).
- [ ] Click **Reactivate System** — the optional notes textarea appears with a `0/500` counter.
- [ ] Type a note, click **Reactivate** — "Confirm Reactivate System" dialog appears with the system name and notes preview.
- [ ] **Cancel** the dialog — form stays open with notes preserved.
- [ ] **Reactivate** again, **Confirm** the dialog — `PUT /fismasystems/{id}/reactivate` fires with `{"notes":"…"}`. Success snackbar; page exits edit mode; the system flips to Active and disappears from the Show-Decommissioned list.
- [ ] Toggle Show Decommissioned off — the reactivated system appears in the active list. Editing it again shows no decommission audit (as expected when `decommissioned=false`), and decommissioning + reactivating it again should now display a "Previously reactivated on …" history line below the new decommission audit.

### 6. Empty / no-notes path on reactivate

- [ ] Decommission another system, then reactivate it without typing any notes — request body is omitted (Network tab shows no body), backend stores `reactivation_notes` as null, snackbar succeeds.

### 7. Role gating

- [ ] Sign in as **READONLY_ADMIN**. The Users page redirects (existing behavior, unchanged). On a decommissioned system's detail page in edit mode (if reachable), reactivate would 403 — backend enforces this; no FE regression expected.

## Verification (local)

- `npx tsc --noEmit` — clean
- `yarn lint:js` and `yarn lint:other` — clean, no new warnings
- `npx vite build` — succeeds (existing chunk-size warning unchanged)
- `yarn test` — 14 passed, 3 skipped (unchanged)
- Pre-commit and pre-push hooks pass without `--no-verify`

## Out of scope

- Pre-existing 401/403 error-handling shape across the codebase
- Per-domain API client refactor
- ztmf-ui#312 (SaaS question reduction)
- Hard-deleted user-fismasystem assignment restore (audit deferred)

## Related

- Backend PR (must merge first): CMS-Enterprise/ztmf#297
- Backend issue: CMS-Enterprise/ztmf#281
- Frontend issue: CMS-Enterprise/ztmf-ui#339
- Decommission UX precedent: ztmf-ui#314, ztmf-ui#318, ztmf-ui#323