### PR TITLE
chore(deps): drop unused uuid and bump axios (security)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -28,10 +28,6 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^react-native$': 'react-native-web',
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
-    // Force module uuid to resolve with the CJS entry point,
-    // because Jest does not support package.json.exports.
-    // See https://github.com/uuidjs/uuid/issues/451
-    uuid: require.resolve('uuid'),
   },
   moduleFileExtensions: [
     // Place tsx and ts to beginning as suggestion from Jest team

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "react-virtuoso": "^4.10.1",
     "recharts": "^3.1.2",
     "uswds": "^2.14.0",
-    "uuid": "^9.0.1",
     "yup": "^1.3.3"
   },
   "devDependencies": {
@@ -119,7 +118,6 @@
     "@types/react-dom": "^18.3.0",
     "@types/react-helmet": "^6.1.11",
     "@types/react-is": "^19",
-    "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react-swc": "^4.3.0",
     "babel-plugin-transform-import-meta": "^2.2.1",
     "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@mui/material": "^5.16.2",
     "@mui/x-data-grid": "^6.19.4",
     "@popperjs/core": "^2.11.8",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "classnames": "^2.5.1",
     "clipboard-copy": "^4.0.1",
     "core-js": "^3.37.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6432,7 +6432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.1, @types/uuid@npm:^9.0.8":
+"@types/uuid@npm:^9.0.1":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: 10/b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
@@ -18040,7 +18040,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0, uuid@npm:^9.0.1":
+"uuid@npm:^9.0.0":
   version: 9.0.1
   resolution: "uuid@npm:9.0.1"
   bin:
@@ -18687,7 +18687,6 @@ __metadata:
     "@types/react-dom": "npm:^18.3.0"
     "@types/react-helmet": "npm:^6.1.11"
     "@types/react-is": "npm:^19"
-    "@types/uuid": "npm:^9.0.8"
     "@vitejs/plugin-react-swc": "npm:^4.3.0"
     axios: "npm:^1.15.2"
     babel-plugin-transform-import-meta: "npm:^2.2.1"
@@ -18747,7 +18746,6 @@ __metadata:
     typescript-eslint: "npm:^8.58.1"
     typescript-plugin-css-modules: "npm:^5.1.0"
     uswds: "npm:^2.14.0"
-    uuid: "npm:^9.0.1"
     vite: "npm:^6.4.2"
     vite-plugin-environment: "npm:^1.1.3"
     web-vitals: "npm:^3.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,14 +7268,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.2":
-  version: 1.15.2
-  resolution: "axios@npm:1.15.2"
+"axios@npm:^1.16.0":
+  version: 1.16.1
+  resolution: "axios@npm:1.16.1"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
+  checksum: 10/9b6218cf96321cfbbf8f160658d695367114bcf4fb62492bdc1ccd647f184b5c71ae400e5ecaaf41079bc561de2ecbaf1fec63f398b3ec53389beff7694df64c
   languageName: node
   linkType: hard
 
@@ -18688,7 +18689,7 @@ __metadata:
     "@types/react-helmet": "npm:^6.1.11"
     "@types/react-is": "npm:^19"
     "@vitejs/plugin-react-swc": "npm:^4.3.0"
-    axios: "npm:^1.15.2"
+    axios: "npm:^1.16.0"
     babel-plugin-transform-import-meta: "npm:^2.2.1"
     camelcase: "npm:^6.3.0"
     classnames: "npm:^2.5.1"


### PR DESCRIPTION
## Summary

Two dependency security fixes:

1. **Remove `uuid`** (and `@types/uuid`). It was a direct dependency but is never imported anywhere in the app or test code, so the cleanest way to clear the alert is to drop it rather than upgrade it. This supersedes Dependabot PR #364 (bump `uuid` 9.0.1 → 14.0.0) — please close #364 in favor of this change.
2. **Bump `axios` 1.15.2 → 1.16.1** to resolve two high-severity advisories.

## uuid — why remove instead of bump

- **`uuid` is unused.** A repo-wide search finds no `import`/`require` of the package. The only reference was a leftover Jest `moduleNameMapper` entry (carried over from the original repo import) whose job was to force uuid's CommonJS entry point — and that mapper only does anything if a test actually imports uuid, which none do. That line is removed here too.
- **It clears the CVE.** Our pinned `9.0.1` is affected by CVE-2026-41907 / GHSA-w5hq-g745-h8pq (out-of-bounds write in `v3()`/`v5()`/`v6()` when a caller-supplied buffer is passed). Removing the direct dependency takes it out of our tree entirely.
- **The Dependabot bump over-reaches.** The fix actually shipped in uuid `11.1.1`; `14.0.0` is just the latest tag. Upgrading would keep an unused package *and* pull in uuid v12's removal of CommonJS support — the exact thing the stale Jest mapper was working around — for no benefit.

### Note on the remaining transitive copy

`@storybook/addon-actions` still pulls in `uuid@9` transitively. That is a **devDependency** and never ships in the production bundle. If the scanner flags it, the minimal follow-up is a `resolutions: { "uuid": "^11.1.1" }` override (11.1.1 keeps CommonJS, so Storybook and Jest are unaffected). Left out here to keep the change scoped to our own direct dependency.

## axios — 1.15.2 → 1.16.1

`axios` is used by the app's API client. Bumped to clear two high-severity advisories present in 1.15.2:

- **SNYK-JS-AXIOS-17111062** — server-side request forgery (SSRF)
- **SNYK-JS-AXIOS-17111079** — prototype pollution

The fixes landed in 1.16.0; the resolved version is 1.16.1. This is a minor bump within our existing `^1` range, no API changes.

## Verification

- `tsc --noEmit` — passes
- `yarn lint` — passes
- `yarn test` — 118 passed, 3 skipped
- `vite build` — production build succeeds
