### PR TITLE
Feat/411 score diff

### DIFF
--- a/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
@@ -1,0 +1,287 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import ScoreDiffModal from './ScoreDiffModal'
+import axiosInstance from '@/axiosConfig'
+import type { ScoreDiffEntry, FismaQuestion, datacall } from '@/types'
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+jest.mock('@/utils/notify', () => ({
+  isAuthHandled: jest.fn(),
+}))
+
+const mockGet = axiosInstance.get as jest.Mock
+
+// Bump past the 10-min cache TTL before each test so module-level caches
+// never serve stale data from a prior test.
+const CACHE_DURATION = 10 * 60 * 1000
+let nowValue = 0
+beforeEach(() => {
+  nowValue += CACHE_DURATION + 1
+  jest.spyOn(Date, 'now').mockReturnValue(nowValue)
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DATACALLS: datacall[] = [
+  {
+    datacallid: 5,
+    datacall: 'FY2025',
+    datecreated: '2025-01-01T00:00:00Z',
+    deadline: '2099-12-31T00:00:00Z',
+  },
+  {
+    datacallid: 4,
+    datacall: 'FY2024',
+    datecreated: '2024-01-01T00:00:00Z',
+    deadline: '2020-12-31T00:00:00Z',
+  },
+  {
+    datacallid: 3,
+    datacall: 'FY2023',
+    datecreated: '2023-01-01T00:00:00Z',
+    deadline: '2020-12-31T00:00:00Z',
+  },
+]
+
+const QUESTIONS: FismaQuestion[] = [
+  {
+    questionid: 1,
+    question: 'Does your org use MFA?',
+    notesprompt: '',
+    pillar: { pillar: 'Identity', pillarid: 1, order: 1 },
+    function: {
+      functionid: 10,
+      function: 'Authentication-Users',
+      description: '',
+      datacenterenvironment: '',
+    },
+  },
+  {
+    questionid: 2,
+    question: 'How do you manage devices?',
+    notesprompt: '',
+    pillar: { pillar: 'Devices', pillarid: 2, order: 2 },
+    function: {
+      functionid: 20,
+      function: 'PolicyEnforcement',
+      description: '',
+      datacenterenvironment: '',
+    },
+  },
+]
+
+const DIFF_ENTRY: ScoreDiffEntry = {
+  fismasystemid: 1001,
+  functionid: 10,
+  function: 'Authentication-Users',
+  question: 'Does your org use MFA?',
+  from: {
+    scoreid: 1,
+    functionoptionid: 1,
+    optionname: 'Traditional',
+    score: 1,
+    notes: null,
+  },
+  to: {
+    scoreid: 2,
+    functionoptionid: 3,
+    optionname: 'Advanced',
+    score: 4,
+    notes: 'Improved this cycle',
+  },
+  changed_at: '2025-01-15T10:30:00Z',
+  changed_by: {
+    userid: 'u1',
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    role: 'ISSO',
+  },
+}
+
+const DEVICES_ENTRY: ScoreDiffEntry = {
+  fismasystemid: 1001,
+  functionid: 20,
+  function: 'PolicyEnforcement',
+  question: 'How do you manage devices?',
+  from: {
+    scoreid: 3,
+    functionoptionid: 2,
+    optionname: 'Managed',
+    score: 3,
+    notes: null,
+  },
+  to: {
+    scoreid: 4,
+    functionoptionid: 4,
+    optionname: 'Optimal',
+    score: 5,
+    notes: null,
+  },
+}
+
+const DEFAULT_PROPS = {
+  open: true,
+  onClose: jest.fn(),
+  fismasystemid: 1001,
+  systemName: 'Test System',
+  systemAcronym: 'TS',
+  selectedDataCallId: 5,
+}
+
+function setupMocks(diffEntries: ScoreDiffEntry[] = [DIFF_ENTRY]) {
+  mockGet.mockImplementation((url: string) => {
+    if (url === '/datacalls')
+      return Promise.resolve({ data: { data: DATACALLS } })
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/scores/diff'))
+      return Promise.resolve({ data: { data: diffEntries } })
+    return Promise.reject(new Error(`Unexpected URL: ${url}`))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ScoreDiffModal', () => {
+  it('does not render when open is false', () => {
+    setupMocks()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} open={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows system name and acronym in the title', () => {
+    setupMocks()
+    render(
+      <ScoreDiffModal
+        {...DEFAULT_PROPS}
+        systemName="My System"
+        systemAcronym="MS"
+      />
+    )
+    expect(
+      screen.getByText(/My System \(MS\) — Compare Datacalls/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows a spinner while datacalls are loading', () => {
+    mockGet.mockReturnValue(new Promise(() => {}))
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    expect(screen.getByLabelText('Loading datacalls')).toBeInTheDocument()
+  })
+
+  it('sets To to selectedDataCallId and From to the prior datacall', async () => {
+    setupMocks()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} selectedDataCallId={5} />)
+    expect(await screen.findByLabelText('To datacall')).toHaveValue('FY2025')
+    expect(screen.getByLabelText('From datacall')).toHaveValue('FY2024')
+  })
+
+  it('fetches the diff with the correct query params', async () => {
+    setupMocks()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith(
+        '/scores/diff?from=4&to=5&fismasystemid=1001'
+      )
+    )
+  })
+
+  it('shows empty-state message when diff returns no entries', async () => {
+    setupMocks([])
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await screen.findByText('No changes between these two datacalls.')
+  })
+
+  it('shows an error alert when the diff fetch fails', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/datacalls')
+        return Promise.resolve({ data: { data: DATACALLS } })
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: QUESTIONS } })
+      return Promise.reject(new Error('Network error'))
+    })
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await screen.findByText('Failed to load diff. Please try again.')
+  })
+
+  it('renders function, question, both answer sides, and attribution', async () => {
+    setupMocks()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await screen.findByText('Authentication-Users')
+    expect(screen.getByText('Does your org use MFA?')).toBeInTheDocument()
+    expect(screen.getByText('Traditional')).toBeInTheDocument()
+    expect(screen.getByText('score 1/5')).toBeInTheDocument()
+    expect(screen.getByText('Advanced')).toBeInTheDocument()
+    expect(screen.getByText('score 4/5')).toBeInTheDocument()
+    expect(screen.getByText('Jane Smith (ISSO)')).toBeInTheDocument()
+    expect(screen.getByText(/Jan 15, 2025/)).toBeInTheDocument()
+  })
+
+  it('shows notes when present and hides them when null', async () => {
+    setupMocks()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    // to.notes = 'Improved this cycle', from.notes = null → only one notes line
+    await screen.findByText('Improved this cycle')
+  })
+
+  it('renders "No answer" for a null side', async () => {
+    setupMocks([{ ...DIFF_ENTRY, from: null }])
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    expect(await screen.findAllByText('No answer')).toHaveLength(1)
+  })
+
+  it('renders pillar group headers ordered by PILLAR_ORDER', async () => {
+    // Devices entry arrives first; Identity should still render before Devices
+    setupMocks([DEVICES_ENTRY, DIFF_ENTRY])
+    render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await screen.findByText('Identity')
+    const identityEl = screen.getByText('Identity')
+    const devicesEl = screen.getByText('Devices')
+    expect(
+      identityEl.compareDocumentPosition(devicesEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it('calls onClose when either close control is clicked', () => {
+    setupMocks()
+    const onClose = jest.fn()
+    render(<ScoreDiffModal {...DEFAULT_PROPS} onClose={onClose} />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Close compare datacalls dialog' })
+    )
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-fetches the diff when the modal is reopened', async () => {
+    setupMocks()
+    const { rerender } = render(<ScoreDiffModal {...DEFAULT_PROPS} />)
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('/scores/diff')
+      )
+    )
+    const firstCount = mockGet.mock.calls.filter(([u]: [string]) =>
+      u.includes('/scores/diff')
+    ).length
+
+    rerender(<ScoreDiffModal {...DEFAULT_PROPS} open={false} />)
+    rerender(<ScoreDiffModal {...DEFAULT_PROPS} open={true} />)
+
+    await waitFor(() => {
+      const newCount = mockGet.mock.calls.filter(([u]: [string]) =>
+        u.includes('/scores/diff')
+      ).length
+      expect(newCount).toBeGreaterThan(firstCount)
+    })
+  })
+})

