### PR TITLE
feat(roles): expand frontend role taxonomy for multi-OpDiv backend (Stage 1)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@
  * Application-wide constants
  * @module constants
  */
-import { userData } from './types'
+import { userData, UserRole } from './types'
 
 //* Application Strings
 export const ORG_NAME = 'CMS'
@@ -30,7 +30,7 @@ export const EMPTY_USER: userData = {
   userid: '',
   email: '',
   fullname: '',
-  role: '',
+  role: '' as UserRole,
   assignedfismasystems: [],
 }
 export const CONFIRMATION_MESSAGE =

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -1,5 +1,5 @@
 import 'core-js/stable/atob'
-import { userData } from '@/types'
+import { userData, UserRole } from '@/types'
 import axiosInstance from '@/axiosConfig'
 /**
  * Auth state loader for react-router data routes.
@@ -11,7 +11,7 @@ const emptyUser: userData = {
   userid: '',
   email: '',
   fullname: '',
-  role: '',
+  role: '' as UserRole,
   assignedfismasystems: [],
 }
 const authLoader = async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,12 +20,33 @@ export type FormField = {
   value?: string | number | boolean | null
   component: React.ElementType
 }
+export type UserRole =
+  | 'OWNER'
+  | 'HHS_ADMIN'
+  | 'HHS_READONLY_ADMIN'
+  | 'OPDIV_ADMIN'
+  | 'OPDIV_READONLY_ADMIN'
+  | 'ISSO'
+  | 'ISSM'
+  | 'ADMIN'
+  | 'READONLY_ADMIN'
+
+export type OpDiv = {
+  opdiv_id: number
+  code: string
+  name: string
+  is_parent: boolean
+  active: boolean
+}
+
 export type userData = {
   userid: string
   email: string
   fullname: string
-  role: string
+  role: UserRole
   assignedfismasystems?: number[]
+  identity_provider?: 'okta' | 'entra'
+  assignedopdivids?: number[] | null
 }
 export type RequestOptions = {
   method: string
@@ -55,6 +76,7 @@ export type FismaSystemType = {
   reactivated_by: string | null
   reactivated_date: string | null
   reactivation_notes: string | null
+  opdiv_id?: number | null
 }
 export type FismaSystems = {
   fismaSystems: FismaSystemType[]
@@ -155,7 +177,7 @@ export type users = {
   assignedfismasystems: number[]
   email: string
   fullname: string
-  role: string
+  role: UserRole
   userid: string
   deleted?: boolean
   isNew?: boolean

--- a/src/utils/opdivs.ts
+++ b/src/utils/opdivs.ts
@@ -1,0 +1,20 @@
+import axiosInstance from '@/axiosConfig'
+import type { OpDiv } from '@/types'
+
+/**
+ * Fetches the OpDiv reference list from GET /api/v1/opdivs.
+ *
+ * The endpoint is open to any authenticated user. By default the
+ * backend filters to active rows only; pass includeInactive to retrieve
+ * deactivated rows as well (used by audit and historical-reference UI).
+ *
+ * Stage 1 publishes this helper so Stage 2+ work (OpDiv badges,
+ * selectors, admin grant management) can consume it without each
+ * caller hand-rolling the request. There is no production caller yet.
+ */
+export async function fetchOpDivs(includeInactive = false): Promise<OpDiv[]> {
+  const response = await axiosInstance.get<{ data: OpDiv[] }>('/opdivs', {
+    params: includeInactive ? { active_only: false } : undefined,
+  })
+  return response.data.data
+}

