### PR TITLE
fix(users): fill OpDivs column from inline list grants, drop N+1

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,7 @@ export type QuestionChoice = {
 }
 export type users = {
   assignedfismasystems: number[]
+  assignedopdivids?: number[] | null
   email: string
   fullname: string
   role: UserRole

--- a/src/utils/userOpdivs.ts
+++ b/src/utils/userOpdivs.ts
@@ -8,9 +8,10 @@ import axiosInstance from '@/axiosConfig'
  * (GET returns { data: number[] }; POST body { opdiv_id }; DELETE by id).
  * Granting/revoking recomputes the user's derived identity_provider server-side.
  *
- * The list endpoint (GET /users) always returns assignedopdivids as null - the
- * join is skipped there - so callers must use fetchUserOpDivs per user rather
- * than reading a list row.
+ * The list endpoint (GET /users) returns each row's grants inline as
+ * assignedopdivids, so the users table reads them off the row directly.
+ * fetchUserOpDivs is for single-user refresh (e.g. after the grant modal) and
+ * as a fallback for older backends that omit the field.
  *
  * NOTE: these endpoints are built on the backend RBAC branch
  * (feature/opdiv-rbac-enforcement) but are not yet in backend/openapi.yaml, so

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -173,8 +173,10 @@ export default function UserTable() {
   const [opdivOptions, setOpDivOptions] = useState<OpDiv[]>([])
   // opdiv_id -> code, for rendering the OpDivs membership column.
   const [opdivCodeMap, setOpDivCodeMap] = useState<Record<number, string>>({})
-  // userid -> granted opdiv ids. The list endpoint omits grants (always null),
-  // so these are fetched per user from the detail endpoint after the list loads.
+  // userid -> granted opdiv ids, used as a refresh override after the grant modal
+  // closes. The list now returns grants inline (assignedopdivids); this map only
+  // holds rows refreshed since load, plus a one-time backfill against older
+  // backends that omit the inline grants (see the load effect).
   const [userOpDivMap, setUserOpDivMap] = useState<Record<string, number[]>>({})
   const handleRowEditStop: GridEventListener<'rowEditStop'> = (
     params,
@@ -447,23 +449,34 @@ export default function UserTable() {
             }
           }
           setFismaSystemsMap(map)
-          // Grants are omitted from the list response, so resolve each user's
-          // OpDivs from the detail endpoint in parallel for the OpDivs column.
-          Promise.all(
-            data.map((u: users) =>
-              fetchUserOpDivs(u.userid)
-                .then((ids) => [u.userid, ids] as [string, number[]])
-                .catch(() => [u.userid, []] as [string, number[]])
-            )
-          ).then((entries) => {
-            if (ignore) return
-            // Merge rather than replace so an in-flight per-user refresh
-            // (e.g. from closing the grant modal) is not clobbered.
-            setUserOpDivMap((prev) => ({
-              ...prev,
-              ...Object.fromEntries(entries),
-            }))
-          })
+          // Grants now arrive inline on each list row (assignedopdivids), so the
+          // OpDivs column reads them directly with no per-user calls. Fall back to
+          // the per-user detail endpoint only against an older backend that omits
+          // them, keeping this safe to ship before or after the backend deploys.
+          // Distinguish "old backend omitted the field" (key absent -> backfill)
+          // from "new backend, user simply has zero grants" (key present, value
+          // null/[] -> no backfill). A value check would misfire on every
+          // zero-grant user and re-introduce the N+1.
+          const missingInlineGrants = data.some(
+            (u: users) => !('assignedopdivids' in u)
+          )
+          if (missingInlineGrants) {
+            Promise.all(
+              data.map((u: users) =>
+                fetchUserOpDivs(u.userid)
+                  .then((ids) => [u.userid, ids] as [string, number[]])
+                  .catch(() => [u.userid, []] as [string, number[]])
+              )
+            ).then((entries) => {
+              if (ignore) return
+              // Merge rather than replace so an in-flight per-user refresh
+              // (e.g. from closing the grant modal) is not clobbered.
+              setUserOpDivMap((prev) => ({
+                ...prev,
+                ...Object.fromEntries(entries),
+              }))
+            })
+          }
         } else {
           return
         }
@@ -572,7 +585,10 @@ export default function UserTable() {
       sortable: false,
       filterable: false,
       renderCell: (params) => {
-        const ids = userOpDivMap[params.row.userid] ?? []
+        // Refresh override (post grant-modal) wins; otherwise use the grants the
+        // list returned inline on the row.
+        const ids =
+          userOpDivMap[params.row.userid] ?? params.row.assignedopdivids ?? []
         if (!ids.length) {
           return (
             <Typography variant="body2" color="text.secondary">

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -467,15 +467,27 @@ export default function UserTable() {
                   .then((ids) => [u.userid, ids] as [string, number[]])
                   .catch(() => [u.userid, []] as [string, number[]])
               )
-            ).then((entries) => {
-              if (ignore) return
-              // Merge rather than replace so an in-flight per-user refresh
-              // (e.g. from closing the grant modal) is not clobbered.
-              setUserOpDivMap((prev) => ({
-                ...prev,
-                ...Object.fromEntries(entries),
-              }))
-            })
+            )
+              .then((entries) => {
+                if (ignore) return
+                // Merge rather than replace so an in-flight per-user refresh
+                // (e.g. from closing the grant modal) is not clobbered.
+                setUserOpDivMap((prev) => ({
+                  ...prev,
+                  ...Object.fromEntries(entries),
+                }))
+              })
+              .catch((error) => {
+                if (ignore) return
+                // The per-user catches above already default to [], so this only
+                // trips on an unexpected failure. Surface it rather than leaving
+                // the OpDivs column silently blank.
+                console.error('Failed to backfill OpDiv grants', error)
+                enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
+                  variant: 'warning',
+                  anchorOrigin: { vertical: 'top', horizontal: 'left' },
+                })
+              })
           }
         } else {
           return


### PR DESCRIPTION
The Users admin table is slow to load. After `GET /users`, `UserTable` fired one `fetchUserOpDivs(userid)` per user (`Promise.all` over the rows) to fill the OpDivs column, because the list response historically returned no grants. At ~640 users that is ~640 requests queued behind the browser per-host connection cap, which is the load delay (the list query itself is ~8ms). It also contributed to the prod Aurora connection storm under the old per-connection data layer.

Now the OpDivs column reads each row's grants from the inline `assignedopdivids` field. No per-row calls on load.

## Safe rollout

Pairs with backend branch `fix/users-list-inline-opdivs`, which `ARRAY_AGG`s each user's grants onto the list row. The frontend falls back to the per-user fetch only when a row lacks the field, so it is correct before and after the backend deploys.

The fallback gate checks **key presence** (`!('assignedopdivids' in u)`), not value. A user with zero grants comes back as `assignedopdivids: null` on the new backend (ARRAY_AGG over no rows is NULL), which is byte-identical to the old backend omitting the field, so a value check would re-fire the N+1 for every grantless user.

## Changes

- `types.ts`: add `assignedopdivids` to the `users` type.
- `UserTable.tsx`: OpDivs column reads `userOpDivMap[userid]` (refresh override) `?? row.assignedopdivids ?? []`; the per-user `Promise.all` backfill is gated on the field being absent. The single-user refresh after the grant modal closes is unchanged.

## Test plan

- [x] tsc, eslint, prettier, jest green (149 passing)
- [x] With the backend branch running: one `/users` request, OpDiv column populated, zero `/users/{id}/assignedopdivs` calls on load
- [x] Against current backend: falls back to per-user fetch, column still correct
- [x] Grant modal add/revoke, then close: single-row refresh updates that row

Note: a separate follow-up will track the `OpDivGrantModal` per-item grant write-loop, which needs a backend batch-grant endpoint.