### PR TITLE
Hide header when in signin screen and session is expired.

### DIFF
--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,5 +1,5 @@
 import { Container, Typography } from '@mui/material'
-import { useLoaderData } from 'react-router-dom'
+import { useLoaderData, useLocation } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
@@ -47,10 +47,13 @@ type PromiseType = {
   serverError?: boolean
 }
 export default function Title() {
+  const location = useLocation()
   const loaderData = useLoaderData() as PromiseType
   const [openDataCallModal, setOpenDataCallModal] = useState<boolean>(false)
   const userInfo: userData =
     loaderData.status != 200 ? emptyUser : loaderData.response
+  // Determine wether we are on the sign-in page or not
+  const isSignInRoute = location.pathname === Routes.SIGNIN
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
@@ -135,159 +138,164 @@ export default function Title() {
   return (
     <>
       <UsaBanner />
-      {/* Branded header bar */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
-          py: 1.5,
-          borderBottom: '1px solid rgba(0,0,0,0.12)',
-          minWidth: 800,
-        }}
-      >
-        {/* left: ZTMF mark + wordmark */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-          <img
-            src={ztmfLogo}
-            alt="ZTMF"
-            style={{ height: LOGO_HEIGHT, width: 'auto', display: 'block' }}
-          />
-          <Box
-            sx={{
-              width: '1px',
-              height: Math.round(LOGO_HEIGHT * 0.7),
-              backgroundColor: 'rgba(0,0,0,0.12)',
-              flexShrink: 0,
-              transform: `translateY(${LOGO_OPTICAL_OFFSET}px)`,
-            }}
-          />
-          <Box
-            sx={{
-              lineHeight: 1.15,
-              transform: `translateY(${LOGO_OPTICAL_OFFSET}px)`,
-            }}
-          >
-            <Typography
+      {/* Branded header bar (hidden on signin so it does not contradict the
+          "please sign in" prompt) */}
+      {!isSignInRoute && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+            py: 1.5,
+            borderBottom: '1px solid rgba(0,0,0,0.12)',
+            minWidth: 800,
+          }}
+        >
+          {/* left: ZTMF mark + wordmark */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <img
+              src={ztmfLogo}
+              alt="ZTMF"
+              style={{ height: LOGO_HEIGHT, width: 'auto', display: 'block' }}
+            />
+            <Box
               sx={{
-                fontSize: 17,
-                fontWeight: 700,
-                color: '#102B52',
-                letterSpacing: '0.2px',
+                width: '1px',
+                height: Math.round(LOGO_HEIGHT * 0.7),
+                backgroundColor: 'rgba(0,0,0,0.12)',
+                flexShrink: 0,
+                transform: `translateY(${LOGO_OPTICAL_OFFSET}px)`,
+              }}
+            />
+            <Box
+              sx={{
                 lineHeight: 1.15,
+                transform: `translateY(${LOGO_OPTICAL_OFFSET}px)`,
               }}
             >
-              Zero Trust Maturity Framework
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: 12,
-                fontWeight: 600,
-                color: '#7997AF',
-                letterSpacing: '2px',
-                textTransform: 'uppercase',
-                lineHeight: 1.15,
-              }}
-            >
-              Scoring Tool
-            </Typography>
-          </Box>
-        </Box>
-
-        {/* right: account chip (shown when logged in) */}
-        {loaderData.status == 200 && (
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <AccountCircleIcon fontSize={'large'} />
-            {userInfo.fullname && (
-              <span
-                style={{ verticalAlign: '13px' }}
-                className="ds-text-body--md"
+              <Typography
+                sx={{
+                  fontSize: 17,
+                  fontWeight: 700,
+                  color: '#102B52',
+                  letterSpacing: '0.2px',
+                  lineHeight: 1.15,
+                }}
               >
-                {userInfo.fullname}
-              </span>
-            )}
-            {hasAdminRead && (
-              <>
-                <IconButton
-                  aria-label="more"
-                  aria-controls="long-menu"
-                  aria-haspopup="true"
-                  onClick={handleClick}
+                Zero Trust Maturity Framework
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: '#7997AF',
+                  letterSpacing: '2px',
+                  textTransform: 'uppercase',
+                  lineHeight: 1.15,
+                }}
+              >
+                Scoring Tool
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* right: account chip (shown when logged in) */}
+          {loaderData.status == 200 && (
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <AccountCircleIcon fontSize={'large'} />
+              {userInfo.fullname && (
+                <span
+                  style={{ verticalAlign: '13px' }}
+                  className="ds-text-body--md"
                 >
-                  <MoreVertIcon />
-                </IconButton>
-                <Menu
-                  id="long-menu"
-                  anchorEl={anchorEl}
-                  keepMounted
-                  open={Boolean(anchorEl)}
-                  onClose={handleClose}
-                >
-                  <Link
-                    to={Routes.ROOT}
-                    style={{ textDecoration: 'none', color: 'black' }}
+                  {userInfo.fullname}
+                </span>
+              )}
+              {hasAdminRead && (
+                <>
+                  <IconButton
+                    aria-label="more"
+                    aria-controls="long-menu"
+                    aria-haspopup="true"
+                    onClick={handleClick}
                   >
-                    <MenuItem onClick={() => handleOption()}>
-                      Dashboard
-                    </MenuItem>
-                  </Link>
-                  {hasAdminRead && (
+                    <MoreVertIcon />
+                  </IconButton>
+                  <Menu
+                    id="long-menu"
+                    anchorEl={anchorEl}
+                    keepMounted
+                    open={Boolean(anchorEl)}
+                    onClose={handleClose}
+                  >
                     <Link
-                      to={Routes.USERS}
-                      style={{ textDecoration: 'none', color: 'black' }}
-                    >
-                      <MenuItem onClick={() => handleOption()}>Users</MenuItem>
-                    </Link>
-                  )}
-                  {userInfo.role === 'OWNER' && (
-                    <Link
-                      to={Routes.ADMIN_OPDIVS}
+                      to={Routes.ROOT}
                       style={{ textDecoration: 'none', color: 'black' }}
                     >
                       <MenuItem onClick={() => handleOption()}>
-                        Manage OpDivs
+                        Dashboard
                       </MenuItem>
                     </Link>
-                  )}
-                  {isAdmin && (
-                    <MenuItem
-                      onClick={() => {
-                        setAnchorEl(null)
-                        setOpenModal(true)
-                      }}
-                    >
-                      Add Fisma System
-                    </MenuItem>
-                  )}
-                  {isUnscopedWriteAdmin(userInfo) && (
-                    <MenuItem
-                      onClick={() => {
-                        setAnchorEl(null)
-                        setOpenEmailModal(true)
-                      }}
-                    >
-                      {'Email Users'}
-                    </MenuItem>
-                  )}
-                  {isAdmin && (
-                    <MenuItem
-                      onClick={() => {
-                        handleClose()
-                        setOpenDataCallModal(true)
-                      }}
-                    >
-                      Create Datacall
-                    </MenuItem>
-                  )}
-                </Menu>
-              </>
-            )}
-          </Box>
-        )}
-      </Box>
-      {/* Datacall sub-bar (shown when logged in) */}
-      {loaderData.status == 200 && (
+                    {hasAdminRead && (
+                      <Link
+                        to={Routes.USERS}
+                        style={{ textDecoration: 'none', color: 'black' }}
+                      >
+                        <MenuItem onClick={() => handleOption()}>
+                          Users
+                        </MenuItem>
+                      </Link>
+                    )}
+                    {userInfo.role === 'OWNER' && (
+                      <Link
+                        to={Routes.ADMIN_OPDIVS}
+                        style={{ textDecoration: 'none', color: 'black' }}
+                      >
+                        <MenuItem onClick={() => handleOption()}>
+                          Manage OpDivs
+                        </MenuItem>
+                      </Link>
+                    )}
+                    {isAdmin && (
+                      <MenuItem
+                        onClick={() => {
+                          setAnchorEl(null)
+                          setOpenModal(true)
+                        }}
+                      >
+                        Add Fisma System
+                      </MenuItem>
+                    )}
+                    {isUnscopedWriteAdmin(userInfo) && (
+                      <MenuItem
+                        onClick={() => {
+                          setAnchorEl(null)
+                          setOpenEmailModal(true)
+                        }}
+                      >
+                        {'Email Users'}
+                      </MenuItem>
+                    )}
+                    {isAdmin && (
+                      <MenuItem
+                        onClick={() => {
+                          handleClose()
+                          setOpenDataCallModal(true)
+                        }}
+                      >
+                        Create Datacall
+                      </MenuItem>
+                    )}
+                  </Menu>
+                </>
+              )}
+            </Box>
+          )}
+        </Box>
+      )}
+      {/* Datacall sub-bar (shown when logged in, hidden on signin) */}
+      {loaderData.status == 200 && !isSignInRoute && (
         <Box
           sx={{
             display: 'flex',

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -53,7 +53,8 @@ export default function Title() {
   const userInfo: userData =
     loaderData.status != 200 ? emptyUser : loaderData.response
   // Determine wether we are on the sign-in page or not
-  const isSignInRoute = location.pathname === Routes.SIGNIN
+  const normalizedPath = location.pathname.toLowerCase().replace(/\/$/, '')
+  const isSignInRoute = normalizedPath === Routes.SIGNIN.toLowerCase()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)


### PR DESCRIPTION
## Summary

`Title` sits above `/signin` via the router topology (signin is a child of the root layout). The header strip's gate was `loaderData.status == 200` (route-unaware) so whenever the session was still valid the admin chrome (datacall label, account chip, avatar, kebab menu) rendered above `LoginPage`. This visually contradicted the "please sign in" prompt below.

Fix: gate the entire branded header bar and the datacall sub-bar on `!isSignInRoute` (derived from `useLocation().pathname === Routes.SIGNIN`). The `UsaBanner` and `Footer` keep showing; only the ZTMF-specific admin chrome is suppressed on `/signin`.

## Behavior change

| URL | Session | UsaBanner | Branded header | Datacall sub-bar | Body |
|---|---|---|---|---|---|
| `/signin` | valid (200) | ✓ | **hidden (new)** | **hidden (new)** | LoginPage via Outlet |
| `/signin` | invalid | ✓ | **hidden (new)** | hidden | LoginPage via inline selector |

## What's in the diff

`src/views/Title/Title.tsx`:

* Imports `useLocation` from `react-router-dom`.
* Adds `const isSignInRoute = useLocation().pathname === Routes.SIGNIN` near the top of the component, with a comment explaining the why.
* Wraps the entire branded header `<Box>` in `{!isSignInRoute && (...)}`.
* Tightens the datacall sub-bar gate from `loaderData.status == 200` to `loaderData.status == 200 && !isSignInRoute`.

The diff stat looks larger than the logic warrants (149 / -138) because Prettier re-indented the wrapped content by +2 spaces. Reviewing with `git diff -w` collapses to ~10 lines of real change. One unrelated reformat: the Users `<MenuItem>` got split across three lines because the new indent depth pushed it past the line-length limit.

## Test plan

* [x] `yarn typecheck` clean
* [x] `yarn lint` clean (prettier clean)
* [x] `yarn test` (118 passing baseline)
* [x] Manual smoke: log in as Admin, address-bar to `localhost:5174/#/signin`, confirm only UsaBanner + LoginPage + Footer render (no branded header, no datacall sub-bar)
* [x] Manual smoke: hard-refresh `#/signin`, confirm header stays hidden (route-based, not loader-based)
* [x] Manual smoke: navigate back to `/`, confirm branded header + datacall sub-bar restored
* [x] Manual smoke: corrupt `VITE_AUTH_TOKEN3`, restart dev server, navigate to `#/signin`, confirm header still hidden in this state

## Screenshots

Before/after of the signin screen (drop in here when posting on GitHub).


closes #386 