--- a/src/components/ScoreDiffModal/ScoreDiffModal.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -20,19 +20,29 @@ import {
   TextField,
   Chip,
   Divider,
-  Tooltip,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Button as CmsButton } from '@cmsgov/design-system'
 import axiosInstance from '@/axiosConfig'
 import { isAuthHandled } from '@/utils/notify'
-import type { datacall, ScoreDiffEntry } from '@/types'
+import { PILLAR_ORDER, PILLAR_FUNCTION_MAP } from '@/constants'
+import type {
+  datacall,
+  ScoreDiffEntry,
+  FismaQuestion,
+  questionPillar,
+} from '@/types'
 
 const datacallsCache: { data: datacall[] | null; timestamp: number | null } = {
   data: null,
   timestamp: null,
 }
+
+const questionsCache = new Map<
+  number,
+  { data: FismaQuestion[]; timestamp: number }
+>()
 const CACHE_DURATION = 10 * 60 * 1000
 
 interface ScoreDiffModalProps {
@@ -54,6 +64,9 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
   const [fromDatacall, setFromDatacall] = useState<datacall | null>(null)
   const [toDatacall, setToDatacall] = useState<datacall | null>(null)
   const [diffResults, setDiffResults] = useState<ScoreDiffEntry[]>([])
+  const [functionPillarMap, setFunctionPillarMap] = useState<
+    Map<number, questionPillar>
+  >(new Map())
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const initialFocusRef = useRef<HTMLButtonElement>(null)
@@ -99,6 +112,84 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
     }
     fetchDatacalls()
   }, [open])
