### PR TITLE
Email pre-auth landing page with IdP lookup (dual-IdP frontend)

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -50,6 +50,11 @@ jobs:
         run: yarn lint
 
       - name: BUILD
+        # VITE_* vars are baked into the bundle at build time, so they must
+        # be set on the build step itself, not on the deployed container.
+        # Default off; flip per environment as IdP rollout progresses.
+        env:
+          VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
         run: yarn build:${{ inputs.environment }}
 
       - name: Get AWS Creds

--- a/src/utils/authLookup.ts
+++ b/src/utils/authLookup.ts
@@ -1,0 +1,65 @@
+import axiosInstance from '@/axiosConfig'
+
+/**
+ * Identity provider routing values returned by the pre-auth lookup endpoint.
+ * `null` is the deliberate non-enumeration response for both unknown and
+ * unprovisioned emails - the same response shape is returned for both to
+ * avoid leaking which emails exist on the backend side.
+ */
+export type IdpRouting = 'okta' | 'entra' | null
+
+/**
+ * Response shape for GET /api/v1/auth/lookup. The envelope mirrors the
+ * project's other read endpoints: payload under `data`.
+ */
+type LookupResponse = {
+  data: { idp: IdpRouting }
+}
+
+/**
+ * 5-second cap on the unauthenticated lookup call so the Continue button
+ * does not hang indefinitely if the endpoint is slow or unreachable. The
+ * landing page treats a timeout the same as any other failure: show the
+ * generic "Contact your administrator" message, no enumeration signal.
+ */
+const LOOKUP_TIMEOUT_MS = 5000
+
+/**
+ * Pre-auth lookup that maps an email to its identity provider so the
+ * landing page can route the user to the matching /login/<idp> path.
+ *
+ * The endpoint is unauthenticated and rate-limited on the backend, and is
+ * forwarded by a dedicated ALB rule (no OIDC challenge). On the FE side
+ * the only state-bearing decision is the timeout: 5 seconds is enough for
+ * a healthy backend and short enough that a stuck call falls back to the
+ * generic error path quickly.
+ *
+ * Local dev hits the same endpoint via the Vite proxy (vite.config.ts
+ * forwards /api/v1 to VITE_CF_DOMAIN which points at the local backend on
+ * localhost:8080 when `make dev-up` is running). No FE-side mock; the
+ * backend's controller.LookupIdP is the single source of truth even in
+ * local dev.
+ *
+ * @param email - The email entered on the landing page. Not validated
+ *   here; the caller is expected to gate on format before calling.
+ * @returns The resolved IdP marker, or null when the email is not
+ *   provisioned (deliberately indistinguishable from "unknown email" per
+ *   the non-enumeration contract).
+ */
+export async function lookupIdpForEmail(email: string): Promise<IdpRouting> {
+  try {
+    const response = await axiosInstance.get<LookupResponse>('/auth/lookup', {
+      params: { email },
+      timeout: LOOKUP_TIMEOUT_MS,
+      // The lookup is unauthenticated; the interceptor's 401/403 redirect
+      // would be wrong here. Caller treats any failure as a null result.
+      skipAuthHandling: true,
+    })
+    return response.data.data.idp
+  } catch {
+    // Timeout, network error, 4xx, 5xx all collapse to null. The landing
+    // page renders the same generic message either way; that is the
+    // non-enumeration contract.
+    return null
+  }
+}

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type ChangeEvent } from 'react'
+import { useState, useRef, type FormEvent, type ChangeEvent } from 'react'
 import { Box, TextField, Typography } from '@mui/material'
 import { Button as CmsButton } from '@cmsgov/design-system'
 import { Navigate, useLocation, useRouteLoaderData } from 'react-router-dom'
@@ -72,6 +72,7 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
   const [email, setEmail] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [lookupError, setLookupError] = useState('')
+  const emailInputRef = useRef<HTMLInputElement>(null)
 
   const trimmedEmail = email.trim()
   const canSubmit =
