### PR TITLE
Redirect to dashboard when visited with active session

### DIFF
--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -1,10 +1,23 @@
 import { Box, Typography } from '@mui/material'
 import { Button as CmsButton } from '@cmsgov/design-system'
-import { useLocation } from 'react-router-dom'
+import { Navigate, useLocation, useRouteLoaderData } from 'react-router-dom'
+import { RouteIds, Routes } from '@/router/constants'
 import ztmfLogo from '@/assets/ztmf-logo-login.png'
 
 export default function LoginPage() {
   const location = useLocation()
+
+  // Read the root route's authLoader payload and edirect to the dashboard
+  // so /signin never appears as a dead-end "log in again" prompt for an
+  // already-authenticated user.
+  const rootLoaderData = useRouteLoaderData(RouteIds.ROOT) as
+    | { status?: number }
+    | undefined
+
+  if (rootLoaderData?.status === 200) {
+    return <Navigate to={Routes.ROOT} replace />
+  }
+
   const message = location.state?.message || ''
   return (
     <Box


### PR DESCRIPTION
Closes #387.

## Summary

A user with an active session navigating to `/signin` (via address bar, bookmark, browser back/forward) used to see `LoginPage` indefinitely — a dead-end "sign in again" prompt for someone already authenticated. The route was never gated on authentication state.

Fix: `LoginPage` reads the root route's `authLoader` payload via `useRouteLoaderData(RouteIds.ROOT)` and returns `<Navigate to={Routes.ROOT} replace />` when `loaderData.status === 200`. The redirect fires declaratively during render, so the user lands on the dashboard without ever seeing `LoginPage` flash. `replace: true` keeps `/signin` out of browser history.

## Behavior change

| URL | Session | Before | After |
|---|---|---|---|
| `/signin` | valid (200) | LoginPage rendered indefinitely | **Redirect to `/` (replace history)** |
| `/signin` | invalid | LoginPage rendered with optional `location.state.message` | LoginPage rendered with optional `location.state.message` (unchanged) |
| `/signin` | server error (5xx) | Handled by Title's inline selector (renders `ServerErrorPage`) | Unchanged — `LoginPage` is never reached on this path |
| Anywhere else | any | unchanged | unchanged |

Rows 2-4 unchanged from prior behavior.

## What's in the diff

`src/views/LoginPage/LoginPage.tsx`:

* Imports `Maps` and `useRouteLoaderData` from `react-router-dom`.
* Imports `RouteIds` and `Routes` from `@/router/constants`.
* Reads `useRouteLoaderData(RouteIds.ROOT)` and types the result as `{ status?: number } | undefined`.
* Returns `<Navigate to={Routes.ROOT} replace />` when `rootLoaderData?.status === 200`.
* Existing `location.state.message` read and the existing JSX render path are otherwise untouched.

~13 lines added, all centered on the new redirect logic.

## Test plan

* [x] `yarn typecheck` clean
* [x] `yarn lint` clean (prettier clean)
* [x] `yarn test` (118 passing baseline)
* [x] Manual smoke: log in as Admin → confirm dashboard loads → type `localhost:5174/#/signin` in address bar → press Enter → confirm URL becomes `localhost:5174/#/` and dashboard renders without a LoginPage flash
* [x] Manual smoke: press browser Back after the redirect → confirm stays on dashboard (`replace: true` removed `/signin` from history)
* [x] Manual smoke: sign out (or corrupt `VITE_AUTH_TOKEN3` + restart dev server) → navigate to `#/signin` → confirm LoginPage renders normally with session-expired message intact

## Screenshots

Before/after of the signin URL with an active session (drop in here when posting on GitHub).

## Notes

* **Pairs with #386 (Hide Title bar on signin).** The two fixes are complementary:
  * This PR (#387) prevents the user from being on `/signin` in the first place when logged in.