+
+  // Fetch function→pillar map for the current system (used to group diff rows)
+  useEffect(() => {
+    if (!open || !fismasystemid) return
+    const fetchQuestions = async () => {
+      try {
+        const now = Date.now()
+        const cached = questionsCache.get(fismasystemid)
+        let questions: FismaQuestion[]
+        if (cached && now - cached.timestamp < CACHE_DURATION) {
+          questions = cached.data
+        } else {
+          const res = await axiosInstance.get(
+            `/fismasystems/${fismasystemid}/questions`
+          )
+          questions = res.data?.data ?? []
+          questionsCache.set(fismasystemid, { data: questions, timestamp: now })
+        }
+        const map = new Map<number, questionPillar>()
+        questions.forEach((q: FismaQuestion) => {
+          if (!map.has(q.function.functionid)) {
+            map.set(q.function.functionid, q.pillar)
+          }
+        })
+        setFunctionPillarMap(map)
+      } catch (err) {
+        if (isAuthHandled(err)) return
+        console.error('Error fetching questions for pillar grouping:', err)
+      }
+    }
+    fetchQuestions()
+  }, [open, fismasystemid])
+
+  // Group and sort diff results by pillar order.
+  // Falls back to a flat list under a single group when pillar info
+  // is not yet available (e.g. questions fetch still in-flight).
+  const groupedResults = useMemo(() => {
+    if (diffResults.length === 0) return []
+    type PillarGroup = { pillar: questionPillar; entries: ScoreDiffEntry[] }
+    const groups = new Map<number, PillarGroup>()
+    const uncategorized: ScoreDiffEntry[] = []
+    diffResults.forEach((entry) => {
+      const pillar = functionPillarMap.get(entry.functionid)
+      if (!pillar) {
+        uncategorized.push(entry)
+        return
+      }
+      if (!groups.has(pillar.pillarid)) {
+        groups.set(pillar.pillarid, { pillar, entries: [] })
+      }
+      groups.get(pillar.pillarid)!.entries.push(entry)
+    })
+    const pillarRank = (name: string) => {
+      const i = PILLAR_ORDER.indexOf(name)
+      return i === -1 ? Number.MAX_SAFE_INTEGER : i
+    }
+    const fnRank = (pillarName: string, fnName: string) => {
+      const i = (PILLAR_FUNCTION_MAP[pillarName] ?? []).indexOf(fnName)
+      return i === -1 ? Number.MAX_SAFE_INTEGER : i
+    }
+    const sorted = Array.from(groups.values()).sort(
+      (a, b) => pillarRank(a.pillar.pillar) - pillarRank(b.pillar.pillar)
+    )
+    sorted.forEach((group) => {
+      group.entries.sort(
+        (a, b) =>
+          fnRank(group.pillar.pillar, a.function) -
+          fnRank(group.pillar.pillar, b.function)
+      )
+    })
+    if (uncategorized.length > 0) {
+      sorted.push({
+        pillar: { pillar: 'Other', pillarid: -1, order: 999 },
+        entries: uncategorized,
+      })
+    }
+    return sorted
+  }, [diffResults, functionPillarMap])
 
   // Fetch diff whenever both pickers are set and different
   useEffect(() => {
@@ -170,13 +261,9 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
 
   const latestId = datacalls[0]?.datacallid ?? -1
 
-  const renderSide = (side: ScoreDiffEntry['from'], label: string) => {
+  const renderSide = (side: ScoreDiffEntry['from']) => {
     if (!side) {
-      return (
-        <em style={{ color: '#666' }}>
-          {label === 'from' ? 'Not answered' : 'Removed'}
-        </em>
-      )
+      return <em style={{ color: '#666' }}>{'No answer'}</em>
     }
     return (
       <>
@@ -184,27 +271,16 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
         <Typography variant="caption" sx={{ color: 'text.secondary' }}>
           score {side.score}/5
         </Typography>
+        {side.notes && (
+          <Typography
+            variant="caption"
+            display="block"
+            sx={{ color: 'text.secondary', fontStyle: 'italic', mt: 0.5 }}
+          >
+            {side.notes}
+          </Typography>
+        )}
       </>
-    )
-  }
-
-  const renderNotes = (entry: ScoreDiffEntry) => {
-    const fromNotes = entry.from?.notes ?? ''
-    const toNotes = entry.to?.notes ?? ''
-    if (fromNotes === toNotes) return '—'
-    return (
-      <Box>
-        {fromNotes && (
-          <Typography variant="caption" display="block">
-            From: {fromNotes}
-          </Typography>
-        )}
-        {toNotes && (
-          <Typography variant="caption" display="block">
-            To: {toNotes}
-          </Typography>
-        )}
-      </Box>
     )
   }
 
@@ -261,94 +337,100 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
           </Typography>
         </Box>
 
-        {/* Picker row */}
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-            mb: 2,
-            flexWrap: 'wrap',
-          }}
-        >
-          <Box sx={{ flex: 1, minWidth: 220 }}>
-            <Typography
-              variant="caption"
-              sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
-            >
-              From
-            </Typography>
-            <Autocomplete
-              size="small"
-              options={datacalls}
-              getOptionLabel={(dc) => dc.datacall}
-              isOptionEqualToValue={(opt, val) =>
-                opt.datacallid === val.datacallid
-              }
-              getOptionDisabled={(opt) =>
-                opt.datacallid === toDatacall?.datacallid
-              }
-              value={fromDatacall ?? undefined}
-              onChange={(_, dc) => {
-                if (dc) setFromDatacall(dc)
-              }}
-              renderOption={(props, option) =>
-                renderOption(props, option, latestId)
-              }
-              disableClearable
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  size="small"
-                  inputProps={{
-                    ...params.inputProps,
-                    'aria-label': 'From datacall',
-                  }}
-                />
-              )}
-            />
+        {/* Picker row — hidden behind a spinner until datacalls are loaded */}
+        {datacalls.length === 0 ? (
+          <Box display="flex" justifyContent="center" py={2}>
+            <CircularProgress size={24} aria-label="Loading datacalls" />
           </Box>
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              mb: 2,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Box sx={{ flex: 1, minWidth: 220 }}>
+              <Typography
+                variant="caption"
+                sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
+              >
+                From
+              </Typography>
+              <Autocomplete
+                size="small"
+                options={datacalls}
+                getOptionLabel={(dc) => dc.datacall}
+                isOptionEqualToValue={(opt, val) =>
+                  opt.datacallid === val.datacallid
+                }
+                getOptionDisabled={(opt) =>
+                  opt.datacallid === toDatacall?.datacallid
+                }
+                value={fromDatacall ?? undefined}
+                onChange={(_, dc) => {
+                  if (dc) setFromDatacall(dc)
+                }}
+                renderOption={(props, option) =>
+                  renderOption(props, option, latestId)
+                }
+                disableClearable
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    size="small"
+                    inputProps={{
+                      ...params.inputProps,
+                      'aria-label': 'From datacall',
+                    }}
+                  />
+                )}
+              />
+            </Box>
 
