### PR TITLE
fix(questionaire): implement fixed pillar sorting and add related tests

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,19 @@ export const CONFIRMATION_MESSAGE =
 export const CONFIRMATION_MESSAGE_QUESTION =
   'Your changes will not be saved! Are you sure you want to leave question without saving your changes?'
 
+/**
+ * The fixed order for pillars on the questionnaire, no matter what order the
+ * API returns them in. Each name has to match the API's
+ * `question.pillar.pillar` value exactly (same keys as {@link PILLAR_FUNCTION_MAP}).
+ */
+export const PILLAR_ORDER: string[] = [
+  'Identity',
+  'Devices',
+  'Networks',
+  'Applications',
+  'Data',
+  'CrossCutting',
+]
 export const PILLAR_FUNCTION_MAP: { [key: string]: string[] } = {
   Identity: [
     'AccessManagement',

--- a/src/utils/sortPillars.test.ts
+++ b/src/utils/sortPillars.test.ts
@@ -1,0 +1,36 @@
+import { sortPillars } from '@/utils/sortPillars'
+
+test('orders pillars into the canonical sequence regardless of input order', () => {
+  const input = [
+    'Data',
+    'Identity',
+    'CrossCutting',
+    'Networks',
+    'Devices',
+    'Applications',
+  ]
+
+  expect(sortPillars(input)).toEqual([
+    'Identity',
+    'Devices',
+    'Networks',
+    'Applications',
+    'Data',
+    'CrossCutting',
+  ])
+})
+
+test('places unknown/unmapped pillar names at the end', () => {
+  const input = ['BrandNewPillar', 'Devices', 'Identity']
+
+  expect(sortPillars(input)).toEqual(['Identity', 'Devices', 'BrandNewPillar'])
+})
+
+test('does not mutate the input array', () => {
+  const input = ['Data', 'Identity']
+  const snapshot = [...input]
+
+  sortPillars(input)
+
+  expect(input).toEqual(snapshot)
+})

--- a/src/utils/sortPillars.ts
+++ b/src/utils/sortPillars.ts
@@ -1,0 +1,25 @@
+import { PILLAR_ORDER } from '@/constants'
+
+/**
+ * Finds where a pillar sits in {@link PILLAR_ORDER}. Lower numbers come first.
+ *
+ * @param pillarName - The pillar name from the API (`question.pillar.pillar`).
+ * @returns Where the pillar should sort.
+ */
+const pillarRank = (pillarName: string): number => {
+  const orderIndex = PILLAR_ORDER.indexOf(pillarName)
+  return orderIndex === -1 ? Number.MAX_SAFE_INTEGER : orderIndex
+}
+
+/**
+ * Puts a list of pillar names in the fixed order (see {@link PILLAR_ORDER}:
+ * Identity, Devices, Networks, Applications, Data, CrossCutting). Returns a
+ * new array and leaves the original alone.
+ *
+ * @param pillarNames - The pillar names to sort.
+ * @returns A new array of pillar names in the fixed order.
+ */
+export const sortPillars = (pillarNames: string[]): string[] =>
+  [...pillarNames].sort(
+    (pillarA, pillarB) => pillarRank(pillarA) - pillarRank(pillarB)
+  )

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -31,6 +31,7 @@ import {
   PILLAR_FUNCTION_MAP,
   CONFIRMATION_MESSAGE_QUESTION,
 } from '@/constants'
+import { sortPillars } from '@/utils/sortPillars'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
 type Category = {
@@ -330,11 +331,9 @@ export default function QuestionnarePage() {
               const data = response.data.data
               const organizedData: Record<string, FismaQuestion[]> = {}
               const questionData: Record<number, Question> = {}
-              const pillarOrder: Record<string, number> = {}
               data.forEach((question: FismaQuestion) => {
                 if (!organizedData[question.pillar.pillar]) {
                   organizedData[question.pillar.pillar] = []
-                  pillarOrder[question.pillar.pillar] = question.pillar.order
                 }
                 questionData[question.function.functionid] = {
                   question: question.question,
@@ -346,9 +345,7 @@ export default function QuestionnarePage() {
                 organizedData[question.pillar.pillar].push(question)
               })
               setQuestions(questionData)
-              const sortedPillars = Object.keys(organizedData).sort(
-                (a, b) => pillarOrder[a] - pillarOrder[b]
-              )
+              const sortedPillars = sortPillars(Object.keys(organizedData))
               const sortSteps = (
                 steps: FismaQuestion[],
                 order: string[]

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -36,6 +36,7 @@ import {
   MAX_QUESTIONNAIRE_NOTES_LENGTH,
   PILLAR_FUNCTION_MAP,
 } from '@/constants'
+import { sortPillars } from '@/utils/sortPillars'
 import { useContextProp } from '../Title/Context'
 const CssTextField = styled(TextField)({
   '& label.Mui-focused': {
@@ -309,17 +310,13 @@ export default function QuestionnareModal({
               }
               const data = response.data.data
               const organizedData: Record<string, FismaQuestion[]> = {}
-              const pillarOrder: Record<string, number> = {}
               data.forEach((question: FismaQuestion) => {
                 if (!organizedData[question.pillar.pillar]) {
                   organizedData[question.pillar.pillar] = []
-                  pillarOrder[question.pillar.pillar] = question.pillar.order
                 }
                 organizedData[question.pillar.pillar].push(question)
               })
-              const sortedPillars = Object.keys(organizedData).sort(
-                (a, b) => pillarOrder[a] - pillarOrder[b]
-              )
+              const sortedPillars = sortPillars(Object.keys(organizedData))
               const sortSteps = (
                 steps: FismaQuestion[],
                 order: string[]


### PR DESCRIPTION
## Summary

Fixes the questionnaire pillar list showing up in different orders on different systems. Pillars now always appear in a single fixed order: Identity, Devices, Networks, Applications, Data, and Cross Cutting.

Fixes #352

## Root cause

Both questionnaire views sorted pillars by the numeric `order` field that the API sends on each question (`question.pillar.order`). When that field is missing or the same value for every pillar, the comparator returns `0` (or `NaN`), so the sort does nothing and the pillars fall back to whatever order the API response happened to use. That response order varies from system to system, which is why the list looked random.

## Fix

Stop trusting the API `order` for pillars and use a fixed, hardcoded order instead. This matches the pattern already used to order functions within a pillar (`PILLAR_FUNCTION_MAP`).

- Added a `PILLAR_ORDER` constant in `src/constants.ts` that lists pillars in the required display order.
- Added a `sortPillars` helper in `src/utils/sortPillars.ts` that orders pillar names by `PILLAR_ORDER`. Unknown pillar names (for example a new one that has not been added to the list yet) sort to the end instead of jumping to the front. The helper returns a new array and does not mutate its input.
- Updated `QuestionnairePage.tsx` and `QuestionnaireModal.tsx` to call `sortPillars` and removed the old `pillarOrder` map logic from both. Function ordering inside each pillar is unchanged.

## Testing

- New unit tests in `src/utils/sortPillars.test.ts` cover the canonical order, unknown pillars landing at the end, and the no-mutation guarantee.
- `yarn test`, `yarn tsc --noEmit`, and `yarn lint` all pass.
- Verified in the app that the pillar list reads Identity, Devices, Networks, Apps and workloads, Data, Cross Cutting on multiple systems, in both the questionnaire page and the modal view.