### PR TITLE
fix(questionnaire): handle null data, drop preemptive disable

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -418,13 +418,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
       disableColumnMenu: true,
       renderCell: (params: GridRenderCellParams) => (
         <>
-          <Tooltip
-            title={
-              params.row.decommissioned
-                ? 'Decommissioned systems have no active questionnaire'
-                : 'Questionnaire'
-            }
-          >
+          <Tooltip title="Questionnaire">
             <span>
               <GridActionsCellItem
                 icon={<QuestionAnswerOutlinedIcon />}
@@ -432,12 +426,8 @@ export default function FismaTable({ scores }: FismaTableProps) {
                 label={`View Questionnaire for ${params.row.fismaname}`}
                 className="textPrimary"
                 role="button"
-                disabled={params.row.decommissioned === true}
                 onClick={(event) => {
                   event.stopPropagation()
-                  if (params.row.decommissioned) {
-                    return
-                  }
                   navigate(
                     `/${RouteNames.QUESTIONNAIRE}/${params.row.fismaacronym.toLowerCase()}`,
                     {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -588,7 +588,9 @@ export default function QuestionnarePage() {
         <BreadCrumbs />
         <Container>
           <Alert severity="info" sx={{ mt: 2 }}>
-            This system is decommissioned and has no active questionnaire.
+            No questionnaire is available for this system. This typically
+            applies to systems whose data center environment is no longer in
+            scope for the current data call.
           </Alert>
         </Container>
       </>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -335,11 +335,14 @@ export default function QuestionnarePage() {
           await axiosInstance
             .get(`/fismasystems/${system}/questions`)
             .then((response) => {
-              const data = response.data.data
               // Decommissioned systems join to zero functions, so the questions
-              // endpoint returns an empty array. Surface a friendly message
-              // instead of crashing on categoriesData[0] below.
-              if (Array.isArray(data) && data.length === 0) {
+              // endpoint returns no rows. The Go backend serializes a nil
+              // slice as JSON null, so the response can be either { data: null }
+              // or { data: [] } depending on driver behavior - treat both as
+              // the empty-state signal. Surface a friendly message instead of
+              // crashing on categoriesData[0] below.
+              const data = response.data?.data
+              if (!data || (Array.isArray(data) && data.length === 0)) {
                 questionsEmpty = true
                 setNoQuestions(true)
                 setLoadingQuestion(false)


### PR DESCRIPTION
## Summary

Follow-up to `#358`. The previous PR shipped the initial empty-state guard, but two follow-up commits never reached dev because the `orchestration-dev.yml` workflow trigger omits the `synchronize` event type, so pushes to a merged PR's branch do not redeploy. The two missing commits are landed here against `main`.

## What this PR adds

### 1. Treat null `data` as the empty-questions signal

The Go backend at `internal/model/questions.go` returns `[]*Question`. `encoding/json` marshals a nil slice as JSON `null`, not `[]`, so the actual production response on a system with no matching `functions` row is `{ data: null }`. The previous guard checked only `Array.isArray(data) && data.length === 0`, missed the null case, and dropped through to `data.forEach(...)` which threw a TypeError. The `.catch` then surfaced the same generic "An error occurred" snackbar the original fix was meant to remove.

Widened to:

```ts
const data = response.data?.data
if (!data || (Array.isArray(data) && data.length === 0)) {
  ...
}
```

Comment in the source explains the Go nil-slice rationale so the next reader does not silently undo it. Truly malformed responses (5xx, network errors, axios parse failures) still hit the existing `.catch` path, so no regression-misattribution risk.

### 2. Drop the preemptive FismaTable disable, reword the empty-state Alert

The `#358` revision preemptively disabled the questionnaire row action for any row with `decommissioned === true`. That was based on the assumption that decommissioned systems always carry `datacenterenvironment = 'DECOMMISSIONED'`. Backend inspection refutes that.

`DeleteFismaSystem` (`internal/model/fismasystems.go:191-203`) only writes the `decommissioned` boolean and audit columns. It never touches `datacenterenvironment`. The `'DECOMMISSIONED'` environment value comes from two narrow paths:

- Migration `0016decommissionfismasystems.go` backfilled `decommissioned=TRUE` for any row that had been retired via the prior workaround of manually editing `datacenterenvironment` to `'DECOMMISSIONED'`.
- Any post-hoc manual edit of a system's environment to that value.

Practical impact: modern-decommissioned systems retain their real datacenter environment, so the `/questions` join still returns rows. Those systems should continue rendering questionnaire history for audit and compliance review. The preemptive disable blocked that legitimate path.

Disable removed. The page-level empty-state guard handles the empty cases without preempting valid rows.

Alert wording also reworded — the prior copy claimed "This system is decommissioned and has no active questionnaire," which is false for the active-with-manual-DECOMMISSIONED-env case. New copy is framed around the actual signal: "No questionnaire is available for this system. This typically applies to systems whose data center environment is no longer in scope for the current data call."

## Workflow trigger follow-up (separate concern)

`.github/workflows/orchestration-dev.yml` lists only `opened` and `reopened` for the `pull_request` trigger. The standard `synchronize` event (commits pushed to the PR branch) is missing, so pushes to a live PR's branch do not redeploy to dev. The same likely applies to `orchestration-prod.yml` and `orchestration-impl.yml`. Filing a follow-up issue rather than fixing it here so the workflow change can be reviewed on its own.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 73 passed / 3 skipped / 0 failed
- [x] Pre-push hooks clean
- [x] Two independent code reviews on the upstream commits — all critical findings addressed before this PR
- [x] Dev smoke: open `/questionnaire/hitech` (legacy retired system, env still `'DECOMMISSIONED'`) — friendly Alert renders, no console error, no snackbar.
- [x] Dev smoke: open a questionnaire for a modern-decommissioned system (one with a real environment) — questionnaire renders against its historical data call. Audit/compliance read path preserved.
- [x] Dev smoke: open an active-system questionnaire from FismaTable — questions render normally, behavior unchanged.
- [x] Dev smoke: paste any questionnaire URL into a fresh tab (no `location.state`) — page renders the "open from system list" Alert, no console error.

## References

- `#358` — initial empty-state guard PR (merged)