### PR TITLE
Finish notify() and parseApiError adoption across views

### DIFF
--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -15,7 +15,6 @@ import {
   Hint,
 } from '@cmsgov/design-system'
 import SentEmailsModal from './SentEmailsModal'
-import { useSnackbar } from 'notistack'
 import TextField from '@mui/material/TextField'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import { EmailModalProps } from '@/types'
@@ -23,7 +22,7 @@ import './EmailModal.css'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
 import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 
 const CssTextField = styled(TextField)({
   '& .MuiInputBase-root': {
@@ -57,7 +56,6 @@ const CssTextField = styled(TextField)({
 })
 
 export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
-  const { enqueueSnackbar } = useSnackbar()
   const [sentToEmails, setSentToEmails] = React.useState<string[]>([])
   const [openSentEmailsDialog, setOpenSentEmailsDialog] =
     React.useState<boolean>(false)
@@ -85,24 +83,14 @@ export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
       })
       .then((res) => {
         setSentGroup(groupValue)
-        enqueueSnackbar(`Emails have successfully been sent`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify('Emails have successfully been sent', 'success', {
           autoHideDuration: 2500,
         })
         setSentToEmails(res.data.data)
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(ERROR_MESSAGES.tryAgain, 'error', {
           autoHideDuration: 2500,
         })
       })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,11 +24,24 @@ export const ERROR_MESSAGES = {
   error:
     'An error occurred. Please log in and try again. If the error persists, please contact support.',
   permission: 'You do not have permission to do this action.',
-  outOfScope:
-    'This item is outside your OpDiv, so you cannot make changes to it.',
   tryAgain: 'An error occurred, please try again later',
   refresh:
     'Could not refresh the latest data. The information shown may be out of date.',
+  systemNotFound: 'System not found',
+}
+
+// Short UI status strings for snackbar toasts on save/create flows. Distinct
+// from ERROR_MESSAGES because these are not errors — they are user-facing
+// status indicators returned by the operation. Keeping them grouped avoids
+// the naming collision with ERROR_MESSAGES.notSaved (which is the long-form
+// session-expired warning).
+export const STATUS_MESSAGES = {
+  saved: 'Saved',
+  notSaved: 'Not Saved',
+  created: 'Created',
+  notCreated: 'Not Created',
+  systemDecommissioned: 'System decommissioned successfully',
+  systemReactivated: 'System reactivated successfully',
 }
 export const EMPTY_USER: userData = {
   userid: '',

--- a/src/utils/authHandling.invariants.test.ts
+++ b/src/utils/authHandling.invariants.test.ts
@@ -22,13 +22,23 @@ const expectations: FileExpectation[] = [
   },
   {
     filePath: 'src/views/DatacallModal/DataCallModal.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['ERROR_MESSAGES.permission', 'Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     filePath: 'src/views/EditSystemModal/EditSystemModal.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     filePath: 'src/views/FismaTable/FismaTable.tsx',
@@ -55,8 +65,13 @@ const expectations: FileExpectation[] = [
   },
   {
     filePath: 'src/views/SystemDetailPage/SystemDetailPage.tsx',
-    includes: ['if (isAuthHandled(error)) return'],
-    excludes: ['Routes.SIGNIN'],
+    includes: ['if (isAuthHandled(error)) return', 'parseApiError(error)'],
+    excludes: [
+      'Routes.SIGNIN',
+      'ERROR_MESSAGES.permission',
+      'ERROR_MESSAGES.outOfScope',
+      'error.response.data.data',
+    ],
   },
   {
     // Title legitimately references Routes.SIGNIN to compare the current path

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -15,9 +15,8 @@ import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import { useSnackbar } from 'notistack'
 import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
 const checkedIcon = <CheckBoxIcon fontSize="small" />
@@ -44,7 +43,6 @@ export default function AssignSystemModal({
     systemid: number
     nextValue: number[]
   } | null>(null)
-  const { enqueueSnackbar } = useSnackbar()
   React.useEffect(() => {
     if (open && userid) {
       axiosInstance.get(`/users/${userid}/assignedfismasystems`).then((res) => {
@@ -64,24 +62,11 @@ export default function AssignSystemModal({
       .delete(`/users/${userid}/assignedfismasystems/${target.systemid}`)
       .then(() => {
         setAssignedSystems(target.nextValue)
-        enqueueSnackbar(`Saved - unassigned system`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-        })
+        notify('Saved - unassigned system', 'success')
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 1500,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 1500 })
       })
   }
 
@@ -141,22 +126,11 @@ export default function AssignSystemModal({
                   })
                   .then(() => {
                     setAssignedSystems(newValue)
-                    enqueueSnackbar(`Saved - assign system`, {
-                      variant: 'success',
-                      anchorOrigin: {
-                        vertical: 'top',
-                        horizontal: 'left',
-                      },
-                    })
+                    notify('Saved - assign system', 'success')
                   })
                   .catch((error) => {
                     if (isAuthHandled(error)) return
-                    enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                      variant: 'error',
-                      anchorOrigin: {
-                        vertical: 'top',
-                        horizontal: 'left',
-                      },
+                    notify(ERROR_MESSAGES.tryAgain, 'error', {
                       autoHideDuration: 1500,
                     })
                   })

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -16,15 +16,13 @@ import {
   // FormControl,
 } from '@mui/material'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
-import { useSnackbar } from 'notistack'
 import { datacallModalProps } from '@/types'
 import './DatacallModal.css'
 import axiosInstance from '@/axiosConfig'
-import { ERROR_MESSAGES } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { parseApiError } from '@/utils/apiErrors'
+import { isAuthHandled, notify } from '@/utils/notify'
 
 export default function DataCallModal({ open, onClose }: datacallModalProps) {
-  const { enqueueSnackbar } = useSnackbar()
   const [datacall, setDatacall] = React.useState<string>('')
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
@@ -72,25 +70,24 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
         deadline: new Date(deadline).toISOString(),
       })
       .then(() => {
-        enqueueSnackbar(`Datacall has successfully been created`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify('Datacall has successfully been created', 'success', {
           autoHideDuration: 2500,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2500,
-        })
+        const parsed = parseApiError(error)
+        // Backend 400 with a field map: route each reason to the matching
+        // field's error setter. No toast on this branch, the inline errors
+        // are the user feedback.
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+            if (key === 'datacall') setDatacallError(message)
+            else if (key === 'deadline') setDeadlineError(message)
+          })
+          return
+        }
+        notify(parsed.message, 'error', { autoHideDuration: 2500 })
       })
   }
   return (

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -16,7 +16,11 @@ import {
   FormValidHelperText,
 } from '@/types'
 import MenuItem from '@mui/material/MenuItem'
-import { CONFIRMATION_MESSAGE } from '@/constants'
+import {
+  CONFIRMATION_MESSAGE,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
+} from '@/constants'
 import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 
 import ValidatedTextField from './ValidatedTextField'
@@ -27,12 +31,8 @@ import CircularProgress from '@mui/material/CircularProgress'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import _ from 'lodash'
 import axiosInstance from '@/axiosConfig'
-import {
-  ERROR_MESSAGES,
-  TEXTFIELD_HELPER_TEXT,
-  INVALID_INPUT_TEXT,
-} from '@/constants'
-import { useSnackbar } from 'notistack'
+import { TEXTFIELD_HELPER_TEXT } from '@/constants'
+import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 /**
  * Component that renders a modal to edit fisma systems.
@@ -59,7 +59,6 @@ export default function EditSystemModal({
   const isFormValid = (): boolean => {
     return Object.values(formValid).every((value) => value === true)
   }
-  const { enqueueSnackbar } = useSnackbar()
   const [loading, setLoading] = React.useState<boolean>(true)
   const [openAlert, setOpenAlert] = React.useState<boolean>(false)
   const [openDecommissionAlert, setOpenDecommissionAlert] =
@@ -237,41 +236,32 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
-          if (error.response?.status === 400) {
-            const data: { [key: string]: string } = error.response.data.data
-            Object.entries(data).forEach(([key]) => {
+          const parsed = parseApiError(error)
+          // Backend 400 with a field map: render each reason inline under
+          // its input via formValid + formValidErrorText. The 'Not Saved'
+          // toast is a status flag, not the detail.
+          if (parsed.fieldErrors) {
+            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({
                 ...prevState,
                 [key]: false,
               }))
               setFormValidErrorText((prevState) => ({
                 ...prevState,
-                [key]: INVALID_INPUT_TEXT(key),
+                [key]: message,
               }))
             })
-            enqueueSnackbar(`Not Saved`, {
-              variant: 'error',
-              anchorOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
+            notify(STATUS_MESSAGES.notSaved, 'error', {
               autoHideDuration: 1500,
             })
-          } else {
-            notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+            return
           }
+          notify(parsed.message, 'error')
         })
     } else if (mode === 'create') {
       await axiosInstance
@@ -290,41 +280,34 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
         .then(() => {
-          enqueueSnackbar(`Created`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+          notify(STATUS_MESSAGES.created, 'success', {
             autoHideDuration: 1500,
           })
           onClose(editedFismaSystem)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
-          if (error.response?.status === 400) {
-            const data: { [key: string]: string } = error.response.data.data
-            Object.entries(data).forEach(([key]) => {
+          const parsed = parseApiError(error)
+          // Backend 400 with a field map: render each reason inline under
+          // its input via formValid + formValidErrorText. The 'Not Created'
+          // toast is a status flag, not the detail.
+          if (parsed.fieldErrors) {
+            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
               setFormValid((prevState) => ({
                 ...prevState,
                 [key]: false,
               }))
               setFormValidErrorText((prevState) => ({
                 ...prevState,
-                [key]: INVALID_INPUT_TEXT(key),
+                [key]: message,
               }))
             })
-            enqueueSnackbar(`Not Created`, {
-              variant: 'error',
-              anchorOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
+            notify(STATUS_MESSAGES.notCreated, 'error', {
               autoHideDuration: 1500,
             })
-          } else {
-            notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+            return
           }
+          notify(parsed.message, 'error')
         })
     }
   }
@@ -376,12 +359,7 @@ export default function EditSystemModal({
       })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          enqueueSnackbar('System decommissioned successfully', {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -400,28 +378,14 @@ export default function EditSystemModal({
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
             autoHideDuration: 2000,
           })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 3000,
-          })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
   const handleReactivate = async () => {
@@ -432,12 +396,7 @@ export default function EditSystemModal({
       .put(`fismasystems/${editedFismaSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          enqueueSnackbar('System reactivated successfully', {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+          notify(STATUS_MESSAGES.systemReactivated, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -455,28 +414,14 @@ export default function EditSystemModal({
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
             autoHideDuration: 2000,
           })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 3000,
-          })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
   if (open && system) {

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -25,7 +25,6 @@ import {
   GridToolbarContainer,
   GridToolbarQuickFilter,
 } from '@mui/x-data-grid'
-import { useSnackbar } from 'notistack'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
@@ -40,7 +39,6 @@ import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import type { OpDiv } from '@/types'
 
-const SNACK_ANCHOR = { vertical: 'top', horizontal: 'left' } as const
 const CODE_MAX = 16
 const NAME_MAX = 128
 
@@ -66,7 +64,6 @@ function CreateToolbar({ onCreate }: { onCreate: () => void }) {
 export default function OpDivAdmin() {
   const navigate = useNavigate()
   const { userInfo } = useContextProp()
-  const { enqueueSnackbar } = useSnackbar()
   const isOwner = userInfo.role === 'OWNER'
 
   const [rows, setRows] = useState<OpDiv[]>([])
@@ -138,12 +135,9 @@ export default function OpDivAdmin() {
       : createOpDiv(input)
     request
       .then(() => {
-        enqueueSnackbar(
+        notify(
           editing ? 'Saved - OpDiv updated' : 'Saved - OpDiv created',
-          {
-            variant: 'success',
-            anchorOrigin: SNACK_ANCHOR,
-          }
+          'success'
         )
         setDialogOpen(false)
         loadOpDivs()
@@ -171,11 +165,11 @@ export default function OpDivAdmin() {
       active: !target.active,
     })
       .then(() => {
-        enqueueSnackbar(
+        notify(
           target.active
             ? 'Saved - OpDiv deactivated'
             : 'Saved - OpDiv activated',
-          { variant: 'success', anchorOrigin: SNACK_ANCHOR }
+          'success'
         )
         loadOpDivs()
       })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -13,7 +13,6 @@ import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import { useSnackbar } from 'notistack'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { fetchUserOpDivs, grantOpDiv, revokeOpDiv } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
@@ -42,8 +41,6 @@ type Props = {
   onChanged?: (userid: string) => void
 }
 
-const SNACK_ANCHOR = { vertical: 'top', horizontal: 'left' } as const
-
 export default function OpDivGrantModal({
   open,
   handleClose,
@@ -56,7 +53,6 @@ export default function OpDivGrantModal({
   const [pendingRevoke, setPendingRevoke] = React.useState<{
     opdivId: number
   } | null>(null)
-  const { enqueueSnackbar } = useSnackbar()
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -99,10 +95,7 @@ export default function OpDivGrantModal({
         // Functional update so a grant that resolved while the confirm was
         // open is not dropped by a stale snapshot.
         setAssignedOpDivs((prev) => prev.filter((id) => id !== target.opdivId))
-        enqueueSnackbar('Saved - revoked OpDiv', {
-          variant: 'success',
-          anchorOrigin: SNACK_ANCHOR,
-        })
+        notify('Saved - revoked OpDiv', 'success')
         onChanged?.(String(userid))
       })
       .catch((error) => handleError(error))
@@ -162,10 +155,7 @@ export default function OpDivGrantModal({
                     setAssignedOpDivs((prev) =>
                       prev.includes(opdivId) ? prev : [...prev, opdivId]
                     )
-                    enqueueSnackbar('Saved - granted OpDiv', {
-                      variant: 'success',
-                      anchorOrigin: SNACK_ANCHOR,
-                    })
+                    notify('Saved - granted OpDiv', 'success')
                     onChanged?.(String(userid))
                   })
                   .catch((error) => handleError(error))

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,16 +21,16 @@ import {
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
-import { useSnackbar } from 'notistack'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
   ERROR_MESSAGES,
+  STATUS_MESSAGES,
   MAX_QUESTIONNAIRE_NOTES_LENGTH,
   CONFIRMATION_MESSAGE_QUESTION,
 } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { sortFunctions } from '@/utils/sortFunctions'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
@@ -167,7 +167,6 @@ export default function QuestionnarePage() {
     )
   }
 
-  const { enqueueSnackbar } = useSnackbar()
   const navigate = useNavigate()
   const location = useLocation()
   const { fismaacronym } = useParams()
@@ -201,27 +200,13 @@ export default function QuestionnarePage() {
         })
         .then(() => {
           // checkValidResponse(res.status)
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
           console.error('Error updating score:', error)
-          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2500,
-          })
+          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         })
     } else {
       axiosInstance
@@ -232,27 +217,13 @@ export default function QuestionnarePage() {
           datacallid: datacallID,
         })
         .then(() => {
-          enqueueSnackbar(`Saved`, {
-            variant: 'success',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 1500,
-          })
+          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
           fetchQuestionScores(system, setQuestionScores)
         })
         .catch((error) => {
           if (isAuthHandled(error)) return
           console.error('Error posting score:', error)
-          enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-            variant: 'error',
-            anchorOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            autoHideDuration: 2500,
-          })
+          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
         })
     }
   }
@@ -287,12 +258,7 @@ export default function QuestionnarePage() {
             })
             .catch((error) => {
               if (isAuthHandled(error)) return
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
+              notify(ERROR_MESSAGES.tryAgain, 'error', {
                 autoHideDuration: 2500,
               })
             })
@@ -370,14 +336,7 @@ export default function QuestionnarePage() {
             })
             .catch((error) => {
               if (isAuthHandled(error)) return
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-                autoHideDuration: 3000,
-              })
+              notify(ERROR_MESSAGES.tryAgain, 'error')
             })
           if (questionsEmpty) {
             return
@@ -402,14 +361,7 @@ export default function QuestionnarePage() {
             .catch((error) => {
               if (isAuthHandled(error)) return
               console.error('Error fetching question scores:', error)
-              enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                variant: 'error',
-                anchorOrigin: {
-                  vertical: 'top',
-                  horizontal: 'left',
-                },
-                autoHideDuration: 3000,
-              })
+              notify(ERROR_MESSAGES.tryAgain, 'error')
             })
         } catch (error) {
           if (isAuthHandled(error)) return
@@ -418,14 +370,7 @@ export default function QuestionnarePage() {
       }
       fetchData()
     }
-  }, [
-    system,
-    navigate,
-    fismaacronym,
-    enqueueSnackbar,
-    selectedDataCallId,
-    selectedDatacall,
-  ])
+  }, [system, navigate, fismaacronym, selectedDataCallId, selectedDatacall])
   React.useEffect(() => {
     if (questionId) {
       // Clear saved-state markers before async load so the last-edited

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -27,12 +27,11 @@ import {
 import LastEditedFooter from '../QuestionnairePage/LastEditedFooter'
 import axiosInstance from '@/axiosConfig'
 import CircularProgress from '@mui/material/CircularProgress'
-import { useSnackbar } from 'notistack'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
-import { MAX_QUESTIONNAIRE_NOTES_LENGTH } from '@/constants'
-import { isAuthHandled } from '@/utils/notify'
+import { MAX_QUESTIONNAIRE_NOTES_LENGTH, STATUS_MESSAGES } from '@/constants'
+import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { sortFunctions } from '@/utils/sortFunctions'
 import { useContextProp } from '../Title/Context'
@@ -78,7 +77,6 @@ export default function QuestionnareModal({
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
-  const { enqueueSnackbar } = useSnackbar()
   const [activeCategoryIndex, setActiveCategoryIndex] =
     React.useState<number>(0)
   const [activeStepIndex, setActiveStepIndex] = React.useState<number>(0)
@@ -160,13 +158,7 @@ export default function QuestionnareModal({
             datacallid: datacallID,
           })
           .then(() => {
-            enqueueSnackbar(`Saved`, {
-              variant: 'success',
-              anchorOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
-            })
+            notify(STATUS_MESSAGES.saved, 'success')
             fetchQuestionScores(
               Number(system?.fismasystemid),
               setQuestionScores

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { Box, CircularProgress, Divider, Typography } from '@mui/material'
-import { useSnackbar } from 'notistack'
 import _ from 'lodash'
 
 import { FismaSystemType, FormValidType, FormValidHelperText } from '@/types'
 import { useContextProp } from '@/views/Title/Context'
 import axiosInstance from '@/axiosConfig'
 import {
-  ERROR_MESSAGES,
   CONFIRMATION_MESSAGE,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
   TEXTFIELD_HELPER_TEXT,
-  INVALID_INPUT_TEXT,
 } from '@/constants'
+import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
@@ -26,7 +26,6 @@ import CfactsRecordCard from './CfactsRecordCard'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const { enqueueSnackbar } = useSnackbar()
   const { fismaSystems, setFismaSystems, userInfo } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
@@ -285,11 +284,7 @@ export default function SystemDetailPage() {
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       })
       .then(() => {
-        enqueueSnackbar('Saved', {
-          variant: 'success',
-          anchorOrigin: { vertical: 'top', horizontal: 'left' },
-          autoHideDuration: 1500,
-        })
+        notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
         setFismaSystems((prev) =>
           prev.map((s) =>
             s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
@@ -298,29 +293,25 @@ export default function SystemDetailPage() {
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        if (error.response?.status === 400) {
-          const data: { [key: string]: string } = error.response.data.data
-          Object.entries(data).forEach(([key]) => {
+        const parsed = parseApiError(error)
+        // Backend 400 with a field map: render each reason inline under its
+        // input via formValid + formValidErrorText. The 'Not Saved' toast
+        // is a status flag, not the detail.
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
             setFormValid((prev) => ({ ...prev, [key]: false }))
-            setFormValidErrorText((prev) => ({
-              ...prev,
-              [key]: INVALID_INPUT_TEXT(key),
-            }))
+            setFormValidErrorText((prev) => ({ ...prev, [key]: message }))
           })
-          enqueueSnackbar('Not Saved', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 1500,
-          })
-        } else if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+          return
+        }
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
             autoHideDuration: 2000,
           })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          return
         }
+        notify(parsed.message, 'error')
       })
       .finally(() => {
         setIsSaving(false)
@@ -347,9 +338,7 @@ export default function SystemDetailPage() {
       .delete(`fismasystems/${editedSystem.fismasystemid}`, { data: body })
       .then((res) => {
         if (res.status === 200 || res.status === 204) {
-          enqueueSnackbar('System decommissioned successfully', {
-            variant: 'success',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -378,22 +367,14 @@ export default function SystemDetailPage() {
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
             autoHideDuration: 2000,
           })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 3000,
-          })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
 
@@ -408,9 +389,7 @@ export default function SystemDetailPage() {
       .put(`fismasystems/${editedSystem.fismasystemid}/reactivate`, body)
       .then((res) => {
         if (res.status === 200) {
-          enqueueSnackbar('System reactivated successfully', {
-            variant: 'success',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+          notify(STATUS_MESSAGES.systemReactivated, 'success', {
             autoHideDuration: 2000,
           })
           const updatedSystem: FismaSystemType = res.data?.data || {
@@ -439,22 +418,14 @@ export default function SystemDetailPage() {
           error.response?.status,
           error.response?.data
         )
-        if (error.response?.status === 404) {
-          enqueueSnackbar('System not found', {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
+        const parsed = parseApiError(error)
+        if (parsed.status === 404) {
+          notify(ERROR_MESSAGES.systemNotFound, 'error', {
             autoHideDuration: 2000,
           })
-        } else if (error.response?.status === 400) {
-          const errorMsg = error.response?.data?.error || 'Invalid request'
-          enqueueSnackbar(`Error: ${errorMsg}`, {
-            variant: 'error',
-            anchorOrigin: { vertical: 'top', horizontal: 'left' },
-            autoHideDuration: 3000,
-          })
-        } else {
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+          return
         }
+        notify(parsed.message, 'error')
       })
   }
 

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -39,16 +39,15 @@ import {
 import { fetchOpDivs } from '@/utils/opdivs'
 import { fetchUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
-import { isAuthHandled } from '@/utils/notify'
+import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
 import Box from '@mui/material/Box'
 import CustomSnackbar from '../Snackbar/Snackbar'
-import { useSnackbar } from 'notistack'
 import AssignSystemModal from '../AssignSystemModal/AssignSystemModal'
 import OpDivGrantModal from '../OpDivGrantModal/OpDivGrantModal'
 import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
-import { ERROR_MESSAGES } from '@/constants'
+import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
@@ -130,7 +129,6 @@ function validateEmail(email: string) {
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()
-  const { enqueueSnackbar } = useSnackbar()
   const { userInfo, fismaSystems } = useContextProp()
   // Write-tier admins get the create/edit/delete/assign controls; read-only
   // admins may view the table but every mutating control is withheld. The
@@ -148,7 +146,9 @@ export default function UserTable() {
   const [userId, setUserId] = useState<GridRowId>('')
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({})
   const [open, setOpen] = useState<boolean>(false)
-  const [snackBarText, setSnackBarText] = useState<string>('Saved')
+  const [snackBarText, setSnackBarText] = useState<string>(
+    STATUS_MESSAGES.saved
+  )
   const [snackBarSeverity, setSnackBarSeverity] = useState<
     'success' | 'error' | 'warning' | 'info'
   >('success')
@@ -249,10 +249,7 @@ export default function UserTable() {
           `Failed to refresh OpDiv grants for user ${userid}`,
           error
         )
-        enqueueSnackbar(ERROR_MESSAGES.refresh, {
-          variant: 'warning',
-          anchorOrigin: { vertical: 'top', horizontal: 'left' },
-        })
+        notify(ERROR_MESSAGES.refresh, 'warning')
       })
     axiosInstance
       .get(`/users/${userid}`)
@@ -306,7 +303,7 @@ export default function UserTable() {
           ])
           apiRef.current.updateRows([updatedRow])
           setSnackBarSeverity('success')
-          setSnackBarText('Saved')
+          setSnackBarText(STATUS_MESSAGES.saved)
           setOpen(true)
         })
         .catch((error) => {
@@ -324,7 +321,7 @@ export default function UserTable() {
         })
         .then(() => {
           setSnackBarSeverity('success')
-          setSnackBarText('Saved')
+          setSnackBarText(STATUS_MESSAGES.saved)
           setOpen(true)
         })
         .catch((error) => {
@@ -368,25 +365,13 @@ export default function UserTable() {
       .delete(`/users/${target.userid}`)
       .then(() => {
         setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        enqueueSnackbar(`Saved - Delete User ${target.fullname}`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(`Saved - Delete User ${target.fullname}`, 'success', {
           autoHideDuration: 2000,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2000,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
       })
   }
   const handleRestoreClick = (id: GridRowId) => () => {
@@ -402,25 +387,13 @@ export default function UserTable() {
       .put(`/users/${target.userid}/restore`)
       .then(() => {
         setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        enqueueSnackbar(`Saved - Restore User ${target.fullname}`, {
-          variant: 'success',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
+        notify(`Saved - Restore User ${target.fullname}`, 'success', {
           autoHideDuration: 2000,
         })
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          autoHideDuration: 2000,
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
       })
   }
   // TODO: Custom hook for fetching data
@@ -483,10 +456,7 @@ export default function UserTable() {
                 // trips on an unexpected failure. Surface it rather than leaving
                 // the OpDivs column silently blank.
                 console.error('Failed to backfill OpDiv grants', error)
-                enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-                  variant: 'warning',
-                  anchorOrigin: { vertical: 'top', horizontal: 'left' },
-                })
+                notify(ERROR_MESSAGES.tryAgain, 'warning')
               })
           }
         } else {
@@ -496,18 +466,12 @@ export default function UserTable() {
       .catch((error) => {
         if (isAuthHandled(error)) return
         console.error('Fetch users error:', error)
-        enqueueSnackbar(ERROR_MESSAGES.tryAgain, {
-          variant: 'error',
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-        })
+        notify(ERROR_MESSAGES.tryAgain, 'error')
       })
     return () => {
       ignore = true
     }
-  }, [canRead, fismaSystems, navigate, enqueueSnackbar, showDeleted])
+  }, [canRead, fismaSystems, navigate, showDeleted])
   // OpDiv options for the grant modal: assignable children only (the HHS
   // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
   // own OpDivs, so narrow the option set to their own grants; the server


### PR DESCRIPTION
Rehomed from #393 (originally @tarratsco) onto a CMS-Enterprise branch so CI can run. His branch was 4 commits behind, so this is a rebase/reconciliation onto current main rather than a clean replay. Commit authored by Onix, co-authored by me for the reconciliation. Supersedes #393.

Closes #389.

## What it does

Finishes adoption of the two helpers from the auth-handling centralization:

- **`notify()`** — migrates every remaining direct `enqueueSnackbar` call across the views to the wrapper (top-left anchor + `DEFAULT_ALERT_TIMEOUT` baked in). After this, `enqueueSnackbar` lives only in `src/utils/notify.ts`.
- **`parseApiError()`** — routes the three form views (`DataCallModal`, `EditSystemModal`, `SystemDetailPage`) through the helper so backend per-field copy surfaces inline on 400s instead of the hardcoded fallback.
- Drops the dead `ERROR_MESSAGES.outOfScope` constant, adds `STATUS_MESSAGES` + `ERROR_MESSAGES.systemNotFound`, and tightens `authHandling.invariants.test.ts` to enforce `parseApiError` in the form views.

## Reconciliation notes (main moved under the branch)

- **QuestionnairePage**: kept #400's historical-datacall effect deps (`selectedDataCallId`/`selectedDatacall`) while dropping `enqueueSnackbar` from the deps per the `notify()` migration.
- **UserTable**: converted the OpDiv-grant backfill warning (added in #394 after this branch was cut) to `notify()`, since the `useSnackbar` destructure is gone. This was a real break the textual merge would have shipped — `enqueueSnackbar` was orphaned and failed `tsc`.
- **QuestionnareModal**: migrated its remaining `Saved` snackbar to `notify(STATUS_MESSAGES.saved, 'success')` so the "all views" adoption is actually complete (it was the lone holdout).
- **invariants test**: reconciled as the union of the OpDiv-view entries + narrowed Title rule (#399) and the new form-view `parseApiError` assertions.

## Behavior changes worth flagging (intentional)

- 400 field errors now show the backend's per-field reason inline, not the hardcoded `INVALID_INPUT_TEXT` fallback.
- The `Error: ` prefix is dropped on decommission/reactivate 400s; the backend message stands alone.
- Success snackbars that relied on notistack's ~5000ms default now inherit the helper's 3000ms.

## Test plan

- [x] tsc, eslint, jest green (152 passing); `enqueueSnackbar` contained to `notify.ts`
- [ ] Manual: 400 field-error on EditSystemModal (duplicate acronym) shows the backend reason inline
- [ ] Manual: a success and an error snackbar render correctly
- [ ] Manual: 404 on SystemDetailPage decommission reads "System not found"
