### PR TITLE
Add push trigger to Orchestration IMPL so impl deploys frontend

### DIFF
--- a/.github/workflows/orchestration-impl.yml
+++ b/.github/workflows/orchestration-impl.yml
@@ -1,6 +1,18 @@
+# Trigger model (mirrors CMS-Enterprise/ztmf orchestration-impl.yml):
+#   - pull_request to `impl`: runs Analysis only (lint, security scan, unit
+#     tests). No S3 deploy. Gives the PR author CI feedback without racing
+#     other open PRs for shared impl state.
+#   - push to `impl`: runs the full pipeline (analysis -> ui) and deploys
+#     the frontend bundle to s3://impl.ztmf.cms.gov + invalidates the impl
+#     CloudFront distribution. Squash-merge from a feature branch into
+#     impl is the intended trigger; the resulting single commit on impl
+#     produces one ordered deploy per merged PR.
 name: Orchestration IMPL
 
 on:
+  push:
+    branches:
+      - impl
   pull_request:
     branches:
       - impl
@@ -13,13 +25,13 @@ on:
 jobs:
   analysis:
     name: Analysis
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     uses: ./.github/workflows/analysis.yml
     secrets: inherit
 
   ui:
     name: ui
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'push' && !failure() && !cancelled()
     needs:
       - analysis
     uses: ./.github/workflows/ui.yml


### PR DESCRIPTION
## Summary

- Add \`push: branches: [impl]\` trigger to \`.github/workflows/orchestration-impl.yml\`.
- Gate the \`analysis\` job to run on both \`push\` and non-draft \`pull_request\` events.
- Gate the \`ui\` deploy job to run only on \`push\` events (post-merge), matching the backend repo's pattern.

## Why

The backend repo (\`CMS-Enterprise/ztmf\`) fires \`Orchestration IMPL\` on push to \`impl\`, so a squash-merge to \`impl\` auto-deploys the API image and applies Terraform. This frontend repo's \`Orchestration IMPL\` only fired on \`pull_request\`, so when \`impl\` was rebased on \`main\` no deploy ran. \`s3://impl.ztmf.cms.gov\` is empty and the impl CloudFront origin returns HTTP 403.

Mirroring the backend trigger model lets a push to \`impl\` deploy the frontend bundle to S3 and invalidate the impl CloudFront distribution, the same way DEV and PROD already work.

## Test plan

- [ ] CI Analysis passes on this PR (\`pull_request\` to \`main\`).
- [ ] After merge, push \`main\` into \`impl\` and verify \`Orchestration IMPL\` runs the \`ui\` job and uploads to \`s3://impl.ztmf.cms.gov\`.
- [ ] Confirm \`https://impl.ztmf.cms.gov\` (or the CF distribution domain) serves the bundle once DNS lands.

## Notes

The \`pull_request\` to \`impl\` path remains analysis-only so PRs against the shared impl branch get fast feedback without racing other open PRs for the deploy slot.