### PR TITLE
indicate most-recent and active vs closed status datacalls

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -214,9 +214,9 @@ const pillarScoresCache = new Map<number, CachedScore>()
 
 export default function FismaTable({ scores }: FismaTableProps) {
   const apiRef = useGridApiRef()
-  const { fismaSystems, latestDataCallId, selectedDataCallId, userInfo } =
+  const { fismaSystems, latestDataCallId, selectedDatacall, userInfo } =
     useContextProp()
-  const activeDataCallId = selectedDataCallId || latestDataCallId
+  const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -14,8 +14,8 @@ import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
   const [scoreMap, setScoreMap] = useState<Record<number, SystemScoreEntry>>({})
-  const { latestDataCallId, selectedDataCallId } = useContextProp()
-  const activeDataCallId = selectedDataCallId || latestDataCallId
+  const { latestDataCallId, selectedDatacall } = useContextProp()
+  const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   useEffect(() => {
     async function fetchScores() {
       if (activeDataCallId !== 0) {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -91,7 +91,13 @@ const addSpace = (str: string) => {
   return str
 }
 export default function QuestionnarePage() {
-  const { userInfo, selectedDataCallId, selectedDatacall } = useContextProp()
+  const {
+    userInfo,
+    selectedDatacall,
+    latestDataCallId,
+    latestDatacall,
+    latestDeadline,
+  } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
@@ -237,31 +243,23 @@ export default function QuestionnarePage() {
         try {
           let questionsEmpty = false
           let datacall = ''
-          const latestDataCallId = await axiosInstance
-            .get(`/datacalls/latest`)
-            .then((res) => {
-              const latestId = res.data.data.datacallid
-              const isHistorical =
-                selectedDataCallId > 0 && selectedDataCallId !== latestId
-              if (isHistorical) {
-                setDatacallID(selectedDataCallId)
-                datacall = selectedDatacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(true)
-              } else {
-                setDatacallID(latestId)
-                datacall = res.data.data.datacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(new Date() > new Date(res.data.data.deadline))
-              }
-              return isHistorical ? selectedDataCallId : latestId
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              notify(ERROR_MESSAGES.tryAgain, 'error', {
-                autoHideDuration: 2500,
-              })
-            })
+          const isHistorical =
+            selectedDatacall !== null &&
+            selectedDatacall.datacallid !== latestDataCallId
+          let activeDataCallId: number
+          if (isHistorical && selectedDatacall) {
+            setDatacallID(selectedDatacall.datacallid)
+            datacall = selectedDatacall.datacall.replaceAll(' ', '_')
+            setDatacall(datacall)
+            setIsPastDeadline(true)
+            activeDataCallId = selectedDatacall.datacallid
+          } else {
+            setDatacallID(latestDataCallId)
+            datacall = latestDatacall.replaceAll(' ', '_')
+            setDatacall(datacall)
+            setIsPastDeadline(new Date() > new Date(latestDeadline))
+            activeDataCallId = latestDataCallId
+          }
           await axiosInstance
             .get(`/fismasystems/${system}/questions`)
             .then((response) => {
@@ -343,7 +341,7 @@ export default function QuestionnarePage() {
           }
           await axiosInstance
             .get(
-              `scores?datacallid=${latestDataCallId}&fismasystemid=${system}&include=functionoption`
+              `scores?datacallid=${activeDataCallId}&fismasystemid=${system}&include=functionoption`
             )
             .then((res) => {
               const hashTable: questionScoreMap = Object.assign(
@@ -370,7 +368,15 @@ export default function QuestionnarePage() {
       }
       fetchData()
     }
-  }, [system, navigate, fismaacronym, selectedDataCallId, selectedDatacall])
+  }, [
+    system,
+    navigate,
+    fismaacronym,
+    selectedDatacall,
+    latestDataCallId,
+    latestDatacall,
+    latestDeadline,
+  ])
   React.useEffect(() => {
     if (questionId) {
       // Clear saved-state markers before async load so the last-edited

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -257,7 +257,9 @@ export default function QuestionnarePage() {
             setDatacallID(latestDataCallId)
             datacall = latestDatacall.replaceAll(' ', '_')
             setDatacall(datacall)
-            setIsPastDeadline(new Date() > new Date(latestDeadline))
+            setIsPastDeadline(
+              latestDeadline ? new Date() > new Date(latestDeadline) : true
+            )
             activeDataCallId = latestDataCallId
           }
           await axiosInstance

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { FismaSystemType, userData } from '@/types'
+import { FismaSystemType, userData, datacall } from '@/types'
 
 type ContextType = {
   fismaSystems: FismaSystemType[] | []
@@ -8,10 +8,9 @@ type ContextType = {
   userInfo: userData
   latestDataCallId: number
   latestDatacall: string
-  selectedDataCallId: number
-  setSelectedDataCallId: React.Dispatch<React.SetStateAction<number>>
-  selectedDatacall: string
-  setSelectedDatacall: React.Dispatch<React.SetStateAction<string>>
+  latestDeadline: string
+  selectedDatacall: datacall | null
+  setSelectedDatacall: React.Dispatch<React.SetStateAction<datacall | null>>
   showDecommissioned: boolean
   setShowDecommissioned: (show: boolean) => void
   fetchFismaSystems: (decommissioned?: boolean) => Promise<void>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,4 +1,10 @@
-import { Container, Typography, Autocomplete, TextField } from '@mui/material'
+import {
+  Container,
+  Typography,
+  Autocomplete,
+  TextField,
+  Chip,
+} from '@mui/material'
 import { useLoaderData, useLocation } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
@@ -59,8 +65,10 @@ export default function Title() {
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [datacalls, setDatacalls] = useState<datacall[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
-  const [selectedDataCallId, setSelectedDataCallId] = useState<number>(0)
-  const [selectedDatacall, setSelectedDatacall] = useState<string>('')
+  const [selectedDatacall, setSelectedDatacall] = useState<datacall | null>(
+    null
+  )
+  const [latestDeadline, setLatestDeadline] = useState<string>('')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
   const [latestDatacall, setLatestDatacall] = useState<string>('')
@@ -104,8 +112,8 @@ export default function Title() {
           if (sorted.length > 0) {
             setLatestDataCallId(sorted[0].datacallid)
             setLatestDatacall(sorted[0].datacall)
-            setSelectedDataCallId(sorted[0].datacallid)
-            setSelectedDatacall(sorted[0].datacall)
+            setLatestDeadline(sorted[0].deadline)
+            setSelectedDatacall(sorted[0])
           }
         })
         .catch((error) => {
@@ -363,16 +371,56 @@ export default function Title() {
                   isOptionEqualToValue={(option, value) =>
                     option.datacallid === value.datacallid
                   }
-                  value={
-                    datacalls.find(
-                      (dc) => dc.datacallid === selectedDataCallId
-                    ) ?? datacalls[0]
-                  }
+                  value={selectedDatacall ?? datacalls[0]}
                   onChange={(_, dc) => {
-                    if (dc) {
-                      setSelectedDataCallId(dc.datacallid)
-                      setSelectedDatacall(dc.datacall)
-                    }
+                    if (dc) setSelectedDatacall(dc)
+                  }}
+                  renderOption={(props, option) => {
+                    const isCurrent = option.datacallid === latestDataCallId
+                    const isClosed = new Date() > new Date(option.deadline)
+                    const { key, ...rest } = props
+                    const deadlineLabel = new Date(
+                      option.deadline
+                    ).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })
+                    return (
+                      <li key={key} {...rest}>
+                        <Box sx={{ width: '100%' }}>
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'space-between',
+                              width: '100%',
+                              gap: 1,
+                            }}
+                          >
+                            <Typography variant="body2">
+                              {option.datacall}
+                            </Typography>
+                            {isCurrent && (
+                              <Chip
+                                label="Current"
+                                size="small"
+                                variant="outlined"
+                                color="primary"
+                                sx={{ height: 18, fontSize: '0.65rem' }}
+                              />
+                            )}
+                          </Box>
+                          <Typography
+                            variant="caption"
+                            sx={{ color: 'text.secondary' }}
+                          >
+                            {isClosed ? 'Closed' : 'Active'} · deadline{' '}
+                            {deadlineLabel}
+                          </Typography>
+                        </Box>
+                      </li>
+                    )
                   }}
                   disableClearable
                   sx={{ minWidth: 260 }}
@@ -406,8 +454,7 @@ export default function Title() {
                   userInfo,
                   latestDataCallId,
                   latestDatacall,
-                  selectedDataCallId,
-                  setSelectedDataCallId,
+                  latestDeadline,
                   selectedDatacall,
                   setSelectedDatacall,
                   showDecommissioned,


### PR DESCRIPTION
## Summary

Follow-up to #400 (merged). Ports changes from costacalvin's fork (PR #407), implementing feedback from the #400 code review and resolving #401.

### Changes

**1. Consolidate parallel state variables**
Replaced `selectedDataCallId: number` + `selectedDatacall: string` (two variables that had to be kept in sync) with a single `selectedDatacall: datacall | null` across `Context.ts`, `Title.tsx`, `Home.tsx`, `FismaTable.tsx`, and `QuestionnairePage.tsx`. Uses `null` as the unset sentinel instead of `0`/`''`.

**2. Fix falsy coercion on datacall ID 0**
`selectedDataCallId || latestDataCallId` would incorrectly fall through for a datacall with ID `0`. Replaced with `selectedDatacall?.datacallid ?? latestDataCallId` everywhere.

**3. Remove redundant `GET /datacalls/latest` in QuestionnairePage**
`QuestionnairePage` was firing a fresh network request on every open solely to detect whether the selected datacall was historical. Since `Title.tsx` already fetches the full sorted list, we now expose `latestDeadline` through context and derive `isHistorical`/`isPastDeadline` from context values — no extra round-trip.

**4. Datacall picker UX**
- `Current` chip on the newest option in the dropdown
- Secondary deadline line under each option: `Active · deadline Jun 30, 2026` or `Closed · deadline Mar 31, 2026`
- Text-based status for 508/WCAG AA compliance (not color alone)
- Closed control continues to show only the datacall name via `getOptionLabel`

## Porting notes

Cherry-picked from costacalvin's fork (PR #407). One conflict in `QuestionnairePage.tsx` resolved by taking Calvin's logic (removal of the `GET /datacalls/latest` call) and dropping the stale `enqueueSnackbar` dep from the effect array (main already migrated to `notify`).

## Test plan
- [ ] `yarn test --watchAll=false` — 152 passing, 3 skipped (no regressions)
- [ ] Dashboard loads → Autocomplete shows latest datacall; dropdown options show `Current` chip on newest entry and `Active/Closed · deadline <date>` secondary line
- [ ] Select a historical datacall → Home scores and FismaTable re-fetch for that datacall
- [ ] Open questionnaire for historical datacall → no `GET /datacalls/latest` in network tab → page loads read-only
- [ ] Open questionnaire for latest datacall → no `GET /datacalls/latest` in network tab → editable before deadline
- [ ] Switch from historical back to latest → `isPastDeadline` resets correctly; questionnaire becomes editable

Closes #401