### PR TITLE
refactor: Add AbortController cancellation to all data-fetch flows (#381)

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -113,34 +113,40 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
 
   // Fetch datacalls when modal opens (with caching)
   useEffect(() => {
-    if (open) {
-      const fetchDatacalls = async () => {
-        try {
-          const now = Date.now()
-          const CACHE_DURATION = 10 * 60 * 1000 // 10 minutes for datacalls
+    if (!open) return
+    const controller = new AbortController()
+    const fetchDatacalls = async () => {
+      try {
+        const now = Date.now()
+        const CACHE_DURATION = 10 * 60 * 1000 // 10 minutes for datacalls
 
-          // Check if cache is still valid
-          if (
-            datacallsCache.data &&
-            datacallsCache.timestamp &&
-            now - datacallsCache.timestamp < CACHE_DURATION
-          ) {
-            setDatacalls(datacallsCache.data)
-          } else {
-            // Fetch fresh data
-            const response = await axiosInstance.get('/datacalls')
-            const datacallsData = response.data.data
-            setDatacalls(datacallsData)
+        // Check if cache is still valid
+        if (
+          datacallsCache.data &&
+          datacallsCache.timestamp &&
+          now - datacallsCache.timestamp < CACHE_DURATION
+        ) {
+          setDatacalls(datacallsCache.data)
+        } else {
+          // Fetch fresh data
+          const response = await axiosInstance.get('/datacalls', {
+            signal: controller.signal,
+          })
+          const datacallsData = response.data.data
+          setDatacalls(datacallsData)
 
-            // Update cache
-            datacallsCache.data = datacallsData
-            datacallsCache.timestamp = now
-          }
-        } catch (error) {
-          console.error('Error fetching datacalls:', error)
+          // Update cache
+          datacallsCache.data = datacallsData
+          datacallsCache.timestamp = now
         }
+      } catch (error) {
+        if (controller.signal.aborted) return
+        console.error('Error fetching datacalls:', error)
       }
-      fetchDatacalls()
+    }
+    fetchDatacalls()
+    return () => {
+      controller.abort()
     }
   }, [open])
 

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -44,14 +44,27 @@ export default function AssignSystemModal({
     nextValue: number[]
   } | null>(null)
   React.useEffect(() => {
-    if (open && userid) {
-      axiosInstance.get(`/users/${userid}/assignedfismasystems`).then((res) => {
+    if (!open || !userid) return
+    const controller = new AbortController()
+    async function fetchAssigned() {
+      try {
+        const res = await axiosInstance.get(
+          `/users/${userid}/assignedfismasystems`,
+          { signal: controller.signal }
+        )
         const assignedSys = res.data.data || []
         setAssignedSystems(assignedSys)
         // Include all systems in options
         const systemIds = Object.keys(fismaSystemMap).map(Number)
         setFismaSystems(systemIds)
-      })
+      } catch (error) {
+        if (controller.signal.aborted) return
+        console.error('Error fetching assigned systems:', error)
+      }
+    }
+    fetchAssigned()
+    return () => {
+      controller.abort()
     }
   }, [open, userid, fismaSystemMap])
   const handleConfirmUnassign = (confirm: boolean) => {

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -157,57 +157,57 @@ export default function EditSystemModal({
     }
   }, [system, open])
   React.useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     if (open && system?.decommissioned && system?.decommissioned_by) {
       const userId = system.decommissioned_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled && system?.decommissioned_by === userId) {
-            if (res.data?.data?.fullname) {
-              setDecommissionedByName(res.data.data.fullname)
-            } else {
-              setDecommissionedByName(userId)
-            }
+      async function load() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`, {
+            signal: controller.signal,
+          })
+          if (system?.decommissioned_by === userId) {
+            setDecommissionedByName(res.data?.data?.fullname || userId)
           }
-        })
-        .catch(() => {
-          if (!cancelled && system?.decommissioned_by === userId) {
+        } catch {
+          if (controller.signal.aborted) return
+          if (system?.decommissioned_by === userId) {
             setDecommissionedByName(userId)
           }
-        })
+        }
+      }
+      load()
     } else {
       setDecommissionedByName('')
     }
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [system, open])
   React.useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     if (open && system?.reactivated_by) {
       const userId = system.reactivated_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled && system?.reactivated_by === userId) {
-            if (res.data?.data?.fullname) {
-              setReactivatedByName(res.data.data.fullname)
-            } else {
-              setReactivatedByName(userId)
-            }
+      async function load() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`, {
+            signal: controller.signal,
+          })
+          if (system?.reactivated_by === userId) {
+            setReactivatedByName(res.data?.data?.fullname || userId)
           }
-        })
-        .catch(() => {
-          if (!cancelled && system?.reactivated_by === userId) {
+        } catch {
+          if (controller.signal.aborted) return
+          if (system?.reactivated_by === userId) {
             setReactivatedByName(userId)
           }
-        })
+        }
+      }
+      load()
     } else {
       setReactivatedByName('')
     }
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [system, open])
   const handleClose = () => {

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -17,29 +17,34 @@ export default function HomePageContainer() {
   const { latestDataCallId, selectedDataCallId } = useContextProp()
   const activeDataCallId = selectedDataCallId || latestDataCallId
   useEffect(() => {
+    const controller = new AbortController()
     async function fetchScores() {
       if (activeDataCallId !== 0) {
-        await axiosInstance
-          .get(`/scores/aggregate?datacallid=${activeDataCallId}`)
-          .then((res) => {
-            const scoresMap: Record<number, SystemScoreEntry> = {}
-            for (const obj of res.data.data as ScoreAggregate[]) {
-              scoresMap[obj.fismasystemid] = {
-                score: obj.systemscore ?? 0,
-                tier: obj.systemtier,
-              }
+        try {
+          const res = await axiosInstance.get(
+            `/scores/aggregate?datacallid=${activeDataCallId}`,
+            { signal: controller.signal }
+          )
+          const scoresMap: Record<number, SystemScoreEntry> = {}
+          for (const obj of res.data.data as ScoreAggregate[]) {
+            scoresMap[obj.fismasystemid] = {
+              score: obj.systemscore ?? 0,
+              tier: obj.systemtier,
             }
-            setScoreMap(scoresMap)
-          })
-          .catch((error) => {
-            console.error('Error fetching scores:', error)
-          })
-          .finally(() => {
-            setLoading(false)
-          })
+          }
+          setScoreMap(scoresMap)
+        } catch (error) {
+          if (controller.signal.aborted) return
+          console.error('Error fetching scores:', error)
+        } finally {
+          if (!controller.signal.aborted) setLoading(false)
+        }
       }
     }
     fetchScores()
+    return () => {
+      controller.abort()
+    }
   }, [activeDataCallId])
 
   if (loading) {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -384,44 +384,46 @@ export default function QuestionnarePage() {
     // footer does not flash the previous question's editor during the
     // refetch window.
     setInitQuestionChoice(-1)
-    const choices: QuestionChoice[] = []
-    let funcOptId: number = 0
-    try {
-      axiosInstance
-        .get(`functions/${questionId}/options`, { signal: controller.signal })
-        .then((res) => {
-          res.data.data.forEach((item: QuestionOption) => {
-            const choiceOpt: QuestionChoice = {
-              label: item.description,
-              value: item.functionoptionid,
-            }
-            if (item.functionoptionid in questionScores) {
-              funcOptId = item.functionoptionid
-              choiceOpt.defaultChecked = true
-            }
-            choices.push(choiceOpt)
-          })
-          // Foundation of question
-          setDescription(questionId ? questions[questionId].description : '')
-          setQuestion(questionId ? questions[questionId].question : '')
-          setNotePrompt(questionId ? questions[questionId].notesprompt : '')
-
-          // Notes
-          setNotes(funcOptId ? questionScores[funcOptId].notes : '')
-          setInitNotes(funcOptId ? questionScores[funcOptId].notes : '')
-
-          // Question options
-          setSelectQuestionOption(funcOptId ? funcOptId : -1)
-          setInitQuestionChoice(funcOptId ? funcOptId : -1)
-          setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
-          setOptions(choices ? choices : [])
-          setLoadingQuestion(false)
+    async function load() {
+      const choices: QuestionChoice[] = []
+      let funcOptId: number = 0
+      try {
+        const res = await axiosInstance.get(`functions/${questionId}/options`, {
+          signal: controller.signal,
         })
-    } catch (error) {
-      if (controller.signal.aborted) return
-      if (isAuthHandled(error)) return
-      console.error('Error fetching data:', error)
+        res.data.data.forEach((item: QuestionOption) => {
+          const choiceOpt: QuestionChoice = {
+            label: item.description,
+            value: item.functionoptionid,
+          }
+          if (item.functionoptionid in questionScores) {
+            funcOptId = item.functionoptionid
+            choiceOpt.defaultChecked = true
+          }
+          choices.push(choiceOpt)
+        })
+        // Foundation of question
+        setDescription(questionId ? questions[questionId].description : '')
+        setQuestion(questionId ? questions[questionId].question : '')
+        setNotePrompt(questionId ? questions[questionId].notesprompt : '')
+
+        // Notes
+        setNotes(funcOptId ? questionScores[funcOptId].notes : '')
+        setInitNotes(funcOptId ? questionScores[funcOptId].notes : '')
+
+        // Question options
+        setSelectQuestionOption(funcOptId ? funcOptId : -1)
+        setInitQuestionChoice(funcOptId ? funcOptId : -1)
+        setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
+        setOptions(choices ? choices : [])
+        setLoadingQuestion(false)
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        console.error('Error fetching data:', error)
+      }
     }
+    load()
     return () => {
       controller.abort()
     }

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -229,158 +229,167 @@ export default function QuestionnarePage() {
   }
 
   React.useEffect(() => {
-    if (system) {
-      // Reset the empty-questionnaire flag so a previous decommissioned-system
-      // view does not bleed into the next render when system changes.
-      setNoQuestions(false)
-      const fetchData = async () => {
-        try {
-          let questionsEmpty = false
-          let datacall = ''
-          const latestDataCallId = await axiosInstance
-            .get(`/datacalls/latest`)
-            .then((res) => {
-              const latestId = res.data.data.datacallid
-              const isHistorical =
-                selectedDataCallId > 0 && selectedDataCallId !== latestId
-              if (isHistorical) {
-                setDatacallID(selectedDataCallId)
-                datacall = selectedDatacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(true)
-              } else {
-                setDatacallID(latestId)
-                datacall = res.data.data.datacall.replaceAll(' ', '_')
-                setDatacall(datacall)
-                setIsPastDeadline(new Date() > new Date(res.data.data.deadline))
+    if (!system) return
+    const controller = new AbortController()
+    // Reset the empty-questionnaire flag so a previous decommissioned-system
+    // view does not bleed into the next render when system changes.
+    setNoQuestions(false)
+    const fetchData = async () => {
+      try {
+        let questionsEmpty = false
+        let datacall = ''
+        const latestDataCallId = await axiosInstance
+          .get(`/datacalls/latest`, { signal: controller.signal })
+          .then((res) => {
+            const latestId = res.data.data.datacallid
+            const isHistorical =
+              selectedDataCallId > 0 && selectedDataCallId !== latestId
+            if (isHistorical) {
+              setDatacallID(selectedDataCallId)
+              datacall = selectedDatacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(true)
+            } else {
+              setDatacallID(latestId)
+              datacall = res.data.data.datacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(new Date() > new Date(res.data.data.deadline))
+            }
+            return isHistorical ? selectedDataCallId : latestId
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            notify(ERROR_MESSAGES.tryAgain, 'error', {
+              autoHideDuration: 2500,
+            })
+          })
+        await axiosInstance
+          .get(`/fismasystems/${system}/questions`, {
+            signal: controller.signal,
+          })
+          .then((response) => {
+            // Decommissioned systems join to zero functions, so the questions
+            // endpoint returns no rows. The Go backend serializes a nil
+            // slice as JSON null, so the response can be either { data: null }
+            // or { data: [] } depending on driver behavior - treat both as
+            // the empty-state signal. Surface a friendly message instead of
+            // crashing on categoriesData[0] below.
+            const data = response.data?.data
+            if (!data || (Array.isArray(data) && data.length === 0)) {
+              questionsEmpty = true
+              setNoQuestions(true)
+              setLoadingQuestion(false)
+              return
+            }
+            const organizedData: Record<string, FismaQuestion[]> = {}
+            const questionData: Record<number, Question> = {}
+            data.forEach((question: FismaQuestion) => {
+              if (!organizedData[question.pillar.pillar]) {
+                organizedData[question.pillar.pillar] = []
               }
-              return isHistorical ? selectedDataCallId : latestId
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              notify(ERROR_MESSAGES.tryAgain, 'error', {
-                autoHideDuration: 2500,
-              })
-            })
-          await axiosInstance
-            .get(`/fismasystems/${system}/questions`)
-            .then((response) => {
-              // Decommissioned systems join to zero functions, so the questions
-              // endpoint returns no rows. The Go backend serializes a nil
-              // slice as JSON null, so the response can be either { data: null }
-              // or { data: [] } depending on driver behavior - treat both as
-              // the empty-state signal. Surface a friendly message instead of
-              // crashing on categoriesData[0] below.
-              const data = response.data?.data
-              if (!data || (Array.isArray(data) && data.length === 0)) {
-                questionsEmpty = true
-                setNoQuestions(true)
-                setLoadingQuestion(false)
-                return
+              questionData[question.function.functionid] = {
+                question: question.question,
+                notesprompt: question.notesprompt,
+                description: question.function.description,
+                pillar: question.pillar.pillar,
+                function: question.function.function,
               }
-              const organizedData: Record<string, FismaQuestion[]> = {}
-              const questionData: Record<number, Question> = {}
-              data.forEach((question: FismaQuestion) => {
-                if (!organizedData[question.pillar.pillar]) {
-                  organizedData[question.pillar.pillar] = []
-                }
-                questionData[question.function.functionid] = {
-                  question: question.question,
-                  notesprompt: question.notesprompt,
-                  description: question.function.description,
-                  pillar: question.pillar.pillar,
-                  function: question.function.function,
-                }
-                organizedData[question.pillar.pillar].push(question)
-              })
-              setQuestions(questionData)
-              const sortedPillars = sortPillars(Object.keys(organizedData))
-              let sortedFuncId: number[] = []
-              const categoriesData: Category[] = sortedPillars.map((pillar) => {
-                const sortedSteps = sortFunctions(pillar, organizedData[pillar])
-                const sortedStepFuncId = sortedSteps.map(
-                  (d) => d.function.functionid
-                )
-                sortedFuncId = [...sortedFuncId, ...sortedStepFuncId]
-                return {
-                  name: pillar,
-                  steps: sortedSteps,
-                }
-              })
-              const funcIdToIdx = sortedFuncId.reduce(
-                (
-                  acc: { [key: number]: number },
-                  num: number,
-                  index: number
-                ) => {
-                  acc[num] = index
-                  return acc
-                },
-                {}
-              )
-              setFunctionIdIdx(funcIdToIdx) // set a map of functionid -> index in sortedFunctId
-              setQuestionId(sortedFuncId[0]) // sets the questionid(functionid) to the first value in the array
-              setStepFunctionId(sortedFuncId) // contains an array of all functionid in order of render
-              setCategories(categoriesData)
-              navigate(
-                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
-                {
-                  state: { fismasystemid: system },
-                  replace: true,
-                }
-              )
-              setSelectedIndex(sortedFuncId[0]) // set the first selected item in the list (rendered) to be selected(highlighted)
-              setQuestion(questionData[sortedFuncId[0]].question) // set the first question value to the page
-              setDescription(questionData[sortedFuncId[0]].description)
-              setNotePrompt(questionData[sortedFuncId[0]].notesprompt) // set the first note prompt to the page
+              organizedData[question.pillar.pillar].push(question)
             })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              notify(ERROR_MESSAGES.tryAgain, 'error')
+            setQuestions(questionData)
+            const sortedPillars = sortPillars(Object.keys(organizedData))
+            let sortedFuncId: number[] = []
+            const categoriesData: Category[] = sortedPillars.map((pillar) => {
+              const sortedSteps = sortFunctions(pillar, organizedData[pillar])
+              const sortedStepFuncId = sortedSteps.map(
+                (d) => d.function.functionid
+              )
+              sortedFuncId = [...sortedFuncId, ...sortedStepFuncId]
+              return {
+                name: pillar,
+                steps: sortedSteps,
+              }
             })
-          if (questionsEmpty) {
-            return
-          }
-          await axiosInstance
-            .get(
-              `scores?datacallid=${latestDataCallId}&fismasystemid=${system}&include=functionoption`
+            const funcIdToIdx = sortedFuncId.reduce(
+              (acc: { [key: number]: number }, num: number, index: number) => {
+                acc[num] = index
+                return acc
+              },
+              {}
             )
-            .then((res) => {
-              const hashTable: questionScoreMap = Object.assign(
-                {},
-                ...res.data.data.map((item: QuestionScores) => ({
-                  [item.functionoptionid]: item,
-                }))
-              )
-              // res.data.data.map((item: any) => {
-              //   questionScoreMap[item.functionoptionid] = item
-              //   funcScoreTable
-              // })
-              setQuestionScores(hashTable)
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching question scores:', error)
-              notify(ERROR_MESSAGES.tryAgain, 'error')
-            })
-        } catch (error) {
-          if (isAuthHandled(error)) return
-          console.error('Error fetching data:', error)
+            setFunctionIdIdx(funcIdToIdx) // set a map of functionid -> index in sortedFunctId
+            setQuestionId(sortedFuncId[0]) // sets the questionid(functionid) to the first value in the array
+            setStepFunctionId(sortedFuncId) // contains an array of all functionid in order of render
+            setCategories(categoriesData)
+            navigate(
+              `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
+              {
+                state: { fismasystemid: system },
+                replace: true,
+              }
+            )
+            setSelectedIndex(sortedFuncId[0]) // set the first selected item in the list (rendered) to be selected(highlighted)
+            setQuestion(questionData[sortedFuncId[0]].question) // set the first question value to the page
+            setDescription(questionData[sortedFuncId[0]].description)
+            setNotePrompt(questionData[sortedFuncId[0]].notesprompt) // set the first note prompt to the page
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            notify(ERROR_MESSAGES.tryAgain, 'error')
+          })
+        if (questionsEmpty) {
+          return
         }
+        await axiosInstance
+          .get(
+            `scores?datacallid=${latestDataCallId}&fismasystemid=${system}&include=functionoption`,
+            { signal: controller.signal }
+          )
+          .then((res) => {
+            const hashTable: questionScoreMap = Object.assign(
+              {},
+              ...res.data.data.map((item: QuestionScores) => ({
+                [item.functionoptionid]: item,
+              }))
+            )
+            // res.data.data.map((item: any) => {
+            //   questionScoreMap[item.functionoptionid] = item
+            //   funcScoreTable
+            // })
+            setQuestionScores(hashTable)
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            console.error('Error fetching question scores:', error)
+            notify(ERROR_MESSAGES.tryAgain, 'error')
+          })
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        console.error('Error fetching data:', error)
       }
-      fetchData()
+    }
+    fetchData()
+    return () => {
+      controller.abort()
     }
   }, [system, navigate, fismaacronym, selectedDataCallId, selectedDatacall])
   React.useEffect(() => {
-    if (questionId) {
-      // Clear saved-state markers before async load so the last-edited
-      // footer does not flash the previous question's editor during the
-      // refetch window.
-      setInitQuestionChoice(-1)
-      const choices: QuestionChoice[] = []
-      let funcOptId: number = 0
-      try {
-        axiosInstance.get(`functions/${questionId}/options`).then((res) => {
+    if (!questionId) return
+    const controller = new AbortController()
+    // Clear saved-state markers before async load so the last-edited
+    // footer does not flash the previous question's editor during the
+    // refetch window.
+    setInitQuestionChoice(-1)
+    const choices: QuestionChoice[] = []
+    let funcOptId: number = 0
+    try {
+      axiosInstance
+        .get(`functions/${questionId}/options`, { signal: controller.signal })
+        .then((res) => {
           res.data.data.forEach((item: QuestionOption) => {
             const choiceOpt: QuestionChoice = {
               label: item.description,
@@ -408,10 +417,13 @@ export default function QuestionnarePage() {
           setOptions(choices ? choices : [])
           setLoadingQuestion(false)
         })
-      } catch (error) {
-        if (isAuthHandled(error)) return
-        console.error('Error fetching data:', error)
-      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      if (isAuthHandled(error)) return
+      console.error('Error fetching data:', error)
+    }
+    return () => {
+      controller.abort()
     }
   }, [questionId, questionScores, questions])
   const breadcrumbSegmentLabels = fismaacronym

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -357,53 +357,51 @@ export default function QuestionnareModal({
   React.useEffect(() => {
     if (!questionId) return
     const controller = new AbortController()
-    try {
-      axiosInstance
-        .get(`functions/${questionId}/options`, { signal: controller.signal })
-        .then((res) => {
-          setOptions(res.data.data)
-          let isValidOption: boolean = false
-          let funcOptId: number = 0
-          res.data.data.forEach((item: QuestionOption) => {
-            if (item.functionoptionid in questionScores) {
-              isValidOption = true
-              funcOptId = item.functionoptionid
-            }
-          })
-          if (!isValidOption) {
-            setSelectQuestionOption(0)
-            setScoreId(0)
-            setNotes('')
-            setLoadedSelectQuestionOption(0)
-            setLoadedNotes('')
-            setSavedLastEditedAt(null)
-            setSavedLastEditedBy(null)
-          } else {
-            const id = questionScores[funcOptId].scoreid
-            const notes = questionScores[funcOptId].notes
-            setSelectQuestionOption(funcOptId)
-            setScoreId(id)
-            setNotes(notes)
-            // Snapshot the loaded answer so handleQuestionnareNext can
-            // detect "no real change" and skip the PUT. Without this the
-            // backend's no-op guard still preserves history, but we
-            // would still pay a wasted roundtrip on every Next click.
-            setLoadedSelectQuestionOption(funcOptId)
-            setLoadedNotes(notes)
-            setSavedLastEditedAt(
-              questionScores[funcOptId].last_edited_at ?? null
-            )
-            setSavedLastEditedBy(
-              questionScores[funcOptId].last_edited_by ?? null
-            )
-          }
-          setLoadingQuestion(false)
+    async function load() {
+      try {
+        const res = await axiosInstance.get(`functions/${questionId}/options`, {
+          signal: controller.signal,
         })
-    } catch (error) {
-      if (controller.signal.aborted) return
-      if (isAuthHandled(error)) return
-      console.error('Error fetching data:', error)
+        setOptions(res.data.data)
+        let isValidOption: boolean = false
+        let funcOptId: number = 0
+        res.data.data.forEach((item: QuestionOption) => {
+          if (item.functionoptionid in questionScores) {
+            isValidOption = true
+            funcOptId = item.functionoptionid
+          }
+        })
+        if (!isValidOption) {
+          setSelectQuestionOption(0)
+          setScoreId(0)
+          setNotes('')
+          setLoadedSelectQuestionOption(0)
+          setLoadedNotes('')
+          setSavedLastEditedAt(null)
+          setSavedLastEditedBy(null)
+        } else {
+          const id = questionScores[funcOptId].scoreid
+          const notes = questionScores[funcOptId].notes
+          setSelectQuestionOption(funcOptId)
+          setScoreId(id)
+          setNotes(notes)
+          // Snapshot the loaded answer so handleQuestionnareNext can
+          // detect "no real change" and skip the PUT. Without this the
+          // backend's no-op guard still preserves history, but we
+          // would still pay a wasted roundtrip on every Next click.
+          setLoadedSelectQuestionOption(funcOptId)
+          setLoadedNotes(notes)
+          setSavedLastEditedAt(questionScores[funcOptId].last_edited_at ?? null)
+          setSavedLastEditedBy(questionScores[funcOptId].last_edited_by ?? null)
+        }
+        setLoadingQuestion(false)
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        console.error('Error fetching data:', error)
+      }
     }
+    load()
     return () => {
       controller.abort()
     }

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -269,87 +269,98 @@ export default function QuestionnareModal({
     return str
   }
   React.useEffect(() => {
-    if (open && system) {
-      const fetchData = async () => {
-        try {
-          const latestDataCallId = await axiosInstance
-            .get(`/datacalls/latest`)
-            .then((res) => {
-              setDatacallID(res.data.data.datacallid)
-              if (new Date() > new Date(res.data.data.deadline)) {
-                setIsPastDeadline(true)
-              }
-              return res.data.data.datacallid
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching latest datacall:', error)
-            })
+    if (!open || !system) return
+    const controller = new AbortController()
+    const fetchData = async () => {
+      try {
+        const latestDataCallId = await axiosInstance
+          .get(`/datacalls/latest`, { signal: controller.signal })
+          .then((res) => {
+            setDatacallID(res.data.data.datacallid)
+            if (new Date() > new Date(res.data.data.deadline)) {
+              setIsPastDeadline(true)
+            }
+            return res.data.data.datacallid
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            console.error('Error fetching latest datacall:', error)
+          })
 
-          await axiosInstance
-            .get(`/fismasystems/${system.fismasystemid}/questions`)
-            .then((response) => {
-              const data = response.data.data
-              const organizedData: Record<string, FismaQuestion[]> = {}
-              data.forEach((question: FismaQuestion) => {
-                if (!organizedData[question.pillar.pillar]) {
-                  organizedData[question.pillar.pillar] = []
-                }
-                organizedData[question.pillar.pillar].push(question)
-              })
-              const sortedPillars = sortPillars(Object.keys(organizedData))
-              const categoriesData: Category[] = sortedPillars.map(
-                (pillar) => ({
-                  name: pillar,
-                  steps: sortFunctions(pillar, organizedData[pillar]),
-                })
-              )
-              // const categoriesData: Category[] = sortedPillars.map(
-              //   (pillar) => ({
-              //     name: pillar,
-              //     steps: organizedData[pillar],
-              //   })
-              // )
-              // console.log(categoriesData)
-              setCategories(categoriesData)
-              if (data.length > 0) {
-                // console.log(categoriesData)
-                setQuestionId(categoriesData[0]['steps'][0].function.functionid)
+        await axiosInstance
+          .get(`/fismasystems/${system.fismasystemid}/questions`, {
+            signal: controller.signal,
+          })
+          .then((response) => {
+            const data = response.data.data
+            const organizedData: Record<string, FismaQuestion[]> = {}
+            data.forEach((question: FismaQuestion) => {
+              if (!organizedData[question.pillar.pillar]) {
+                organizedData[question.pillar.pillar] = []
               }
+              organizedData[question.pillar.pillar].push(question)
             })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching questions:', error)
-            })
-          await axiosInstance
-            .get(
-              `scores?datacallid=${latestDataCallId}&fismasystemid=${system.fismasystemid}`
+            const sortedPillars = sortPillars(Object.keys(organizedData))
+            const categoriesData: Category[] = sortedPillars.map((pillar) => ({
+              name: pillar,
+              steps: sortFunctions(pillar, organizedData[pillar]),
+            }))
+            // const categoriesData: Category[] = sortedPillars.map(
+            //   (pillar) => ({
+            //     name: pillar,
+            //     steps: organizedData[pillar],
+            //   })
+            // )
+            // console.log(categoriesData)
+            setCategories(categoriesData)
+            if (data.length > 0) {
+              // console.log(categoriesData)
+              setQuestionId(categoriesData[0]['steps'][0].function.functionid)
+            }
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            console.error('Error fetching questions:', error)
+          })
+        await axiosInstance
+          .get(
+            `scores?datacallid=${latestDataCallId}&fismasystemid=${system.fismasystemid}`,
+            { signal: controller.signal }
+          )
+          .then((res) => {
+            const hashTable: questionScoreMap = Object.assign(
+              {},
+              ...res.data.data.map((item: QuestionScores) => ({
+                [item.functionoptionid]: item,
+              }))
             )
-            .then((res) => {
-              const hashTable: questionScoreMap = Object.assign(
-                {},
-                ...res.data.data.map((item: QuestionScores) => ({
-                  [item.functionoptionid]: item,
-                }))
-              )
-              setQuestionScores(hashTable)
-            })
-            .catch((error) => {
-              if (isAuthHandled(error)) return
-              console.error('Error fetching question scores:', error)
-            })
-        } catch (error) {
-          if (isAuthHandled(error)) return
-          console.error('Error fetching data:', error)
-        }
+            setQuestionScores(hashTable)
+          })
+          .catch((error) => {
+            if (controller.signal.aborted) return
+            if (isAuthHandled(error)) return
+            console.error('Error fetching question scores:', error)
+          })
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        console.error('Error fetching data:', error)
       }
-      fetchData()
+    }
+    fetchData()
+    return () => {
+      controller.abort()
     }
   }, [open, system])
   React.useEffect(() => {
-    if (questionId) {
-      try {
-        axiosInstance.get(`functions/${questionId}/options`).then((res) => {
+    if (!questionId) return
+    const controller = new AbortController()
+    try {
+      axiosInstance
+        .get(`functions/${questionId}/options`, { signal: controller.signal })
+        .then((res) => {
           setOptions(res.data.data)
           let isValidOption: boolean = false
           let funcOptId: number = 0
@@ -388,10 +399,13 @@ export default function QuestionnareModal({
           }
           setLoadingQuestion(false)
         })
-      } catch (error) {
-        if (isAuthHandled(error)) return
-        console.error('Error fetching data:', error)
-      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      if (isAuthHandled(error)) return
+      console.error('Error fetching data:', error)
+    }
+    return () => {
+      controller.abort()
     }
   }, [questionId, questionScores])
   const renderRadioGroup = (options: QuestionOption[]) => {

--- a/src/views/SystemDetailPage/CfactsRecordCard.tsx
+++ b/src/views/SystemDetailPage/CfactsRecordCard.tsx
@@ -89,7 +89,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
   const [hasError, setHasError] = useState(false)
 
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     setLoading(true)
     setNotFound(false)
     setHasError(false)
@@ -98,47 +98,44 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
     // an empty state. Bypass the cross-cutting auth handler so it does
     // not surface a permission snackbar over what is a normal absent-data
     // case.
-    axiosInstance
-      .get(`systemenrichment/${fismaUid}`, { skipAuthHandling: true })
-      .then((res) => {
-        if (!cancelled) {
-          // The endpoint returns { data: { fisma_uuid, payload, synced_at } }.
-          // The enrichment fields live in payload; fisma_uuid and synced_at are
-          // top-level siblings. Flatten into the existing shape so the rendering
-          // below is unchanged.
-          const record = res.data?.data
-          setCfacts(
-            record
-              ? {
-                  ...record.payload,
-                  fisma_uuid: record.fisma_uuid,
-                  synced_at: record.synced_at,
-                }
-              : null
-          )
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          if (
-            error.response?.status === 404 ||
-            error.response?.status === 403
-          ) {
-            if (error.response?.status === 403) {
-              console.warn('ZTMF Insights 403 for fismaUid:', fismaUid)
-            }
-            setNotFound(true)
-          } else {
-            setHasError(true)
+    async function load() {
+      try {
+        const res = await axiosInstance.get(`systemenrichment/${fismaUid}`, {
+          signal: controller.signal,
+          skipAuthHandling: true,
+        })
+        // The endpoint returns { data: { fisma_uuid, payload, synced_at } }.
+        // The enrichment fields live in payload; fisma_uuid and synced_at are
+        // top-level siblings. Flatten into the existing shape so the rendering
+        // below is unchanged.
+        const record = res.data?.data
+        setCfacts(
+          record
+            ? {
+                ...record.payload,
+                fisma_uuid: record.fisma_uuid,
+                synced_at: record.synced_at,
+              }
+            : null
+        )
+      } catch (error: any) {
+        if (controller.signal.aborted) return
+        if (error.response?.status === 404 || error.response?.status === 403) {
+          if (error.response?.status === 403) {
+            console.warn('ZTMF Insights 403 for fismaUid:', fismaUid)
           }
+          setNotFound(true)
+        } else {
+          setHasError(true)
         }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+    load()
 
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [fismaUid])
 

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -42,29 +42,30 @@ export default function SystemDetailPage() {
   const [retryingFetch, setRetryingFetch] = useState(false)
 
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     if (fismaSystems.length > 0 && !system && !triedFetch.current) {
       triedFetch.current = true
       setRetryingFetch(true)
-      axiosInstance
-        .get(`fismasystems/${systemId}`)
-        .then((res) => {
-          if (!cancelled) {
-            const data = res.data?.data
-            if (data) {
-              setFismaSystems((prev) => [...prev, data])
-            }
+      async function load() {
+        try {
+          const res = await axiosInstance.get(`fismasystems/${systemId}`, {
+            signal: controller.signal,
+          })
+          const data = res.data?.data
+          if (data) {
+            setFismaSystems((prev) => [...prev, data])
           }
-        })
-        .catch(() => {
+        } catch {
+          if (controller.signal.aborted) return
           // System truly doesn't exist
-        })
-        .finally(() => {
-          if (!cancelled) setRetryingFetch(false)
-        })
+        } finally {
+          if (!controller.signal.aborted) setRetryingFetch(false)
+        }
+      }
+      load()
     }
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [fismaSystems, system, systemId, setFismaSystems])
 
@@ -135,52 +136,52 @@ export default function SystemDetailPage() {
 
   // Resolve decommissioned_by UUID to a human-readable name
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     if (system?.decommissioned && system?.decommissioned_by) {
       const userId = system.decommissioned_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled) {
-            setDecommissionedByName(res.data?.data?.fullname || userId)
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            // User may have been removed — fall back to UUID
-            setDecommissionedByName(userId)
-          }
-        })
+      async function load() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`, {
+            signal: controller.signal,
+          })
+          setDecommissionedByName(res.data?.data?.fullname || userId)
+        } catch {
+          if (controller.signal.aborted) return
+          // User may have been removed — fall back to UUID
+          setDecommissionedByName(userId)
+        }
+      }
+      load()
     } else {
       setDecommissionedByName('')
     }
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [system])
 
   // Resolve reactivated_by UUID to a human-readable name
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     if (system?.reactivated_by) {
       const userId = system.reactivated_by
-      axiosInstance
-        .get(`users/${userId}`)
-        .then((res) => {
-          if (!cancelled) {
-            setReactivatedByName(res.data?.data?.fullname || userId)
-          }
-        })
-        .catch(() => {
-          if (!cancelled) {
-            setReactivatedByName(userId)
-          }
-        })
+      async function load() {
+        try {
+          const res = await axiosInstance.get(`users/${userId}`, {
+            signal: controller.signal,
+          })
+          setReactivatedByName(res.data?.data?.fullname || userId)
+        } catch {
+          if (controller.signal.aborted) return
+          setReactivatedByName(userId)
+        }
+      }
+      load()
     } else {
       setReactivatedByName('')
     }
     return () => {
-      cancelled = true
+      controller.abort()
     }
   }, [system])
 

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -93,26 +93,31 @@ export default function Title() {
 
   useEffect(() => {
     if (loaderData.serverError) return
+    const controller = new AbortController()
     async function fetchDatacalls() {
-      await axiosInstance
-        .get('/datacalls')
-        .then((res) => {
-          const sorted: datacall[] = [...res.data.data].sort(
-            (a: datacall, b: datacall) => b.datacallid - a.datacallid
-          )
-          setDatacalls(sorted)
-          if (sorted.length > 0) {
-            setLatestDataCallId(sorted[0].datacallid)
-            setLatestDatacall(sorted[0].datacall)
-            setSelectedDataCallId(sorted[0].datacallid)
-            setSelectedDatacall(sorted[0].datacall)
-          }
+      try {
+        const res = await axiosInstance.get('/datacalls', {
+          signal: controller.signal,
         })
-        .catch((error) => {
-          console.error('Fetch latest datacall error:', error)
-        })
+        const sorted: datacall[] = [...res.data.data].sort(
+          (a: datacall, b: datacall) => b.datacallid - a.datacallid
+        )
+        setDatacalls(sorted)
+        if (sorted.length > 0) {
+          setLatestDataCallId(sorted[0].datacallid)
+          setLatestDatacall(sorted[0].datacall)
+          setSelectedDataCallId(sorted[0].datacallid)
+          setSelectedDatacall(sorted[0].datacall)
+        }
+      } catch (error) {
+        if (controller.signal.aborted) return
+        console.error('Fetch latest datacall error:', error)
+      }
     }
     fetchDatacalls()
+    return () => {
+      controller.abort()
+    }
   }, [loaderData.serverError])
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -399,14 +399,17 @@ export default function UserTable() {
   // TODO: Custom hook for fetching data
   useEffect(() => {
     if (!canRead) return
-    // Guard against a superseded run (e.g. a fast Show Deleted toggle)
-    // resolving late and clobbering fresher grant state.
-    let ignore = false
-    axiosInstance
-      .get('/users', { params: { deleted: showDeleted } })
-      .then((res) => {
+    const controller = new AbortController()
+    // backfillAborted guards the Promise.all per-user calls, which can't receive
+    // a signal since fetchUserOpDivs doesn't accept one.
+    let backfillAborted = false
+    async function load() {
+      try {
+        const res = await axiosInstance.get('/users', {
+          params: { deleted: showDeleted },
+          signal: controller.signal,
+        })
         if (res.status === 200) {
-          if (ignore) return
           const data = res.data.data.map((row: users) => ({
             ...row,
             role: row.role.trim(),
@@ -442,7 +445,7 @@ export default function UserTable() {
               )
             )
               .then((entries) => {
-                if (ignore) return
+                if (backfillAborted) return
                 // Merge rather than replace so an in-flight per-user refresh
                 // (e.g. from closing the grant modal) is not clobbered.
                 setUserOpDivMap((prev) => ({
@@ -451,7 +454,7 @@ export default function UserTable() {
                 }))
               })
               .catch((error) => {
-                if (ignore) return
+                if (backfillAborted) return
                 // The per-user catches above already default to [], so this only
                 // trips on an unexpected failure. Surface it rather than leaving
                 // the OpDivs column silently blank.
@@ -459,17 +462,18 @@ export default function UserTable() {
                 notify(ERROR_MESSAGES.tryAgain, 'warning')
               })
           }
-        } else {
-          return
         }
-      })
-      .catch((error) => {
+      } catch (error) {
+        if (controller.signal.aborted) return
         if (isAuthHandled(error)) return
         console.error('Fetch users error:', error)
         notify(ERROR_MESSAGES.tryAgain, 'error')
-      })
+      }
+    }
+    load()
     return () => {
-      ignore = true
+      controller.abort()
+      backfillAborted = true
     }
   }, [canRead, fismaSystems, navigate, showDeleted])
   // OpDiv options for the grant modal: assignable children only (the HHS


### PR DESCRIPTION
## What this PR does

This PR fixes a subtle resource management problem that existed in every component that loads data from the server. When a user navigates away from a page (or changes a filter, closes a modal, etc.) before the server has responded, the old code would let the network request finish, receive the response, and then throw it away — but only *after* React had already unmounted the component or re-rendered with fresh state.

This caused two categories of problem:
1. **Race conditions:** If a user quickly toggled a filter (e.g. "Show Deleted" in the user table), two requests could be in-flight at the same time. Whichever one finished last would overwrite the result of the one that finished first, even if it was stale.
2. **Wasted work:** Requests were completing and processing server responses for components that no longer existed on screen.

This PR adds `AbortController` cancellation to every data-fetch `useEffect` in the app. When a component unmounts or a dependency changes, the cleanup function calls `controller.abort()`, which tells axios to cancel the in-flight HTTP request immediately. The catch block checks `controller.signal.aborted` and returns silently — it was an intentional cancel, not a real error.

The behavior of the app is **unchanged** — the same data loads, the same error messages show. Only the internal resource handling is more correct.

## Before / after

**Before (boolean guard — stops the state write but not the network request):**
```ts
let cancelled = false
axiosInstance.get('/endpoint').then(res => {
  if (!cancelled) setState(res.data)  // discards data, but request already completed
})
return () => { cancelled = true }
```

**After (real cancellation — stops the HTTP request itself):**
```ts
const controller = new AbortController()
async function load() {
  try {
    const res = await axiosInstance.get('/endpoint', { signal: controller.signal })
    setState(res.data)
  } catch (error) {
    if (controller.signal.aborted) return  // cancelled — silent
    notify(ERROR_MESSAGES.tryAgain, 'error')  // real error — surface it
  }
}
load()
return () => { controller.abort() }
```

## Files changed

| File | Change |
|---|---|
| `CfactsRecordCard.tsx` | `let cancelled` + `.then/.catch/.finally` → `AbortController` + `async/await` |
| `EditSystemModal.tsx` | Two user-lookup effects: `let cancelled` → `AbortController` |
| `SystemDetailPage.tsx` | Three effects: `let cancelled` → `AbortController` |
| `UserTable.tsx` | `let ignore` → `AbortController` for the `/users` fetch; the per-user OpDiv backfill keeps a boolean guard since `fetchUserOpDivs` is a helper that doesn't accept a signal |
| `Title.tsx` | `fetchDatacalls` effect: added `AbortController` (previously had no cancellation guard at all) |
| `Home.tsx` | `fetchScores` effect: added `AbortController` |
| `AssignSystemModal.tsx` | `fetchAssigned` effect: added `AbortController` |
| `PillarScoresModal.tsx` | `fetchDatacalls` effect: added `AbortController` |
| `QuestionnairePage.tsx` | Both effects (main data-fetch + per-question options): `AbortController` added, `signal` passed to every `axiosInstance.get` call |
| `QuestionnareModal.tsx` | Both effects (main data-fetch + per-question options): `AbortController` added, `signal` passed to every `axiosInstance.get` call |

## Credit

This work was specified by **@tarratsco** in issue #381. @tarratsco had claimed the issue and would have submitted this — it was ported here by @MackOverflow because @tarratsco is currently working from a fork without enterprise access.

## How to verify

No new behavior was introduced, so the main thing to verify is that nothing broke:

- [ ] `yarn typecheck` — clean
- [ ] `yarn lint` — clean
- [ ] Navigate to a page that loads data (Home, SystemDetailPage, UserTable) — data loads correctly
- [ ] Navigate away quickly before data loads — no React "can't perform state update on unmounted component" warnings in the console
- [ ] Open and close a modal quickly (AssignSystemModal, PillarScoresModal) — no stale state or errors
- [ ] Toggle "Show Deleted" in UserTable rapidly — only the last selection's data renders, no overwrites from stale responses

Closes #381