### PR TITLE
Last-edited footer on questionnaire and responsive layout cleanup

### DIFF
--- a/src/components/BreadCrumbs/BreadCrumbs.test.tsx
+++ b/src/components/BreadCrumbs/BreadCrumbs.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import BreadCrumbs from './BreadCrumbs'
+
+function renderAt(pathname: string, segmentLabels?: Record<string, string>) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <BreadCrumbs segmentLabels={segmentLabels} />
+    </MemoryRouter>
+  )
+}
+
+describe('BreadCrumbs', () => {
+  it('renders Dashboard root link', () => {
+    renderAt('/questionnaire/aco-ms')
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('capitalizes lowercase segments and replaces hyphen with space by default', () => {
+    renderAt('/questionnaire/aco-ms')
+    // 'aco-ms' becomes 'Aco ms' — the case that prompted the segmentLabels
+    // override on the questionnaire page.
+    expect(screen.getByText('Aco ms')).toBeInTheDocument()
+  })
+
+  it('passes through segments that already start uppercase', () => {
+    renderAt('/questionnaire/aco-ms/FY2026_Q1')
+    expect(screen.getByText('FY2026 Q1')).toBeInTheDocument()
+  })
+
+  it('honors segmentLabels override and preserves casing/hyphens', () => {
+    renderAt('/questionnaire/aco-ms/FY2026_Q1', { 'aco-ms': 'ACO-MS' })
+    expect(screen.getByText('ACO-MS')).toBeInTheDocument()
+    expect(screen.queryByText('Aco ms')).not.toBeInTheDocument()
+  })
+
+  it('renders Dashboard as plain text on root path', () => {
+    renderAt('/')
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('decodes percent-encoded segments before displaying', () => {
+    renderAt('/questionnaire/Acumen%20gss')
+    expect(screen.getByText('Acumen gss')).toBeInTheDocument()
+    expect(screen.queryByText(/Acumen%20gss/)).not.toBeInTheDocument()
+  })
+
+  it('matches segmentLabels against decoded keys', () => {
+    renderAt('/questionnaire/acumen%20gss', { 'acumen gss': 'ACUMEN-GSS' })
+    expect(screen.getByText('ACUMEN-GSS')).toBeInTheDocument()
+  })
+})

--- a/src/components/BreadCrumbs/BreadCrumbs.tsx
+++ b/src/components/BreadCrumbs/BreadCrumbs.tsx
@@ -36,7 +36,14 @@ export default function BreadCrumbs({ segmentLabels }: BreadCrumbsProps) {
     </Typography>,
   ]
   const crumbs = location.pathname.split('/').filter((x) => x)
-  const path = crumbs.map((value) => {
+  const path = crumbs.map((rawValue) => {
+    const value = (() => {
+      try {
+        return decodeURIComponent(rawValue)
+      } catch {
+        return rawValue
+      }
+    })()
     const displayText =
       segmentLabels && segmentLabels[value]
         ? segmentLabels[value]

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,13 @@ export type questionPillar = {
   order: number
 }
 
+export type LastEditedBy = {
+  userid: string
+  name: string
+  email: string
+  role?: UserRole
+}
+
 export type QuestionScores = {
   scoreid: number
   fismasystemid: number
@@ -121,6 +128,8 @@ export type QuestionScores = {
   notes: string
   functionoptionid: number
   datacallid: number
+  last_edited_at?: string | null
+  last_edited_by?: LastEditedBy | null
 }
 
 export type Question = {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -325,6 +325,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
       headerName: 'ISSO Name',
       flex: 1.2,
       minWidth: 120,
+      maxWidth: 240,
       hideable: false,
       valueGetter: (value) => {
         const name = value.row.issoemail.split('@')
@@ -349,9 +350,9 @@ export default function FismaTable({ scores }: FismaTableProps) {
       field: 'Score',
       headerName: 'Zero Trust Score',
       type: 'number',
-      flex: 1,
-      minWidth: 140,
+      width: 160,
       align: 'center',
+      headerAlign: 'center',
       hideable: false,
       valueGetter: (value) => {
         const entry = scores[value.row.fismasystemid]

--- a/src/views/QuestionnairePage/LastEditedFooter.test.tsx
+++ b/src/views/QuestionnairePage/LastEditedFooter.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import LastEditedFooter from './LastEditedFooter'
+import { LastEditedBy } from '@/types'
+
+describe('LastEditedFooter', () => {
+  const editor: LastEditedBy = {
+    userid: '9f000000-0000-0000-0000-000000000001',
+    name: 'John Smith',
+    email: 'john.smith@cms.hhs.gov',
+    role: 'ISSO',
+  }
+
+  it('renders nothing when lastEditedAt is null', () => {
+    const { container } = render(
+      <LastEditedFooter lastEditedAt={null} lastEditedBy={null} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when lastEditedAt is undefined', () => {
+    const { container } = render(<LastEditedFooter />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when lastEditedBy is null but timestamp present', () => {
+    const { container } = render(
+      <LastEditedFooter
+        lastEditedAt="2026-04-14T22:12:40Z"
+        lastEditedBy={null}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders name + role + formatted date when fully populated', () => {
+    render(
+      <LastEditedFooter
+        lastEditedAt="2026-04-14T22:12:40Z"
+        lastEditedBy={editor}
+      />
+    )
+    const caption = screen.getByText(/Last edited by John Smith \(ISSO\) —/)
+    expect(caption).toBeInTheDocument()
+  })
+
+  it('omits role parens when role is absent', () => {
+    const { name, email, userid } = editor
+    render(
+      <LastEditedFooter
+        lastEditedAt="2026-04-14T22:12:40Z"
+        lastEditedBy={{ name, email, userid }}
+      />
+    )
+    const caption = screen.getByText(/Last edited by John Smith —/)
+    expect(caption).toBeInTheDocument()
+    expect(caption.textContent).not.toMatch(/\(/)
+  })
+
+  it('renders nothing when lastEditedAt is an empty string', () => {
+    const { container } = render(
+      <LastEditedFooter lastEditedAt="" lastEditedBy={editor} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when lastEditedBy.name is an empty string', () => {
+    const { container } = render(
+      <LastEditedFooter
+        lastEditedAt="2026-04-14T22:12:40Z"
+        lastEditedBy={{ ...editor, name: '' }}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('falls back to raw iso when timestamp is unparseable', () => {
+    render(<LastEditedFooter lastEditedAt="not-a-date" lastEditedBy={editor} />)
+    expect(screen.getByText(/not-a-date/)).toBeInTheDocument()
+  })
+
+  it('exposes email + iso in tooltip title attribute', () => {
+    render(
+      <LastEditedFooter
+        lastEditedAt="2026-04-14T22:12:40Z"
+        lastEditedBy={editor}
+      />
+    )
+    // MUI Tooltip sets aria-label on the child via a wrapping span; the
+    // title prop is rendered to the DOM after hover. We assert the
+    // tooltip-bearing element exposes the email + iso content via
+    // aria-label or title fallback on the typography element.
+    const caption = screen.getByText(/Last edited by John Smith/)
+    // Walk up to the element MUI Tooltip wraps with aria-label.
+    const wrapper = caption.closest('[aria-label]') ?? caption.parentElement
+    expect(wrapper?.getAttribute('aria-label') ?? '').toMatch(
+      /john\.smith@cms\.hhs\.gov/
+    )
+  })
+})

--- a/src/views/QuestionnairePage/LastEditedFooter.tsx
+++ b/src/views/QuestionnairePage/LastEditedFooter.tsx
@@ -1,0 +1,40 @@
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { LastEditedBy } from '@/types'
+
+type Props = {
+  lastEditedAt?: string | null
+  lastEditedBy?: LastEditedBy | null
+}
+
+function formatHumanDate(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+export default function LastEditedFooter({
+  lastEditedAt,
+  lastEditedBy,
+}: Props) {
+  if (!lastEditedAt || !lastEditedBy || !lastEditedBy.name) return null
+
+  const { name, email, role } = lastEditedBy
+  const caption = `Last edited by ${name}${role ? ` (${role})` : ''} — ${formatHumanDate(lastEditedAt)}`
+  const tooltip = `${email} · ${lastEditedAt}`
+
+  return (
+    <Tooltip title={tooltip} placement="top">
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', textAlign: 'center', mt: 1 }}
+      >
+        {caption}
+      </Typography>
+    </Tooltip>
+  )
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -145,16 +145,24 @@ export default function QuestionnarePage() {
   }
   const renderRadioGroup = (options: QuestionChoice[]) => {
     return (
-      <ChoiceList
-        choices={options}
-        name={'radio-choices'}
-        type={'radio'}
-        label={undefined}
-        className="ds-u-margin-top--05"
-        size="small"
-        onChange={handleChoiceChange}
-        disabled={isReadOnly}
-      />
+      <Box
+        sx={{
+          '& .ds-c-choice-wrapper': {
+            maxWidth: 'none',
+          },
+        }}
+      >
+        <ChoiceList
+          choices={options}
+          name={'radio-choices'}
+          type={'radio'}
+          label={undefined}
+          className="ds-u-margin-top--05"
+          size="small"
+          onChange={handleChoiceChange}
+          disabled={isReadOnly}
+        />
+      </Box>
     )
   }
 

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -614,7 +614,7 @@ export default function QuestionnarePage() {
       )}
       <Container maxWidth={false} disableGutters>
         <Grid container columnSpacing={2} sx={{ mt: 2 }}>
-          <Grid item xs={12} md={3}>
+          <Grid item xs={3}>
             <List
               sx={{
                 width: '100%',
@@ -623,7 +623,7 @@ export default function QuestionnarePage() {
                 position: 'relative',
                 overflow: 'auto',
                 overflowX: 'hidden',
-                maxHeight: { xs: 300, md: 'calc(100vh - 240px)' },
+                maxHeight: 'calc(100vh - 240px)',
                 '& ul': { padding: 0 },
                 msOverflowStyle: 'none', // Hide scrollbar in IE/Edge
                 '&::-webkit-scrollbar': { display: 'none' },
@@ -694,7 +694,7 @@ export default function QuestionnarePage() {
               ))}
             </List>
           </Grid>
-          <Grid item xs={12} md={9}>
+          <Grid item xs={9}>
             <Box>
               <Box
                 sx={{

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -34,6 +34,7 @@ import {
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
+import LastEditedFooter from './LastEditedFooter'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -519,6 +520,10 @@ export default function QuestionnarePage() {
   }, [system, navigate, fismaacronym, enqueueSnackbar])
   React.useEffect(() => {
     if (questionId) {
+      // Clear saved-state markers before async load so the last-edited
+      // footer does not flash the previous question's editor during the
+      // refetch window.
+      setInitQuestionChoice(-1)
       const choices: QuestionChoice[] = []
       let funcOptId: number = 0
       try {
@@ -569,11 +574,14 @@ export default function QuestionnarePage() {
       }
     }
   }, [questionId, questionScores, questions, navigate])
+  const breadcrumbSegmentLabels = fismaacronym
+    ? { [fismaacronym]: fismaacronym.toUpperCase() }
+    : undefined
   if (!system) {
     return (
       <>
-        <BreadCrumbs />
-        <Container>
+        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Container maxWidth={false} disableGutters>
           <Alert severity="warning" sx={{ mt: 2 }}>
             Cannot load questionnaire from a direct link. Please open it from
             the system list.
@@ -585,8 +593,8 @@ export default function QuestionnarePage() {
   if (noQuestions) {
     return (
       <>
-        <BreadCrumbs />
-        <Container>
+        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Container maxWidth={false} disableGutters>
           <Alert severity="info" sx={{ mt: 2 }}>
             No questionnaire is available for this system. This typically
             applies to systems whose data center environment is no longer in
@@ -598,15 +606,15 @@ export default function QuestionnarePage() {
   }
   return (
     <>
-      <BreadCrumbs />
+      <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
           This datacall has closed. Changes will be recorded as post-deadline.
         </Alert>
       )}
-      <Container>
+      <Container maxWidth={false} disableGutters>
         <Grid container columnSpacing={2} sx={{ mt: 2 }}>
-          <Grid item xs={3}>
+          <Grid item xs={12} md={3}>
             <List
               sx={{
                 width: '100%',
@@ -615,7 +623,7 @@ export default function QuestionnarePage() {
                 position: 'relative',
                 overflow: 'auto',
                 overflowX: 'hidden',
-                maxHeight: 600,
+                maxHeight: { xs: 300, md: 'calc(100vh - 240px)' },
                 '& ul': { padding: 0 },
                 msOverflowStyle: 'none', // Hide scrollbar in IE/Edge
                 '&::-webkit-scrollbar': { display: 'none' },
@@ -686,7 +694,7 @@ export default function QuestionnarePage() {
               ))}
             </List>
           </Grid>
-          <Grid item xs={9}>
+          <Grid item xs={12} md={9}>
             <Box>
               <Box
                 sx={{
@@ -829,6 +837,20 @@ export default function QuestionnarePage() {
                       {/* <NavigateNextIcon sx={{ pt: '2px' }} /> */}
                     </CmsButton>
                   </Box>
+                  <LastEditedFooter
+                    lastEditedAt={
+                      initQuestionChoice !== -1 &&
+                      questionScores[initQuestionChoice]
+                        ? questionScores[initQuestionChoice].last_edited_at
+                        : null
+                    }
+                    lastEditedBy={
+                      initQuestionChoice !== -1 &&
+                      questionScores[initQuestionChoice]
+                        ? questionScores[initQuestionChoice].last_edited_by
+                        : null
+                    }
+                  />
                 </Box>
               )}
             </Box>

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -23,7 +23,9 @@ import {
   QuestionOption,
   SystemDetailsModalProps,
   QuestionScores,
+  LastEditedBy,
 } from '@/types'
+import LastEditedFooter from '../QuestionnairePage/LastEditedFooter'
 import axiosInstance from '@/axiosConfig'
 import CircularProgress from '@mui/material/CircularProgress'
 import { useSnackbar } from 'notistack'
@@ -115,6 +117,16 @@ export default function QuestionnareModal({
   const [notes, setNotes] = React.useState<string>('')
   const [selectQuestionOption, setSelectQuestionOption] =
     React.useState<number>(0)
+  // Saved-state mirror for the last-edited footer. The page component
+  // tracks an `initQuestionChoice` funcOptId and looks the score up live;
+  // the modal does not, so we cache the two fields directly when the load
+  // effect resolves. Updated alongside `scoreid` / `notes` to stay in
+  // lockstep with the saved score.
+  const [savedLastEditedAt, setSavedLastEditedAt] = React.useState<
+    string | null
+  >(null)
+  const [savedLastEditedBy, setSavedLastEditedBy] =
+    React.useState<LastEditedBy | null>(null)
   const activeCategory = categories[activeCategoryIndex]
   const activeStep = activeCategory?.steps[activeStepIndex]
 
@@ -429,12 +441,20 @@ export default function QuestionnareModal({
             setSelectQuestionOption(0)
             setScoreId(0)
             setNotes('')
+            setSavedLastEditedAt(null)
+            setSavedLastEditedBy(null)
           } else {
             const id = questionScores[funcOptId].scoreid
             const notes = questionScores[funcOptId].notes
             setSelectQuestionOption(funcOptId)
             setScoreId(id)
             setNotes(notes)
+            setSavedLastEditedAt(
+              questionScores[funcOptId].last_edited_at ?? null
+            )
+            setSavedLastEditedBy(
+              questionScores[funcOptId].last_edited_by ?? null
+            )
           }
           setLoadingQuestion(false)
         })
@@ -476,7 +496,7 @@ export default function QuestionnareModal({
   }
   return (
     <>
-      <Dialog open={open} onClose={handClose} maxWidth="lg" fullWidth>
+      <Dialog open={open} onClose={handClose} maxWidth="xl" fullWidth>
         <DialogTitle align="center">
           <div>
             <Typography variant="h3">{'Questionnaire'}</Typography>
@@ -489,14 +509,23 @@ export default function QuestionnareModal({
               post-deadline.
             </Alert>
           )}
-          <Box display="flex" flexDirection="row" sx={{ height: '50vh' }}>
+          <Box
+            display="flex"
+            sx={{
+              flexDirection: { xs: 'column', md: 'row' },
+              height: { xs: 'auto', md: '60vh', lg: '70vh' },
+            }}
+          >
             <Box
               display="flex"
               flexDirection="column"
-              flex={0.3}
               overflow="auto"
               maxHeight="100%"
-              sx={{ paddingRight: '40px' }}
+              sx={{
+                flex: { xs: 1, md: 0.3 },
+                paddingRight: { xs: 0, md: '40px' },
+                mb: { xs: 2, md: 0 },
+              }}
             >
               {categories.map((category, categoryIndex) => (
                 <Box key={category.name} sx={{ mb: 2, mt: 0 }}>
@@ -576,8 +605,8 @@ export default function QuestionnareModal({
               ))}
             </Box>
             <Box
-              flex={0.7}
               sx={{
+                flex: { xs: 1, md: 0.7 },
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
@@ -668,6 +697,10 @@ export default function QuestionnareModal({
                       <NavigateNextIcon sx={{ pt: '2px' }} />
                     </CmsButton>
                   </Box>
+                  <LastEditedFooter
+                    lastEditedAt={savedLastEditedAt}
+                    lastEditedBy={savedLastEditedBy}
+                  />
                 </Box>
               )}
             </Box>

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -511,21 +511,16 @@ export default function QuestionnareModal({
           )}
           <Box
             display="flex"
-            sx={{
-              flexDirection: { xs: 'column', md: 'row' },
-              height: { xs: 'auto', md: '60vh', lg: '70vh' },
-            }}
+            flexDirection="row"
+            sx={{ height: { md: '60vh', lg: '70vh' } }}
           >
             <Box
               display="flex"
               flexDirection="column"
+              flex={0.3}
               overflow="auto"
               maxHeight="100%"
-              sx={{
-                flex: { xs: 1, md: 0.3 },
-                paddingRight: { xs: 0, md: '40px' },
-                mb: { xs: 2, md: 0 },
-              }}
+              sx={{ paddingRight: '40px' }}
             >
               {categories.map((category, categoryIndex) => (
                 <Box key={category.name} sx={{ mb: 2, mt: 0 }}>
@@ -605,8 +600,8 @@ export default function QuestionnareModal({
               ))}
             </Box>
             <Box
+              flex={0.7}
               sx={{
-                flex: { xs: 1, md: 0.7 },
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -117,6 +117,15 @@ export default function QuestionnareModal({
   const [notes, setNotes] = React.useState<string>('')
   const [selectQuestionOption, setSelectQuestionOption] =
     React.useState<number>(0)
+  // Loaded-state snapshot for the dirty check on Next/Back. The product
+  // rule is "save on real change, not on read-through" -- otherwise a
+  // user walking past a question already answered by someone else gets
+  // stamped as the new editor and overwrites the prior cycle's history.
+  // The backend enforces the same rule as defense in depth, but the FE
+  // check saves a wasted PUT roundtrip on every read-through navigation.
+  const [loadedNotes, setLoadedNotes] = React.useState<string>('')
+  const [loadedSelectQuestionOption, setLoadedSelectQuestionOption] =
+    React.useState<number>(0)
   // Saved-state mirror for the last-edited footer. The page component
   // tracks an `initQuestionChoice` funcOptId and looks the score up live;
   // the modal does not, so we cache the two fields directly when the load
@@ -153,7 +162,19 @@ export default function QuestionnareModal({
   }
   const handleQuestionnareNext = () => {
     setLoadingQuestion(true)
-    if (!isReadOnly) {
+    // Dirty check: skip the API call entirely when nothing changed. The
+    // questionnaire intentionally shows last cycle's answer as a default
+    // (rolled forward by copyPreviousScores), so clicking Next without
+    // editing is a read-through, not an edit. PUTting on a read-through
+    // would overwrite the prior cycle's editor in the audit trail with
+    // whoever happens to be scrolling. The backend enforces the same
+    // rule, but skipping here saves the wasted PUT roundtrip.
+    const isReadThrough =
+      !isReadOnly &&
+      scoreid !== 0 &&
+      selectQuestionOption === loadedSelectQuestionOption &&
+      (notes ?? '') === (loadedNotes ?? '')
+    if (!isReadOnly && !isReadThrough) {
       if (scoreid) {
         axiosInstance
           .put(`scores/${scoreid}`, {
@@ -441,6 +462,8 @@ export default function QuestionnareModal({
             setSelectQuestionOption(0)
             setScoreId(0)
             setNotes('')
+            setLoadedSelectQuestionOption(0)
+            setLoadedNotes('')
             setSavedLastEditedAt(null)
             setSavedLastEditedBy(null)
           } else {
@@ -449,6 +472,12 @@ export default function QuestionnareModal({
             setSelectQuestionOption(funcOptId)
             setScoreId(id)
             setNotes(notes)
+            // Snapshot the loaded answer so handleQuestionnareNext can
+            // detect "no real change" and skip the PUT. Without this the
+            // backend's no-op guard still preserves history, but we
+            // would still pay a wasted roundtrip on every Next click.
+            setLoadedSelectQuestionOption(funcOptId)
+            setLoadedNotes(notes)
             setSavedLastEditedAt(
               questionScores[funcOptId].last_edited_at ?? null
             )

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -144,7 +144,10 @@ export default function Title() {
       <UsaBanner />
       <Container
         maxWidth={false}
-        sx={{ px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 } }}
+        sx={{
+          px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+          minWidth: 800,
+        }}
       >
         {loaderData.status == 200 ? (
           <Box
@@ -254,7 +257,10 @@ export default function Title() {
       </Container>
       <Container
         maxWidth={false}
-        sx={{ px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 } }}
+        sx={{
+          px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+          minWidth: 800,
+        }}
       >
         {loaderData.serverError ? (
           <ServerErrorPage />

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -142,7 +142,10 @@ export default function Title() {
   return (
     <>
       <UsaBanner />
-      <Container>
+      <Container
+        maxWidth={false}
+        sx={{ px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 } }}
+      >
         {loaderData.status == 200 ? (
           <Box
             sx={{
@@ -249,7 +252,10 @@ export default function Title() {
           <div></div>
         )}
       </Container>
-      <Container>
+      <Container
+        maxWidth={false}
+        sx={{ px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 } }}
+      >
         {loaderData.serverError ? (
           <ServerErrorPage />
         ) : loaderData.status !== 200 ? (


### PR DESCRIPTION
## Summary

- Adds a per-question footer showing "Last edited by Name (ROLE) on Date" on the questionnaire page and modal. Reads the new optional last_edited_at and last_edited_by fields off the existing Score response. Renders nothing until backend ships them, so this lands ahead non-destructively.
- Widens the page chrome to full viewport with responsive horizontal padding (16, 32, 64, 96, 128px from xs to xl) and enforces a 800px minimum so layout never crushes. Sidebar and content stay side-by-side; below 800 wide the page falls back to horizontal scroll.
- Restores the dirty check on Next in the modal so read-through navigation does not write a fresh event and overwrite the prior cycle's editor in the audit trail.
- Drops the CMS Design System max-width cap on radio choice rows so option text lines up with the question and notes textarea.
- Fixes breadcrumb display: decode percent-encoded segments, and preserve uppercase casing for the fisma acronym (ACO-MS instead of Aco ms, Acumen gss instead of Acumen%20gss).

Closes #310
Closes #349

Depends on CMS-Enterprise/ztmf#319 for the backend fields. The frontend null paths cleanly while the backend PR is in flight.

## Test plan

- [x] yarn dev, sign in as ISSO on an assigned system, open a saved question, footer shows the prior editor and timestamp with email and ISO timestamp on hover
- [x] Edit the answer and click Next, footer on return shows current user as editor
- [x] Click Next on an unchanged question, footer keeps showing the prior editor (no PUT issued)
- [x] Sign in as ADMIN, footer renders on the same questions
- [x] Resize between 800 and 1920 wide, sidebar and content stay side-by-side and use the available space
- [x] Resize below 800 wide, horizontal scroll appears instead of stacking or crushing
- [x] Breadcrumb shows ACO-MS and Acumen gss correctly on systems whose acronym contains a hyphen or space
- [x] yarn lint, npx tsc --noEmit, and yarn jest are clean