### PR TITLE
fix(login): redirect active sessions away from /signin; bump ws to 8.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,6 +257,6 @@
     "brace-expansion": "^1.1.13",
     "@tootallnate/once": "^3.0.1",
     "follow-redirects": "^1.16.0",
-    "ws": "^8.20.0"
+    "ws": "^8.21.0"
   }
 }

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -1,10 +1,23 @@
 import { Box, Typography } from '@mui/material'
 import { Button as CmsButton } from '@cmsgov/design-system'
-import { useLocation } from 'react-router-dom'
+import { Navigate, useLocation, useRouteLoaderData } from 'react-router-dom'
+import { RouteIds, Routes } from '@/router/constants'
 import ztmfLogo from '@/assets/ztmf-logo-login.png'
 
 export default function LoginPage() {
   const location = useLocation()
+
+  // Read the root route's authLoader payload and edirect to the dashboard
+  // so /signin never appears as a dead-end "log in again" prompt for an
+  // already-authenticated user.
+  const rootLoaderData = useRouteLoaderData(RouteIds.ROOT) as
+    | { status?: number }
+    | undefined
+
+  if (rootLoaderData?.status === 200) {
+    return <Navigate to={Routes.ROOT} replace />
+  }
+
   const message = location.state?.message || ''
   return (
     <Box

--- a/yarn.lock
+++ b/yarn.lock
@@ -18507,9 +18507,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.20.0":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
+"ws@npm:^8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -18518,7 +18518,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
+  checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rehomed from #392 (originally @tarratsco) onto a CMS-Enterprise branch so CI can run, and folded in the dependabot `ws` security bump (#384) since dependabot PRs can't run the secrets-backed CI either.

Closes #387. Supersedes #392 and #384.

## 1. Redirect signed-in users away from /signin (Onix's fix, #387)

A user with an active session who lands on `/signin` (address bar, bookmark, browser back/forward) used to see `LoginPage` as a dead-end "sign in again" prompt. `LoginPage` now reads the root route's authLoader payload via `useRouteLoaderData(RouteIds.ROOT)` and redirects to the dashboard with `<Navigate to={Routes.ROOT} replace />` when `status === 200`. A logged-out user has no `status`, so they still see the login page (and any session-expired message) as before. No redirect loop: `Title` gates on auth before rendering the `/signin` outlet, so the cycle terminates at Home.

## 2. Bump ws to 8.21.0 (#384)

`ws` is a `resolutions` security override, not a direct dependency. Updated the override `^8.20.0` to `^8.21.0` and regenerated the lockfile (resolves a single `ws@8.21.0`, no peer-dep changes).

## Test plan

- [x] tsc, eslint, jest green (152 passing)
- [ ] Manual: with an active session, visit /signin directly -> redirected to dashboard
- [ ] Manual: logged out, visit /signin -> login page shows (and session-expired message still renders on 401)
- [ ] App boots and builds with ws 8.21.0
