### PR TITLE
Add multi-env Makefile pattern for impl/main worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
 # ZTMF UI Development Makefile
 
-.PHONY: help install lint lint-fix format format-check build build-dev test dev clean
+# Auto-detect env from current git branch.
+# impl / feature/impl-* -> impl; everything else -> main.
+# Override on command line: make dev ZTMF_ENV=impl
+ZTMF_ENV ?= $(shell git branch --show-current 2>/dev/null | grep -qE '^(impl|feature/impl-)' && echo impl || echo main)
+-include Makefile.$(ZTMF_ENV)
+
+# Defaults (overridden by Makefile.impl when ZTMF_ENV=impl)
+FRONTEND_PORT ?= 5174
+export VITE_DEV_PORT = $(FRONTEND_PORT)
+
+.PHONY: help install lint lint-fix format format-check build build-dev test dev clean env
 
 # Default target
 help:
+	@echo "Active env: $(ZTMF_ENV) (frontend port $(FRONTEND_PORT))"
+	@echo ""
 	@echo "Available commands:"
+	@echo "  env          - Show resolved env variables"
 	@echo "  install      - Install dependencies"
 	@echo "  lint         - Run linting checks"
 	@echo "  lint-fix     - Run linting with auto-fix"
@@ -57,8 +70,14 @@ test:
 
 # Development server
 dev:
-	@echo "Starting development server..."
-	yarn dev
+	@echo "Starting development server ($(ZTMF_ENV)) on port $(FRONTEND_PORT)..."
+	VITE_DEV_PORT=$(FRONTEND_PORT) yarn dev
+
+# Show resolved env
+env:
+	@echo "ZTMF_ENV       = $(ZTMF_ENV)"
+	@echo "FRONTEND_PORT  = $(FRONTEND_PORT)"
+	@echo "VITE_DEV_PORT  = $(VITE_DEV_PORT)"
 
 # Clean up
 clean:

--- a/Makefile.impl
+++ b/Makefile.impl
@@ -1,0 +1,3 @@
+# impl environment - offset port so main worktree can run alongside.
+# Matches backend Makefile.impl offset convention.
+FRONTEND_PORT = 5175

--- a/Makefile.main
+++ b/Makefile.main
@@ -1,0 +1,3 @@
+# main environment - default ports
+# Vars left at defaults; file exists for symmetry and future overrides.
+FRONTEND_PORT = 5174

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig(({ mode }) => {
 
     server: {
       host: true,
-      port: 5174,
+      port: Number(process.env.VITE_DEV_PORT) || 5174,
       proxy: {
         '/api/v1': {
           target: process.env.VITE_CF_DOMAIN,


### PR DESCRIPTION
## Summary
- Auto-detect `ZTMF_ENV` from the current git branch (`impl` / `feature/impl-*` → impl, else main) and `-include Makefile.$(ZTMF_ENV)` for per-env overrides.
- `Makefile.main` keeps the default frontend port (5174); `Makefile.impl` offsets to 5175 so the main worktree dev server can run alongside.
- `vite.config.ts` now reads `server.port` from `VITE_DEV_PORT` (default 5174), exported by the Makefile.
- Mirrors the backend repo's Makefile.main / Makefile.impl pattern so both worktrees behave consistently.

Override on demand: `make dev ZTMF_ENV=main`.

## Test plan
- [ ] In this worktree (branch impl/feature/impl-*): \`make env\` reports `ZTMF_ENV=impl`, `FRONTEND_PORT=5175`.
- [ ] `make env ZTMF_ENV=main` reports `FRONTEND_PORT=5174`.
- [ ] `make dev` from impl worktree binds 5175; main worktree `make dev` binds 5174; both run simultaneously.
- [ ] `npx tsc --noEmit` clean.