### PR TITLE
Read ZTMF Insights from the new system_enrichment endpoint, gate on sdl_sync_enabled

### DIFF
--- a/src/views/SystemDetailPage/CfactsRecordCard.tsx
+++ b/src/views/SystemDetailPage/CfactsRecordCard.tsx
@@ -95,10 +95,23 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
     setHasError(false)
 
     axiosInstance
-      .get(`cfactssystems/${fismaUid}`)
+      .get(`systemenrichment/${fismaUid}`)
       .then((res) => {
         if (!cancelled) {
-          setCfacts(res.data?.data ?? res.data)
+          // The endpoint returns { data: { fisma_uuid, payload, synced_at } }.
+          // The enrichment fields live in payload; fisma_uuid and synced_at are
+          // top-level siblings. Flatten into the existing shape so the rendering
+          // below is unchanged.
+          const record = res.data?.data
+          setCfacts(
+            record
+              ? {
+                  ...record.payload,
+                  fisma_uuid: record.fisma_uuid,
+                  synced_at: record.synced_at,
+                }
+              : null
+          )
         }
       })
       .catch((error) => {
@@ -108,7 +121,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
             error.response?.status === 403
           ) {
             if (error.response?.status === 403) {
-              console.warn('CFACTS 403 for fismaUid:', fismaUid)
+              console.warn('ZTMF Insights 403 for fismaUid:', fismaUid)
             }
             setNotFound(true)
           } else {
@@ -136,7 +149,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
   if (hasError) {
     return (
       <Typography variant="body2" color="error" sx={{ mt: 1 }}>
-        Failed to load CFACTS data. Please try again.
+        Failed to load ZTMF Insights data. Please try again.
       </Typography>
     )
   }
@@ -144,7 +157,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
   if (notFound || !cfacts) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-        No CFACTS record found.
+        No ZTMF Insights data found.
       </Typography>
     )
   }

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -602,11 +602,13 @@ export default function SystemDetailPage() {
         />
       )}
 
-      {system.fismauid && (
+      {/* ZTMF Insights enrichment is CMS-only for now; gate the whole section on
+          the per-system sdl_sync_enabled toggle (default false for new OpDivs). */}
+      {system.fismauid && system.sdl_sync_enabled && (
         <>
           <Divider sx={{ my: 4 }} />
           <Typography variant="h6" sx={{ mb: 2 }}>
-            CFACTS Record
+            ZTMF Insights
           </Typography>
           <CfactsRecordCard fismaUid={system.fismauid} />
         </>


### PR DESCRIPTION
## Summary

Points the system detail page's enrichment card at the new generic `system_enrichment` endpoint, and gates the section so it only appears for systems opted into ZTMF Insights. This is the frontend half of decoupling ZTMF Insights from the core scoring app.

## Changes

- The enrichment card now reads from `GET /api/v1/systemenrichment/{fisma_uuid}` instead of the old `cfactssystems` endpoint. The new response nests the enrichment fields under `payload`, with `fisma_uuid` and `synced_at` as top-level siblings, so the fetch flattens them back into the shape the card already renders. The display, loading, and 404/403 empty states are unchanged.
- The whole section is now gated on `system.sdl_sync_enabled`. ZTMF Insights is CMS-only for now, and the toggle is off by default, so future HHS and OpDiv systems will not see the section until they opt in.
- Relabeled the user-facing "CFACTS" text to "ZTMF Insights" (section header and empty/error states).

## Testing

- `yarn typecheck` and `yarn lint` pass clean.
- Verified against dev, where the endpoint is live with real enrichment data (the backend shipped in CMS-Enterprise/ztmf#323, deployed to dev and prod).

Refs CMS-Enterprise/ztmf-misc#212
