### PR TITLE
fixed bug where downloading all active systems included decommissioned

### DIFF
--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CustomFooterSaveComponent } from './FismaTable'
+import type { FismaSystemType } from '@/types'
+
+// GridFooterContainer and GridFooter internally call useGridRootProps which
+// requires the MUI DataGrid context. Stub them out for isolated unit tests.
+jest.mock('@mui/x-data-grid', () => ({
+  ...jest.requireActual('@mui/x-data-grid'),
+  GridFooterContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  GridFooter: () => <div data-testid="grid-footer" />,
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+const mockAxiosGet = require('@/axiosConfig').default.get as jest.Mock
+
+// Minimal blob download stubs
+const createObjectURL = jest.fn(() => 'blob:mock')
+const revokeObjectURL = jest.fn()
+Object.defineProperty(window, 'URL', {
+  value: { createObjectURL, revokeObjectURL },
+  writable: true,
+})
+
+const SYSTEMS = [
+  { fismasystemid: 1, fismaname: 'Active A' },
+  { fismasystemid: 2, fismaname: 'Active B' },
+]
+
+const baseProps = {
+  fismaSystems: SYSTEMS as unknown as FismaSystemType[],
+  latestDataCallId: 42,
+  scores: {},
+}
+
+const blobResponse = {
+  headers: {
+    'content-disposition': 'attachment; filename=export.xlsx',
+    'content-type':
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  },
+  data: new Blob(),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockAxiosGet.mockResolvedValue(blobResponse)
+})
+
+function renderFooter(selectedRows: number[]) {
+  return render(
+    <MemoryRouter>
+      <CustomFooterSaveComponent {...baseProps} selectedRows={selectedRows} />
+    </MemoryRouter>
+  )
+}
+
+describe('CustomFooterSaveComponent download button', () => {
+  it('is disabled when no rows are selected', () => {
+    renderFooter([])
+    expect(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    ).toBeDisabled()
+  })
+
+  it('sends fsids for a partial selection', () => {
+    renderFooter([1])
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      expect.stringContaining('fsids=1'),
+      expect.objectContaining({ responseType: 'blob' })
+    )
+  })
+
+  it('sends fsids when all visible rows are selected (regression: #375 select-all bug)', () => {
+    // Before the fix: selectedRows.length === fismaSystems.length caused the
+    // condition to short-circuit, sending no fsids and downloading all systems
+    // including those from the opposite decommissioned/active view.
+    renderFooter([1, 2])
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('fsids=1')
+    expect(calledUrl).toContain('fsids=2')
+    // Must NOT be a bare export URL (no fsids = download everything)
+    expect(calledUrl).not.toMatch(/\/export$/)
+    expect(calledUrl).not.toMatch(/\/export\?$/)
+  })
+})

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -58,21 +58,15 @@ export function CustomFooterSaveComponent(
   }
   const saveSystemAnswers = async () => {
     let exportUrl = `/datacalls/${props.latestDataCallId}/export`
-    if (
-      props.selectedRows &&
-      props.fismaSystems &&
-      props.selectedRows.length < props.fismaSystems.length
-    ) {
+    if (props.selectedRows && props.selectedRows.length > 0) {
       exportUrl += '?'
       let idString: string = ''
-      if (props.selectedRows) {
-        props.selectedRows.forEach((id, index) => {
-          idString += 'fsids=' + id
-          if (index < (props.selectedRows ?? []).length - 1) {
-            idString += '&'
-          }
-        })
-      }
+      props.selectedRows.forEach((id, index) => {
+        idString += 'fsids=' + id
+        if (props.selectedRows && index < props.selectedRows.length - 1) {
+          idString += '&'
+        }
+      })
       exportUrl += idString
     }
     return await axiosInstance


### PR DESCRIPTION
## Summary

Fixes the "Download selected system answers" export including systems from the opposite active/decommissioned view when all visible rows are selected.

Closes #375

## Root cause

`FismaTable.tsx` guarded the `fsids` query parameter construction with:

```js
if (selectedRows.length < fismaSystems.length)
```

`fismaSystems` in context is a filtered subset — either active-only or decommissioned-only depending on the current toggle state. When a user selected all visible rows, `selectedRows.length === fismaSystems.length`, the condition evaluated to `false`, no `fsids` params were appended, and the backend's bare `/export` endpoint returned every system in the database regardless of what was selected.

## Fix

Replaced the length comparison with a simple presence check — if any rows are selected, always build and append `fsids` params. The backend then filters to exactly those systems.

- `FismaTable.tsx` — removed the `fismaSystems.length` guard; `fsids` params are now always sent when `selectedRows` is non-empty.
- `FismaTable.test.tsx` — added unit tests for `CustomFooterSaveComponent` covering: button disabled with no selection, `fsids` sent for a partial selection, and a regression test for the select-all case that triggered this bug.

Possible enhancement for future ticket is allowing the user to download all active and decommissioned system answers all at once, either through a new button or restructuring of how the select system view works.

## Testing

Verified locally:
- Selecting all active systems and downloading produces an export containing only those active systems
- Selecting all decommissioned systems and downloading produces an export containing only those decommissioned systems
- Partial selections correctly pass only the selected `fsids`
- The download button remains disabled when no rows are selected
- All 3 unit tests pass with no console errors