--- a/src/utils/userRoles.test.ts
+++ b/src/utils/userRoles.test.ts
@@ -1,0 +1,160 @@
+import type { UserRole } from '@/types'
+import {
+  hasAdminRead,
+  hasSystemAccess,
+  hasUnscopedRead,
+  isAdmin,
+  isAdminTierRole,
+  isReadOnlyAdmin,
+  isReadOnlyAdminRole,
+  isWriteAdminRole,
+} from '@/utils/userRoles'
+
+/**
+ * Regression contract for the multi-OpDiv role taxonomy.
+ *
+ * Stage 1 of the migration kept the legacy `ADMIN` and `READONLY_ADMIN`
+ * role values valid alongside the new tiers so the frontend can render
+ * correctly against both the pre-migration backend and the paired
+ * backend. These tests pin that contract until Stage D drops the legacy
+ * values from the backend enum. When that work lands, the legacy rows
+ * below should be removed in the same PR — failing tests are the signal
+ * that an intentional decision is required, not an error to suppress.
+ */
+
+const roleUser = (role: UserRole) => ({ role })
+
+type Case = [role: UserRole, expected: boolean]
+
+const isAdminCases: Case[] = [
+  ['OWNER', true],
+  ['HHS_ADMIN', true],
+  ['OPDIV_ADMIN', true],
+  ['ADMIN', true], // legacy, removed in Stage D
+  ['HHS_READONLY_ADMIN', false],
+  ['OPDIV_READONLY_ADMIN', false],
+  ['READONLY_ADMIN', false], // legacy, removed in Stage D
+  ['ISSO', false],
+  ['ISSM', false],
+]
+
+const isReadOnlyAdminCases: Case[] = [
+  ['HHS_READONLY_ADMIN', true],
+  ['OPDIV_READONLY_ADMIN', true],
+  ['READONLY_ADMIN', true], // legacy, removed in Stage D
+  ['OWNER', false],
+  ['HHS_ADMIN', false],
+  ['OPDIV_ADMIN', false],
+  ['ADMIN', false],
+  ['ISSO', false],
+  ['ISSM', false],
+]
+
+const hasUnscopedReadCases: Case[] = [
+  ['OWNER', true],
+  ['HHS_ADMIN', true],
+  ['HHS_READONLY_ADMIN', true],
+  ['ADMIN', true], // legacy, removed in Stage D
+  ['READONLY_ADMIN', true], // legacy, removed in Stage D
+  ['OPDIV_ADMIN', false],
+  ['OPDIV_READONLY_ADMIN', false],
+  ['ISSO', false],
+  ['ISSM', false],
+]
+
+const hasSystemAccessCases: Case[] = [
+  ['OWNER', true],
+  ['HHS_ADMIN', true],
+  ['HHS_READONLY_ADMIN', true],
+  ['OPDIV_ADMIN', true],
+  ['OPDIV_READONLY_ADMIN', true],
+  ['ADMIN', true], // legacy, removed in Stage D
+  ['READONLY_ADMIN', true], // legacy, removed in Stage D
+  ['ISSO', true],
+  ['ISSM', true],
+]
+
+test.each(isAdminCases)('isAdmin(%s) === %s', (role, expected) => {
+  expect(isAdmin(roleUser(role))).toBe(expected)
+  expect(isWriteAdminRole(role)).toBe(expected)
+})
+
+test.each(isReadOnlyAdminCases)(
+  'isReadOnlyAdmin(%s) === %s',
+  (role, expected) => {
+    expect(isReadOnlyAdmin(roleUser(role))).toBe(expected)
+    expect(isReadOnlyAdminRole(role)).toBe(expected)
+  }
+)
+
+test('hasAdminRead is the union of isAdmin and isReadOnlyAdmin', () => {
+  const allRoles: UserRole[] = [
+    'OWNER',
+    'HHS_ADMIN',
+    'HHS_READONLY_ADMIN',
+    'OPDIV_ADMIN',
+    'OPDIV_READONLY_ADMIN',
+    'ISSO',
+    'ISSM',
+    'ADMIN',
+    'READONLY_ADMIN',
+  ]
+  allRoles.forEach((role) => {
+    const user = roleUser(role)
+    expect(hasAdminRead(user)).toBe(isAdmin(user) || isReadOnlyAdmin(user))
+  })
+})
+
+test.each(hasUnscopedReadCases)(
+  'hasUnscopedRead(%s) === %s',
+  (role, expected) => {
+    expect(hasUnscopedRead(roleUser(role))).toBe(expected)
+  }
+)
+
+test.each(hasSystemAccessCases)(
+  'hasSystemAccess(%s) === %s',
+  (role, expected) => {
+    expect(hasSystemAccess(roleUser(role))).toBe(expected)
+  }
+)
+
+test('isAdminTierRole returns true for every admin tier (write or read-only)', () => {
+  const adminTiers: UserRole[] = [
+    'OWNER',
+    'HHS_ADMIN',
+    'OPDIV_ADMIN',
+    'HHS_READONLY_ADMIN',
+    'OPDIV_READONLY_ADMIN',
+    'ADMIN', // legacy, removed in Stage D
+    'READONLY_ADMIN', // legacy, removed in Stage D
+  ]
+  adminTiers.forEach((role) => {
+    expect(isAdminTierRole(role)).toBe(true)
+  })
+
+  const nonAdmin: UserRole[] = ['ISSO', 'ISSM']
+  nonAdmin.forEach((role) => {
+    expect(isAdminTierRole(role)).toBe(false)
+  })
+})
+
+test('all helpers reject null, undefined, and empty-role placeholder users', () => {
+  const placeholder = { role: '' as UserRole }
+  ;[null, undefined, placeholder].forEach((user) => {
+    expect(isAdmin(user)).toBe(false)
+    expect(isReadOnlyAdmin(user)).toBe(false)
+    expect(hasAdminRead(user)).toBe(false)
+    expect(hasUnscopedRead(user)).toBe(false)
+    expect(hasSystemAccess(user)).toBe(false)
+  })
+})
+
+test('role-string helpers reject unknown strings', () => {
+  const unknown = ['', 'admin', 'SUPERUSER', 'OPDIV-ADMIN', 'OWNERS']
+  unknown.forEach((role) => {
+    expect(isWriteAdminRole(role)).toBe(false)
+    expect(isReadOnlyAdminRole(role)).toBe(false)
+    expect(isAdminTierRole(role)).toBe(false)
+  })
+})

