### PR TITLE
refactor: convert mixed async/await+.then/.catch to linear async/await

### DIFF
--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -75,25 +75,21 @@ export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
   const submitEmail = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
-    await axiosInstance
-      .post('/massemails', {
+    try {
+      const res = await axiosInstance.post('/massemails', {
         group: formData.get('email_group'),
         subject: formData.get('email_subject'),
         body: formData.get('email_body'),
       })
-      .then((res) => {
-        setSentGroup(groupValue)
-        notify('Emails have successfully been sent', 'success', {
-          autoHideDuration: 2500,
-        })
-        setSentToEmails(res.data.data)
+      setSentGroup(groupValue)
+      notify('Emails have successfully been sent', 'success', {
+        autoHideDuration: 2500,
       })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        notify(ERROR_MESSAGES.tryAgain, 'error', {
-          autoHideDuration: 2500,
-        })
-      })
+      setSentToEmails(res.data.data)
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+    }
   }
 
   const handleChange = (value: string) => {

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -45,29 +45,37 @@ export default function AssignSystemModal({
   } | null>(null)
   React.useEffect(() => {
     if (open && userid) {
-      axiosInstance.get(`/users/${userid}/assignedfismasystems`).then((res) => {
-        const assignedSys = res.data.data || []
-        setAssignedSystems(assignedSys)
-        // Include all systems in options
-        const systemIds = Object.keys(fismaSystemMap).map(Number)
-        setFismaSystems(systemIds)
-      })
+      async function fetchAssigned() {
+        try {
+          const res = await axiosInstance.get(
+            `/users/${userid}/assignedfismasystems`
+          )
+          const assignedSys = res.data.data || []
+          setAssignedSystems(assignedSys)
+          const systemIds = Object.keys(fismaSystemMap).map(Number)
+          setFismaSystems(systemIds)
+        } catch (error) {
+          if (isAuthHandled(error)) return
+          console.error('Error fetching assigned systems:', error)
+        }
+      }
+      fetchAssigned()
     }
   }, [open, userid, fismaSystemMap])
-  const handleConfirmUnassign = (confirm: boolean) => {
+  const handleConfirmUnassign = async (confirm: boolean) => {
     const target = pendingUnassign
     setPendingUnassign(null)
     if (!confirm || !target) return
-    axiosInstance
-      .delete(`/users/${userid}/assignedfismasystems/${target.systemid}`)
-      .then(() => {
-        setAssignedSystems(target.nextValue)
-        notify('Saved - unassigned system', 'success')
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 1500 })
-      })
+    try {
+      await axiosInstance.delete(
+        `/users/${userid}/assignedfismasystems/${target.systemid}`
+      )
+      setAssignedSystems(target.nextValue)
+      notify('Saved - unassigned system', 'success')
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 1500 })
+    }
   }
 
   return (
@@ -112,7 +120,7 @@ export default function AssignSystemModal({
               )
             }}
             value={assignedSystems}
