### PR TITLE
feat(datacalls): view historical data calls via header picker

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -53,6 +53,7 @@ interface PillarScoresModalProps {
   systemName: string
   systemAcronym: string
   scores: ScoreAggregate[]
+  selectedDataCallId: number
 }
 
 // Background color used when the API has not (yet) returned a tier
@@ -66,16 +67,19 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   systemName,
   systemAcronym,
   scores,
+  selectedDataCallId,
 }) => {
   const [datacalls, setDatacalls] = useState<DataCall[]>([])
   const [showDataTable, setShowDataTable] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
   const initialFocusRef = useRef<HTMLButtonElement>(null)
 
-  // Get the latest datacall (highest datacallid)
+  // Use the selected datacall if it exists in the scores, otherwise fall back
+  // to the highest datacallid (e.g. when modal is opened before context loads).
   const latestScore =
     scores.length > 0
-      ? scores.reduce((latest, current) =>
+      ? scores.find((s) => s.datacallid === selectedDataCallId) ??
+        scores.reduce((latest, current) =>
           current.datacallid > latest.datacallid ? current : latest
         )
       : null
@@ -91,7 +95,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     if (!hasValidData || !latestScore?.pillarscores) return []
 
     const previousDatacall = scores
-      .filter((s) => s.datacallid !== latestScore.datacallid)
+      .filter((s) => s.datacallid < latestScore.datacallid)
       .sort((a, b) => b.datacallid - a.datacallid)[0]
 
     return latestScore.pillarscores.map((pillar) => {
@@ -309,7 +313,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                   {(() => {
                     // Find previous system score for trend calculation
                     const previousSystemScore = scores
-                      .filter((s) => s.datacallid !== latestScore.datacallid)
+                      .filter((s) => s.datacallid < latestScore.datacallid)
                       .sort(
                         (a, b) => b.datacallid - a.datacallid
                       )[0]?.systemscore
@@ -340,7 +344,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                 {(() => {
                   // Show previous score and change information
                   const previousSystemScore = scores
-                    .filter((s) => s.datacallid !== latestScore.datacallid)
+                    .filter((s) => s.datacallid < latestScore.datacallid)
                     .sort((a, b) => b.datacallid - a.datacallid)[0]?.systemscore
 
                   if (latestScore.systemscore && previousSystemScore) {
@@ -398,13 +402,13 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
               gutterBottom
               sx={{ mt: 3, mb: 1.5, textAlign: 'center', fontSize: '1.25rem' }}
             >
-              Pillar Scores - {getQuarterName(latestScore.datacallid)} (Latest)
+              Pillar Scores - {getQuarterName(latestScore.datacallid)}
             </Typography>
             <Grid container spacing={2}>
               {(latestScore.pillarscores ?? []).map((pillar) => {
                 // Find previous score for this pillar
                 const previousDatacall = scores
-                  .filter((s) => s.datacallid !== latestScore.datacallid)
+                  .filter((s) => s.datacallid < latestScore.datacallid)
                   .sort((a, b) => b.datacallid - a.datacallid)[0]
 
                 const previousPillarScore =
@@ -712,7 +716,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         {latestScore?.pillarscores?.map((pillar) => {
                           const previousDatacall = scores
                             .filter(
-                              (s) => s.datacallid !== latestScore.datacallid
+                              (s) => s.datacallid < latestScore.datacallid
                             )
                             .sort((a, b) => b.datacallid - a.datacallid)[0]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,7 +244,6 @@ export type FormValidHelperText = {
 
 export type FismaTableProps = {
   scores: Record<number, SystemScoreEntry>
-  latestDataCallId: number
 }
 
 export type ThemeColor =

--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -35,7 +35,7 @@ const SYSTEMS = [
 
 const baseProps = {
   fismaSystems: SYSTEMS as unknown as FismaSystemType[],
-  latestDataCallId: 42,
+  activeDataCallId: 42,
   scores: {},
 }
 
@@ -89,6 +89,8 @@ describe('CustomFooterSaveComponent download button', () => {
       screen.getByRole('button', { name: /download selected system answers/i })
     )
     const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    // Exports against the active datacall (selected or latest), not a stale id
+    expect(calledUrl).toContain('/datacalls/42/export')
     expect(calledUrl).toContain('fsids=1')
     expect(calledUrl).toContain('fsids=2')
     // Must NOT be a bare export URL (no fsids = download everything)

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -40,7 +40,7 @@ declare module '@mui/x-data-grid' {
   interface FooterPropsOverrides {
     selectedRows: selectedRowsType
     fismaSystems: FismaSystemType[]
-    latestDataCallId: number
+    activeDataCallId: number
     scores: Record<number, SystemScoreEntry>
   }
 }
@@ -57,7 +57,7 @@ export function CustomFooterSaveComponent(
     setOpenSnackbar(false)
   }
   const saveSystemAnswers = async () => {
-    let exportUrl = `/datacalls/${props.latestDataCallId}/export`
+    let exportUrl = `/datacalls/${props.activeDataCallId}/export`
     if (props.selectedRows && props.selectedRows.length > 0) {
       exportUrl += '?'
       let idString: string = ''
@@ -214,7 +214,9 @@ const pillarScoresCache = new Map<number, CachedScore>()
 
 export default function FismaTable({ scores }: FismaTableProps) {
   const apiRef = useGridApiRef()
-  const { fismaSystems, latestDataCallId, userInfo } = useContextProp()
+  const { fismaSystems, latestDataCallId, selectedDataCallId, userInfo } =
+    useContextProp()
+  const activeDataCallId = selectedDataCallId || latestDataCallId
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
@@ -463,7 +465,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
           setSelectedRows(selectedIDs)
         }}
         slotProps={{
-          footer: { selectedRows, fismaSystems, latestDataCallId, scores },
+          footer: { selectedRows, fismaSystems, activeDataCallId, scores },
           filterPanel: {
             sx: {
               '& .MuiFormLabel-root': {
@@ -518,6 +520,7 @@ export default function FismaTable({ scores }: FismaTableProps) {
         systemName={pillarScoresModal.systemName}
         systemAcronym={pillarScoresModal.systemAcronym}
         scores={pillarScoresModal.scores}
+        selectedDataCallId={activeDataCallId}
       />
     </Box>
   )

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -14,12 +14,13 @@ import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
   const [scoreMap, setScoreMap] = useState<Record<number, SystemScoreEntry>>({})
-  const { latestDataCallId } = useContextProp()
+  const { latestDataCallId, selectedDataCallId } = useContextProp()
+  const activeDataCallId = selectedDataCallId || latestDataCallId
   useEffect(() => {
     async function fetchScores() {
-      if (latestDataCallId !== 0) {
+      if (activeDataCallId !== 0) {
         await axiosInstance
-          .get(`/scores/aggregate?datacallid=${latestDataCallId}`)
+          .get(`/scores/aggregate?datacallid=${activeDataCallId}`)
           .then((res) => {
             const scoresMap: Record<number, SystemScoreEntry> = {}
             for (const obj of res.data.data as ScoreAggregate[]) {
@@ -39,7 +40,7 @@ export default function HomePageContainer() {
       }
     }
     fetchScores()
-  }, [latestDataCallId])
+  }, [activeDataCallId])
 
   if (loading) {
     return (
@@ -59,7 +60,7 @@ export default function HomePageContainer() {
     <Box>
       <StatisticsBlocks scores={scoreMap} />
       <BreadCrumbs />
-      <FismaTable scores={scoreMap} latestDataCallId={latestDataCallId} />
+      <FismaTable scores={scoreMap} />
     </Box>
   )
 }

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -91,7 +91,7 @@ const addSpace = (str: string) => {
   return str
 }
 export default function QuestionnarePage() {
-  const { userInfo } = useContextProp()
+  const { userInfo, selectedDataCallId, selectedDatacall } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
@@ -105,7 +105,6 @@ export default function QuestionnarePage() {
   const [question, setQuestion] = React.useState<string>('')
   const [datacallID, setDatacallID] = React.useState<number>(0)
   const [datacall, setDatacall] = React.useState<string>('')
-  // const { latestDatacall, latestDatacallId } = useContextProp()
   const [loadingQuestion, setLoadingQuestion] = React.useState<boolean>(true)
   const [noQuestions, setNoQuestions] = React.useState<boolean>(false)
   const [categories, setCategories] = React.useState<Category[]>([])
@@ -270,13 +269,21 @@ export default function QuestionnarePage() {
           const latestDataCallId = await axiosInstance
             .get(`/datacalls/latest`)
             .then((res) => {
-              setDatacallID(res.data.data.datacallid)
-              datacall = res.data.data.datacall.replaceAll(' ', '_')
-              setDatacall(datacall)
-              if (new Date() > new Date(res.data.data.deadline)) {
+              const latestId = res.data.data.datacallid
+              const isHistorical =
+                selectedDataCallId > 0 && selectedDataCallId !== latestId
+              if (isHistorical) {
+                setDatacallID(selectedDataCallId)
+                datacall = selectedDatacall.replaceAll(' ', '_')
+                setDatacall(datacall)
                 setIsPastDeadline(true)
+              } else {
+                setDatacallID(latestId)
+                datacall = res.data.data.datacall.replaceAll(' ', '_')
+                setDatacall(datacall)
+                setIsPastDeadline(new Date() > new Date(res.data.data.deadline))
               }
-              return res.data.data.datacallid
+              return isHistorical ? selectedDataCallId : latestId
             })
             .catch((error) => {
               if (isAuthHandled(error)) return
@@ -411,7 +418,14 @@ export default function QuestionnarePage() {
       }
       fetchData()
     }
-  }, [system, navigate, fismaacronym, enqueueSnackbar])
+  }, [
+    system,
+    navigate,
+    fismaacronym,
+    enqueueSnackbar,
+    selectedDataCallId,
+    selectedDatacall,
+  ])
   React.useEffect(() => {
     if (questionId) {
       // Clear saved-state markers before async load so the last-edited

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -8,6 +8,10 @@ type ContextType = {
   userInfo: userData
   latestDataCallId: number
   latestDatacall: string
+  selectedDataCallId: number
+  setSelectedDataCallId: React.Dispatch<React.SetStateAction<number>>
+  selectedDatacall: string
+  setSelectedDatacall: React.Dispatch<React.SetStateAction<string>>
   showDecommissioned: boolean
   setShowDecommissioned: (show: boolean) => void
   fetchFismaSystems: (decommissioned?: boolean) => Promise<void>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,10 +1,10 @@
-import { Container, Typography } from '@mui/material'
+import { Container, Typography, Autocomplete, TextField } from '@mui/material'
 import { useLoaderData, useLocation } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import 'core-js/stable/atob'
-import { userData, UserRole } from '@/types'
+import { userData, UserRole, datacall } from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead as checkHasAdminRead,
@@ -57,7 +57,10 @@ export default function Title() {
   const isSignInRoute = normalizedPath === Routes.SIGNIN.toLowerCase()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
+  const [datacalls, setDatacalls] = useState<datacall[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
+  const [selectedDataCallId, setSelectedDataCallId] = useState<number>(0)
+  const [selectedDatacall, setSelectedDatacall] = useState<string>('')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
   const [latestDatacall, setLatestDatacall] = useState<string>('')
@@ -90,18 +93,26 @@ export default function Title() {
 
   useEffect(() => {
     if (loaderData.serverError) return
-    async function fetchLatestDatacall() {
+    async function fetchDatacalls() {
       await axiosInstance
-        .get('/datacalls/latest')
+        .get('/datacalls')
         .then((res) => {
-          setLatestDataCallId(res.data.data.datacallid)
-          setLatestDatacall(res.data.data.datacall)
+          const sorted: datacall[] = [...res.data.data].sort(
+            (a: datacall, b: datacall) => b.datacallid - a.datacallid
+          )
+          setDatacalls(sorted)
+          if (sorted.length > 0) {
+            setLatestDataCallId(sorted[0].datacallid)
+            setLatestDatacall(sorted[0].datacall)
+            setSelectedDataCallId(sorted[0].datacallid)
+            setSelectedDatacall(sorted[0].datacall)
+          }
         })
         .catch((error) => {
           console.error('Fetch latest datacall error:', error)
         })
     }
-    fetchLatestDatacall()
+    fetchDatacalls()
   }, [loaderData.serverError])
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
@@ -128,6 +139,7 @@ export default function Title() {
   }
   const isAdmin = checkIsAdmin(userInfo)
   const hasAdminRead = checkHasAdminRead(userInfo)
+  const isSystemDetail = location.pathname.startsWith('/systems/')
   // Single source of truth for header logo sizing; divider scales with it
   // so the mark, divider, and wordmark stay vertically centered on resize.
   const LOGO_HEIGHT = 55
@@ -309,10 +321,47 @@ export default function Title() {
             minWidth: 800,
           }}
         >
-          <Typography variant="subtitle1">
-            <span className="ds-u-font-weight--semibold">Datacall:</span>{' '}
-            {latestDatacall}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="subtitle1"
+              component="span"
+              sx={{ fontWeight: 600, whiteSpace: 'nowrap' }}
+            >
+              Datacall:
+            </Typography>
+            {isSystemDetail ? (
+              <Typography variant="subtitle1" component="span">
+                {latestDatacall}
+              </Typography>
+            ) : (
+              datacalls.length > 0 && (
+                <Autocomplete
+                  size="small"
+                  options={datacalls}
+                  getOptionLabel={(dc) => dc.datacall}
+                  isOptionEqualToValue={(option, value) =>
+                    option.datacallid === value.datacallid
+                  }
+                  value={
+                    datacalls.find(
+                      (dc) => dc.datacallid === selectedDataCallId
+                    ) ?? datacalls[0]
+                  }
+                  onChange={(_, dc) => {
+                    if (dc) {
+                      setSelectedDataCallId(dc.datacallid)
+                      setSelectedDatacall(dc.datacall)
+                    }
+                  }}
+                  disableClearable
+                  sx={{ minWidth: 260 }}
+                  renderInput={(params) => (
+                    <TextField {...params} size="small" />
+                  )}
+                />
+              )
+            )}
+          </Box>
         </Box>
       )}
       <Container
@@ -336,6 +385,10 @@ export default function Title() {
                   userInfo,
                   latestDataCallId,
                   latestDatacall,
+                  selectedDataCallId,
+                  setSelectedDataCallId,
+                  selectedDatacall,
+                  setSelectedDatacall,
                   showDecommissioned,
                   setShowDecommissioned,
                   fetchFismaSystems,


### PR DESCRIPTION
Rehomed from #373 (originally @costacalvin) onto a CMS-Enterprise branch so CI can run. His branch was 4 commits behind, so this is a rebase/reconciliation onto current `main` rather than a clean cherry-pick. Authorship preserved (commit authored by Calvin, co-authored by me for the rebase). Supersedes #373.

Closes #25.

## What this does

Adds a datacall picker to the header so users can view pillar scores, FISMA data, and questionnaires for any past data call, not just the latest. Context gains `selectedDataCallId`/`selectedDatacall`; the "active" datacall (selected or latest) is threaded through:

- Home score fetch (`/scores/aggregate` for the active datacall)
- FismaTable export and the pillar-scores modal
- Questionnaire (a historical datacall opens read-only)

`/systems/` detail keeps a static latest label rather than the picker.

## Reconciliation notes

Calvin's branch predated four changes that merged this week. Each was preserved (verified by review):

- **#382** branded header + **#399** hide-header-on-signin: the datacall picker is grafted onto the current branded header's sub-bar and respects the `isSignInRoute` gating, rather than reverting to the old header layout.
- **#396** export-selection fix: the export keeps the `selectedRows.length > 0` guard. Calvin's branch still had the old `length < fismaSystems.length` form (the bug #396 fixed); the reconciliation uses the fixed guard, just retargeted to the active datacall.
- **#394** `assignedopdivids` on the `users` type: untouched.

## Test plan

- [x] tsc, eslint, jest green (152 passing)
- [x] Header datacall dropdown lists all datacalls; selecting an older one re-fetches Home scores + FismaTable for that datacall
- [x] Questionnaire for a historical datacall opens read-only
- [ ] Export downloads the selected datacall's systems, current view only (active/decommissioned)
- [ ] /systems/ detail shows the static latest label, not the dropdown
