### PR TITLE
fix(questionnaire): skip score save on Next when nothing changed

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -37,6 +37,7 @@ import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
+import { shouldPersistResponse } from './saveGuard'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -190,6 +191,16 @@ export default function QuestionnarePage() {
   }
 
   const saveResponse = () => {
+    if (
+      !shouldPersistResponse({
+        selectQuestionOption,
+        initQuestionChoice,
+        notes,
+        initNotes,
+      })
+    ) {
+      return
+    }
     if (scoreid) {
       axiosInstance
         .put(`scores/${scoreid}`, {

--- a/src/views/QuestionnairePage/saveGuard.test.ts
+++ b/src/views/QuestionnairePage/saveGuard.test.ts
@@ -1,0 +1,46 @@
+import { shouldPersistResponse, ResponseState } from './saveGuard'
+
+const base: ResponseState = {
+  selectQuestionOption: 5,
+  initQuestionChoice: 5,
+  notes: 'hello',
+  initNotes: 'hello',
+}
+
+describe('shouldPersistResponse', () => {
+  it('returns false when neither answer nor notes changed (no re-stamp on Next)', () => {
+    expect(shouldPersistResponse(base)).toBe(false)
+  })
+
+  it('returns true when the answer changed', () => {
+    expect(shouldPersistResponse({ ...base, selectQuestionOption: 7 })).toBe(
+      true
+    )
+  })
+
+  it('returns true when the notes changed and an answer is selected', () => {
+    expect(shouldPersistResponse({ ...base, notes: 'edited' })).toBe(true)
+  })
+
+  it('returns false for an unanswered question with unchanged notes', () => {
+    expect(
+      shouldPersistResponse({
+        selectQuestionOption: -1,
+        initQuestionChoice: -1,
+        notes: '',
+        initNotes: '',
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when notes were typed but no answer is selected (no functionoptionid: -1 POST)', () => {
+    expect(
+      shouldPersistResponse({
+        selectQuestionOption: -1,
+        initQuestionChoice: -1,
+        notes: 'typed something',
+        initNotes: '',
+      })
+    ).toBe(false)
+  })
+})

--- a/src/views/QuestionnairePage/saveGuard.ts
+++ b/src/views/QuestionnairePage/saveGuard.ts
@@ -15,9 +15,10 @@ export interface ResponseState {
  * last_edited_at, corrupting the audit trail (see issue #412).
  */
 export const shouldPersistResponse = (s: ResponseState): boolean => {
-  const isDirty =
-    (s.selectQuestionOption !== -1 &&
-      s.initQuestionChoice !== s.selectQuestionOption) ||
-    s.initNotes !== s.notes
-  return isDirty && s.selectQuestionOption !== -1
+  // No answer selected: never persist. `-1` is the sentinel and the backend
+  // cannot store a score without a real functionoptionid.
+  if (s.selectQuestionOption === -1) return false
+  return (
+    s.selectQuestionOption !== s.initQuestionChoice || s.notes !== s.initNotes
+  )
 }

--- a/src/views/QuestionnairePage/saveGuard.ts
+++ b/src/views/QuestionnairePage/saveGuard.ts
@@ -1,0 +1,23 @@
+export interface ResponseState {
+  selectQuestionOption: number
+  initQuestionChoice: number
+  notes: string
+  initNotes: string
+}
+
+/**
+ * Determines whether a questionnaire response should be persisted.
+ *
+ * Returns true only when the user actually changed the selected answer or the
+ * notes AND an answer is currently selected. `-1` is the "no answer" sentinel
+ * and must never be written: a score record requires a real functionoptionid,
+ * and persisting an unchanged response would re-stamp last_edited_by /
+ * last_edited_at, corrupting the audit trail (see issue #412).
+ */
+export const shouldPersistResponse = (s: ResponseState): boolean => {
+  const isDirty =
+    (s.selectQuestionOption !== -1 &&
+      s.initQuestionChoice !== s.selectQuestionOption) ||
+    s.initNotes !== s.notes
+  return isDirty && s.selectQuestionOption !== -1
+}


### PR DESCRIPTION
## Summary

The questionnaire **Next** button called `saveResponse()` unconditionally for any non-read-only user. Because the backend stamps `last_edited_by` / `last_edited_at` on every write, paging forward through questions silently re-stamped the current user onto answers they only read through, overwriting the genuine last editor in the audit trail. For unanswered questions the same path could POST `functionoptionid: -1` (the no-answer sentinel).

This worked correctly before the last-edited footer shipped (Refs #363): the unconditional save was harmless when writes were idempotent, but once last-edited tracking landed a no-op save became a visible data-integrity bug.

## Fix

New pure helper `shouldPersistResponse()` (`src/views/QuestionnairePage/saveGuard.ts`) returns true only when the user actually changed the answer or the notes **and** an answer is selected. `saveResponse()` early-returns through it, so the Next path and any future caller are covered in one place. The `-1` guard only ever affects the new-score POST path, since a loaded answer already forces a real `functionoptionid` and radios cannot be deselected back to `-1`.

The Back button and sidebar navigation are unchanged — they gate their own confirm dialog and never called `saveResponse()`.

## Acceptance criteria

- [x] Clicking Next with no answer/notes change issues no API call and does not alter `last_edited_by` / `last_edited_at`
- [x] Clicking Next after a real answer or notes change still saves
- [x] Paging through unanswered questions does not POST a score with `functionoptionid: -1`
- [x] Last-edited footer reflects only real edits
- [x] Test added (`saveGuard.test.ts`)

## Testing

- `npx tsc --noEmit` clean
- `npx jest saveGuard` — 5/5 pass, covering the full AC matrix including notes-typed-on-an-unanswered-question

Closes #412