-            onChange={(_event, newValue) => {
+            onChange={async (_event, newValue) => {
               const added = newValue.filter(
                 (item) => !assignedSystems.includes(item)
               )
@@ -120,20 +128,19 @@ export default function AssignSystemModal({
                 (item) => !newValue.includes(item)
               )
               if (added.length) {
-                axiosInstance
-                  .post(`/users/${userid}/assignedfismasystems`, {
-                    fismasystemid: added[0],
+                try {
+                  await axiosInstance.post(
+                    `/users/${userid}/assignedfismasystems`,
+                    { fismasystemid: added[0] }
+                  )
+                  setAssignedSystems(newValue)
+                  notify('Saved - assign system', 'success')
+                } catch (error) {
+                  if (isAuthHandled(error)) return
+                  notify(ERROR_MESSAGES.tryAgain, 'error', {
+                    autoHideDuration: 1500,
                   })
-                  .then(() => {
-                    setAssignedSystems(newValue)
-                    notify('Saved - assign system', 'success')
-                  })
-                  .catch((error) => {
-                    if (isAuthHandled(error)) return
-                    notify(ERROR_MESSAGES.tryAgain, 'error', {
-                      autoHideDuration: 1500,
-                    })
-                  })
+                }
               } else if (removed.length) {
                 setPendingUnassign({
                   systemid: removed[0],

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -64,31 +64,29 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
   }
   const submitDatacall = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    await axiosInstance
-      .post(`/datacalls`, {
+    try {
+      await axiosInstance.post(`/datacalls`, {
         datacall: datacall.toUpperCase(),
         deadline: new Date(deadline).toISOString(),
       })
-      .then(() => {
-        notify('Datacall has successfully been created', 'success', {
-          autoHideDuration: 2500,
+      notify('Datacall has successfully been created', 'success', {
+        autoHideDuration: 2500,
+      })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      const parsed = parseApiError(error)
+      // Backend 400 with a field map: route each reason to the matching
+      // field's error setter. No toast on this branch, the inline errors
+      // are the user feedback.
+      if (parsed.fieldErrors) {
+        Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+          if (key === 'datacall') setDatacallError(message)
+          else if (key === 'deadline') setDeadlineError(message)
         })
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        const parsed = parseApiError(error)
-        // Backend 400 with a field map: route each reason to the matching
-        // field's error setter. No toast on this branch, the inline errors
-        // are the user feedback.
-        if (parsed.fieldErrors) {
-          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
-            if (key === 'datacall') setDatacallError(message)
-            else if (key === 'deadline') setDeadlineError(message)
-          })
-          return
-        }
-        notify(parsed.message, 'error', { autoHideDuration: 2500 })
-      })
+        return
+      }
+      notify(parsed.message, 'error', { autoHideDuration: 2500 })
+    }
   }
   return (
     <Dialog

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -160,22 +160,19 @@ export default function EditSystemModal({
     let cancelled = false
     if (open && system?.decommissioned && system?.decommissioned_by) {
       const userId = system.decommissioned_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
+      async function fetchDecommissionedBy() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`)
           if (!cancelled && system?.decommissioned_by === userId) {
-            if (res.data?.data?.fullname) {
-              setDecommissionedByName(res.data.data.fullname)
-            } else {
-              setDecommissionedByName(userId)
-            }
+            setDecommissionedByName(res.data?.data?.fullname || userId)
           }
-        })
-        .catch(() => {
+        } catch {
           if (!cancelled && system?.decommissioned_by === userId) {
             setDecommissionedByName(userId)
           }
-        })
+        }
+      }
+      fetchDecommissionedBy()
     } else {
       setDecommissionedByName('')
     }
@@ -187,22 +184,19 @@ export default function EditSystemModal({
     let cancelled = false
     if (open && system?.reactivated_by) {
       const userId = system.reactivated_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
+      async function fetchReactivatedBy() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`)
           if (!cancelled && system?.reactivated_by === userId) {
-            if (res.data?.data?.fullname) {
-              setReactivatedByName(res.data.data.fullname)
-            } else {
-              setReactivatedByName(userId)
-            }
+            setReactivatedByName(res.data?.data?.fullname || userId)
           }
-        })
-        .catch(() => {
+        } catch {
           if (!cancelled && system?.reactivated_by === userId) {
             setReactivatedByName(userId)
           }
-        })
+        }
+      }
+      fetchReactivatedBy()
     } else {
       setReactivatedByName('')
     }
@@ -220,52 +214,48 @@ export default function EditSystemModal({
   }
   const handleSave = async () => {
     if (mode === 'edit') {
-      await axiosInstance
-        .put(`fismasystems/${editedFismaSystem.fismasystemid}`, {
-          fismauid: editedFismaSystem.fismauid,
-          fismaacronym: editedFismaSystem.fismaacronym,
-          fismaname: editedFismaSystem.fismaname,
-          fismasubsystem: editedFismaSystem.fismasubsystem,
-          component: editedFismaSystem.component,
-          groupacronym: editedFismaSystem.groupacronym,
-          groupname: editedFismaSystem.groupname,
-          divisionname: editedFismaSystem.divisionname,
-          datacenterenvironment: editedFismaSystem.datacenterenvironment,
-          datacallcontact: editedFismaSystem.datacallcontact,
-          issoemail: editedFismaSystem.issoemail,
-          sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
-        })
-        .then(() => {
-          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-          onClose(editedFismaSystem)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          const parsed = parseApiError(error)
-          // Backend 400 with a field map: render each reason inline under
-          // its input via formValid + formValidErrorText. The 'Not Saved'
-          // toast is a status flag, not the detail.
-          if (parsed.fieldErrors) {
-            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
-              setFormValid((prevState) => ({
-                ...prevState,
-                [key]: false,
-              }))
-              setFormValidErrorText((prevState) => ({
-                ...prevState,
-                [key]: message,
-              }))
-            })
-            notify(STATUS_MESSAGES.notSaved, 'error', {
-              autoHideDuration: 1500,
-            })
-            return
+      try {
+        await axiosInstance.put(
+          `fismasystems/${editedFismaSystem.fismasystemid}`,
+          {
+            fismauid: editedFismaSystem.fismauid,
+            fismaacronym: editedFismaSystem.fismaacronym,
+            fismaname: editedFismaSystem.fismaname,
+            fismasubsystem: editedFismaSystem.fismasubsystem,
+            component: editedFismaSystem.component,
+            groupacronym: editedFismaSystem.groupacronym,
+            groupname: editedFismaSystem.groupname,
+            divisionname: editedFismaSystem.divisionname,
+            datacenterenvironment: editedFismaSystem.datacenterenvironment,
+            datacallcontact: editedFismaSystem.datacallcontact,
+            issoemail: editedFismaSystem.issoemail,
+            sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
           }
-          notify(parsed.message, 'error')
-        })
+        )
+        notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+        onClose(editedFismaSystem)
+      } catch (error) {
+        if (isAuthHandled(error)) return
+        const parsed = parseApiError(error)
+        // Backend 400 with a field map: render each reason inline under
+        // its input via formValid + formValidErrorText. The 'Not Saved'
+        // toast is a status flag, not the detail.
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+            setFormValid((prevState) => ({ ...prevState, [key]: false }))
+            setFormValidErrorText((prevState) => ({
+              ...prevState,
+              [key]: message,
+            }))
+          })
+          notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+          return
+        }
+        notify(parsed.message, 'error')
+      }
     } else if (mode === 'create') {
-      await axiosInstance
-        .post(`fismasystems`, {
+      try {
+        await axiosInstance.post(`fismasystems`, {
           fismauid: editedFismaSystem.fismauid,
           fismaacronym: editedFismaSystem.fismaacronym,
           fismaname: editedFismaSystem.fismaname,
@@ -279,36 +269,29 @@ export default function EditSystemModal({
           issoemail: editedFismaSystem.issoemail,
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
         })
-        .then(() => {
-          notify(STATUS_MESSAGES.created, 'success', {
+        notify(STATUS_MESSAGES.created, 'success', { autoHideDuration: 1500 })
+        onClose(editedFismaSystem)
+      } catch (error) {
+        if (isAuthHandled(error)) return
+        const parsed = parseApiError(error)
+        // Backend 400 with a field map: render each reason inline under
+        // its input via formValid + formValidErrorText. The 'Not Created'
+        // toast is a status flag, not the detail.
+        if (parsed.fieldErrors) {
+          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+            setFormValid((prevState) => ({ ...prevState, [key]: false }))
+            setFormValidErrorText((prevState) => ({
+              ...prevState,
+              [key]: message,
+            }))
+          })
+          notify(STATUS_MESSAGES.notCreated, 'error', {
             autoHideDuration: 1500,
           })
-          onClose(editedFismaSystem)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          const parsed = parseApiError(error)
-          // Backend 400 with a field map: render each reason inline under
-          // its input via formValid + formValidErrorText. The 'Not Created'
-          // toast is a status flag, not the detail.
-          if (parsed.fieldErrors) {
-            Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
-              setFormValid((prevState) => ({
-                ...prevState,
-                [key]: false,
-              }))
-              setFormValidErrorText((prevState) => ({
-                ...prevState,
-                [key]: message,
-              }))
-            })
-            notify(STATUS_MESSAGES.notCreated, 'error', {
-              autoHideDuration: 1500,
-            })
-            return
-          }
-          notify(parsed.message, 'error')
-        })
+          return
+        }
+        notify(parsed.message, 'error')
+      }
     }
   }
   const validateDecommissionDate = (dateStr: string): boolean => {
@@ -353,76 +336,80 @@ export default function EditSystemModal({
     if (trimmedNotes) {
       body.notes = trimmedNotes
     }
-    await axiosInstance
-      .delete(`fismasystems/${editedFismaSystem.fismasystemid}`, {
-        data: body,
-      })
-      .then((res) => {
-        if (res.status === 200 || res.status === 204) {
-          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
-            autoHideDuration: 2000,
-          })
-          const updatedSystem: FismaSystemType = res.data?.data || {
-            ...editedFismaSystem,
-            decommissioned: true,
-            decommissioned_date: isoDate,
-            decommissioned_notes: trimmedNotes || null,
-          }
-          onClose(updatedSystem)
+    try {
+      const res = await axiosInstance.delete(
+        `fismasystems/${editedFismaSystem.fismasystemid}`,
+        { data: body }
+      )
+      if (res.status === 200 || res.status === 204) {
+        notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
+          autoHideDuration: 2000,
+        })
+        const updatedSystem: FismaSystemType = res.data?.data || {
+          ...editedFismaSystem,
+          decommissioned: true,
+          decommissioned_date: isoDate,
+          decommissioned_notes: trimmedNotes || null,
         }
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        console.error(
-          'Decommission error:',
-          error.response?.status,
-          error.response?.data
-        )
-        const parsed = parseApiError(error)
-        if (parsed.status === 404) {
-          notify(ERROR_MESSAGES.systemNotFound, 'error', {
-            autoHideDuration: 2000,
-          })
-          return
-        }
-        notify(parsed.message, 'error')
-      })
+        onClose(updatedSystem)
+      }
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error(
+        'Decommission error:',
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.status,
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.data
+      )
+      const parsed = parseApiError(error)
+      if (parsed.status === 404) {
+        notify(ERROR_MESSAGES.systemNotFound, 'error', {
+          autoHideDuration: 2000,
+        })
+        return
+      }
+      notify(parsed.message, 'error')
+    }
   }
   const handleReactivate = async () => {
     setOpenReactivateAlert(false)
     const trimmedNotes = reactivationNotes.trim()
     const body = trimmedNotes ? { notes: trimmedNotes } : undefined
-    await axiosInstance
-      .put(`fismasystems/${editedFismaSystem.fismasystemid}/reactivate`, body)
-      .then((res) => {
-        if (res.status === 200) {
-          notify(STATUS_MESSAGES.systemReactivated, 'success', {
-            autoHideDuration: 2000,
-          })
-          const updatedSystem: FismaSystemType = res.data?.data || {
-            ...editedFismaSystem,
-            decommissioned: false,
-            reactivation_notes: trimmedNotes || null,
-          }
-          onClose(updatedSystem)
+    try {
+      const res = await axiosInstance.put(
+        `fismasystems/${editedFismaSystem.fismasystemid}/reactivate`,
+        body
+      )
+      if (res.status === 200) {
+        notify(STATUS_MESSAGES.systemReactivated, 'success', {
+          autoHideDuration: 2000,
+        })
+        const updatedSystem: FismaSystemType = res.data?.data || {
+          ...editedFismaSystem,
+          decommissioned: false,
+          reactivation_notes: trimmedNotes || null,
         }
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        console.error(
-          'Reactivate error:',
-          error.response?.status,
-          error.response?.data
-        )
-        const parsed = parseApiError(error)
-        if (parsed.status === 404) {
-          notify(ERROR_MESSAGES.systemNotFound, 'error', {
-            autoHideDuration: 2000,
-          })
-          return
-        }
-        notify(parsed.message, 'error')
-      })
+        onClose(updatedSystem)
+      }
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error(
+        'Reactivate error:',
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.status,
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.data
+      )
+      const parsed = parseApiError(error)
+      if (parsed.status === 404) {
+        notify(ERROR_MESSAGES.systemNotFound, 'error', {
+          autoHideDuration: 2000,
+        })
+        return
+      }
+      notify(parsed.message, 'error')
+    }
   }
   if (open && system) {
     if (loading) {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -214,9 +214,9 @@ const pillarScoresCache = new Map<number, CachedScore>()
 
 export default function FismaTable({ scores }: FismaTableProps) {
   const apiRef = useGridApiRef()
-  const { fismaSystems, latestDataCallId, selectedDataCallId, userInfo } =
+  const { fismaSystems, latestDataCallId, selectedDatacall, userInfo } =
     useContextProp()
-  const activeDataCallId = selectedDataCallId || latestDataCallId
+  const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -69,31 +69,29 @@ export function CustomFooterSaveComponent(
       })
       exportUrl += idString
     }
-    return await axiosInstance
-      .get(exportUrl, {
+    try {
+      const response = await axiosInstance.get(exportUrl, {
         responseType: 'blob',
       })
-      .then((response) => {
-        const [, filename] =
-          response.headers['content-disposition'].split('filename=')
-        const contentType = response.headers['content-type']
-        const data = new Blob([response.data], {
-          type: typeof contentType === 'string' ? contentType : undefined,
-        })
-        const url = window.URL.createObjectURL(data)
-        const tempLink = document.createElement('a')
-        tempLink.href = url
-        tempLink.setAttribute('download', filename)
-        tempLink.setAttribute('target', '_blank')
-        tempLink.click()
-        window.URL.revokeObjectURL(url)
+      const [, filename] =
+        response.headers['content-disposition'].split('filename=')
+      const contentType = response.headers['content-type']
+      const data = new Blob([response.data], {
+        type: typeof contentType === 'string' ? contentType : undefined,
       })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        setErrorMessage(ERROR_MESSAGES.tryAgain)
-        setSnackBarSeverity('warning')
-        setOpenSnackbar(true)
-      })
+      const url = window.URL.createObjectURL(data)
+      const tempLink = document.createElement('a')
+      tempLink.href = url
+      tempLink.setAttribute('download', filename)
+      tempLink.setAttribute('target', '_blank')
+      tempLink.click()
+      window.URL.revokeObjectURL(url)
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      setErrorMessage(ERROR_MESSAGES.tryAgain)
+      setSnackBarSeverity('warning')
+      setOpenSnackbar(true)
+    }
   }
   return (
     <>

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -19,24 +19,23 @@ export default function HomePageContainer() {
   useEffect(() => {
     async function fetchScores() {
       if (activeDataCallId !== 0) {
-        await axiosInstance
-          .get(`/scores/aggregate?datacallid=${activeDataCallId}`)
-          .then((res) => {
-            const scoresMap: Record<number, SystemScoreEntry> = {}
-            for (const obj of res.data.data as ScoreAggregate[]) {
-              scoresMap[obj.fismasystemid] = {
-                score: obj.systemscore ?? 0,
-                tier: obj.systemtier,
-              }
+        try {
+          const res = await axiosInstance.get(
+            `/scores/aggregate?datacallid=${activeDataCallId}`
+          )
+          const scoresMap: Record<number, SystemScoreEntry> = {}
+          for (const obj of res.data.data as ScoreAggregate[]) {
+            scoresMap[obj.fismasystemid] = {
+              score: obj.systemscore ?? 0,
+              tier: obj.systemtier,
             }
-            setScoreMap(scoresMap)
-          })
-          .catch((error) => {
-            console.error('Error fetching scores:', error)
-          })
-          .finally(() => {
-            setLoading(false)
-          })
+          }
+          setScoreMap(scoresMap)
+        } catch (error) {
+          console.error('Error fetching scores:', error)
+        } finally {
+          setLoading(false)
+        }
       }
     }
     fetchScores()

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -14,8 +14,8 @@ import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
   const [scoreMap, setScoreMap] = useState<Record<number, SystemScoreEntry>>({})
-  const { latestDataCallId, selectedDataCallId } = useContextProp()
-  const activeDataCallId = selectedDataCallId || latestDataCallId
+  const { latestDataCallId, selectedDatacall } = useContextProp()
+  const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   useEffect(() => {
     async function fetchScores() {
       if (activeDataCallId !== 0) {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -195,42 +195,29 @@ export default function QuestionnarePage() {
     setQuestionId(index)
   }
 
-  const saveResponse = () => {
-    if (scoreid) {
-      axiosInstance
-        .put(`scores/${scoreid}`, {
+  const saveResponse = async () => {
+    try {
+      if (scoreid) {
+        await axiosInstance.put(`scores/${scoreid}`, {
           fismasystemid: system,
           notes: notes,
           functionoptionid: selectQuestionOption,
           datacallid: datacallID,
         })
-        .then(() => {
-          // checkValidResponse(res.status)
-          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-          fetchQuestionScores(system, setQuestionScores)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          console.error('Error updating score:', error)
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
-        })
-    } else {
-      axiosInstance
-        .post(`scores`, {
+      } else {
+        await axiosInstance.post(`scores`, {
           fismasystemid: system,
           notes: notes,
           functionoptionid: selectQuestionOption,
           datacallid: datacallID,
         })
-        .then(() => {
-          notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-          fetchQuestionScores(system, setQuestionScores)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          console.error('Error posting score:', error)
-          notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
-        })
+      }
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      fetchQuestionScores(system, setQuestionScores)
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error('Error saving score:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
     }
   }
 
@@ -385,8 +372,9 @@ export default function QuestionnarePage() {
       setInitQuestionChoice(-1)
       const choices: QuestionChoice[] = []
       let funcOptId: number = 0
-      try {
-        axiosInstance.get(`functions/${questionId}/options`).then((res) => {
+      async function fetchOptions() {
+        try {
+          const res = await axiosInstance.get(`functions/${questionId}/options`)
           res.data.data.forEach((item: QuestionOption) => {
             const choiceOpt: QuestionChoice = {
               label: item.description,
@@ -413,11 +401,12 @@ export default function QuestionnarePage() {
           setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
           setOptions(choices ? choices : [])
           setLoadingQuestion(false)
-        })
-      } catch (error) {
-        if (isAuthHandled(error)) return
-        console.error('Error fetching data:', error)
+        } catch (error) {
+          if (isAuthHandled(error)) return
+          console.error('Error fetching data:', error)
+        }
       }
+      fetchOptions()
     }
   }, [questionId, questionScores, questions])
   const breadcrumbSegmentLabels = fismaacronym

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -91,7 +91,13 @@ const addSpace = (str: string) => {
   return str
 }
 export default function QuestionnarePage() {
-  const { userInfo, selectedDataCallId, selectedDatacall } = useContextProp()
+  const {
+    userInfo,
+    selectedDatacall,
+    latestDataCallId,
+    latestDatacall,
+    latestDeadline,
+  } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
@@ -237,31 +243,23 @@ export default function QuestionnarePage() {
         try {
           let questionsEmpty = false
           let datacall = ''
-          const latestDataCallId = await axiosInstance
-            .get(`/datacalls/latest`)
-            .then((res) => {
-              const latestId = res.data.data.datacallid
-              const isHistorical =
-                selectedDataCallId > 0 && selectedDataCallId !== latestId
-              if (isHistorical) {
-                setDatacallID(selectedDataCallId)
-                datacall = selectedDatacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(true)
-              } else {
-                setDatacallID(latestId)
-                datacall = res.data.data.datacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(new Date() > new Date(res.data.data.deadline))
-              }
-              return isHistorical ? selectedDataCallId : latestId
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              notify(ERROR_MESSAGES.tryAgain, 'error', {
-                autoHideDuration: 2500,
-              })
-            })
+          const isHistorical =
+            selectedDatacall !== null &&
+            selectedDatacall.datacallid !== latestDataCallId
+          let activeDataCallId: number
+          if (isHistorical && selectedDatacall) {
+            setDatacallID(selectedDatacall.datacallid)
+            datacall = selectedDatacall.datacall.replaceAll(' ', '_')
+            setDatacall(datacall)
+            setIsPastDeadline(true)
+            activeDataCallId = selectedDatacall.datacallid
+          } else {
+            setDatacallID(latestDataCallId)
+            datacall = latestDatacall.replaceAll(' ', '_')
+            setDatacall(datacall)
+            setIsPastDeadline(new Date() > new Date(latestDeadline))
+            activeDataCallId = latestDataCallId
+          }
           await axiosInstance
             .get(`/fismasystems/${system}/questions`)
             .then((response) => {
@@ -343,7 +341,7 @@ export default function QuestionnarePage() {
           }
           await axiosInstance
             .get(
-              `scores?datacallid=${latestDataCallId}&fismasystemid=${system}&include=functionoption`
+              `scores?datacallid=${activeDataCallId}&fismasystemid=${system}&include=functionoption`
             )
             .then((res) => {
               const hashTable: questionScoreMap = Object.assign(
@@ -370,7 +368,15 @@ export default function QuestionnarePage() {
       }
       fetchData()
     }
-  }, [system, navigate, fismaacronym, selectedDataCallId, selectedDatacall])
+  }, [
+    system,
+    navigate,
+    fismaacronym,
+    selectedDatacall,
+    latestDataCallId,
+    latestDatacall,
+    latestDeadline,
+  ])
   React.useEffect(() => {
     if (questionId) {
       // Clear saved-state markers before async load so the last-edited

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -247,22 +247,22 @@ export default function QuestionnarePage() {
             setIsPastDeadline(new Date() > new Date(latestDeadline))
             activeDataCallId = latestDataCallId
           }
-          await axiosInstance
-            .get(`/fismasystems/${system}/questions`)
-            .then((response) => {
-              // Decommissioned systems join to zero functions, so the questions
-              // endpoint returns no rows. The Go backend serializes a nil
-              // slice as JSON null, so the response can be either { data: null }
-              // or { data: [] } depending on driver behavior - treat both as
-              // the empty-state signal. Surface a friendly message instead of
-              // crashing on categoriesData[0] below.
-              const data = response.data?.data
-              if (!data || (Array.isArray(data) && data.length === 0)) {
-                questionsEmpty = true
-                setNoQuestions(true)
-                setLoadingQuestion(false)
-                return
-              }
+          try {
+            const response = await axiosInstance.get(
+              `/fismasystems/${system}/questions`
+            )
+            // Decommissioned systems join to zero functions, so the questions
+            // endpoint returns no rows. The Go backend serializes a nil
+            // slice as JSON null, so the response can be either { data: null }
+            // or { data: [] } depending on driver behavior - treat both as
+            // the empty-state signal. Surface a friendly message instead of
+            // crashing on categoriesData[0] below.
+            const data = response.data?.data
+            if (!data || (Array.isArray(data) && data.length === 0)) {
+              questionsEmpty = true
+              setNoQuestions(true)
+              setLoadingQuestion(false)
+            } else {
               const organizedData: Record<string, FismaQuestion[]> = {}
               const questionData: Record<number, Question> = {}
               data.forEach((question: FismaQuestion) => {
@@ -293,11 +293,7 @@ export default function QuestionnarePage() {
                 }
               })
               const funcIdToIdx = sortedFuncId.reduce(
-                (
-                  acc: { [key: number]: number },
-                  num: number,
-                  index: number
-                ) => {
+                (acc: { [key: number]: number }, num: number, index: number) => {
                   acc[num] = index
                   return acc
                 },
@@ -318,36 +314,31 @@ export default function QuestionnarePage() {
               setQuestion(questionData[sortedFuncId[0]].question) // set the first question value to the page
               setDescription(questionData[sortedFuncId[0]].description)
               setNotePrompt(questionData[sortedFuncId[0]].notesprompt) // set the first note prompt to the page
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              notify(ERROR_MESSAGES.tryAgain, 'error')
-            })
+            }
+          } catch (error) {
+            if (isAuthHandled(error)) return
+            notify(ERROR_MESSAGES.tryAgain, 'error')
+            return
+          }
           if (questionsEmpty) {
             return
           }
-          await axiosInstance
-            .get(
+          try {
+            const res = await axiosInstance.get(
               `scores?datacallid=${activeDataCallId}&fismasystemid=${system}&include=functionoption`
             )
-            .then((res) => {
-              const hashTable: questionScoreMap = Object.assign(
-                {},
-                ...res.data.data.map((item: QuestionScores) => ({
-                  [item.functionoptionid]: item,
-                }))
-              )
-              // res.data.data.map((item: any) => {
-              //   questionScoreMap[item.functionoptionid] = item
-              //   funcScoreTable
-              // })
-              setQuestionScores(hashTable)
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching question scores:', error)
-              notify(ERROR_MESSAGES.tryAgain, 'error')
-            })
+            const hashTable: questionScoreMap = Object.assign(
+              {},
+              ...res.data.data.map((item: QuestionScores) => ({
+                [item.functionoptionid]: item,
+              }))
+            )
+            setQuestionScores(hashTable)
+          } catch (error) {
+            if (isAuthHandled(error)) return
+            console.error('Error fetching question scores:', error)
+            notify(ERROR_MESSAGES.tryAgain, 'error')
+          }
         } catch (error) {
           if (isAuthHandled(error)) return
           console.error('Error fetching data:', error)

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -149,46 +149,32 @@ export default function QuestionnareModal({
       selectQuestionOption === loadedSelectQuestionOption &&
       (notes ?? '') === (loadedNotes ?? '')
     if (!isReadOnly && !isReadThrough) {
-      if (scoreid) {
-        axiosInstance
-          .put(`scores/${scoreid}`, {
-            fismasystemid: system?.fismasystemid,
-            notes: notes,
-            functionoptionid: selectQuestionOption,
-            datacallid: datacallID,
-          })
-          .then(() => {
+      async function saveScore() {
+        try {
+          if (scoreid) {
+            await axiosInstance.put(`scores/${scoreid}`, {
+              fismasystemid: system?.fismasystemid,
+              notes: notes,
+              functionoptionid: selectQuestionOption,
+              datacallid: datacallID,
+            })
             notify(STATUS_MESSAGES.saved, 'success')
-            fetchQuestionScores(
-              Number(system?.fismasystemid),
-              setQuestionScores
-            )
-            setLoadingQuestion(false)
-          })
-          .catch((error) => {
-            if (isAuthHandled(error)) return
-            console.error('Error updating score:', error)
-          })
-      } else {
-        axiosInstance
-          .post(`scores`, {
-            fismasystemid: system?.fismasystemid,
-            notes: notes,
-            functionoptionid: selectQuestionOption,
-            datacallid: datacallID,
-          })
-          .then(() => {
-            fetchQuestionScores(
-              Number(system?.fismasystemid),
-              setQuestionScores
-            )
-            setLoadingQuestion(false)
-          })
-          .catch((error) => {
-            if (isAuthHandled(error)) return
-            console.error('Error posting score:', error)
-          })
+          } else {
+            await axiosInstance.post(`scores`, {
+              fismasystemid: system?.fismasystemid,
+              notes: notes,
+              functionoptionid: selectQuestionOption,
+              datacallid: datacallID,
+            })
+          }
+          fetchQuestionScores(Number(system?.fismasystemid), setQuestionScores)
+          setLoadingQuestion(false)
+        } catch (error) {
+          if (isAuthHandled(error)) return
+          console.error('Error saving score:', error)
+        }
       }
+      saveScore()
     }
     let nextCategoryIndex = activeCategoryIndex
     let nextStepIndex = activeStepIndex + 1
@@ -272,72 +258,44 @@ export default function QuestionnareModal({
     if (open && system) {
       const fetchData = async () => {
         try {
-          const latestDataCallId = await axiosInstance
-            .get(`/datacalls/latest`)
-            .then((res) => {
-              setDatacallID(res.data.data.datacallid)
-              if (new Date() > new Date(res.data.data.deadline)) {
-                setIsPastDeadline(true)
-              }
-              return res.data.data.datacallid
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching latest datacall:', error)
-            })
+          const latestRes = await axiosInstance.get(`/datacalls/latest`)
+          const latestDataCallId = latestRes.data.data.datacallid
+          setDatacallID(latestDataCallId)
+          if (new Date() > new Date(latestRes.data.data.deadline)) {
+            setIsPastDeadline(true)
+          }
 
-          await axiosInstance
-            .get(`/fismasystems/${system.fismasystemid}/questions`)
-            .then((response) => {
-              const data = response.data.data
-              const organizedData: Record<string, FismaQuestion[]> = {}
-              data.forEach((question: FismaQuestion) => {
-                if (!organizedData[question.pillar.pillar]) {
-                  organizedData[question.pillar.pillar] = []
-                }
-                organizedData[question.pillar.pillar].push(question)
-              })
-              const sortedPillars = sortPillars(Object.keys(organizedData))
-              const categoriesData: Category[] = sortedPillars.map(
-                (pillar) => ({
-                  name: pillar,
-                  steps: sortFunctions(pillar, organizedData[pillar]),
-                })
-              )
-              // const categoriesData: Category[] = sortedPillars.map(
-              //   (pillar) => ({
-              //     name: pillar,
-              //     steps: organizedData[pillar],
-              //   })
-              // )
-              // console.log(categoriesData)
-              setCategories(categoriesData)
-              if (data.length > 0) {
-                // console.log(categoriesData)
-                setQuestionId(categoriesData[0]['steps'][0].function.functionid)
-              }
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching questions:', error)
-            })
-          await axiosInstance
-            .get(
-              `scores?datacallid=${latestDataCallId}&fismasystemid=${system.fismasystemid}`
-            )
-            .then((res) => {
-              const hashTable: questionScoreMap = Object.assign(
-                {},
-                ...res.data.data.map((item: QuestionScores) => ({
-                  [item.functionoptionid]: item,
-                }))
-              )
-              setQuestionScores(hashTable)
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching question scores:', error)
-            })
+          const questionsRes = await axiosInstance.get(
+            `/fismasystems/${system.fismasystemid}/questions`
+          )
+          const data = questionsRes.data.data
+          const organizedData: Record<string, FismaQuestion[]> = {}
+          data.forEach((question: FismaQuestion) => {
+            if (!organizedData[question.pillar.pillar]) {
+              organizedData[question.pillar.pillar] = []
+            }
+            organizedData[question.pillar.pillar].push(question)
+          })
+          const sortedPillars = sortPillars(Object.keys(organizedData))
+          const categoriesData: Category[] = sortedPillars.map((pillar) => ({
+            name: pillar,
+            steps: sortFunctions(pillar, organizedData[pillar]),
+          }))
+          setCategories(categoriesData)
+          if (data.length > 0) {
+            setQuestionId(categoriesData[0]['steps'][0].function.functionid)
+          }
+
+          const scoresRes = await axiosInstance.get(
+            `scores?datacallid=${latestDataCallId}&fismasystemid=${system.fismasystemid}`
+          )
+          const hashTable: questionScoreMap = Object.assign(
+            {},
+            ...scoresRes.data.data.map((item: QuestionScores) => ({
+              [item.functionoptionid]: item,
+            }))
+          )
+          setQuestionScores(hashTable)
         } catch (error) {
           if (isAuthHandled(error)) return
           console.error('Error fetching data:', error)
@@ -348,8 +306,9 @@ export default function QuestionnareModal({
   }, [open, system])
   React.useEffect(() => {
     if (questionId) {
-      try {
-        axiosInstance.get(`functions/${questionId}/options`).then((res) => {
+      async function fetchOptions() {
+        try {
+          const res = await axiosInstance.get(`functions/${questionId}/options`)
           setOptions(res.data.data)
           let isValidOption: boolean = false
           let funcOptId: number = 0
@@ -387,11 +346,12 @@ export default function QuestionnareModal({
             )
           }
           setLoadingQuestion(false)
-        })
-      } catch (error) {
-        if (isAuthHandled(error)) return
-        console.error('Error fetching data:', error)
+        } catch (error) {
+          if (isAuthHandled(error)) return
+          console.error('Error fetching data:', error)
+        }
       }
+      fetchOptions()
     }
   }, [questionId, questionScores])
   const renderRadioGroup = (options: QuestionOption[]) => {

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -46,22 +46,22 @@ export default function SystemDetailPage() {
     if (fismaSystems.length > 0 && !system && !triedFetch.current) {
       triedFetch.current = true
       setRetryingFetch(true)
-      axiosInstance
-        .get(`fismasystems/${systemId}`)
-        .then((res) => {
+      async function fetchSystem() {
+        try {
+          const res = await axiosInstance.get(`fismasystems/${systemId}`)
           if (!cancelled) {
             const data = res.data?.data
             if (data) {
               setFismaSystems((prev) => [...prev, data])
             }
           }
-        })
-        .catch(() => {
+        } catch {
           // System truly doesn't exist
-        })
-        .finally(() => {
+        } finally {
           if (!cancelled) setRetryingFetch(false)
-        })
+        }
+      }
+      fetchSystem()
     }
     return () => {
       cancelled = true
@@ -138,19 +138,16 @@ export default function SystemDetailPage() {
     let cancelled = false
     if (system?.decommissioned && system?.decommissioned_by) {
       const userId = system.decommissioned_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled) {
+      async function fetchDecommissionedBy() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`)
+          if (!cancelled)
             setDecommissionedByName(res.data?.data?.fullname || userId)
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            // User may have been removed — fall back to UUID
-            setDecommissionedByName(userId)
-          }
-        })
+        } catch {
+          if (!cancelled) setDecommissionedByName(userId)
+        }
+      }
+      fetchDecommissionedBy()
     } else {
       setDecommissionedByName('')
     }
@@ -164,18 +161,16 @@ export default function SystemDetailPage() {
     let cancelled = false
     if (system?.reactivated_by) {
       const userId = system.reactivated_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled) {
+      async function fetchReactivatedBy() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`)
+          if (!cancelled)
             setReactivatedByName(res.data?.data?.fullname || userId)
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            setReactivatedByName(userId)
-          }
-        })
+        } catch {
+          if (!cancelled) setReactivatedByName(userId)
+        }
+      }
+      fetchReactivatedBy()
     } else {
       setReactivatedByName('')
     }
@@ -267,9 +262,8 @@ export default function SystemDetailPage() {
   const handleSave = async () => {
     if (!editedSystem) return
     setIsSaving(true)
-
-    await axiosInstance
-      .put(`fismasystems/${editedSystem.fismasystemid}`, {
+    try {
+      await axiosInstance.put(`fismasystems/${editedSystem.fismasystemid}`, {
         fismauid: editedSystem.fismauid,
         fismaacronym: editedSystem.fismaacronym,
         fismaname: editedSystem.fismaname,
@@ -283,39 +277,36 @@ export default function SystemDetailPage() {
         issoemail: editedSystem.issoemail,
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       })
-      .then(() => {
-        notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-        setFismaSystems((prev) =>
-          prev.map((s) =>
-            s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
-          )
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      setFismaSystems((prev) =>
+        prev.map((s) =>
+          s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
         )
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        const parsed = parseApiError(error)
-        // Backend 400 with a field map: render each reason inline under its
-        // input via formValid + formValidErrorText. The 'Not Saved' toast
-        // is a status flag, not the detail.
-        if (parsed.fieldErrors) {
-          Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
-            setFormValid((prev) => ({ ...prev, [key]: false }))
-            setFormValidErrorText((prev) => ({ ...prev, [key]: message }))
-          })
-          notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
-          return
-        }
-        if (parsed.status === 404) {
-          notify(ERROR_MESSAGES.systemNotFound, 'error', {
-            autoHideDuration: 2000,
-          })
-          return
-        }
-        notify(parsed.message, 'error')
-      })
-      .finally(() => {
-        setIsSaving(false)
-      })
+      )
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      const parsed = parseApiError(error)
+      // Backend 400 with a field map: render each reason inline under its
+      // input via formValid + formValidErrorText. The 'Not Saved' toast
+      // is a status flag, not the detail.
+      if (parsed.fieldErrors) {
+        Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+          setFormValid((prev) => ({ ...prev, [key]: false }))
+          setFormValidErrorText((prev) => ({ ...prev, [key]: message }))
+        })
+        notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+        return
+      }
+      if (parsed.status === 404) {
+        notify(ERROR_MESSAGES.systemNotFound, 'error', {
+          autoHideDuration: 2000,
+        })
+        return
+      }
+      notify(parsed.message, 'error')
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   const handleDecommission = async () => {
@@ -334,48 +325,49 @@ export default function SystemDetailPage() {
       body.notes = trimmedNotes
     }
 
-    await axiosInstance
-      .delete(`fismasystems/${editedSystem.fismasystemid}`, { data: body })
-      .then((res) => {
-        if (res.status === 200 || res.status === 204) {
-          notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
-            autoHideDuration: 2000,
-          })
-          const updatedSystem: FismaSystemType = res.data?.data || {
-            ...editedSystem,
-            decommissioned: true,
-            decommissioned_date: isoDate,
-            decommissioned_by: userInfo.userid,
-            decommissioned_notes: trimmedNotes || null,
-          }
-          setFismaSystems((prev) =>
-            prev.map((s) =>
-              s.fismasystemid === updatedSystem.fismasystemid
-                ? updatedSystem
-                : s
-            )
+    try {
+      const res = await axiosInstance.delete(
+        `fismasystems/${editedSystem.fismasystemid}`,
+        { data: body }
+      )
+      if (res.status === 200 || res.status === 204) {
+        notify(STATUS_MESSAGES.systemDecommissioned, 'success', {
+          autoHideDuration: 2000,
+        })
+        const updatedSystem: FismaSystemType = res.data?.data || {
+          ...editedSystem,
+          decommissioned: true,
+          decommissioned_date: isoDate,
+          decommissioned_by: userInfo.userid,
+          decommissioned_notes: trimmedNotes || null,
+        }
+        setFismaSystems((prev) =>
+          prev.map((s) =>
+            s.fismasystemid === updatedSystem.fismasystemid ? updatedSystem : s
           )
-          setDecommissionedByName(userInfo.fullname || userInfo.userid)
-          setIsEditing(false)
-          setEditedSystem(null)
-        }
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        console.error(
-          'Decommission error:',
-          error.response?.status,
-          error.response?.data
         )
-        const parsed = parseApiError(error)
-        if (parsed.status === 404) {
-          notify(ERROR_MESSAGES.systemNotFound, 'error', {
-            autoHideDuration: 2000,
-          })
-          return
-        }
-        notify(parsed.message, 'error')
-      })
+        setDecommissionedByName(userInfo.fullname || userInfo.userid)
+        setIsEditing(false)
+        setEditedSystem(null)
+      }
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error(
+        'Decommission error:',
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.status,
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.data
+      )
+      const parsed = parseApiError(error)
+      if (parsed.status === 404) {
+        notify(ERROR_MESSAGES.systemNotFound, 'error', {
+          autoHideDuration: 2000,
+        })
+        return
+      }
+      notify(parsed.message, 'error')
+    }
   }
 
   const handleReactivate = async () => {
@@ -385,48 +377,49 @@ export default function SystemDetailPage() {
     const trimmedNotes = reactivationNotes.trim()
     const body = trimmedNotes ? { notes: trimmedNotes } : undefined
 
-    await axiosInstance
-      .put(`fismasystems/${editedSystem.fismasystemid}/reactivate`, body)
-      .then((res) => {
-        if (res.status === 200) {
-          notify(STATUS_MESSAGES.systemReactivated, 'success', {
-            autoHideDuration: 2000,
-          })
-          const updatedSystem: FismaSystemType = res.data?.data || {
-            ...editedSystem,
-            decommissioned: false,
-            reactivated_by: userInfo.userid,
-            reactivated_date: new Date().toISOString(),
-            reactivation_notes: trimmedNotes || null,
-          }
-          setFismaSystems((prev) =>
-            prev.map((s) =>
-              s.fismasystemid === updatedSystem.fismasystemid
-                ? updatedSystem
-                : s
-            )
+    try {
+      const res = await axiosInstance.put(
+        `fismasystems/${editedSystem.fismasystemid}/reactivate`,
+        body
+      )
+      if (res.status === 200) {
+        notify(STATUS_MESSAGES.systemReactivated, 'success', {
+          autoHideDuration: 2000,
+        })
+        const updatedSystem: FismaSystemType = res.data?.data || {
+          ...editedSystem,
+          decommissioned: false,
+          reactivated_by: userInfo.userid,
+          reactivated_date: new Date().toISOString(),
+          reactivation_notes: trimmedNotes || null,
+        }
+        setFismaSystems((prev) =>
+          prev.map((s) =>
+            s.fismasystemid === updatedSystem.fismasystemid ? updatedSystem : s
           )
-          setReactivatedByName(userInfo.fullname || userInfo.userid)
-          setIsEditing(false)
-          setEditedSystem(null)
-        }
-      })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        console.error(
-          'Reactivate error:',
-          error.response?.status,
-          error.response?.data
         )
-        const parsed = parseApiError(error)
-        if (parsed.status === 404) {
-          notify(ERROR_MESSAGES.systemNotFound, 'error', {
-            autoHideDuration: 2000,
-          })
-          return
-        }
-        notify(parsed.message, 'error')
-      })
+        setReactivatedByName(userInfo.fullname || userInfo.userid)
+        setIsEditing(false)
+        setEditedSystem(null)
+      }
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error(
+        'Reactivate error:',
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.status,
+        (error as { response?: { status?: number; data?: unknown } }).response
+          ?.data
+      )
+      const parsed = parseApiError(error)
+      if (parsed.status === 404) {
+        notify(ERROR_MESSAGES.systemNotFound, 'error', {
+          autoHideDuration: 2000,
+        })
+        return
+      }
+      notify(parsed.message, 'error')
+    }
   }
 
   // Build decommission confirmation text

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { FismaSystemType, userData } from '@/types'
+import { FismaSystemType, userData, datacall } from '@/types'
 
 type ContextType = {
   fismaSystems: FismaSystemType[] | []
@@ -8,10 +8,9 @@ type ContextType = {
   userInfo: userData
   latestDataCallId: number
   latestDatacall: string
-  selectedDataCallId: number
-  setSelectedDataCallId: React.Dispatch<React.SetStateAction<number>>
-  selectedDatacall: string
-  setSelectedDatacall: React.Dispatch<React.SetStateAction<string>>
+  latestDeadline: string
+  selectedDatacall: datacall | null
+  setSelectedDatacall: React.Dispatch<React.SetStateAction<datacall | null>>
   showDecommissioned: boolean
   setShowDecommissioned: (show: boolean) => void
   fetchFismaSystems: (decommissioned?: boolean) => Promise<void>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,4 +1,10 @@
-import { Container, Typography, Autocomplete, TextField } from '@mui/material'
+import {
+  Container,
+  Typography,
+  Autocomplete,
+  TextField,
+  Chip,
+} from '@mui/material'
 import { useLoaderData, useLocation } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
@@ -59,8 +65,10 @@ export default function Title() {
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [datacalls, setDatacalls] = useState<datacall[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
-  const [selectedDataCallId, setSelectedDataCallId] = useState<number>(0)
-  const [selectedDatacall, setSelectedDatacall] = useState<string>('')
+  const [selectedDatacall, setSelectedDatacall] = useState<datacall | null>(
+    null
+  )
+  const [latestDeadline, setLatestDeadline] = useState<string>('')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
   const [latestDatacall, setLatestDatacall] = useState<string>('')
@@ -104,8 +112,8 @@ export default function Title() {
           if (sorted.length > 0) {
             setLatestDataCallId(sorted[0].datacallid)
             setLatestDatacall(sorted[0].datacall)
-            setSelectedDataCallId(sorted[0].datacallid)
-            setSelectedDatacall(sorted[0].datacall)
+            setLatestDeadline(sorted[0].deadline)
+            setSelectedDatacall(sorted[0])
           }
         })
         .catch((error) => {
@@ -363,16 +371,56 @@ export default function Title() {
                   isOptionEqualToValue={(option, value) =>
                     option.datacallid === value.datacallid
                   }
-                  value={
-                    datacalls.find(
-                      (dc) => dc.datacallid === selectedDataCallId
-                    ) ?? datacalls[0]
-                  }
+                  value={selectedDatacall ?? datacalls[0]}
                   onChange={(_, dc) => {
-                    if (dc) {
-                      setSelectedDataCallId(dc.datacallid)
-                      setSelectedDatacall(dc.datacall)
-                    }
+                    if (dc) setSelectedDatacall(dc)
+                  }}
+                  renderOption={(props, option) => {
+                    const isCurrent = option.datacallid === latestDataCallId
+                    const isClosed = new Date() > new Date(option.deadline)
+                    const { key, ...rest } = props
+                    const deadlineLabel = new Date(
+                      option.deadline
+                    ).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })
+                    return (
+                      <li key={key} {...rest}>
+                        <Box sx={{ width: '100%' }}>
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'space-between',
+                              width: '100%',
+                              gap: 1,
+                            }}
+                          >
+                            <Typography variant="body2">
+                              {option.datacall}
+                            </Typography>
+                            {isCurrent && (
+                              <Chip
+                                label="Current"
+                                size="small"
+                                variant="outlined"
+                                color="primary"
+                                sx={{ height: 18, fontSize: '0.65rem' }}
+                              />
+                            )}
+                          </Box>
+                          <Typography
+                            variant="caption"
+                            sx={{ color: 'text.secondary' }}
+                          >
+                            {isClosed ? 'Closed' : 'Active'} · deadline{' '}
+                            {deadlineLabel}
+                          </Typography>
+                        </Box>
+                      </li>
+                    )
                   }}
                   disableClearable
                   sx={{ minWidth: 260 }}
@@ -406,8 +454,7 @@ export default function Title() {
                   userInfo,
                   latestDataCallId,
                   latestDatacall,
-                  selectedDataCallId,
-                  setSelectedDataCallId,
+                  latestDeadline,
                   selectedDatacall,
                   setSelectedDatacall,
                   showDecommissioned,

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -79,18 +79,18 @@ export default function Title() {
       const url = decommissioned
         ? '/fismasystems?decommissioned=true'
         : '/fismasystems'
-      await axiosInstance
-        .get(url)
-        .then((res) => {
-          setFismaSystems(res.data.data)
-        })
-        .catch((error) => {
-          console.error(
-            'Fetch systems error:',
-            error.response?.status,
-            error.response?.data
-          )
-        })
+      try {
+        const res = await axiosInstance.get(url)
+        setFismaSystems(res.data.data)
+      } catch (error) {
+        console.error(
+          'Fetch systems error:',
+          (error as { response?: { status?: number; data?: unknown } }).response
+            ?.status,
+          (error as { response?: { status?: number; data?: unknown } }).response
+            ?.data
+        )
+      }
     },
     []
   )
@@ -102,23 +102,21 @@ export default function Title() {
   useEffect(() => {
     if (loaderData.serverError) return
     async function fetchDatacalls() {
-      await axiosInstance
-        .get('/datacalls')
-        .then((res) => {
-          const sorted: datacall[] = [...res.data.data].sort(
-            (a: datacall, b: datacall) => b.datacallid - a.datacallid
-          )
-          setDatacalls(sorted)
-          if (sorted.length > 0) {
-            setLatestDataCallId(sorted[0].datacallid)
-            setLatestDatacall(sorted[0].datacall)
-            setLatestDeadline(sorted[0].deadline)
-            setSelectedDatacall(sorted[0])
-          }
-        })
-        .catch((error) => {
-          console.error('Fetch latest datacall error:', error)
-        })
+      try {
+        const res = await axiosInstance.get('/datacalls')
+        const sorted: datacall[] = [...res.data.data].sort(
+          (a: datacall, b: datacall) => b.datacallid - a.datacallid
+        )
+        setDatacalls(sorted)
+        if (sorted.length > 0) {
+          setLatestDataCallId(sorted[0].datacallid)
+          setLatestDatacall(sorted[0].datacall)
+          setLatestDeadline(sorted[0].deadline)
+          setSelectedDatacall(sorted[0])
+        }
+      } catch (error) {
+        console.error('Fetch latest datacall error:', error)
+      }
     }
     fetchDatacalls()
   }, [loaderData.serverError])

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -280,7 +280,7 @@ export default function UserTable() {
       setRows(rows.filter((row) => row.userid !== id))
     }
   }
-  const processRowUpdate = (newRow: GridRowModel) => {
+  const processRowUpdate = async (newRow: GridRowModel) => {
     const updatedRow = {
       ...selectedRow,
       ...newRow,
@@ -289,45 +289,38 @@ export default function UserTable() {
     } as users
     const curRowUserId = updatedRow.userid
     if (newRow.isNew) {
-      axiosInstance
-        .post('/users', {
+      try {
+        const res = await axiosInstance.post('/users', {
           email: updatedRow.email,
           fullname: updatedRow.fullname,
           role: updatedRow.role,
         })
-        .then((res) => {
-          newRow = res.data.data
-          updatedRow.userid = newRow.userid
-          apiRef.current.updateRows([
-            { userid: curRowUserId, _action: 'delete' },
-          ])
-          apiRef.current.updateRows([updatedRow])
-          setSnackBarSeverity('success')
-          setSnackBarText(STATUS_MESSAGES.saved)
-          setOpen(true)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          console.error('Error updating score:', error)
-          setSaveError(error)
-        })
+        newRow = res.data.data
+        updatedRow.userid = newRow.userid
+        apiRef.current.updateRows([{ userid: curRowUserId, _action: 'delete' }])
+        apiRef.current.updateRows([updatedRow])
+        setSnackBarSeverity('success')
+        setSnackBarText(STATUS_MESSAGES.saved)
+        setOpen(true)
+      } catch (error) {
+        if (isAuthHandled(error)) return updatedRow
+        console.error('Error updating score:', error)
+        setSaveError(error)
+      }
     } else {
-      // const updatedRow = { ...newRow } as users
-      axiosInstance
-        .put(`/users/${updatedRow?.userid}`, {
+      try {
+        await axiosInstance.put(`/users/${updatedRow?.userid}`, {
           email: updatedRow?.email,
           fullname: updatedRow?.fullname,
           role: updatedRow?.role,
         })
-        .then(() => {
-          setSnackBarSeverity('success')
-          setSnackBarText(STATUS_MESSAGES.saved)
-          setOpen(true)
-        })
-        .catch((error) => {
-          if (isAuthHandled(error)) return
-          setSaveError(error)
-        })
+        setSnackBarSeverity('success')
+        setSnackBarText(STATUS_MESSAGES.saved)
+        setOpen(true)
+      } catch (error) {
+        if (isAuthHandled(error)) return updatedRow
+        setSaveError(error)
+      }
     }
     setRows(rows.map((row) => (row.userid === curRowUserId ? updatedRow : row)))
     return updatedRow
@@ -357,44 +350,40 @@ export default function UserTable() {
     if (!curRow) return
     setPendingDeleteRow(curRow)
   }
-  const handleConfirmDelete = (confirm: boolean) => {
+  const handleConfirmDelete = async (confirm: boolean) => {
     const target = pendingDeleteRow
     setPendingDeleteRow(null)
     if (!confirm || !target) return
-    axiosInstance
-      .delete(`/users/${target.userid}`)
-      .then(() => {
-        setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        notify(`Saved - Delete User ${target.fullname}`, 'success', {
-          autoHideDuration: 2000,
-        })
+    try {
+      await axiosInstance.delete(`/users/${target.userid}`)
+      setRows((prev) => prev.filter((row) => row.userid !== target.userid))
+      notify(`Saved - Delete User ${target.fullname}`, 'success', {
+        autoHideDuration: 2000,
       })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
-      })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
+    }
   }
   const handleRestoreClick = (id: GridRowId) => () => {
     const curRow = apiRef.current.getRow(id) as users | undefined
     if (!curRow) return
     setPendingRestoreRow(curRow)
   }
-  const handleConfirmRestore = (confirm: boolean) => {
+  const handleConfirmRestore = async (confirm: boolean) => {
     const target = pendingRestoreRow
     setPendingRestoreRow(null)
     if (!confirm || !target) return
-    axiosInstance
-      .put(`/users/${target.userid}/restore`)
-      .then(() => {
-        setRows((prev) => prev.filter((row) => row.userid !== target.userid))
-        notify(`Saved - Restore User ${target.fullname}`, 'success', {
-          autoHideDuration: 2000,
-        })
+    try {
+      await axiosInstance.put(`/users/${target.userid}/restore`)
+      setRows((prev) => prev.filter((row) => row.userid !== target.userid))
+      notify(`Saved - Restore User ${target.fullname}`, 'success', {
+        autoHideDuration: 2000,
       })
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
-      })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2000 })
+    }
   }
   // TODO: Custom hook for fetching data
   useEffect(() => {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -391,72 +391,71 @@ export default function UserTable() {
     // Guard against a superseded run (e.g. a fast Show Deleted toggle)
     // resolving late and clobbering fresher grant state.
     let ignore = false
-    axiosInstance
-      .get('/users', { params: { deleted: showDeleted } })
-      .then((res) => {
-        if (res.status === 200) {
-          if (ignore) return
-          const data = res.data.data.map((row: users) => ({
-            ...row,
-            role: row.role.trim(),
-          }))
-          setRows(data)
-          const map: Record<number, { name: string; acronym: string }> = {}
-          for (const obj of fismaSystems) {
-            map[obj.fismasystemid] = {
-              name: obj.fismasubsystem
-                ? obj.fismaname + ' - ' + obj.fismasubsystem
-                : obj.fismaname,
-              acronym: obj.fismaacronym,
-            }
+    async function fetchUsers() {
+      try {
+        const res = await axiosInstance.get('/users', {
+          params: { deleted: showDeleted },
+        })
+        if (res.status !== 200) return
+        if (ignore) return
+        const data = res.data.data.map((row: users) => ({
+          ...row,
+          role: row.role.trim(),
+        }))
+        setRows(data)
+        const map: Record<number, { name: string; acronym: string }> = {}
+        for (const obj of fismaSystems) {
+          map[obj.fismasystemid] = {
+            name: obj.fismasubsystem
+              ? obj.fismaname + ' - ' + obj.fismasubsystem
+              : obj.fismaname,
+            acronym: obj.fismaacronym,
           }
-          setFismaSystemsMap(map)
-          // Grants now arrive inline on each list row (assignedopdivids), so the
-          // OpDivs column reads them directly with no per-user calls. Fall back to
-          // the per-user detail endpoint only against an older backend that omits
-          // them, keeping this safe to ship before or after the backend deploys.
-          // Distinguish "old backend omitted the field" (key absent -> backfill)
-          // from "new backend, user simply has zero grants" (key present, value
-          // null/[] -> no backfill). A value check would misfire on every
-          // zero-grant user and re-introduce the N+1.
-          const missingInlineGrants = data.some(
-            (u: users) => !('assignedopdivids' in u)
-          )
-          if (missingInlineGrants) {
-            Promise.all(
+        }
+        setFismaSystemsMap(map)
+        // Grants now arrive inline on each list row (assignedopdivids), so the
+        // OpDivs column reads them directly with no per-user calls. Fall back to
+        // the per-user detail endpoint only against an older backend that omits
+        // them, keeping this safe to ship before or after the backend deploys.
+        // Distinguish "old backend omitted the field" (key absent -> backfill)
+        // from "new backend, user simply has zero grants" (key present, value
+        // null/[] -> no backfill). A value check would misfire on every
+        // zero-grant user and re-introduce the N+1.
+        const missingInlineGrants = data.some(
+          (u: users) => !('assignedopdivids' in u)
+        )
+        if (missingInlineGrants) {
+          try {
+            const entries = await Promise.all(
               data.map((u: users) =>
                 fetchUserOpDivs(u.userid)
                   .then((ids) => [u.userid, ids] as [string, number[]])
                   .catch(() => [u.userid, []] as [string, number[]])
               )
             )
-              .then((entries) => {
-                if (ignore) return
-                // Merge rather than replace so an in-flight per-user refresh
-                // (e.g. from closing the grant modal) is not clobbered.
-                setUserOpDivMap((prev) => ({
-                  ...prev,
-                  ...Object.fromEntries(entries),
-                }))
-              })
-              .catch((error) => {
-                if (ignore) return
-                // The per-user catches above already default to [], so this only
-                // trips on an unexpected failure. Surface it rather than leaving
-                // the OpDivs column silently blank.
-                console.error('Failed to backfill OpDiv grants', error)
-                notify(ERROR_MESSAGES.tryAgain, 'warning')
-              })
+            if (ignore) return
+            // Merge rather than replace so an in-flight per-user refresh
+            // (e.g. from closing the grant modal) is not clobbered.
+            setUserOpDivMap((prev) => ({
+              ...prev,
+              ...Object.fromEntries(entries),
+            }))
+          } catch (error) {
+            if (ignore) return
+            // The per-user catches above already default to [], so this only
+            // trips on an unexpected failure. Surface it rather than leaving
+            // the OpDivs column silently blank.
+            console.error('Failed to backfill OpDiv grants', error)
+            notify(ERROR_MESSAGES.tryAgain, 'warning')
           }
-        } else {
-          return
         }
-      })
-      .catch((error) => {
+      } catch (error) {
         if (isAuthHandled(error)) return
         console.error('Fetch users error:', error)
         notify(ERROR_MESSAGES.tryAgain, 'error')
-      })
+      }
+    }
+    fetchUsers()
     return () => {
       ignore = true
     }
@@ -470,8 +469,9 @@ export default function UserTable() {
     // Pull the full list (incl. inactive/parent) so any granted id resolves to
     // a code in the OpDivs column; derive the assignable subset from the same
     // response for the grant modal.
-    fetchOpDivs(true)
-      .then((all) => {
+    async function loadOpDivs() {
+      try {
+        const all = await fetchOpDivs(true)
         const codeMap: Record<number, string> = {}
         all.forEach((od) => {
           codeMap[od.opdiv_id] = od.code
@@ -484,12 +484,13 @@ export default function UserTable() {
           assignable = assignable.filter((od) => own.has(od.opdiv_id))
         }
         setOpDivOptions(assignable)
-      })
-      .catch(() => {
+      } catch {
         // Non-fatal: the grant modal simply shows no options if this fails.
         setOpDivOptions([])
         setOpDivCodeMap({})
-      })
+      }
+    }
+    loadOpDivs()
   }, [isAdmin, userInfo])
   const columns: GridColDef[] = [
     {


### PR DESCRIPTION
## What this PR does

This PR cleans up a code style inconsistency that existed throughout the frontend. Many of our async functions (functions that run in the background, like saving a form or fetching data) were written in two different styles at the same time — a mix of `await` and `.then()/.catch()` chained together. This is confusing to read and caused at least one real bug (described below).

This PR rewrites all of those functions to use a single consistent style: `try / await / catch / finally`. The behavior of the app is **unchanged** — the same things happen on success, the same error messages show, and 401 redirects still work. Only the internal structure of the code is different.

## Why this needed fixing

**Readability:** When a function mixes both styles, a reader has to track two different mental models at once to understand what it does. The `try/await/catch` style reads top-to-bottom like plain English.

**Bug fixed:** Several handlers (`EditSystemModal`, `SystemDetailPage`) were missing a `finally` block because it is awkward to attach correctly to a `.then()/.catch()` chain. This meant the "saving..." spinner could get stuck showing if a network request failed. Those handlers now have a proper `finally { setIsSaving(false) }` so the spinner always clears, whether the save succeeded or failed.

**Error surfacing:** `.catch()` attached to an `await`ed promise can silently swallow errors thrown inside `.then()` callbacks. The `try/catch` form catches everything uniformly.

## Credit

This work was specified in full by **@tarratsco** in issue #380, including identifying every file and handler that needed to change, the exact before/after code shape, and the reasoning behind each category of fix. This PR implements that spec as written. @tarratsco had claimed the issue and would have submitted this — it was ported here by @MackOverflow because @tarratsco is currently working from a fork without enterprise access.

## Files changed

| File | What was converted |
|------|--------------------|
| `src/views/Home/Home.tsx` | `fetchScores` |
| `src/views/Title/Title.tsx` | `fetchFismaSystems`, `fetchDatacalls` |
| `src/components/EmailModal/EmailModal.tsx` | `submitEmail` |
| `src/views/DatacallModal/DataCallModal.tsx` | `submitDatacall` |
| `src/views/FismaTable/FismaTable.tsx` | `saveSystemAnswers` |
| `src/views/UserTable/UserTable.tsx` | `processRowUpdate`, `handleConfirmDelete`, `handleConfirmRestore` |
| `src/views/AssignSystemModal/AssignSystemModal.tsx` | `useEffect` data fetch, `onChange` assign handler, `handleConfirmUnassign` |
| `src/views/EditSystemModal/EditSystemModal.tsx` | `handleSave` (edit + create modes), `handleDecommission`, `handleReactivate`, two name-lookup `useEffect`s |
| `src/views/SystemDetailPage/SystemDetailPage.tsx` | `handleSave`, `handleDecommission`, `handleReactivate`, two name-lookup `useEffect`s, retry-fetch `useEffect` |
| `src/views/QuestionnairePage/QuestionnairePage.tsx` | `saveResponse`, functions/options `useEffect` |
| `src/views/QuestionnareModal/QuestionnareModal.tsx` | `fetchData` `useEffect` (3 sequential requests), `handleQuestionnareNext` save logic, `fetchOptions` `useEffect` |

## How to verify

No new behavior was introduced, so the main thing to verify is that nothing broke:

- [ ] `yarn test --watchAll=false` — 152 passing, 3 skipped (no regressions)
- [ ] `yarn typecheck` — clean
- [ ] `yarn lint` — clean
- [ ] Submit a form (email modal, datacall modal, edit system) — success toast appears, spinner clears
- [ ] Simulate a network error — error toast appears, spinner clears (previously the spinner could get stuck)
- [ ] Navigate the questionnaire — saves work correctly, 401 redirect still fires via the centralized interceptor

Closes #380