--- a/src/utils/userRoles.test.ts
+++ b/src/utils/userRoles.test.ts
@@ -5,6 +5,8 @@ import {
   hasUnscopedRead,
   isAdmin,
   isAdminTierRole,
+  isHHSTier,
+  isOpDivTier,
   isReadOnlyAdmin,
   isReadOnlyAdminRole,
   isWriteAdminRole,
@@ -74,6 +76,30 @@ const hasSystemAccessCases: Case[] = [
   ['ISSM', true],
 ]
 
+const isHHSTierCases: Case[] = [
+  ['HHS_ADMIN', true],
+  ['HHS_READONLY_ADMIN', true],
+  ['OWNER', false],
+  ['OPDIV_ADMIN', false],
+  ['OPDIV_READONLY_ADMIN', false],
+  ['ISSO', false],
+  ['ISSM', false],
+  ['ADMIN', false], // legacy is CMS-tenant pre-migration, not HHS tier
+  ['READONLY_ADMIN', false],
+]
+
+const isOpDivTierCases: Case[] = [
+  ['OPDIV_ADMIN', true],
+  ['OPDIV_READONLY_ADMIN', true],
+  ['OWNER', false],
+  ['HHS_ADMIN', false],
+  ['HHS_READONLY_ADMIN', false],
+  ['ISSO', false],
+  ['ISSM', false],
+  ['ADMIN', false],
+  ['READONLY_ADMIN', false],
+]
+
 test.each(isAdminCases)('isAdmin(%s) === %s', (role, expected) => {
   expect(isAdmin(roleUser(role))).toBe(expected)
   expect(isWriteAdminRole(role)).toBe(expected)
@@ -119,6 +145,32 @@ test.each(hasSystemAccessCases)(
   }
 )
 
+test.each(isHHSTierCases)('isHHSTier(%s) === %s', (role, expected) => {
+  expect(isHHSTier(roleUser(role))).toBe(expected)
+})
+
+test.each(isOpDivTierCases)('isOpDivTier(%s) === %s', (role, expected) => {
+  expect(isOpDivTier(roleUser(role))).toBe(expected)
+})
+
+test('HHS and OpDiv tiers are mutually exclusive', () => {
+  const allRoles: UserRole[] = [
+    'OWNER',
+    'HHS_ADMIN',
+    'HHS_READONLY_ADMIN',
+    'OPDIV_ADMIN',
+    'OPDIV_READONLY_ADMIN',
+    'ISSO',
+    'ISSM',
+    'ADMIN',
+    'READONLY_ADMIN',
+  ]
+  allRoles.forEach((role) => {
+    const user = roleUser(role)
+    expect(isHHSTier(user) && isOpDivTier(user)).toBe(false)
+  })
+})
+
 test('isAdminTierRole returns true for every admin tier (write or read-only)', () => {
   const adminTiers: UserRole[] = [
     'OWNER',
@@ -147,6 +199,8 @@ test('all helpers reject null, undefined, and empty-role placeholder users', () 
     expect(hasAdminRead(user)).toBe(false)
     expect(hasUnscopedRead(user)).toBe(false)
     expect(hasSystemAccess(user)).toBe(false)
+    expect(isHHSTier(user)).toBe(false)
+    expect(isOpDivTier(user)).toBe(false)
   })
 })
 

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -1,0 +1,55 @@
+import type { userData, UserRole } from '@/types'
+
+const WRITE_ADMIN_ROLES = new Set<UserRole>([
+  'OWNER',
+  'HHS_ADMIN',
+  'OPDIV_ADMIN',
+  'ADMIN', // legacy, removed in Stage D
+])
+
+const READ_ONLY_ADMIN_ROLES = new Set<UserRole>([
+  'HHS_READONLY_ADMIN',
+  'OPDIV_READONLY_ADMIN',
+  'READONLY_ADMIN', // legacy, removed in Stage D
+])
+
+const UNSCOPED_READ_ROLES = new Set<UserRole>([
+  'OWNER',
+  'HHS_ADMIN',
+  'HHS_READONLY_ADMIN',
+  'ADMIN', // legacy, removed in Stage D
+  'READONLY_ADMIN', // legacy, removed in Stage D
+])
+
+const SYSTEM_SCOPED_ROLES = new Set<UserRole>(['ISSO', 'ISSM'])
+
+type UserLike = Pick<userData, 'role'> | null | undefined
+
+export const isWriteAdminRole = (role: string): boolean =>
+  WRITE_ADMIN_ROLES.has(role as UserRole)
+
+export const isReadOnlyAdminRole = (role: string): boolean =>
+  READ_ONLY_ADMIN_ROLES.has(role as UserRole)
+
+export const isAdminTierRole = (role: string): boolean =>
+  isWriteAdminRole(role) || isReadOnlyAdminRole(role)
+
+export const isAdmin = (user: UserLike): boolean =>
+  !!user && isWriteAdminRole(user.role)
+
+export const isReadOnlyAdmin = (user: UserLike): boolean =>
+  !!user && isReadOnlyAdminRole(user.role)
+
+export const hasAdminRead = (user: UserLike): boolean =>
+  isAdmin(user) || isReadOnlyAdmin(user)
+
+export const hasUnscopedRead = (user: UserLike): boolean =>
+  !!user && UNSCOPED_READ_ROLES.has(user.role as UserRole)
+
+// Row-level OpDiv scoping is server-enforced — the backend narrows the
+// fismaSystems list before it reaches the frontend, so this gate only needs
+// to decide whether the user belongs to a tier that gets system-detail UI at
+// all (any admin tier + ISSO/ISSM).
+export const hasSystemAccess = (user: UserLike): boolean =>
+  hasAdminRead(user) ||
+  (!!user && SYSTEM_SCOPED_ROLES.has(user.role as UserRole))

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -46,10 +46,21 @@ export const hasAdminRead = (user: UserLike): boolean =>
 export const hasUnscopedRead = (user: UserLike): boolean =>
   !!user && UNSCOPED_READ_ROLES.has(user.role as UserRole)
 
-// Row-level OpDiv scoping is server-enforced — the backend narrows the
+// Row-level OpDiv scoping is server-enforced - the backend narrows the
 // fismaSystems list before it reaches the frontend, so this gate only needs
 // to decide whether the user belongs to a tier that gets system-detail UI at
 // all (any admin tier + ISSO/ISSM).
 export const hasSystemAccess = (user: UserLike): boolean =>
   hasAdminRead(user) ||
   (!!user && SYSTEM_SCOPED_ROLES.has(user.role as UserRole))
+
+// Tier membership checks mirror the backend's IsHHSTier and IsOpDivTier
+// helpers. Both cover the read-only variant of the tier, so callers must
+// not use these as a write gate - use isAdmin for that. Stage 2+ UI work
+// (OpDiv badges, scoped admin panels) will be the first consumer.
+export const isHHSTier = (user: UserLike): boolean =>
+  !!user && (user.role === 'HHS_ADMIN' || user.role === 'HHS_READONLY_ADMIN')
+
+export const isOpDivTier = (user: UserLike): boolean =>
+  !!user &&
+  (user.role === 'OPDIV_ADMIN' || user.role === 'OPDIV_READONLY_ADMIN')

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -31,6 +31,7 @@ import BarChartIcon from '@mui/icons-material/BarChart'
 import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresModal'
 // import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import { FismaTableProps } from '@/types'
+import { hasSystemAccess } from '@/utils/userRoles'
 type selectedRowsType = GridRowId[]
 declare module '@mui/x-data-grid' {
   interface FooterPropsOverrides {
@@ -241,11 +242,7 @@ const pillarScoresCache = new Map<number, CachedScore>()
 export default function FismaTable({ scores }: FismaTableProps) {
   const apiRef = useGridApiRef()
   const { fismaSystems, latestDataCallId, userInfo } = useContextProp()
-  const hasSystemDetailAccess =
-    userInfo.role === 'ADMIN' ||
-    userInfo.role === 'READONLY_ADMIN' ||
-    userInfo.role === 'ISSO' ||
-    userInfo.role === 'ISSM'
+  const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
   const [selectedRows, setSelectedRows] = useState<GridRowId[]>([])

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/constants'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
+import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -90,8 +91,7 @@ export default function QuestionnarePage() {
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
-    userInfo.role === 'READONLY_ADMIN' ||
-    (isPastDeadline && userInfo.role !== 'ADMIN')
+    isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
     {}
   )

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -37,6 +37,7 @@ import {
   PILLAR_FUNCTION_MAP,
 } from '@/constants'
 import { useContextProp } from '../Title/Context'
+import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 const CssTextField = styled(TextField)({
   '& label.Mui-focused': {
     color: 'rgb(13, 36, 153)',
@@ -77,8 +78,7 @@ export default function QuestionnareModal({
   const { userInfo } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
-    userInfo.role === 'READONLY_ADMIN' ||
-    (isPastDeadline && userInfo.role !== 'ADMIN')
+    isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const checkValidResponse = (status: number) => {
     if (status !== 200 && status.toString()[0] === '4') {
       navigate(Routes.SIGNIN, {

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -17,6 +17,7 @@ import {
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import { getTodayISO, truncateNotes } from '@/utils/decommission'
+import { isAdmin as checkIsAdmin } from '@/utils/userRoles'
 
 import SystemDetailHeader from './SystemDetailHeader'
 import SystemDetailReadView from './SystemDetailReadView'
@@ -29,7 +30,7 @@ export default function SystemDetailPage() {
   const { enqueueSnackbar } = useSnackbar()
   const { fismaSystems, setFismaSystems, userInfo } = useContextProp()
 
-  const isAdmin = userInfo.role === 'ADMIN'
+  const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
 
   const system = useMemo(

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -4,7 +4,11 @@ import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import 'core-js/stable/atob'
-import { userData } from '@/types'
+import { userData, UserRole } from '@/types'
+import {
+  isAdmin as checkIsAdmin,
+  hasAdminRead as checkHasAdminRead,
+} from '@/utils/userRoles'
 import { Box } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -32,7 +36,7 @@ const emptyUser: userData = {
   userid: '',
   email: '',
   fullname: '',
-  role: '',
+  role: '' as UserRole,
   assignedfismasystems: [],
 }
 
@@ -133,9 +137,8 @@ export default function Title() {
   const handleDataCallClose = () => {
     setOpenDataCallModal(false)
   }
-  const isAdmin = userInfo.role === 'ADMIN'
-  const hasAdminRead =
-    userInfo.role === 'ADMIN' || userInfo.role === 'READONLY_ADMIN'
+  const isAdmin = checkIsAdmin(userInfo)
+  const hasAdminRead = checkHasAdminRead(userInfo)
   return (
     <>
       <UsaBanner />

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -41,6 +41,7 @@ import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
 import axiosInstance from '@/axiosConfig'
 import { users } from '@/types'
+import { isAdmin as checkIsAdmin, isAdminTierRole } from '@/utils/userRoles'
 import { useContextProp } from '../Title/Context'
 import Box from '@mui/material/Box'
 import CustomSnackbar from '../Snackbar/Snackbar'
@@ -132,7 +133,7 @@ export default function UserTable() {
   const navigate = useNavigate()
   const { enqueueSnackbar } = useSnackbar()
   const { userInfo, fismaSystems } = useContextProp()
-  const isAdmin = userInfo.role === 'ADMIN'
+  const isAdmin = checkIsAdmin(userInfo)
   useEffect(() => {
     if (userInfo.role && !isAdmin) {
       navigate(Routes.ROOT, { replace: true })
@@ -172,10 +173,7 @@ export default function UserTable() {
               params.id,
               'fullname'
             )
-            if (
-              event.target.value === 'ADMIN' ||
-              event.target.value === 'READONLY_ADMIN'
-            ) {
+            if (isAdminTierRole(event.target.value as string)) {
               setUserName(fullname)
               setSelectedRole(event.target.value)
               setOpenAlert(true)
@@ -214,7 +212,7 @@ export default function UserTable() {
     userid: '',
     email: '',
     fullname: '',
-    role: '',
+    role: '' as users['role'],
     assignedfismasystems: [],
   })
   const [userName, setUserName] = useState<string | undefined>(undefined)


### PR DESCRIPTION
## Where this fits

The multi-OpDiv frontend work is rolling out in five stages. Naming follows the handoff doc at `tmp/frontend-stage1-handoff.md`.

| Stage | Scope | Status |
| --- | --- | --- |
| **1** | **This PR.** Role taxonomy expansion, type updates, helper module, `/api/v1/opdivs` client | Open |
| 2 | Multi-IdP auth, pre-auth lookup, `identity_provider` surfacing | Not started (`#328`, `#329`) |
| 3 | OpDiv selectors, badges, `opdiv_id` surfacing, UI consumers of `/api/v1/opdivs` | Not started |
| 4 | Grant management UI (`users_opdivs` assign/revoke) | Not started |
| 5 | Drop legacy `ADMIN` / `READONLY_ADMIN` once the backend stops returning them | Blocked on backend (`#357`) |

The backend runs a parallel "Stage A through D" sequence covering the same migration server-side. "Stage D" is the point at which the backend stops accepting and emitting the legacy role values.

## Summary

Stage 1 of the multi-OpDiv frontend rollout. Pairs with backend PR `CMS-Enterprise/ztmf#316` (branch `feature/multi-opdiv-schema`).

- Adds `UserRole` union covering the new tiers: `OWNER`, `HHS_ADMIN`, `HHS_READONLY_ADMIN`, `OPDIV_ADMIN`, `OPDIV_READONLY_ADMIN`. Legacy `ADMIN` / `READONLY_ADMIN` remain valid through the Stage D back-compat window.
- Introduces `src/utils/userRoles.ts` as the single source of truth for role predicates (`isAdmin`, `isReadOnlyAdmin`, `hasAdminRead`, `hasUnscopedRead`, `hasSystemAccess`, `isHHSTier`, `isOpDivTier`, plus role-string variants). Stage D legacy drop will touch one file.
- `isHHSTier` and `isOpDivTier` mirror the backend's `IsHHSTier` and `IsOpDivTier` helpers (renamed from `IsHHSAdmin` / `IsOpDivAdmin` to make explicit that they cover the read-only variant). Tier-membership check, not a write gate.
- Replaces 8 inline `userInfo.role === 'ADMIN' / 'READONLY_ADMIN'` literal sites across `Title`, `UserTable`, `SystemDetailPage`, `FismaTable`, `QuestionnairePage`, and `QuestionnareModal` with helper calls.
- Wires `GET /api/v1/opdivs` into the client layer via `fetchOpDivs` in `src/utils/opdivs.ts`. No UI caller yet; published so Stage 2+ work has a typed call site.
- Adds additive types for `identity_provider`, `assignedopdivids`, `FismaSystem.opdiv_id`, and a full `OpDiv` type. Frontend reads none of them at Stage 1.
- Adds `src/utils/userRoles.test.ts`: 73-case regression contract pinning the role taxonomy across every predicate, including explicit assertions on the legacy `ADMIN` / `READONLY_ADMIN` strings. Stage D removal will remove the corresponding test rows in the same PR, forcing the legacy drop to be an intentional, named change rather than a silent regression.

## Merge order

**Backend `CMS-Enterprise/ztmf#316` must merge and deploy to dev before this PR merges.** The new `identity_provider`, `assignedopdivids`, and `opdiv_id` fields plus the `/api/v1/opdivs` endpoint need to be live on the paired backend before the frontend types and client helpers have a real backing to consume. Frontend back-compat handles the legacy role strings so this PR is safe to sit open until the backend lands.

## Out of scope (later stages)

- Multi-IdP auth / pre-auth lookup endpoint — Stage 2 (`#328`, `#329`)
- OpDiv dropdown on system create/edit — Stage 3
- OpDiv badge or filter in list views — Stage 3
- Surfacing `opdiv_id` on system pages — Stage 3
- Grant management UI (assign/revoke users to OpDivs) — Stage 4
- Calling `fetchOpDivs` from any UI surface — Stage 2/3
- Surfacing `identity_provider` or `assignedopdivids` in UI — Stage 2
- Removing legacy `ADMIN` / `READONLY_ADMIN` from helpers — Stage 5

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 73 passed / 3 skipped / 0 failed
- [x] Pre-push hooks clean (typecheck + lint)
- [x] Independent code review — no critical findings
- [ ] After paired backend `CMS-Enterprise/ztmf#316` deploys to dev: smoke against current backend confirming the legacy `ADMIN` and `READONLY_ADMIN` paths still render admin UI; confirm `ISSO` continues to see only assigned systems.
- [ ] Once paired backend lands, re-verify the new role tiers (`OWNER`, `HHS_ADMIN`, `HHS_READONLY_ADMIN`, `OPDIV_ADMIN`, `OPDIV_READONLY_ADMIN`) each render the expected scope of UI. Confirm `/users/current` returns `identity_provider` and `assignedopdivids`; confirm `/opdivs` returns the reference list via `fetchOpDivs`.

## References

- Handoff doc: `tmp/frontend-stage1-handoff.md`
- Backend pair PR: `CMS-Enterprise/ztmf#316` (branch `feature/multi-opdiv-schema`)
- Related issues: `CMS-Enterprise/ztmf-ui#328`, `#329`, `CMS-Enterprise/ztmf-misc#170`, `#198`, `CMS-Enterprise/ztmf#266`