-          <ArrowForwardIcon sx={{ mt: 2.5, color: 'text.secondary' }} />
+            <ArrowForwardIcon sx={{ mt: 2.5, color: 'text.secondary' }} />
 
-          <Box sx={{ flex: 1, minWidth: 220 }}>
-            <Typography
-              variant="caption"
-              sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
-            >
-              To
-            </Typography>
-            <Autocomplete
-              size="small"
-              options={datacalls}
-              getOptionLabel={(dc) => dc.datacall}
-              isOptionEqualToValue={(opt, val) =>
-                opt.datacallid === val.datacallid
-              }
-              getOptionDisabled={(opt) =>
-                opt.datacallid === fromDatacall?.datacallid
-              }
-              value={toDatacall ?? undefined}
-              onChange={(_, dc) => {
-                if (dc) setToDatacall(dc)
-              }}
-              renderOption={(props, option) =>
-                renderOption(props, option, latestId)
-              }
-              disableClearable
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  size="small"
-                  inputProps={{
-                    ...params.inputProps,
-                    'aria-label': 'To datacall',
-                  }}
-                />
-              )}
-            />
+            <Box sx={{ flex: 1, minWidth: 220 }}>
+              <Typography
+                variant="caption"
+                sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
+              >
+                To
+              </Typography>
+              <Autocomplete
+                size="small"
+                options={datacalls}
+                getOptionLabel={(dc) => dc.datacall}
+                isOptionEqualToValue={(opt, val) =>
+                  opt.datacallid === val.datacallid
+                }
+                getOptionDisabled={(opt) =>
+                  opt.datacallid === fromDatacall?.datacallid
+                }
+                value={toDatacall ?? undefined}
+                onChange={(_, dc) => {
+                  if (dc) setToDatacall(dc)
+                }}
+                renderOption={(props, option) =>
+                  renderOption(props, option, latestId)
+                }
+                disableClearable
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    size="small"
+                    inputProps={{
+                      ...params.inputProps,
+                      'aria-label': 'To datacall',
+                    }}
+                  />
+                )}
+              />
+            </Box>
           </Box>
-        </Box>
+        )}
 
         <Divider sx={{ mb: 2 }} />
 
@@ -398,9 +480,6 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
                     To answer
                   </TableCell>
                   <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
-                    Notes
-                  </TableCell>
-                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
                     Changed by
                   </TableCell>
                   <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
@@ -409,57 +488,68 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {diffResults.map((entry) => (
-                  <TableRow
-                    key={entry.functionid}
-                    sx={{
-                      '&:nth-of-type(even)': { backgroundColor: '#f5f5f5' },
-                    }}
-                  >
-                    <TableCell component="th" scope="row">
-                      <Typography variant="body2" fontWeight={500}>
-                        {entry.function}
-                      </Typography>
-                    </TableCell>
-                    <TableCell sx={{ maxWidth: 240 }}>
-                      <Tooltip title={entry.question} placement="top">
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            maxWidth: 240,
-                            cursor: 'default',
-                          }}
-                        >
-                          {entry.question}
-                        </Typography>
-                      </Tooltip>
-                    </TableCell>
-                    <TableCell>{renderSide(entry.from, 'from')}</TableCell>
-                    <TableCell>{renderSide(entry.to, 'to')}</TableCell>
-                    <TableCell sx={{ maxWidth: 200 }}>
-                      {renderNotes(entry)}
-                    </TableCell>
-                    <TableCell>
-                      {entry.changed_by
-                        ? `${entry.changed_by.name} (${entry.changed_by.role})`
-                        : 'Unknown'}
-                    </TableCell>
-                    <TableCell>
-                      {entry.changed_at
-                        ? new Date(entry.changed_at).toLocaleDateString(
-                            'en-US',
-                            {
-                              month: 'short',
-                              day: 'numeric',
-                              year: 'numeric',
-                            }
-                          )
-                        : '—'}
-                    </TableCell>
-                  </TableRow>
+                {groupedResults.map(({ pillar, entries }) => (
+                  <React.Fragment key={pillar.pillarid}>
+                    <TableRow>
+                      <TableCell
+                        colSpan={6}
+                        sx={{
+                          backgroundColor: '#e8edf7',
+                          fontWeight: 700,
+                          fontSize: '0.8rem',
+                          letterSpacing: '0.05em',
+                          textTransform: 'uppercase',
+                          color: '#004297',
+                          py: 0.75,
+                          borderTop: '2px solid #b3c2e8',
+                        }}
+                      >
+                        {pillar.pillar}
+                      </TableCell>
+                    </TableRow>
+                    {entries.map((entry) => (
+                      <TableRow
+                        key={entry.functionid}
+                        sx={{
+                          '&:nth-of-type(even)': {
+                            backgroundColor: '#f5f5f5',
+                          },
+                        }}
+                      >
+                        <TableCell component="th" scope="row">
+                          <Typography variant="body2" fontWeight={500}>
+                            {entry.function}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2">
+                            {entry.question}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>{renderSide(entry.from)}</TableCell>
+                        <TableCell>{renderSide(entry.to)}</TableCell>
+                        <TableCell>
+                          {entry.changed_by
+                            ? `${entry.changed_by.name} (${entry.changed_by.role})`
+                            : 'Unknown'}
+                        </TableCell>
+                        <TableCell>
+                          {entry.changed_at
+                            ? new Date(entry.changed_at).toLocaleString(
+                                'en-US',
+                                {
+                                  month: 'short',
+                                  day: 'numeric',
+                                  year: 'numeric',
+                                  hour: 'numeric',
+                                  minute: '2-digit',
+                                }
+                              )
+                            : '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </React.Fragment>
                 ))}
               </TableBody>
             </Table>

--- a/src/components/ScoreDiffModal/ScoreDiffModal.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.tsx
@@ -51,6 +51,7 @@ interface ScoreDiffModalProps {
   fismasystemid: number
   systemName: string
   systemAcronym: string
+  selectedDataCallId?: number
 }
 
 const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
@@ -59,6 +60,7 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
   fismasystemid,
   systemName,
   systemAcronym,
+  selectedDataCallId,
 }) => {
   const [datacalls, setDatacalls] = useState<datacall[]>([])
   const [fromDatacall, setFromDatacall] = useState<datacall | null>(null)
@@ -67,6 +69,7 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
   const [functionPillarMap, setFunctionPillarMap] = useState<
     Map<number, questionPillar>
   >(new Map())
+  const [diffKey, setDiffKey] = useState(0)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const initialFocusRef = useRef<HTMLButtonElement>(null)
@@ -78,6 +81,18 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
         initialFocusRef.current?.focus()
       }, 100)
       return () => clearTimeout(timer)
+    }
+  }, [open])
+
+  // Reset transient state on close; bump diffKey on open so the diff
+  // re-fetches even when picker references haven't changed (cached datacalls).
+  useEffect(() => {
+    if (open) {
+      setDiffKey((k) => k + 1)
+    } else {
+      setDiffResults([])
+      setFunctionPillarMap(new Map())
+      setError(null)
     }
   }, [open])
 
