### PR TITLE
Finish notify() and parseApiError adoption across views

### DIFF
--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -15,7 +15,6 @@ import {
   Hint,
 } from '@cmsgov/design-system'
 import SentEmailsModal from './SentEmailsModal'
-import { useSnackbar } from 'notistack'
 import TextField from '@mui/material/TextField'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import { EmailModalProps } from '@/types'
@@ -23,7 +22,7 @@ import './EmailModal.css'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
 import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 
 const CssTextField = styled(TextField)({
   '& .MuiInputBase-root': {
@@ -57,7 +56,6 @@ const CssTextField = styled(TextField)({
 })
 
 export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
-  const { enqueueSnackbar } = useSnackbar()
   const [sentToEmails, setSentToEmails] = React.useState<string[]>([])
   const [openSentEmailsDialog, setOpenSentEmailsDialog] =
     React.useState<boolean>(false)
@@ -85,24 +83,14 @@ export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
       })
       .then((res) => {
         setSentGroup(groupValue)
-        enqueueSnackbar(`Emails have successfully been sent`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify('Emails have successfully been sent', 'success', {
           autoHideDuration: 2500,
         })
         setSentToEmails(res.data.data)
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(ERROR_MESSAGES.tryAgain, 'error', {
           autoHideDuration: 2500,
         })
       })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,8 +24,6 @@ export const ERROR_MESSAGES = {
   error:
     'An error occurred. Please log in and try again. If the error persists, please contact support.',
   permission: 'You do not have permission to do this action.',
-  outOfScope:
-    'This item is outside your OpDiv, so you cannot make changes to it.',
   tryAgain: 'An error occurred, please try again later',
   refresh:
     'Could not refresh the latest data. The information shown may be out of date.',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,21 @@ export const ERROR_MESSAGES = {
   tryAgain: 'An error occurred, please try again later',
   refresh:
     'Could not refresh the latest data. The information shown may be out of date.',
+  systemNotFound: 'System not found',
+}
+
+// Short UI status strings for snackbar toasts on save/create flows. Distinct
+// from ERROR_MESSAGES because these are not errors — they are user-facing
+// status indicators returned by the operation. Keeping them grouped avoids
+// the naming collision with ERROR_MESSAGES.notSaved (which is the long-form
+// session-expired warning).
+export const STATUS_MESSAGES = {
+  saved: 'Saved',
+  notSaved: 'Not Saved',
+  created: 'Created',
+  notCreated: 'Not Created',
+  systemDecommissioned: 'System decommissioned successfully',
+  systemReactivated: 'System reactivated successfully',
 }
 export const EMPTY_USER: userData = {
   userid: '',

--- a/src/utils/authHandling.invariants.test.ts
+++ b/src/utils/authHandling.invariants.test.ts
@@ -22,13 +22,23 @@ const expectations: FileExpectation[] = [
   },
   {
     filePath: 'src/views/DatacallModal/DataCallModal.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['ERROR_MESSAGES.permission', 'Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     filePath: 'src/views/EditSystemModal/EditSystemModal.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     filePath: 'src/views/FismaTable/FismaTable.tsx',
@@ -55,8 +65,13 @@ const expectations: FileExpectation[] = [
   },
   {
     filePath: 'src/views/SystemDetailPage/SystemDetailPage.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     filePath: 'src/views/Title/Title.tsx',

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -15,9 +15,8 @@ import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import { useSnackbar } from 'notistack'
 import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
 const checkedIcon = <CheckBoxIcon fontSize="small" />
@@ -44,7 +43,6 @@ export default function AssignSystemModal({
     systemid: number
     nextValue: number[]
   } | null>(null)
-  const { enqueueSnackbar } = useSnackbar()
   React.useEffect(() => {
     if (open && userid) {
       axiosInstance.get(`/users/${userid}/assignedfismasystems`).then((res) => {
@@ -64,24 +62,11 @@ export default function AssignSystemModal({
       .delete(`/users/${userid}/assignedfismasystems/${target.systemid}`)
       .then(() => {
         setAssignedSystems(target.nextValue)
-        enqueueSnackbar(`Saved - unassigned system`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-        })
+        notify('Saved - unassigned system', 'success')
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 1500,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 1500 })
       })
   }
 
@@ -141,22 +126,11 @@ export default function AssignSystemModal({
                   })
                   .then(() => {
                     setAssignedSystems(newValue)
-                    enqueueSnackbar(`Saved - assign system`, {
-                      variant: 'success',
-                      anchorOrigin: {
-                        vertical: 'top',
-                        horizontal: 'left',
-                      },
-                    })
+                    notify('Saved - assign system', 'success')
                   })
                   .catch((error) => {
                     if (isAuthHandled(error)) return
-                    enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                      variant: 'error',
-                      anchorOrigin: {
-                        vertical: 'top',
-                        horizontal: 'left',
-                      },
+                    notify(ERROR_MESSAGES.tryAgain, 'error', {
                       autoHideDuration: 1500,
                     })
                   })

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -19,7 +19,7 @@ import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import { datacallModalProps } from '@/types'
 import './DatacallModal.css'
 import axiosInstance from '@/axiosConfig'
-import { ERROR_MESSAGES } from '@/constants'
+import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 
 export default function DataCallModal({ open, onClose }: datacallModalProps) {
@@ -76,7 +76,9 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+        notify(parseApiError(error).message, 'error', {
+          autoHideDuration: 2500,
+        })
       })
   }
   return (

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -76,9 +76,18 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        notify(parseApiError(error).message, 'error', {
-          autoHideDuration: 2500,
-        })
+        const parsed = parseApiError(error)
+        // Backend 400 with a field map: route each reason to the matching
+        // field's error setter. No toast on this branch, the inline errors
+        // are the user feedback.
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+            if (key === 'datacall') setDatacallError(message)
+            else if (key === 'deadline') setDeadlineError(message)
+          })
+          return
+        }
+        notify(parsed.message, 'error', { autoHideDuration: 2500 })
       })
   }
   return (

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -16,15 +16,13 @@ import {
   // FormControl,
 } from '@mui/material'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
-import { useSnackbar } from 'notistack'
 import { datacallModalProps } from '@/types'
 import './DatacallModal.css'
 import axiosInstance from '@/axiosConfig'
 import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 
 export default function DataCallModal({ open, onClose }: datacallModalProps) {
-  const { enqueueSnackbar } = useSnackbar()
   const [datacall, setDatacall] = React.useState<string>('')
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
@@ -72,25 +70,13 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
         deadline: new Date(deadline).toISOString(),
       })
       .then(() => {
-        enqueueSnackbar(`Datacall has successfully been created`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify('Datacall has successfully been created', 'success', {
           autoHideDuration: 2500,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2500,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
       })
   }
   return (

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -242,6 +242,9 @@ export default function EditSystemModal({
         .catch((error) => {
           if (isAuthHandled(error)) return
           const parsed = parseApiError(error)
+          // Backend 400 with a field map: render each reason inline under
+          // its input via formValid + formValidErrorText. The 'Not Saved'
+          // toast is a status flag, not the detail.
           if (parsed.fieldErrors) {
             Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({
@@ -285,6 +288,9 @@ export default function EditSystemModal({
         .catch((error) => {
           if (isAuthHandled(error)) return
           const parsed = parseApiError(error)
+          // Backend 400 with a field map: render each reason inline under
+          // its input via formValid + formValidErrorText. The 'Not Created'
+          // toast is a status flag, not the detail.
           if (parsed.fieldErrors) {
             Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -16,7 +16,11 @@ import {
   FormValidHelperText,
 } from '@/types'
 import MenuItem from '@mui/material/MenuItem'
-import { CONFIRMATION_MESSAGE } from '@/constants'
+import {
+  CONFIRMATION_MESSAGE,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
+} from '@/constants'
 import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 
 import ValidatedTextField from './ValidatedTextField'
@@ -27,11 +31,8 @@ import CircularProgress from '@mui/material/CircularProgress'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import _ from 'lodash'
 import axiosInstance from '@/axiosConfig'
-import {
-  ERROR_MESSAGES,
-  TEXTFIELD_HELPER_TEXT,
-  INVALID_INPUT_TEXT,
-} from '@/constants'
+import { TEXTFIELD_HELPER_TEXT } from '@/constants'
+import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 /**
  * Component that renders a modal to edit fisma systems.
@@ -235,27 +236,29 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          notify('Saved', 'success', { autoHideDuration: 1500 })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
-          if (error.response?.status === 400) {
-            const data: { [key: string]: string } = error.response.data.data
-            Object.entries(data).forEach(([key]) => {
+          const parsed = parseApiError(error)
+          if (parsed.fieldErrors) {
+            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({
                 ...prevState,
                 [key]: false,
               }))
               setFormValidErrorText((prevState) => ({
                 ...prevState,
-                [key]: INVALID_INPUT_TEXT(key),
+                [key]: message,
               }))
             })
-            notify('Not Saved', 'error', { autoHideDuration: 1500 })
-          } else {
-            notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+            notify(STATUS_MESSAGES.notSaved, 'error', {
+              autoHideDuration: 1500,
+            })
+            return
           }
+          notify(parsed.message, 'error')
         })
     } else if (mode === 'create') {
       await axiosInstance
@@ -274,27 +277,31 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          notify('Created', 'success', { autoHideDuration: 1500 })
+          notify(STATUS_MESSAGES.created, 'success', {
+            autoHideDuration: 1500,
+          })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
-          if (error.response?.status === 400) {
-            const data: { [key: string]: string } = error.response.data.data
-            Object.entries(data).forEach(([key]) => {
+          const parsed = parseApiError(error)
+          if (parsed.fieldErrors) {
+            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({
                 ...prevState,
                 [key]: false,
               }))
               setFormValidErrorText((prevState) => ({
                 ...prevState,
-                [key]: INVALID_INPUT_TEXT(key),
+                [key]: message,
               }))
             })
-            notify('Not Created', 'error', { autoHideDuration: 1500 })
-          } else {
-            notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+            notify(STATUS_MESSAGES.notCreated, 'error', {
+              autoHideDuration: 1500,
+            })
+            return
           }
+          notify(parsed.message, 'error')
         })
     }
   }
@@ -346,7 +353,7 @@ export default function EditSystemModal({
       })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          notify('System decommissioned successfully', 'success', {
+          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -365,14 +372,14 @@ export default function EditSystemModal({
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          notify('System not found', 'error', { autoHideDuration: 2000 })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          notify(`Error: ${errorMsg}`, 'error')
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
+            autoHideDuration: 2000,
+          })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
   const handleReactivate = async () => {
@@ -383,7 +390,7 @@ export default function EditSystemModal({
       .put(`fismasystems/${editedFismaSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          notify('System reactivated successfully', 'success', {
+          notify(STATUS_MESSAGES.systemReactivated, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -401,14 +408,14 @@ export default function EditSystemModal({
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          notify('System not found', 'error', { autoHideDuration: 2000 })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          notify(`Error: ${errorMsg}`, 'error')
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
+            autoHideDuration: 2000,
+          })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
   if (open && system) {

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -32,7 +32,6 @@ import {
   TEXTFIELD_HELPER_TEXT,
   INVALID_INPUT_TEXT,
 } from '@/constants'
-import { useSnackbar } from 'notistack'
 import { isAuthHandled, notify } from '@/utils/notify'
 /**
  * Component that renders a modal to edit fisma systems.
@@ -59,7 +58,6 @@ export default function EditSystemModal({
   const isFormValid = (): boolean => {
     return Object.values(formValid).every((value) => value === true)
   }
-  const { enqueueSnackbar } = useSnackbar()
   const [loading, setLoading] = React.useState<boolean>(true)
   const [openAlert, setOpenAlert] = React.useState<boolean>(false)
   const [openDecommissionAlert, setOpenDecommissionAlert] =
@@ -237,14 +235,7 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify('Saved', 'success', { autoHideDuration: 1500 })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
@@ -261,14 +252,7 @@ export default function EditSystemModal({
                 [key]: INVALID_INPUT_TEXT(key),
               }))
             })
-            enqueueSnackbar(`Not Saved`, {
-              variant: 'error',
-              anchorOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
-              autoHideDuration: 1500,
-            })
+            notify('Not Saved', 'error', { autoHideDuration: 1500 })
           } else {
             notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
           }
@@ -290,14 +274,7 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          enqueueSnackbar(`Created`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify('Created', 'success', { autoHideDuration: 1500 })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
@@ -314,14 +291,7 @@ export default function EditSystemModal({
                 [key]: INVALID_INPUT_TEXT(key),
               }))
             })
-            enqueueSnackbar(`Not Created`, {
-              variant: 'error',
-              anchorOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
-              autoHideDuration: 1500,
-            })
+            notify('Not Created', 'error', { autoHideDuration: 1500 })
           } else {
             notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
           }
@@ -376,12 +346,7 @@ export default function EditSystemModal({
       })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          enqueueSnackbar('System decommissioned successfully', {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+          notify('System decommissioned successfully', 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -401,24 +366,10 @@ export default function EditSystemModal({
           error.response?.data
         )
         if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2000,
-          })
+          notify('System not found', 'error', { autoHideDuration: 2000 })
         } else if (error.response?.status === 400) {
           const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 3000,
-          })
+          notify(`Error: ${errorMsg}`, 'error')
         } else {
           notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         }
@@ -432,12 +383,7 @@ export default function EditSystemModal({
       .put(`fismasystems/${editedFismaSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          enqueueSnackbar('System reactivated successfully', {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+          notify('System reactivated successfully', 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -456,24 +402,10 @@ export default function EditSystemModal({
           error.response?.data
         )
         if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2000,
-          })
+          notify('System not found', 'error', { autoHideDuration: 2000 })
         } else if (error.response?.status === 400) {
           const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 3000,
-          })
+          notify(`Error: ${errorMsg}`, 'error')
         } else {
           notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         }

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -25,7 +25,6 @@ import {
   GridToolbarContainer,
   GridToolbarQuickFilter,
 } from '@mui/x-data-grid'
-import { useSnackbar } from 'notistack'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
@@ -40,7 +39,6 @@ import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import type { OpDiv } from '@/types'
 
-const SNACK_ANCHOR = { vertical: 'top', horizontal: 'left' } as const
 const CODE_MAX = 16
 const NAME_MAX = 128
 
@@ -66,7 +64,6 @@ function CreateToolbar({ onCreate }: { onCreate: () => void }) {
 export default function OpDivAdmin() {
   const navigate = useNavigate()
   const { userInfo } = useContextProp()
-  const { enqueueSnackbar } = useSnackbar()
   const isOwner = userInfo.role === 'OWNER'
 
   const [rows, setRows] = useState<OpDiv[]>([])
@@ -138,12 +135,9 @@ export default function OpDivAdmin() {
       : createOpDiv(input)
     request
       .then(() => {
-        enqueueSnackbar(
+        notify(
           editing ? 'Saved - OpDiv updated' : 'Saved - OpDiv created',
-          {
-            variant: 'success',
-            anchorOrigin: SNACK_ANCHOR,
-          }
+          'success'
         )
         setDialogOpen(false)
         loadOpDivs()
@@ -171,11 +165,11 @@ export default function OpDivAdmin() {
       active: !target.active,
     })
       .then(() => {
-        enqueueSnackbar(
+        notify(
           target.active
             ? 'Saved - OpDiv deactivated'
             : 'Saved - OpDiv activated',
-          { variant: 'success', anchorOrigin: SNACK_ANCHOR }
+          'success'
         )
         loadOpDivs()
       })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -13,7 +13,6 @@ import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import { useSnackbar } from 'notistack'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { fetchUserOpDivs, grantOpDiv, revokeOpDiv } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
@@ -42,8 +41,6 @@ type Props = {
   onChanged?: (userid: string) => void
 }
 
-const SNACK_ANCHOR = { vertical: 'top', horizontal: 'left' } as const
-
 export default function OpDivGrantModal({
   open,
   handleClose,
@@ -56,7 +53,6 @@ export default function OpDivGrantModal({
   const [pendingRevoke, setPendingRevoke] = React.useState<{
     opdivId: number
   } | null>(null)
-  const { enqueueSnackbar } = useSnackbar()
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -99,10 +95,7 @@ export default function OpDivGrantModal({
         // Functional update so a grant that resolved while the confirm was
         // open is not dropped by a stale snapshot.
         setAssignedOpDivs((prev) => prev.filter((id) => id !== target.opdivId))
-        enqueueSnackbar('Saved - revoked OpDiv', {
-          variant: 'success',
-          anchorOrigin: SNACK_ANCHOR,
-        })
+        notify('Saved - revoked OpDiv', 'success')
         onChanged?.(String(userid))
       })
       .catch((error) => handleError(error))
@@ -162,10 +155,7 @@ export default function OpDivGrantModal({
                     setAssignedOpDivs((prev) =>
                       prev.includes(opdivId) ? prev : [...prev, opdivId]
                     )
-                    enqueueSnackbar('Saved - granted OpDiv', {
-                      variant: 'success',
-                      anchorOrigin: SNACK_ANCHOR,
-                    })
+                    notify('Saved - granted OpDiv', 'success')
                     onChanged?.(String(userid))
                   })
                   .catch((error) => handleError(error))

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,7 +21,6 @@ import {
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
-import { useSnackbar } from 'notistack'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
@@ -30,7 +29,7 @@ import {
   MAX_QUESTIONNAIRE_NOTES_LENGTH,
   CONFIRMATION_MESSAGE_QUESTION,
 } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { sortFunctions } from '@/utils/sortFunctions'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
@@ -168,7 +167,6 @@ export default function QuestionnarePage() {
     )
   }
 
-  const { enqueueSnackbar } = useSnackbar()
   const navigate = useNavigate()
   const location = useLocation()
   const { fismaacronym } = useParams()
@@ -202,27 +200,13 @@ export default function QuestionnarePage() {
         })
         .then(() => {
           // checkValidResponse(res.status)
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify('Saved', 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
           console.error('Error updating score:', error)
-          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2500,
-          })
+          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         })
     } else {
       axiosInstance
@@ -233,27 +217,13 @@ export default function QuestionnarePage() {
           datacallid: datacallID,
         })
         .then(() => {
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify('Saved', 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
           console.error('Error posting score:', error)
-          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2500,
-          })
+          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         })
     }
   }
@@ -280,12 +250,7 @@ export default function QuestionnarePage() {
             })
             .catch((error) => {
               if (isAuthHandled(error)) return
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
+              notify(ERROR_MESSAGES.tryAgain, 'error', {
                 autoHideDuration: 2500,
               })
             })
@@ -363,14 +328,7 @@ export default function QuestionnarePage() {
             })
             .catch((error) => {
               if (isAuthHandled(error)) return
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-                autoHideDuration: 3000,
-              })
+              notify(ERROR_MESSAGES.tryAgain, 'error')
             })
           if (questionsEmpty) {
             return
@@ -395,14 +353,7 @@ export default function QuestionnarePage() {
             .catch((error) => {
               if (isAuthHandled(error)) return
               console.error('Error fetching question scores:', error)
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-                autoHideDuration: 3000,
-              })
+              notify(ERROR_MESSAGES.tryAgain, 'error')
             })
         } catch (error) {
           if (isAuthHandled(error)) return
@@ -411,7 +362,7 @@ export default function QuestionnarePage() {
       }
       fetchData()
     }
-  }, [system, navigate, fismaacronym, enqueueSnackbar])
+  }, [system, navigate, fismaacronym])
   React.useEffect(() => {
     if (questionId) {
       // Clear saved-state markers before async load so the last-edited

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -26,6 +26,7 @@ import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
   ERROR_MESSAGES,
+  STATUS_MESSAGES,
   MAX_QUESTIONNAIRE_NOTES_LENGTH,
   CONFIRMATION_MESSAGE_QUESTION,
 } from '@/constants'
@@ -200,7 +201,7 @@ export default function QuestionnarePage() {
         })
         .then(() => {
           // checkValidResponse(res.status)
-          notify('Saved', 'success', { autoHideDuration: 1500 })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {
@@ -217,7 +218,7 @@ export default function QuestionnarePage() {
           datacallid: datacallID,
         })
         .then(() => {
-          notify('Saved', 'success', { autoHideDuration: 1500 })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -294,6 +294,9 @@ export default function SystemDetailPage() {
       .catch((error) => {
         if (isAuthHandled(error)) return
         const parsed = parseApiError(error)
+        // Backend 400 with a field map: render each reason inline under its
+        // input via formValid + formValidErrorText. The 'Not Saved' toast
+        // is a status flag, not the detail.
         if (parsed.fieldErrors) {
           Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
             setFormValid((prev) => ({ ...prev, [key]: false }))

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -7,11 +7,12 @@ import { FismaSystemType, FormValidType, FormValidHelperText } from '@/types'
 import { useContextProp } from '@/views/Title/Context'
 import axiosInstance from '@/axiosConfig'
 import {
-  ERROR_MESSAGES,
   CONFIRMATION_MESSAGE,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
   TEXTFIELD_HELPER_TEXT,
-  INVALID_INPUT_TEXT,
 } from '@/constants'
+import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
@@ -283,7 +284,7 @@ export default function SystemDetailPage() {
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       })
       .then(() => {
-        notify('Saved', 'success', { autoHideDuration: 1500 })
+        notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
         setFismaSystems((prev) =>
           prev.map((s) =>
             s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
@@ -292,21 +293,22 @@ export default function SystemDetailPage() {
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        if (error.response?.status === 400) {
-          const data: { [key: string]: string } = error.response.data.data
-          Object.entries(data).forEach(([key]) => {
+        const parsed = parseApiError(error)
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
             setFormValid((prev) => ({ ...prev, [key]: false }))
-            setFormValidErrorText((prev) => ({
-              ...prev,
-              [key]: INVALID_INPUT_TEXT(key),
-            }))
+            setFormValidErrorText((prev) => ({ ...prev, [key]: message }))
           })
-          notify('Not Saved', 'error', { autoHideDuration: 1500 })
-        } else if (error.response?.status === 404) {
-          notify('System not found', 'error', { autoHideDuration: 2000 })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+          return
         }
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
+            autoHideDuration: 2000,
+          })
+          return
+        }
+        notify(parsed.message, 'error')
       })
       .finally(() => {
         setIsSaving(false)
@@ -333,7 +335,7 @@ export default function SystemDetailPage() {
       .delete(`fismasystems/${editedSystem.fismasystemid}`, { data: body })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          notify('System decommissioned successfully', 'success', {
+          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -362,14 +364,14 @@ export default function SystemDetailPage() {
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          notify('System not found', 'error', { autoHideDuration: 2000 })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          notify(`Error: ${errorMsg}`, 'error')
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
+            autoHideDuration: 2000,
+          })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
 
@@ -384,7 +386,7 @@ export default function SystemDetailPage() {
       .put(`fismasystems/${editedSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          notify('System reactivated successfully', 'success', {
+          notify(STATUS_MESSAGES.systemReactivated, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -413,14 +415,14 @@ export default function SystemDetailPage() {
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          notify('System not found', 'error', { autoHideDuration: 2000 })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          notify(`Error: ${errorMsg}`, 'error')
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
+            autoHideDuration: 2000,
+          })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
 

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { Box, CircularProgress, Divider, Typography } from '@mui/material'
-import { useSnackbar } from 'notistack'
 import _ from 'lodash'
 
 import { FismaSystemType, FormValidType, FormValidHelperText } from '@/types'
@@ -26,7 +25,6 @@ import CfactsRecordCard from './CfactsRecordCard'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const { enqueueSnackbar } = useSnackbar()
   const { fismaSystems, setFismaSystems, userInfo } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
@@ -285,11 +283,7 @@ export default function SystemDetailPage() {
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       })
       .then(() => {
-        enqueueSnackbar('Saved', {
-          variant: 'success',
-          anchorOrigin: { vertical: 'top', horizontal: 'left' },
-          autoHideDuration: 1500,
-        })
+        notify('Saved', 'success', { autoHideDuration: 1500 })
         setFismaSystems((prev) =>
           prev.map((s) =>
             s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
@@ -307,17 +301,9 @@ export default function SystemDetailPage() {
               [key]: INVALID_INPUT_TEXT(key),
             }))
           })
-          enqueueSnackbar('Not Saved', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 1500,
-          })
+          notify('Not Saved', 'error', { autoHideDuration: 1500 })
         } else if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 2000,
-          })
+          notify('System not found', 'error', { autoHideDuration: 2000 })
         } else {
           notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         }
@@ -347,9 +333,7 @@ export default function SystemDetailPage() {
       .delete(`fismasystems/${editedSystem.fismasystemid}`, { data: body })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          enqueueSnackbar('System decommissioned successfully', {
-            variant: 'success',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          notify('System decommissioned successfully', 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -379,18 +363,10 @@ export default function SystemDetailPage() {
           error.response?.data
         )
         if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 2000,
-          })
+          notify('System not found', 'error', { autoHideDuration: 2000 })
         } else if (error.response?.status === 400) {
           const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 3000,
-          })
+          notify(`Error: ${errorMsg}`, 'error')
         } else {
           notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         }
@@ -408,9 +384,7 @@ export default function SystemDetailPage() {
       .put(`fismasystems/${editedSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          enqueueSnackbar('System reactivated successfully', {
-            variant: 'success',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          notify('System reactivated successfully', 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -440,18 +414,10 @@ export default function SystemDetailPage() {
           error.response?.data
         )
         if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 2000,
-          })
+          notify('System not found', 'error', { autoHideDuration: 2000 })
         } else if (error.response?.status === 400) {
           const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 3000,
-          })
+          notify(`Error: ${errorMsg}`, 'error')
         } else {
           notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         }

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -39,11 +39,10 @@ import {
 import { fetchOpDivs } from '@/utils/opdivs'
 import { fetchUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
 import Box from '@mui/material/Box'
 import CustomSnackbar from '../Snackbar/Snackbar'
-import { useSnackbar } from 'notistack'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 import OpDivGrantModal from '../OpDivGrantModal/OpDivGrantModal'
 import { useNavigate } from 'react-router-dom'
@@ -130,7 +129,6 @@ function validateEmail(email: string) {
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()
-  const { enqueueSnackbar } = useSnackbar()
   const { userInfo, fismaSystems } = useContextProp()
   // Write-tier admins get the create/edit/delete/assign controls; read-only
   // admins may view the table but every mutating control is withheld. The
@@ -247,10 +245,7 @@ export default function UserTable() {
           `Failed to refresh OpDiv grants for user ${userid}`,
           error
         )
-        enqueueSnackbar(ERROR_MESSAGES.refresh, {
-          variant: 'warning',
-          anchorOrigin: { vertical: 'top', horizontal: 'left' },
-        })
+        notify(ERROR_MESSAGES.refresh, 'warning')
       })
     axiosInstance
       .get(`/users/${userid}`)
@@ -366,25 +361,13 @@ export default function UserTable() {
       .delete(`/users/${target.userid}`)
       .then(() => {
         setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        enqueueSnackbar(`Saved - Delete User ${target.fullname}`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(`Saved - Delete User ${target.fullname}`, 'success', {
           autoHideDuration: 2000,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2000,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
       })
   }
   const handleRestoreClick = (id: GridRowId) => () => {
@@ -400,25 +383,13 @@ export default function UserTable() {
       .put(`/users/${target.userid}/restore`)
       .then(() => {
         setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        enqueueSnackbar(`Saved - Restore User ${target.fullname}`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(`Saved - Restore User ${target.fullname}`, 'success', {
           autoHideDuration: 2000,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2000,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
       })
   }
   // TODO: Custom hook for fetching data
@@ -471,18 +442,12 @@ export default function UserTable() {
       .catch((error) => {
         if (isAuthHandled(error)) return
         console.error('Fetch users error:', error)
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error')
       })
     return () => {
       ignore = true
     }
-  }, [canRead, fismaSystems, navigate, enqueueSnackbar, showDeleted])
+  }, [canRead, fismaSystems, navigate, showDeleted])
   // OpDiv options for the grant modal: assignable children only (the HHS
   // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
   // own OpDivs, so narrow the option set to their own grants; the server

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -47,7 +47,7 @@ import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 import OpDivGrantModal from '../OpDivGrantModal/OpDivGrantModal'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
-import { ERROR_MESSAGES } from '@/constants'
+import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
@@ -146,7 +146,9 @@ export default function UserTable() {
   const [userId, setUserId] = useState<GridRowId>('')
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({})
   const [open, setOpen] = useState<boolean>(false)
-  const [snackBarText, setSnackBarText] = useState<string>('Saved')
+  const [snackBarText, setSnackBarText] = useState<string>(
+    STATUS_MESSAGES.saved
+  )
   const [snackBarSeverity, setSnackBarSeverity] = useState<
     'success' | 'error' | 'warning' | 'info'
   >('success')
@@ -299,7 +301,7 @@ export default function UserTable() {
           ])
           apiRef.current.updateRows([updatedRow])
           setSnackBarSeverity('success')
-          setSnackBarText('Saved')
+          setSnackBarText(STATUS_MESSAGES.saved)
           setOpen(true)
         })
         .catch((error) => {
@@ -317,7 +319,7 @@ export default function UserTable() {
         })
         .then(() => {
           setSnackBarSeverity('success')
-          setSnackBarText('Saved')
+          setSnackBarText(STATUS_MESSAGES.saved)
           setOpen(true)
         })
         .catch((error) => {


### PR DESCRIPTION
Closes #389.

## Summary

Two helpers shipped during the auth-handling centralization (PR #388 + #378) need broader adoption now that the auth work itself has landed. This PR completes both.

* **`notify()` (added in #388)** is a thin wrapper around notistack's standalone `enqueueSnackbar` that bakes in project defaults (top-left anchor, `DEFAULT_ALERT_TIMEOUT`). Before this PR, 44 direct `enqueueSnackbar` calls remained across 9 view files. All migrated.
* **`parseApiError()` (added in #378)** normalizes axios errors into `{ status, fieldErrors?, message }`. Three form views (`DataCallModal`, `EditSystemModal`, `SystemDetailPage`) still hand-rolled `error.response.data.data` to dispatch 400 field errors. All migrated. Backend per-field copy now surfaces inline instead of the hardcoded `INVALID_INPUT_TEXT(key)` fallback.

While in the area: extracted `STATUS_MESSAGES` for short repeated UI status strings, added `ERROR_MESSAGES.systemNotFound`, dropped the dead `ERROR_MESSAGES.outOfScope` constant, and tightened the auth-handling invariants test to enforce `parseApiError(error)` in the three form views.

## What's in the diff

| Commit | Scope |
|---|---|
| `refactor(notifier): migrate enqueueSnackbar calls to notify() across views` | 44 calls in 9 files; all `useSnackbar()` destructures removed; dead `SNACK_ANCHOR` consts trimmed from OpDiv views |
| `refactor(notifier): propagate parseApiError and extract status constants` | 7 hand-rolled 400/404 catches in 3 form views switched to `parseApiError(error)`; new `STATUS_MESSAGES` + `ERROR_MESSAGES.systemNotFound`; 20 callsites updated to use the new constants |
| `chore(constants): drop dead ERROR_MESSAGES.outOfScope` | 3-line deletion of the unreachable OpDiv-scope 403 copy that #378 introduced and #388 made dead |
| `test(authHandling): tighten invariants for the form views` | Adds `parseApiError(error)` includes and `error.response.data.data` excludes for the three form-view entries; locks out the regression vector this PR pays down |

## Behavior changes worth flagging

### Per-field copy on 400 errors

* Before: `setFormValidErrorText(prev => ({ ...prev, [key]: INVALID_INPUT_TEXT(key) }))` (hardcoded per-field text regardless of backend response).
* After: `setFormValidErrorText(prev => ({ ...prev, [key]: message }))` where `message` comes from `parseApiError(error).fieldErrors[key]` (backend's per-field reason reaches the user).

If the backend returns an empty string for a field, the inline text will be empty too. Worth a quick smoke test on a real duplicate-acronym flow.

### "Error: " prefix dropped on 400 messages

`EditSystemModal` and `SystemDetailPage` decommission/reactivate 400 catches previously rendered `notify('Error: ${errorMsg}', 'error')`. Now: `notify(parsed.message, 'error')`. Backend message stands on its own.

### Snackbar timing alignment

Several `autoHideDuration` overrides matched `DEFAULT_ALERT_TIMEOUT` (3000ms) and those overrides are now dropped. A handful of success snackbars in `AssignSystemModal` and the OpDiv views previously relied on notistack's ~5000ms default; they now inherit the helper's 3000ms. Slight tightening, consistent with the helper's purpose.

### `ERROR_MESSAGES.outOfScope` deletion

The constant was unreachable post-#388. The auth-handling invariants test still excludes the substring as a defensive guard against re-introduction. Restoring scope-specific 403 copy is deferred to backend message work (the side that knows why it rejected the request should ship the message).

## Test plan

* [x] `make check` clean (format, lint, build)
* [x] `make test` passes (149 passing)
* [x] Manual smoke: trigger a 400 field-error on `EditSystemModal` (duplicate acronym) and confirm inline error text shows the backend's specific reason, not the generic `INVALID_INPUT_TEXT` fallback
* [x] Manual smoke: trigger one success snackbar and one error snackbar in any flow and confirm visual rendering matches expectations
* [x] Manual smoke: trigger a 404 on `SystemDetailPage`'s decommission flow (Requestly response inject) and confirm the toast reads "System not found"

## Notes
* **`CfactsRecordCard` intentionally not touched.** It uses `skipAuthHandling: true` to render a quiet empty state on 403 instead of a permission toast. The invariants test enforces this exception; it stays out of the `parseApiError` migration by design.
* **Non-form views (EmailModal, AssignSystemModal, QuestionnairePage) still use `notify(ERROR_MESSAGES.tryAgain, 'error')` directly** rather than routing through `parseApiError`. They have no field-error path; the marginal gain of surfacing backend messages there is small enough to leave for a follow-up if desired.