@@ -107,6 +108,9 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
     // timeout) into the same generic message. No enumeration signal.
     setLookupError(UNKNOWN_EMAIL_MESSAGE)
     setIsSubmitting(false)
+    // Return focus to the field so keyboard/SR users land on the input the
+    // error refers to, not the now-disabled submit button.
+    emailInputRef.current?.focus()
   }
 
   return (
@@ -134,7 +138,10 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
           autoComplete="email"
           disabled={isSubmitting}
           error={!!lookupError}
-          inputProps={{ 'aria-label': 'Email address' }}
+          inputRef={emailInputRef}
+          inputProps={{
+            'aria-describedby': lookupError ? 'login-lookup-error' : undefined,
+          }}
           InputLabelProps={{ sx: { marginTop: 0 } }}
         />
         <CmsButton type="submit" disabled={!canSubmit} aria-busy={isSubmitting}>
@@ -142,6 +149,7 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
         </CmsButton>
         {lookupError && (
           <Typography
+            id="login-lookup-error"
             variant="body2"
             role="alert"
             sx={{ color: 'error.main', fontWeight: 600, mt: 1 }}

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -1,11 +1,36 @@
-import { Box, Typography } from '@mui/material'
+import { useState, type FormEvent, type ChangeEvent } from 'react'
+import { Box, TextField, Typography } from '@mui/material'
 import { Button as CmsButton } from '@cmsgov/design-system'
 import { Navigate, useLocation, useRouteLoaderData } from 'react-router-dom'
+import CONFIG from '@/utils/config'
 import { RouteIds, Routes } from '@/router/constants'
+import { lookupIdpForEmail } from '@/utils/authLookup'
 import ztmfLogo from '@/assets/ztmf-logo-login.png'
 
+const UNKNOWN_EMAIL_MESSAGE =
+  "We can't determine an identity provider for that email. Contact your ZTMF administrator."
+
+/**
+ * Basic shape check. The backend is the source of truth for whether the
+ * email maps to a real account; the FE just gates the Continue button on
+ * "looks roughly like an email" so a stray click does not fire the lookup.
+ */
+function isValidEmailFormat(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+/**
+ * Pre-auth landing page. When CONFIG.IDP_ENABLED is on, prompts for an
+ * email, calls the backend pre-auth lookup, and redirects to the matching
+ * /login/<idp> path. When the flag is off, falls back to the single-button
+ * Okta-only behavior so prod-style deployments without the multi-IdP
+ * rollout are unchanged.
+ *
+ * Rendered by Title.tsx when loaderData.status !== 200 (no active session).
+ */
 export default function LoginPage() {
   const location = useLocation()
+  const sessionMessage = location.state?.message || ''
 
   // Read the root route's authLoader payload and edirect to the dashboard
   // so /signin never appears as a dead-end "log in again" prompt for an
@@ -13,12 +38,130 @@ export default function LoginPage() {
   const rootLoaderData = useRouteLoaderData(RouteIds.ROOT) as
     | { status?: number }
     | undefined
-
   if (rootLoaderData?.status === 200) {
     return <Navigate to={Routes.ROOT} replace />
   }
 
-  const message = location.state?.message || ''
+  if (!CONFIG.IDP_ENABLED) {
+    return <LegacyOktaLogin sessionMessage={sessionMessage} />
+  }
+  return <IdpLookupLogin sessionMessage={sessionMessage} />
+}
+
+/**
+ * Existing single-button Okta flow. Kept as a fallback for environments
+ * where the multi-IdP rollout has not landed yet (typically prod before
+ * cutover). Removed when every environment has VITE_IDP_ENABLED=true.
+ */
+function LegacyOktaLogin({ sessionMessage }: { sessionMessage: string }) {
+  return (
+    <LoginShell>
+      {sessionMessage && <SessionMessage text={sessionMessage} />}
+      <CmsButton href="/login" size="big">
+        Sign in
+      </CmsButton>
+    </LoginShell>
+  )
+}
+
+/**
+ * New email-driven landing page. The backend lookup is the only source of
+ * truth for IdP routing; the FE never maps domain to provider locally.
+ */
+function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
+  const [email, setEmail] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [lookupError, setLookupError] = useState('')
+
+  const trimmedEmail = email.trim()
+  const canSubmit =
+    !isSubmitting && trimmedEmail.length > 0 && isValidEmailFormat(trimmedEmail)
+
+  const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value)
+    // Clear any stale "not configured" copy as soon as the user edits the
+    // field. They get a fresh shot at each submit.
+    if (lookupError) setLookupError('')
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!canSubmit) return
+
+    setIsSubmitting(true)
+    setLookupError('')
+
+    const idp = await lookupIdpForEmail(trimmedEmail)
+
+    if (idp === 'okta') {
+      // Full-page navigation. /login is an ALB rule, not a router route.
+      window.location.href = '/login'
+      return
+    }
+    if (idp === 'entra') {
+      window.location.href = '/login/entra'
+      return
+    }
+
+    // idp === null collapses every failure mode (unknown email, error,
+    // timeout) into the same generic message. No enumeration signal.
+    setLookupError(UNKNOWN_EMAIL_MESSAGE)
+    setIsSubmitting(false)
+  }
+
+  return (
+    <LoginShell>
+      {sessionMessage && <SessionMessage text={sessionMessage} />}
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 2,
+          width: '100%',
+        }}
+      >
+        <TextField
+          label="Enter your email to get started"
+          type="email"
+          value={email}
+          onChange={handleEmailChange}
+          fullWidth
+          variant="outlined"
+          margin="normal"
+          autoComplete="email"
+          disabled={isSubmitting}
+          error={!!lookupError}
+          inputProps={{ 'aria-label': 'Email address' }}
+          InputLabelProps={{ sx: { marginTop: 0 } }}
+        />
+        <CmsButton type="submit" disabled={!canSubmit} aria-busy={isSubmitting}>
+          {isSubmitting ? 'Checking...' : 'Continue'}
+        </CmsButton>
+        {lookupError && (
+          <Typography
+            variant="body2"
+            role="alert"
+            sx={{ color: 'error.main', fontWeight: 600, mt: 1 }}
+          >
+            {lookupError}
+          </Typography>
+        )}
+      </Box>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mt: 2 }}>
+        Having trouble? Contact the ZTMF support team.
+      </Typography>
+    </LoginShell>
+  )
+}
+
+/**
+ * Shared outer layout for both the legacy and IdP-lookup variants. Pure
+ * presentational shell so the two flows stay visually consistent.
+ */
+function LoginShell({ children }: { children: React.ReactNode }) {
   return (
     <Box
       flex={1}
@@ -36,31 +179,31 @@ export default function LoginPage() {
           alignItems: 'center',
           gap: 2.5,
           maxWidth: 520,
+          width: '100%',
           textAlign: 'center',
+          px: 2,
         }}
       >
-        {/* ZTMF logo - large, branded hero moment */}
         <img
           src={ztmfLogo}
           alt="ZTMF - Zero Trust Maturity Framework Scoring Tool"
-          style={{ width: 540, height: 'auto' }}
+          style={{ width: 540, maxWidth: '100%', height: 'auto' }}
         />
-
-        {/* error / session message */}
-        {message && (
-          <Typography
-            variant="body2"
-            sx={{ color: 'error.main', fontWeight: 600 }}
-          >
-            {message}
-          </Typography>
-        )}
-
-        {/* login button */}
-        <CmsButton href="/login" size="big">
-          Sign in
-        </CmsButton>
+        {children}
       </Box>
     </Box>
+  )
+}
+
+/**
+ * Pre-existing session-expired / redirect message surface. Kept in both
+ * variants so the message still renders if the user is bounced here from
+ * the auth interceptor.
+ */
+function SessionMessage({ text }: { text: string }) {
+  return (
+    <Typography variant="body2" sx={{ color: 'error.main', fontWeight: 600 }}>
+      {text}
+    </Typography>
   )
 }

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -113,6 +113,15 @@ export default function Title() {
   const handleClose = () => {
     setAnchorEl(null)
   }
+  // Display name for the IdP that minted the user's session. Surfaced
+  // as a small badge next to the name so support can debug "I logged
+  // in but the dashboard looks wrong" without DevTools.
+  const idpBadge =
+    userInfo.identity_provider === 'entra'
+      ? 'Entra'
+      : userInfo.identity_provider === 'okta'
+        ? 'Okta'
+        : ''
   const handleCloseModal = (newRowData: FismaSystemType) => {
     if (!_.isEqual(EMPTY_SYSTEM, newRowData)) {
       setFismaSystems((prevFismSystems) => [...prevFismSystems, newRowData])
@@ -211,6 +220,18 @@ export default function Title() {
                   className="ds-text-body--md"
                 >
                   {userInfo.fullname}
+                  {idpBadge && (
+                    <Typography
+                      component="span"
+                      sx={{
+                        color: 'text.secondary',
+                        ml: 0.5,
+                        fontSize: '0.85em',
+                      }}
+                    >
+                      ({idpBadge})
+                    </Typography>
+                  )}
                 </span>
               )}
               {hasAdminRead && (

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,7 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_AWS_REGION: string
-  readonly VITE_IDP_ENABLED: boolean
+  readonly VITE_IDP_ENABLED: string
   readonly VITE_COGNITO_DOMAIN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_IN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_OUT: string


### PR DESCRIPTION
Rehomed from #402 (originally @tarratsco) onto a CMS-Enterprise branch so CI can run. Onix's four commits are cherry-picked unchanged (authorship preserved); one a11y/type follow-up commit is added on top. This is the final frontend piece of the dual-IdP / OIDC Entra work.

Closes #328. Pairs with backend `CMS-Enterprise/ztmf#341` (dual-IdP, dormant behind `entra_enabled`); ops flips dev via `ztmf#347`.

## What it does

Replaces the single Sign-in button with an email pre-auth landing page gated by `CONFIG.IDP_ENABLED`. On submit it calls `GET /api/v1/auth/lookup?email=<value>` (unauthenticated, `skipAuthHandling: true`, 5s timeout) and routes:

- `{idp:"okta"}` -> full-page nav to `/login`
- `{idp:"entra"}` -> `/login/entra`
- `null` / error / timeout -> one generic message, no enumeration signal

When `CONFIG.IDP_ENABLED` is false, the legacy single-button Okta flow renders unchanged. `ui.yml` sets `VITE_IDP_ENABLED` on the BUILD step, true for dev only. Also adds an `(Okta)`/`(Entra)` badge next to the user name for support debugging. #397 (authenticated -> `/`) and #399 (header hidden on `/signin`) are preserved.

## Review

Independent review confirmed the non-enumeration contract holds, the unauthenticated lookup can't leak session or fall through to the interceptor, redirect targets are hardcoded literals (no open-redirect), and #397/#399 are intact. The added follow-up commit addresses the a11y findings:

- email field no longer sets an `aria-label` that overrode the visible label (WCAG 2.5.3)
- lookup error is associated with the input via `aria-describedby` and focus returns to the field on error
- `VITE_IDP_ENABLED` typed as `string` to match Vite's runtime injection

## Follow-ups (not in this PR)

- The 429 rate-limit response currently collapses into the generic message rather than distinct "too many attempts" copy (per #329). Defensible for non-enumeration; left as a product decision.
- `isValidEmailFormat` here duplicates `emailValidator` in `EditSystemModal/validators.ts` — worth consolidating into a shared util.
- No logout affordance exists yet; worth a separate ticket.

## Test plan

- [x] tsc, eslint, jest green (152 passing)
- [x] Local smoke: okta/entra/unknown three-branch routing; invalid format keeps Continue disabled; unknown email shows the generic message
- [x] Authenticated: `(Okta)`/`(Entra)` badge renders; visiting `/signin` redirects to `/`; header hidden on `/signin`
- [x] Deployed-dev once `entra_enabled` flips (ztmf#347): full Entra OIDC handshake -> session -> `/users/current` 200