@@ -103,15 +118,21 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
           datacallsCache.timestamp = now
         }
         setDatacalls(sorted)
-        setToDatacall(sorted[0] ?? null)
-        setFromDatacall(sorted[1] ?? null)
+        const toId = selectedDataCallId
+        const toDefault =
+          sorted.find((dc) => dc.datacallid === toId) ?? sorted[0] ?? null
+        const fromDefault =
+          sorted.find((dc) => dc.datacallid < (toDefault?.datacallid ?? 0)) ??
+          null
+        setToDatacall(toDefault)
+        setFromDatacall(fromDefault)
       } catch (err) {
         if (isAuthHandled(err)) return
         console.error('Error fetching datacalls:', err)
       }
     }
     fetchDatacalls()
-  }, [open])
+  }, [open, selectedDataCallId])
 
   // Fetch function→pillar map for the current system (used to group diff rows)
   useEffect(() => {
@@ -214,7 +235,7 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
       .finally(() => {
         setLoading(false)
       })
-  }, [fromDatacall, toDatacall, fismasystemid])
+  }, [fromDatacall, toDatacall, fismasystemid, diffKey])
 
   const renderOption = (
     props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key },
@@ -507,13 +528,11 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
                         {pillar.pillar}
                       </TableCell>
                     </TableRow>
