### PR TITLE
fix(export): only export selected systems from the current view

### DIFF
--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CustomFooterSaveComponent } from './FismaTable'
+import type { FismaSystemType } from '@/types'
+
+// GridFooterContainer and GridFooter internally call useGridRootProps which
+// requires the MUI DataGrid context. Stub them out for isolated unit tests.
+jest.mock('@mui/x-data-grid', () => ({
+  ...jest.requireActual('@mui/x-data-grid'),
+  GridFooterContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  GridFooter: () => <div data-testid="grid-footer" />,
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+const mockAxiosGet = require('@/axiosConfig').default.get as jest.Mock
+
+// Minimal blob download stubs
+const createObjectURL = jest.fn(() => 'blob:mock')
+const revokeObjectURL = jest.fn()
+Object.defineProperty(window, 'URL', {
+  value: { createObjectURL, revokeObjectURL },
+  writable: true,
+})
+
+const SYSTEMS = [
+  { fismasystemid: 1, fismaname: 'Active A' },
+  { fismasystemid: 2, fismaname: 'Active B' },
+]
+
+const baseProps = {
+  fismaSystems: SYSTEMS as unknown as FismaSystemType[],
+  latestDataCallId: 42,
+  scores: {},
+}
+
+const blobResponse = {
+  headers: {
+    'content-disposition': 'attachment; filename=export.xlsx',
+    'content-type':
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  },
+  data: new Blob(),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockAxiosGet.mockResolvedValue(blobResponse)
+})
+
+function renderFooter(selectedRows: number[]) {
+  return render(
+    <MemoryRouter>
+      <CustomFooterSaveComponent {...baseProps} selectedRows={selectedRows} />
+    </MemoryRouter>
+  )
+}
+
+describe('CustomFooterSaveComponent download button', () => {
+  it('is disabled when no rows are selected', () => {
+    renderFooter([])
+    expect(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    ).toBeDisabled()
+  })
+
+  it('sends fsids for a partial selection', () => {
+    renderFooter([1])
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      expect.stringContaining('fsids=1'),
+      expect.objectContaining({ responseType: 'blob' })
+    )
+  })
+
+  it('sends fsids when all visible rows are selected (regression: #375 select-all bug)', () => {
+    // Before the fix: selectedRows.length === fismaSystems.length caused the
+    // condition to short-circuit, sending no fsids and downloading all systems
+    // including those from the opposite decommissioned/active view.
+    renderFooter([1, 2])
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('fsids=1')
+    expect(calledUrl).toContain('fsids=2')
+    // Must NOT be a bare export URL (no fsids = download everything)
+    expect(calledUrl).not.toMatch(/\/export$/)
+    expect(calledUrl).not.toMatch(/\/export\?$/)
+  })
+})

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -58,21 +58,15 @@ export function CustomFooterSaveComponent(
   }
   const saveSystemAnswers = async () => {
     let exportUrl = `/datacalls/${props.latestDataCallId}/export`
-    if (
-      props.selectedRows &&
-      props.fismaSystems &&
-      props.selectedRows.length < props.fismaSystems.length
-    ) {
+    if (props.selectedRows && props.selectedRows.length > 0) {
       exportUrl += '?'
       let idString: string = ''
-      if (props.selectedRows) {
-        props.selectedRows.forEach((id, index) => {
-          idString += 'fsids=' + id
-          if (index < (props.selectedRows ?? []).length - 1) {
-            idString += '&'
-          }
-        })
-      }
+      props.selectedRows.forEach((id, index) => {
+        idString += 'fsids=' + id
+        if (props.selectedRows && index < props.selectedRows.length - 1) {
+          idString += '&'
+        }
+      })
       exportUrl += idString
     }
     return await axiosInstance


### PR DESCRIPTION
Rehomed from #376 (originally @costacalvin) onto a CMS-Enterprise branch so CI can run. Cherry-picked his commit onto current `main` (his fork branch was 5 commits behind); the change is unchanged and his authorship is preserved.

Fixes #375.

## The bug

In FismaTable, "Download selected system answers" included systems from the opposite active/decommissioned view when all visible rows were selected. The export guard was `selectedRows.length < fismaSystems.length`, so on select-all (`length === length`) it appended no `fsids` and sent a bare `/datacalls/{id}/export`, which the backend treats as "export everything" regardless of the active/decommissioned view.

## The fix

Guard on `selectedRows.length > 0` instead, so the explicit fsids are always sent whenever anything is selected. `fismaSystems` only ever holds the currently-visible view (the toggle re-fetches and replaces the array), and the selection model is materialized to concrete visible row ids, so partial and select-all both resolve to visible-only ids. Symmetric across both views.

## Changes

- `FismaTable.tsx`: export guard `length < total` becomes `length > 0`.
- `FismaTable.test.tsx` (new): covers disabled-when-empty, partial selection, and the select-all regression (#375), asserting the request is not a bare `/export`.

## Test plan

- [x] tsc, eslint, jest green (3 new FismaTable tests pass, including the #375 regression)
- [ ] Manual: active view, select-all, export only active systems
- [ ] Manual: decommissioned view, select-all, export only decommissioned systems
- [ ] Manual: partial selection in each view only the picked systems' fsids