-                    {entries.map((entry) => (
+                    {entries.map((entry, i) => (
                       <TableRow
                         key={entry.functionid}
                         sx={{
-                          '&:nth-of-type(even)': {
-                            backgroundColor: '#f5f5f5',
-                          },
+                          backgroundColor: i % 2 === 1 ? '#f5f5f5' : 'inherit',
                         }}
                       >
                         <TableCell component="th" scope="row">

--- a/src/components/ScoreDiffModal/ScoreDiffModal.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.tsx
@@ -1,0 +1,477 @@
+import React, { useState, useEffect, useRef } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Typography,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  CircularProgress,
+  Alert,
+  Autocomplete,
+  TextField,
+  Chip,
+  Divider,
+  Tooltip,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import axiosInstance from '@/axiosConfig'
+import { isAuthHandled } from '@/utils/notify'
+import type { datacall, ScoreDiffEntry } from '@/types'
+
+const datacallsCache: { data: datacall[] | null; timestamp: number | null } = {
+  data: null,
+  timestamp: null,
+}
+const CACHE_DURATION = 10 * 60 * 1000
+
+interface ScoreDiffModalProps {
+  open: boolean
+  onClose: () => void
+  fismasystemid: number
+  systemName: string
+  systemAcronym: string
+}
+
+const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
+  open,
+  onClose,
+  fismasystemid,
+  systemName,
+  systemAcronym,
+}) => {
+  const [datacalls, setDatacalls] = useState<datacall[]>([])
+  const [fromDatacall, setFromDatacall] = useState<datacall | null>(null)
+  const [toDatacall, setToDatacall] = useState<datacall | null>(null)
+  const [diffResults, setDiffResults] = useState<ScoreDiffEntry[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const initialFocusRef = useRef<HTMLButtonElement>(null)
+
+  // Focus close button on open for accessibility
+  useEffect(() => {
+    if (open && initialFocusRef.current) {
+      const timer = setTimeout(() => {
+        initialFocusRef.current?.focus()
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [open])
+
+  // Fetch datacalls with cache; set defaults on first open
+  useEffect(() => {
+    if (!open) return
+    const fetchDatacalls = async () => {
+      try {
+        const now = Date.now()
+        let sorted: datacall[]
+        if (
+          datacallsCache.data &&
+          datacallsCache.timestamp &&
+          now - datacallsCache.timestamp < CACHE_DURATION
+        ) {
+          sorted = datacallsCache.data
+        } else {
+          const res = await axiosInstance.get('/datacalls')
+          sorted = [...res.data.data].sort(
+            (a: datacall, b: datacall) => b.datacallid - a.datacallid
+          )
+          datacallsCache.data = sorted
+          datacallsCache.timestamp = now
+        }
+        setDatacalls(sorted)
+        setToDatacall(sorted[0] ?? null)
+        setFromDatacall(sorted[1] ?? null)
+      } catch (err) {
+        if (isAuthHandled(err)) return
+        console.error('Error fetching datacalls:', err)
+      }
+    }
+    fetchDatacalls()
+  }, [open])
+
+  // Fetch diff whenever both pickers are set and different
+  useEffect(() => {
+    if (!fromDatacall || !toDatacall) return
+    if (fromDatacall.datacallid === toDatacall.datacallid) return
+
+    setLoading(true)
+    setError(null)
+    setDiffResults([])
+
+    axiosInstance
+      .get(
+        `/scores/diff?from=${fromDatacall.datacallid}&to=${toDatacall.datacallid}&fismasystemid=${fismasystemid}`
+      )
+      .then((res) => {
+        setDiffResults(res.data.data ?? [])
+      })
+      .catch((err) => {
+        if (isAuthHandled(err)) return
+        setError('Failed to load diff. Please try again.')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [fromDatacall, toDatacall, fismasystemid])
+
+  const renderOption = (
+    props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key },
+    option: datacall,
+    latestId: number
+  ) => {
+    const isCurrent = option.datacallid === latestId
+    const isClosed = new Date() > new Date(option.deadline)
+    const { key, ...rest } = props
+    const deadlineLabel = new Date(option.deadline).toLocaleDateString(
+      'en-US',
+      { month: 'short', day: 'numeric', year: 'numeric' }
+    )
+    return (
+      <li key={key} {...rest}>
+        <Box sx={{ width: '100%' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              width: '100%',
+              gap: 1,
+            }}
+          >
+            <Typography variant="body2">{option.datacall}</Typography>
+            {isCurrent && (
+              <Chip
+                label="Current"
+                size="small"
+                variant="outlined"
+                color="primary"
+                sx={{ height: 18, fontSize: '0.65rem' }}
+              />
+            )}
+          </Box>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            {isClosed ? 'Closed' : 'Active'} · deadline {deadlineLabel}
+          </Typography>
+        </Box>
+      </li>
+    )
+  }
+
+  const latestId = datacalls[0]?.datacallid ?? -1
+
+  const renderSide = (side: ScoreDiffEntry['from'], label: string) => {
+    if (!side) {
+      return (
+        <em style={{ color: '#666' }}>
+          {label === 'from' ? 'Not answered' : 'Removed'}
+        </em>
+      )
+    }
+    return (
+      <>
+        <Typography variant="body2">{side.optionname}</Typography>
+        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          score {side.score}/5
+        </Typography>
+      </>
+    )
+  }
+
+  const renderNotes = (entry: ScoreDiffEntry) => {
+    const fromNotes = entry.from?.notes ?? ''
+    const toNotes = entry.to?.notes ?? ''
+    if (fromNotes === toNotes) return '—'
+    return (
+      <Box>
+        {fromNotes && (
+          <Typography variant="caption" display="block">
+            From: {fromNotes}
+          </Typography>
+        )}
+        {toNotes && (
+          <Typography variant="caption" display="block">
+            To: {toNotes}
+          </Typography>
+        )}
+      </Box>
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      aria-labelledby="score-diff-modal-title"
+      aria-describedby="score-diff-modal-description"
+    >
+      <DialogTitle>
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          position="relative"
+        >
+          <Typography
+            variant="h2"
+            sx={{ textAlign: 'center', flex: 1, fontSize: '1.25rem' }}
+            id="score-diff-modal-title"
+          >
+            {systemName} ({systemAcronym}) — Compare Datacalls
+          </Typography>
+          <IconButton
+            ref={initialFocusRef}
+            onClick={onClose}
+            size="small"
+            sx={{ position: 'absolute', right: 0 }}
+            aria-label="Close compare datacalls dialog"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        <Box
+          id="score-diff-modal-description"
+          sx={{
+            position: 'absolute',
+            left: '-10000px',
+            width: '1px',
+            height: '1px',
+            overflow: 'hidden',
+          }}
+        >
+          <Typography component="p">
+            This dialog compares questionnaire answers between two data calls
+            for {systemName}, showing functions whose answers changed and who
+            made each change.
+          </Typography>
+        </Box>
+
+        {/* Picker row */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            mb: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 220 }}>
+            <Typography
+              variant="caption"
+              sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
+            >
+              From
+            </Typography>
+            <Autocomplete
+              size="small"
+              options={datacalls}
+              getOptionLabel={(dc) => dc.datacall}
+              isOptionEqualToValue={(opt, val) =>
+                opt.datacallid === val.datacallid
+              }
+              getOptionDisabled={(opt) =>
+                opt.datacallid === toDatacall?.datacallid
+              }
+              value={fromDatacall ?? undefined}
+              onChange={(_, dc) => {
+                if (dc) setFromDatacall(dc)
+              }}
+              renderOption={(props, option) =>
+                renderOption(props, option, latestId)
+              }
+              disableClearable
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  size="small"
+                  inputProps={{
+                    ...params.inputProps,
+                    'aria-label': 'From datacall',
+                  }}
+                />
+              )}
+            />
+          </Box>
+
+          <ArrowForwardIcon sx={{ mt: 2.5, color: 'text.secondary' }} />
+
+          <Box sx={{ flex: 1, minWidth: 220 }}>
+            <Typography
+              variant="caption"
+              sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}
+            >
+              To
+            </Typography>
+            <Autocomplete
+              size="small"
+              options={datacalls}
+              getOptionLabel={(dc) => dc.datacall}
+              isOptionEqualToValue={(opt, val) =>
+                opt.datacallid === val.datacallid
+              }
+              getOptionDisabled={(opt) =>
+                opt.datacallid === fromDatacall?.datacallid
+              }
+              value={toDatacall ?? undefined}
+              onChange={(_, dc) => {
+                if (dc) setToDatacall(dc)
+              }}
+              renderOption={(props, option) =>
+                renderOption(props, option, latestId)
+              }
+              disableClearable
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  size="small"
+                  inputProps={{
+                    ...params.inputProps,
+                    'aria-label': 'To datacall',
+                  }}
+                />
+              )}
+            />
+          </Box>
+        </Box>
+
+        <Divider sx={{ mb: 2 }} />
+
+        {/* Results area */}
+        {loading && (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress aria-label="Loading diff results" />
+          </Box>
+        )}
+
+        {!loading && error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {!loading &&
+          !error &&
+          diffResults.length === 0 &&
+          fromDatacall &&
+          toDatacall && (
+            <Box textAlign="center" py={4}>
+              <Typography variant="body1" color="text.secondary">
+                No changes between these two datacalls.
+              </Typography>
+            </Box>
+          )}
+
+        {!loading && !error && diffResults.length > 0 && (
+          <TableContainer
+            component={Paper}
+            aria-label="Questionnaire diff results"
+          >
+            <Table size="small">
+              <TableHead>
+                <TableRow sx={{ backgroundColor: '#004297' }}>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    Function
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    Question
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    From answer
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    To answer
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    Notes
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    Changed by
+                  </TableCell>
+                  <TableCell sx={{ color: '#fff', fontWeight: 700 }}>
+                    Changed at
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {diffResults.map((entry) => (
+                  <TableRow
+                    key={entry.functionid}
+                    sx={{
+                      '&:nth-of-type(even)': { backgroundColor: '#f5f5f5' },
+                    }}
+                  >
+                    <TableCell component="th" scope="row">
+                      <Typography variant="body2" fontWeight={500}>
+                        {entry.function}
+                      </Typography>
+                    </TableCell>
+                    <TableCell sx={{ maxWidth: 240 }}>
+                      <Tooltip title={entry.question} placement="top">
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            maxWidth: 240,
+                            cursor: 'default',
+                          }}
+                        >
+                          {entry.question}
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>{renderSide(entry.from, 'from')}</TableCell>
+                    <TableCell>{renderSide(entry.to, 'to')}</TableCell>
+                    <TableCell sx={{ maxWidth: 200 }}>
+                      {renderNotes(entry)}
+                    </TableCell>
+                    <TableCell>
+                      {entry.changed_by
+                        ? `${entry.changed_by.name} (${entry.changed_by.role})`
+                        : 'Unknown'}
+                    </TableCell>
+                    <TableCell>
+                      {entry.changed_at
+                        ? new Date(entry.changed_at).toLocaleDateString(
+                            'en-US',
+                            {
+                              month: 'short',
+                              day: 'numeric',
+                              year: 'numeric',
+                            }
+                          )
+                        : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <CmsButton onClick={onClose}>Close</CmsButton>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ScoreDiffModal

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,7 +281,7 @@ export type ScoreDiffSide = {
   functionoptionid: number
   optionname: string
   score: number
-  notes: string
+  notes: string | null
 }
 
 export type ScoreDiffEntry = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,3 +275,27 @@ export type CfactsSystemType = {
   last_modified_date: string | null
   synced_at: string
 }
+
+export type ScoreDiffSide = {
+  scoreid: number
+  functionoptionid: number
+  optionname: string
+  score: number
+  notes: string
+}
+
+export type ScoreDiffEntry = {
+  fismasystemid: number
+  functionid: number
+  function: string
+  question: string
+  from: ScoreDiffSide | null
+  to: ScoreDiffSide | null
+  changed_at?: string
+  changed_by?: {
+    userid: string
+    name: string
+    email: string
+    role: string
+  }
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -731,6 +731,7 @@ export default function QuestionnarePage() {
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
+        selectedDataCallId={selectedDataCallId}
       />
     </>
   )

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -33,7 +33,9 @@ import {
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { sortFunctions } from '@/utils/sortFunctions'
+import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
+import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
@@ -91,8 +93,10 @@ const addSpace = (str: string) => {
   return str
 }
 export default function QuestionnarePage() {
-  const { userInfo, selectedDataCallId, selectedDatacall } = useContextProp()
+  const { userInfo, selectedDataCallId, selectedDatacall, fismaSystems } =
+    useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
+  const [diffModalOpen, setDiffModalOpen] = React.useState(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
@@ -175,6 +179,8 @@ export default function QuestionnarePage() {
   // location.state. Optional-chain instead of crashing on first render; the
   // missing-system path is handled by an early render guard below.
   const system = location.state?.fismasystemid as number | undefined
+  const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
+  const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
   const [selectedIndex, setSelectedIndex] = React.useState(1)
   const handleConfirmReturn = (confirm: boolean) => {
     if (confirm) {
@@ -446,7 +452,23 @@ export default function QuestionnarePage() {
   }
   return (
     <>
-      <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={() => setDiffModalOpen(true)}
+          sx={{ whiteSpace: 'nowrap' }}
+        >
+          Compare Datacalls
+        </Button>
+      </Box>
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
           This datacall has closed. Changes will be recorded as post-deadline.
@@ -703,6 +725,13 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
+      <ScoreDiffModal
+        open={diffModalOpen}
+        onClose={() => setDiffModalOpen(false)}
+        fismasystemid={system ?? 0}
+        systemName={systemName}
+        systemAcronym={fismaacronym ?? ''}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary

Implements [UI Issue #411](https://github.com/CMS-Enterprise/ztmf-ui/issues/411) — consumes the `GET /api/v1/scores/diff` endpoint to surface questionnaire answer changes between two data calls for a FISMA system.

Pillar grouping is resolved on the frontend via a separate `GET /fismasystems/:id/questions` call (cached, 10-min TTL). This keeps the diff endpoint lean; adding pillar fields to the diff response is straightforward if needed later.

### Changes

**New component: `ScoreDiffModal`** (`src/components/ScoreDiffModal/ScoreDiffModal.tsx`)
- Opens from a "Compare Datacalls" button added to the `QuestionnairePage` header
- **To picker defaults to the currently viewed data call** (`selectedDataCallId` prop); From defaults to the immediately preceding data call — so the common "what changed since last cycle" case requires no extra interaction
- Pickers show Current chip, Active/Closed status, and deadline date — consistent with the data call picker in #401
- Diff results table groups changed functions **by pillar**, ordered to match the questionnaire's canonical pillar and function ordering (`PILLAR_ORDER` / `PILLAR_FUNCTION_MAP`)
- Each row shows: Function, full Question text (wrapping), From answer, To answer (with score and notes inline), Changed by, Changed at (date + time)
- Null sides render as *No answer* for clean one-sided rows (covers both newly-answered and no-longer-answered functions)
- Empty state: "No changes between these two datacalls."
- Datacalls and questions fetches are cached (10-min module-level TTL) to avoid redundant requests on re-open
- `diffKey` counter forces a fresh diff fetch on every re-open even when picker references haven't changed (React Object.is equality edge case with cached objects)

**`src/types.ts`**
- Added `ScoreDiffSide` and `ScoreDiffEntry` types matching the `/scores/diff` response shape

**`src/views/QuestionnairePage/QuestionnairePage.tsx`**
- Added "Compare Datacalls" button and wired `ScoreDiffModal` with `selectedDataCallId`

**`src/components/ScoreDiffModal/ScoreDiffModal.test.tsx`**
- Unit tests covering: dialog visibility, title, loading states, picker defaults, diff URL params, empty/error states, table rendering (optionname, score, notes, attribution), null sides, pillar ordering, close behavior, and re-open re-fetch

### Acceptance Criteria Coverage

| Criterion | Status |
|---|---|
| Pick two datacalls, view per-function diff | ✅ |
| From → To answer with score and notes | ✅ |
| One-sided rows (new / removed answers) | ✅ |
| Attribution (changed by / changed at) | ✅ |
| Empty state | ✅ |
| Default selection: currently viewed and previous cycle | ✅ |
| Prevent same-call selection | ✅ via `getOptionDisabled` |
| Pillar grouping matching questionnaire order | ✅ |
| 508 / WCAG AA | ✅ text-only status labels, ARIA on dialog and inputs |
| No backend changes | ✅ frontend only |


### UI
New Compare Datacalls button within the questionnaire
<img width="1728" height="343" alt="image" src="https://github.com/user-attachments/assets/2d13ba56-b2a0-4f4d-8032-698c6aab6221" />

ScoresDiffModal.tsx
<img width="1728" height="954" alt="image" src="https://github.com/user-attachments/assets/7336a428-7e65-45a1-a94a-cfa0b2335714" />

### Test Plan

- [ ] Open any system's QuestionnairePage → "Compare Datacalls" button visible in header
- [ ] Click button → modal opens with To = currently viewed data call, From = previous data call
- [ ] Verify diff table shows pillar group headers in canonical order (Identity → Devices → Networks → Applications → Data → CrossCutting)
- [ ] Verify functions within each pillar group follow questionnaire function order
- [ ] Change picker selections → diff re-fetches for the new pair
- [ ] Select same data call in both pickers → confirmed disabled in opposite picker
- [ ] Pick two calls with no changes → "No changes between these two datacalls." message
- [ ] Close and re-open modal → fresh diff fetch runs; no stale "no changes" shown
- [ ] Verify a row where `from` or `to` is null → *No answer* renders
- [ ] Verify a row with no `changed_by` → "Unknown" renders
- [ ] `yarn test --watchAll=false` — all tests pass

Closes #411