### PR TITLE
Handle account not provisioned errors and gate branded header

### DIFF
--- a/src/components/EmailModal/EmailModal.test.tsx
+++ b/src/components/EmailModal/EmailModal.test.tsx
@@ -77,7 +77,7 @@ test('success path fires the success snackbar and surfaces sent emails', async (
   expect(mockedNavigate).not.toHaveBeenCalled()
 })
 
-test('401 redirects to sign-in with the expired-session message', async () => {
+test('401 redirects to sign-in with the expired-session message and reason', async () => {
   mock.onPost('/massemails').reply(401)
 
   renderWithProviders(<EmailModal openModal={true} closeModal={jest.fn()} />)
@@ -86,7 +86,7 @@ test('401 redirects to sign-in with the expired-session message', async () => {
   await waitFor(() => {
     expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
       replace: true,
-      state: { message: ERROR_MESSAGES.expired },
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
     })
   })
   // No generic fallback snackbar fires on top of the redirect.

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -1,6 +1,7 @@
 import 'core-js/stable/atob'
 import { userData, UserRole } from '@/types'
 import axiosInstance from '@/axiosConfig'
+import { AuthCodes, SignInReasons, type SignInReason } from '@/utils/authCodes'
 /**
  * Auth state loader for react-router data routes.
  * @module router/authLoader
@@ -14,31 +15,74 @@ const emptyUser: userData = {
   role: '' as UserRole,
   assignedfismasystems: [],
 }
-const authLoader = async () => {
+
+/**
+ * Loader return shape. Title.tsx and LoginPage.tsx both read this.
+ *
+ * - `status === 200`: provisioned user, render the dashboard.
+ * - `serverError === true`: 5xx / network failure, render ServerErrorPage.
+ * - `reason === 'NO_ACCOUNT'`: authenticated identity has no ZTMF account
+ *   (or is soft-deleted) - LoginPage renders terminal "contact your
+ *   administrator" copy with no retry CTA.
+ * - `reason === 'EXPIRED'` (or `ok: false` with no reason): no session or
+ *   expired session - LoginPage renders the existing "sign in" affordance.
+ */
+export type AuthLoaderData = {
+  status?: number
+  ok?: boolean
+  serverError?: boolean
+  reason?: SignInReason
+  /** BE message body, surfaced verbatim on the NO_ACCOUNT terminal screen. */
+  message?: string
+  response: userData
+}
+
+const authLoader = async (): Promise<AuthLoaderData> => {
   try {
     // skipAuthHandling: the centralized 401-redirect interceptor would
     // hijack this call's 401 with router.navigate('/signin'), which
     // re-runs this loader on the new route and creates an infinite
     // redirect loop. authLoader is the OWNER of the session-expired
     // decision: a 401 here means "render LoginPage as a child route"
-    // (via the { ok: false, response: emptyUser } return below), not
-    // "redirect away."
+    // (via the discriminated return below), not "redirect away."
     const axiosUser = await axiosInstance.get('/users/current', {
       skipAuthHandling: true,
     })
     if (axiosUser.status != 200) {
-      return { ok: false, response: emptyUser }
+      return { ok: false, reason: SignInReasons.EXPIRED, response: emptyUser }
     }
     return { status: axiosUser.status, response: axiosUser.data.data }
   } catch (error: unknown) {
-    const err = error as { response?: { status?: number }; status?: number }
+    const err = error as {
+      response?: { status?: number; data?: { code?: string; error?: string } }
+      status?: number
+    }
     const status = err?.response?.status || err?.status || 0
     if (status >= 500 || status === 0) {
       return { status, serverError: true, response: emptyUser }
     }
+    // BE middleware returns 403 with code=ACCOUNT_NOT_PROVISIONED for an
+    // authenticated identity that has no ZTMF account or has been soft-
+    // deleted. Distinct from a 401 (no/expired session): the IdP session
+    // is valid; the user just has no app account. Surface as a terminal
+    // state so LoginPage drops the Sign in retry CTA.
+    if (
+      status === 403 &&
+      err?.response?.data?.code === AuthCodes.ACCOUNT_NOT_PROVISIONED
+    ) {
+      return {
+        ok: false,
+        reason: SignInReasons.NO_ACCOUNT,
+        message: err?.response?.data?.error,
+        response: emptyUser,
+      }
+    }
+    if (status === 401) {
+      return { ok: false, reason: SignInReasons.EXPIRED, response: emptyUser }
+    }
     console.error('Error:', error)
   }
-  return { ok: false, response: emptyUser }
+  return { ok: false, reason: SignInReasons.EXPIRED, response: emptyUser }
 }
 
 export default authLoader

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -78,7 +78,12 @@ const authLoader = async (): Promise<AuthLoaderData> => {
       }
     }
     if (status === 401) {
-      return { ok: false, reason: SignInReasons.EXPIRED, response: emptyUser }
+      return {
+        ok: false,
+        reason: SignInReasons.EXPIRED,
+        message: err?.response?.data?.error,
+        response: emptyUser,
+      }
     }
     console.error('Error:', error)
   }

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -78,12 +78,10 @@ const authLoader = async (): Promise<AuthLoaderData> => {
       }
     }
     if (status === 401) {
-      return {
-        ok: false,
-        reason: SignInReasons.EXPIRED,
-        message: err?.response?.data?.error,
-        response: emptyUser,
-      }
+      // A 401 here might be an expired session, or just a first-time
+      // visit with no session yet. We can't tell which, so no message.
+      // The interceptor handles the real "session expired" case.
+      return { ok: false, reason: SignInReasons.EXPIRED, response: emptyUser }
     }
     console.error('Error:', error)
   }

--- a/src/utils/apiErrors.ts
+++ b/src/utils/apiErrors.ts
@@ -16,6 +16,12 @@ export type ParsedApiError = {
   fieldErrors?: Record<string, string>
   /** human-readable fallback for a toast */
   message: string
+  /**
+   * Stable error code from the BE auth middleware (e.g. ACCOUNT_NOT_PROVISIONED).
+   * Mirrored in src/utils/authCodes.ts. Present only on middleware rejections;
+   * controller-level errors do not set it.
+   */
+  code?: string
 }
 
 const isStringMap = (value: unknown): value is Record<string, string> =>
@@ -32,8 +38,9 @@ export function parseApiError(error: unknown): ParsedApiError {
 
   const status = error.response?.status
   const body = error.response?.data as
-    | { data?: unknown; error?: unknown }
+    | { data?: unknown; error?: unknown; code?: unknown }
     | undefined
+  const code = typeof body?.code === 'string' ? body.code : undefined
 
   // Field-level validation: a 400 whose data is a { field: reason } map.
   if (status === 400 && isStringMap(body?.data)) {
@@ -43,16 +50,24 @@ export function parseApiError(error: unknown): ParsedApiError {
       fieldErrors,
       message:
         typeof body?.error === 'string' ? body.error : ERROR_MESSAGES.tryAgain,
+      code,
     }
   }
 
+  // 403 with a code is a middleware rejection (e.g. ACCOUNT_NOT_PROVISIONED) and
+  // carries an honest backend message worth surfacing. 403 without a code is a
+  // controller-level rejection (IsAdmin etc.) whose body text is not user-facing,
+  // so fall back to the generic permission copy.
   if (status === 403) {
-    return { status, message: ERROR_MESSAGES.permission }
+    if (code && typeof body?.error === 'string' && body.error.length > 0) {
+      return { status, message: body.error, code }
+    }
+    return { status, message: ERROR_MESSAGES.permission, code }
   }
 
   if (typeof body?.error === 'string' && body.error.length > 0) {
-    return { status, message: body.error }
+    return { status, message: body.error, code }
   }
 
-  return { status, message: ERROR_MESSAGES.tryAgain }
+  return { status, message: ERROR_MESSAGES.tryAgain, code }
 }

--- a/src/utils/authCodes.ts
+++ b/src/utils/authCodes.ts
@@ -1,0 +1,30 @@
+/**
+ * Mirrors the BE auth package's response-body codes (see
+ * backend/cmd/api/internal/auth/middleware.go). The FE branches on these
+ * to distinguish "session expired" from "authenticated but no app
+ * account" without resorting to message-string matching.
+ *
+ * Keep in lockstep with the BE side: any new code added in middleware.go
+ * should land here too, and a grep for the literal should turn up here
+ * first.
+ */
+export const AuthCodes = {
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  ACCOUNT_NOT_PROVISIONED: 'ACCOUNT_NOT_PROVISIONED',
+  FORBIDDEN_ORIGIN: 'FORBIDDEN_ORIGIN',
+} as const
+
+export type AuthCode = (typeof AuthCodes)[keyof typeof AuthCodes]
+
+/**
+ * Reason surfaced on the /signin route's location.state and on the
+ * authLoader's discriminated return. The LoginPage keys off this to pick
+ * between the terminal "no account" UX and the retryable "session
+ * expired" UX.
+ */
+export const SignInReasons = {
+  NO_ACCOUNT: 'NO_ACCOUNT',
+  EXPIRED: 'EXPIRED',
+} as const
+
+export type SignInReason = (typeof SignInReasons)[keyof typeof SignInReasons]

--- a/src/utils/authInterceptor.test.ts
+++ b/src/utils/authInterceptor.test.ts
@@ -1,6 +1,7 @@
 import type { AxiosError } from 'axios'
 import { ERROR_MESSAGES } from '@/constants'
 import { Routes } from '@/router/constants'
+import { AuthCodes, SignInReasons } from '@/utils/authCodes'
 
 jest.mock('@/router/router', () => ({
   __esModule: true,
@@ -24,7 +25,7 @@ function makeError(
   status: number | undefined,
   data?: unknown,
   config: { skipAuthHandling?: boolean } = {}
-): AxiosError<{ error?: string }> {
+): AxiosError<{ error?: string; code?: string }> {
   return {
     config,
     response:
@@ -35,7 +36,7 @@ function makeError(
     toJSON: () => ({}),
     name: 'AxiosError',
     message: 'mock',
-  } as unknown as AxiosError<{ error?: string }>
+  } as unknown as AxiosError<{ error?: string; code?: string }>
 }
 
 beforeEach(() => {
@@ -43,20 +44,72 @@ beforeEach(() => {
   mockedNotify.mockReset()
 })
 
-test('401 redirects to sign-in with the expired-session message', async () => {
-  const error = makeError(401)
+test('401 redirects to sign-in with the expired-session message and reason', async () => {
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
 
   await expect(handleAuthError(error)).rejects.toMatchObject({
     __authHandled: true,
   })
   expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
     replace: true,
-    state: { message: ERROR_MESSAGES.expired },
+    state: {
+      message: ERROR_MESSAGES.expired,
+      reason: SignInReasons.EXPIRED,
+    },
   })
   expect(mockedNotify).not.toHaveBeenCalled()
 })
 
-test('403 fires the generic permission snackbar when no backend message', async () => {
+test('403 with ACCOUNT_NOT_PROVISIONED redirects to sign-in as NO_ACCOUNT and suppresses the toast', async () => {
+  const error = makeError(403, {
+    code: AuthCodes.ACCOUNT_NOT_PROVISIONED,
+    error:
+      'your authenticated identity does not have a ZTMF account; contact your administrator to request access',
+  })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message:
+        'your authenticated identity does not have a ZTMF account; contact your administrator to request access',
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+  expect(mockedNotify).not.toHaveBeenCalled()
+})
+
+test('403 with ACCOUNT_NOT_PROVISIONED and no message body falls back to the permission copy', async () => {
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: ERROR_MESSAGES.permission,
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+  expect(mockedNotify).not.toHaveBeenCalled()
+})
+
+test('403 with FORBIDDEN_ORIGIN fires the generic permission snackbar (defensive)', async () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  const error = makeError(403, { code: AuthCodes.FORBIDDEN_ORIGIN })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNotify).toHaveBeenCalledWith(ERROR_MESSAGES.permission, 'error')
+  expect(mockedNavigate).not.toHaveBeenCalled()
+  consoleSpy.mockRestore()
+})
+
+test('403 with no code fires the generic permission snackbar (controller-level path)', async () => {
   const error = makeError(403, {})
 
   await expect(handleAuthError(error)).rejects.toMatchObject({
@@ -66,7 +119,7 @@ test('403 fires the generic permission snackbar when no backend message', async 
   expect(mockedNavigate).not.toHaveBeenCalled()
 })
 
-test('403 surfaces the backend message when response.data.error is set', async () => {
+test('403 with no code surfaces the backend message when response.data.error is set', async () => {
   const error = makeError(403, { error: 'No access to this datacall' })
 
   await expect(handleAuthError(error)).rejects.toMatchObject({
@@ -78,8 +131,12 @@ test('403 surfaces the backend message when response.data.error is set', async (
   )
 })
 
-test('skipAuthHandling on the request config bypasses both branches', async () => {
-  const error = makeError(403, { error: 'ignored' }, { skipAuthHandling: true })
+test('skipAuthHandling on the request config bypasses every branch', async () => {
+  const error = makeError(
+    403,
+    { code: AuthCodes.ACCOUNT_NOT_PROVISIONED, error: 'ignored' },
+    { skipAuthHandling: true }
+  )
 
   await expect(handleAuthError(error)).rejects.toBe(error)
   expect(mockedNavigate).not.toHaveBeenCalled()

--- a/src/utils/authInterceptor.ts
+++ b/src/utils/authInterceptor.ts
@@ -7,40 +7,75 @@ import router from '@/router/router'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
 import { markAuthHandled, notify } from '@/utils/notify'
+import { AuthCodes, SignInReasons } from '@/utils/authCodes'
 
 /**
  * Centralized 401/403 handling for axios responses. Registered as the
  * response interceptor's rejection callback in axiosConfig.
  *
- * - 401: navigates to sign-in with the "session expired" message.
- * - 403: surfaces response.data.error if present, else the generic
- *   permission message, via notify().
- * - skipAuthHandling on the request config bypasses both branches.
+ * - 401: redirects to /signin with reason=EXPIRED and the "session
+ *   expired" message.
+ * - 403 with code=ACCOUNT_NOT_PROVISIONED: middleware says the
+ *   authenticated identity has no app account (or is soft-deleted).
+ *   Redirects to /signin with reason=NO_ACCOUNT and the backend message
+ *   so LoginPage can render terminal copy with no retry CTA. No toast,
+ *   since the page itself is the surface.
+ * - 403 with code=FORBIDDEN_ORIGIN: CSRF guard tripped. Should not fire
+ *   in the normal browser flow; log and show a generic toast so the
+ *   failure is visible during development.
+ * - 403 without a code: controller-level rejection (IsAdmin etc.).
+ *   Existing behavior preserved - surfaces the backend message or the
+ *   generic permission message via notify().
+ * - skipAuthHandling on the request config bypasses everything.
  * - All other statuses (and network errors) pass through untouched.
  *
  * 401 and 403 errors are tagged with __authHandled so caller catch
  * blocks can short-circuit via isAuthHandled.
  *
  * @param error - The rejected AxiosError. The response body is narrowed
- *   to `{ error?: string }` so the 403 branch can read it directly.
+ *   to `{ error?: string; code?: string }` so both branches can read it
+ *   directly without re-parsing through apiErrors.
  * @returns A rejected promise. Always rejects, never resolves.
  */
 export async function handleAuthError(
-  error: AxiosError<{ error?: string }>
+  error: AxiosError<{ error?: string; code?: string }>
 ): Promise<never> {
   if (error.config?.skipAuthHandling) {
     throw error
   }
   const status = error.response?.status
+  const code = error.response?.data?.code
+  const backendMessage = error.response?.data?.error
+
   if (status === 401) {
     router.navigate(Routes.SIGNIN, {
       replace: true,
-      state: { message: ERROR_MESSAGES.expired },
+      state: {
+        message: ERROR_MESSAGES.expired,
+        reason: SignInReasons.EXPIRED,
+      },
     })
     throw markAuthHandled(error)
   }
   if (status === 403) {
-    const backendMessage = error.response?.data?.error
+    if (code === AuthCodes.ACCOUNT_NOT_PROVISIONED) {
+      router.navigate(Routes.SIGNIN, {
+        replace: true,
+        state: {
+          message:
+            typeof backendMessage === 'string' && backendMessage.length > 0
+              ? backendMessage
+              : ERROR_MESSAGES.permission,
+          reason: SignInReasons.NO_ACCOUNT,
+        },
+      })
+      throw markAuthHandled(error)
+    }
+    if (code === AuthCodes.FORBIDDEN_ORIGIN) {
+      console.error('FORBIDDEN_ORIGIN from API; request blocked by CSRF guard')
+      notify(ERROR_MESSAGES.permission, 'error')
+      throw markAuthHandled(error)
+    }
     notify(
       typeof backendMessage === 'string' && backendMessage.length > 0
         ? backendMessage

--- a/src/views/LoginPage/LoginPage.test.tsx
+++ b/src/views/LoginPage/LoginPage.test.tsx
@@ -158,21 +158,26 @@ describe('LoginPage EXPIRED / default state', () => {
     expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
   })
 
-  it('renders the BE expired message from the loader (cold-load 401 path)', () => {
+  it('shows no session-expired copy on cold-load EXPIRED (loader path)', () => {
+    // A loader-path 401 is ambiguous (expired session vs first visit),
+    // so LoginPage stays quiet here. Real expiry copy comes from the
+    // interceptor path.
     mutableConfig.IDP_ENABLED = true
     mockedUseLocation.mockReturnValue({ pathname: '/', state: null })
     mockedUseRouteLoaderData.mockReturnValue({
       ok: false,
       reason: SignInReasons.EXPIRED,
-      message: 'your session is missing or has expired',
       response: {},
     })
 
     render(<LoginPage />)
 
-    expect(
-      screen.getByText(/your session is missing or has expired/i)
-    ).toBeInTheDocument()
     expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/your session has expired/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/your session is missing/i)
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/views/LoginPage/LoginPage.test.tsx
+++ b/src/views/LoginPage/LoginPage.test.tsx
@@ -157,4 +157,22 @@ describe('LoginPage EXPIRED / default state', () => {
 
     expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
   })
+
+  it('renders the BE expired message from the loader (cold-load 401 path)', () => {
+    mutableConfig.IDP_ENABLED = true
+    mockedUseLocation.mockReturnValue({ pathname: '/', state: null })
+    mockedUseRouteLoaderData.mockReturnValue({
+      ok: false,
+      reason: SignInReasons.EXPIRED,
+      message: 'your session is missing or has expired',
+      response: {},
+    })
+
+    render(<LoginPage />)
+
+    expect(
+      screen.getByText(/your session is missing or has expired/i)
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
+  })
 })

--- a/src/views/LoginPage/LoginPage.test.tsx
+++ b/src/views/LoginPage/LoginPage.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen } from '@testing-library/react'
+import { SignInReasons } from '@/utils/authCodes'
+import { Routes } from '@/router/constants'
+
+// Hoist-safe mocks: react-router-dom is mocked module-wide so we can drive
+// useLocation / useRouteLoaderData / Navigate per-test without spinning up
+// a data router.
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useLocation: jest.fn(),
+  useRouteLoaderData: jest.fn(),
+  Navigate: ({ to }: { to: string }) => <div>NAVIGATE:{to}</div>,
+}))
+
+// CONFIG.IDP_ENABLED is read at module load by LoginPage; the mock
+// returns a mutable object so beforeEach can flip the flag per-test.
+// Inline declaration avoids the "Cannot access before initialization"
+// hoist trap with const declared above jest.mock.
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { IDP_ENABLED: false },
+}))
+
+// authLookup makes a network call we do not want firing from a unit test.
+jest.mock('@/utils/authLookup', () => ({
+  __esModule: true,
+  lookupIdpForEmail: jest.fn(),
+}))
+
+// The project's fileTransform.cjs still returns the old (pre-Jest 28) raw
+// string contract, so a real PNG import errors out during transform. Stub
+// the asset so LoginPage can load. (Fixing the transformer is out of
+// scope for this PR.)
+jest.mock('@/assets/ztmf-logo-login.png', () => 'ztmf-logo-login.png', {
+  virtual: true,
+})
+
+import { useLocation, useRouteLoaderData } from 'react-router-dom'
+import CONFIG from '@/utils/config'
+import LoginPage from './LoginPage'
+
+const mockedUseLocation = useLocation as jest.Mock
+const mockedUseRouteLoaderData = useRouteLoaderData as jest.Mock
+const mutableConfig = CONFIG as unknown as { IDP_ENABLED: boolean }
+
+beforeEach(() => {
+  mockedUseLocation.mockReset()
+  mockedUseRouteLoaderData.mockReset()
+  mutableConfig.IDP_ENABLED = false
+})
+
+describe('LoginPage active-session redirect', () => {
+  it('redirects to the dashboard when the loader reports an active session', () => {
+    mockedUseLocation.mockReturnValue({ pathname: '/signin', state: null })
+    mockedUseRouteLoaderData.mockReturnValue({ status: 200, response: {} })
+
+    render(<LoginPage />)
+
+    expect(screen.getByText(`NAVIGATE:${Routes.ROOT}`)).toBeInTheDocument()
+  })
+})
+
+describe('LoginPage NO_ACCOUNT terminal state', () => {
+  it('renders the backend message and no Sign in button when reason comes from location.state', () => {
+    mockedUseLocation.mockReturnValue({
+      pathname: '/signin',
+      state: {
+        reason: SignInReasons.NO_ACCOUNT,
+        message:
+          'your ZTMF account is no longer active; contact your administrator',
+      },
+    })
+    mockedUseRouteLoaderData.mockReturnValue(undefined)
+
+    render(<LoginPage />)
+
+    expect(
+      screen.getByText(/no longer active; contact your administrator/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
+    expect(screen.queryByLabelText(/enter your email/i)).toBeNull()
+  })
+
+  it('reads the reason from the root loader when location.state is empty', () => {
+    mockedUseLocation.mockReturnValue({ pathname: '/', state: null })
+    mockedUseRouteLoaderData.mockReturnValue({
+      ok: false,
+      reason: SignInReasons.NO_ACCOUNT,
+      message:
+        'your authenticated identity does not have a ZTMF account; contact your administrator to request access',
+      response: {},
+    })
+
+    render(<LoginPage />)
+
+    expect(
+      screen.getByText(/does not have a ZTMF account/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
+  })
+
+  it('falls back to the canned terminal copy when no message is provided', () => {
+    mockedUseLocation.mockReturnValue({
+      pathname: '/signin',
+      state: { reason: SignInReasons.NO_ACCOUNT },
+    })
+    mockedUseRouteLoaderData.mockReturnValue(undefined)
+
+    render(<LoginPage />)
+
+    expect(
+      screen.getByText(/Your ZTMF account is not set up/i)
+    ).toBeInTheDocument()
+  })
+})
+
+describe('LoginPage EXPIRED / default state', () => {
+  it('renders the Sign in button on the legacy Okta variant', () => {
+    mockedUseLocation.mockReturnValue({
+      pathname: '/signin',
+      state: {
+        reason: SignInReasons.EXPIRED,
+        message: 'Your session has expired. Please log in again.',
+      },
+    })
+    mockedUseRouteLoaderData.mockReturnValue(undefined)
+
+    render(<LoginPage />)
+
+    expect(screen.getByText(/your session has expired/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+  })
+
+  it('renders the email-lookup form on the IDP_ENABLED variant', () => {
+    mutableConfig.IDP_ENABLED = true
+    mockedUseLocation.mockReturnValue({ pathname: '/signin', state: null })
+    mockedUseRouteLoaderData.mockReturnValue(undefined)
+
+    render(<LoginPage />)
+
+    expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /continue/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the IDP_ENABLED form when reason is unset (cold load)', () => {
+    mutableConfig.IDP_ENABLED = true
+    mockedUseLocation.mockReturnValue({ pathname: '/', state: null })
+    mockedUseRouteLoaderData.mockReturnValue({
+      ok: false,
+      reason: SignInReasons.EXPIRED,
+      response: {},
+    })
+
+    render(<LoginPage />)
+
+    expect(screen.getByLabelText(/enter your email/i)).toBeInTheDocument()
+  })
+})

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -5,10 +5,19 @@ import { Navigate, useLocation, useRouteLoaderData } from 'react-router-dom'
 import CONFIG from '@/utils/config'
 import { RouteIds, Routes } from '@/router/constants'
 import { lookupIdpForEmail } from '@/utils/authLookup'
+import { SignInReasons, type SignInReason } from '@/utils/authCodes'
+import type { AuthLoaderData } from '@/router/authLoader'
 import ztmfLogo from '@/assets/ztmf-logo-login.png'
 
 const UNKNOWN_EMAIL_MESSAGE =
   "We can't determine an identity provider for that email. Contact your ZTMF administrator."
+
+// Fallback copy when the BE didn't send a message body (or the user
+// landed here without one passing through). The BE message is preferred
+// because it differentiates "no account" from "account deactivated" -
+// this string covers both since the FE UX is identical.
+const NO_ACCOUNT_FALLBACK_MESSAGE =
+  'Your ZTMF account is not set up. Contact your ZTMF administrator for access.'
 
 /**
  * Basic shape check. The backend is the source of truth for whether the
@@ -26,26 +35,64 @@ function isValidEmailFormat(value: string): boolean {
  * Okta-only behavior so prod-style deployments without the multi-IdP
  * rollout are unchanged.
  *
- * Rendered by Title.tsx when loaderData.status !== 200 (no active session).
+ * Rendered by Title.tsx when loaderData.status !== 200 (no active session)
+ * and as the /signin route's element when the interceptor redirects here.
  */
 export default function LoginPage() {
   const location = useLocation()
-  const sessionMessage = location.state?.message || ''
-
-  // Read the root route's authLoader payload and edirect to the dashboard
-  // so /signin never appears as a dead-end "log in again" prompt for an
-  // already-authenticated user.
   const rootLoaderData = useRouteLoaderData(RouteIds.ROOT) as
-    | { status?: number }
+    | AuthLoaderData
     | undefined
+
+  // Active-session redirect: bounces an already-authenticated user away
+  // from /signin so it never appears as a dead-end "log in again" prompt.
   if (rootLoaderData?.status === 200) {
     return <Navigate to={Routes.ROOT} replace />
   }
 
-  if (!CONFIG.IDP_ENABLED) {
-    return <LegacyOktaLogin sessionMessage={sessionMessage} />
+  // Reason can come from two places: the interceptor's redirect carries
+  // it on location.state for subsequent API failures; the authLoader's
+  // discriminated return carries it for the initial cold load. Prefer
+  // location.state - if the interceptor just fired, that signal is the
+  // most recent.
+  const locationState = location.state as {
+    message?: string
+    reason?: SignInReason
+  } | null
+  const reason: SignInReason | undefined =
+    locationState?.reason ?? rootLoaderData?.reason
+  const incomingMessage =
+    locationState?.message ?? rootLoaderData?.message ?? ''
+
+  if (reason === SignInReasons.NO_ACCOUNT) {
+    return <NoAccountTerminal message={incomingMessage} />
   }
-  return <IdpLookupLogin sessionMessage={sessionMessage} />
+
+  if (!CONFIG.IDP_ENABLED) {
+    return <LegacyOktaLogin sessionMessage={incomingMessage} />
+  }
+  return <IdpLookupLogin sessionMessage={incomingMessage} />
+}
+
+/**
+ * Terminal state for an authenticated identity with no ZTMF account
+ * (or a soft-deleted one). Renders the BE-provided message verbatim
+ * and intentionally exposes NO retry affordance - the user has to
+ * contact an administrator out-of-band, and a Sign in button here
+ * would just loop them back through the IdP -> 403 cycle.
+ */
+function NoAccountTerminal({ message }: { message: string }) {
+  return (
+    <LoginShell>
+      <Typography
+        variant="body1"
+        role="alert"
+        sx={{ color: 'error.main', fontWeight: 600 }}
+      >
+        {message || NO_ACCOUNT_FALLBACK_MESSAGE}
+      </Typography>
+    </LoginShell>
+  )
 }
 
 /**
@@ -158,9 +205,6 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
           </Typography>
         )}
       </Box>
-      <Typography variant="body2" sx={{ color: 'text.secondary', mt: 2 }}>
-        Having trouble? Contact the ZTMF support team.
-      </Typography>
     </LoginShell>
   )
 }

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -24,6 +24,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { useState, useEffect, useCallback } from 'react'
 import { FismaSystemType } from '@/types'
 import { Routes } from '@/router/constants'
+import type { AuthLoaderData } from '@/router/authLoader'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
 import LoginPage from '../LoginPage/LoginPage'
@@ -47,14 +48,9 @@ const emptyUser: userData = {
   assignedfismasystems: [],
 }
 
-type PromiseType = {
-  status: boolean | number
-  response: userData
-  serverError?: boolean
-}
 export default function Title() {
   const location = useLocation()
-  const loaderData = useLoaderData() as PromiseType
+  const loaderData = useLoaderData() as AuthLoaderData
   const [openDataCallModal, setOpenDataCallModal] = useState<boolean>(false)
   const userInfo: userData =
     loaderData.status != 200 ? emptyUser : loaderData.response
@@ -95,12 +91,19 @@ export default function Title() {
     []
   )
 
+  // Both of the effects below gate on loaderData.status === 200 (an active
+  // app session) rather than only on serverError. When the user is not
+  // logged in or has no app account, the loader returns { ok: false } with
+  // no status field, and these calls would 401. Those 401s do not use
+  // skipAuthHandling, so the centralized interceptor catches them and
+  // redirects to /signin with the "session expired" message - misleading
+  // for the never-logged-in case and noisy on every cold load.
   useEffect(() => {
-    if (!loaderData.serverError) fetchFismaSystems(showDecommissioned)
-  }, [showDecommissioned, fetchFismaSystems, loaderData.serverError])
+    if (loaderData.status === 200) fetchFismaSystems(showDecommissioned)
+  }, [showDecommissioned, fetchFismaSystems, loaderData.status])
 
   useEffect(() => {
-    if (loaderData.serverError) return
+    if (loaderData.status !== 200) return
     const controller = new AbortController()
     async function fetchDatacalls() {
       try {
@@ -126,7 +129,7 @@ export default function Title() {
     return () => {
       controller.abort()
     }
-  }, [loaderData.serverError])
+  }, [loaderData.status])
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
@@ -173,9 +176,11 @@ export default function Title() {
   return (
     <>
       <UsaBanner />
-      {/* Branded header bar (hidden on signin so it does not contradict the
-          "please sign in" prompt) */}
-      {!isSignInRoute && (
+      {/* Branded header bar. Hidden on the /signin route AND any time
+          LoginPage is rendered as the body (loaderData.status !== 200),
+          so the header never sits above a "please sign in" prompt at any
+          URL, not just /signin. Matches the datacall sub-bar's gate. */}
+      {!isSignInRoute && loaderData.status === 200 && (
         <Box
           sx={{
             display: 'flex',


### PR DESCRIPTION
## Summary

Closes the FE half of #403.

Pre-existing bug: an IdP-authenticated identity with no ZTMF account (or a soft-deleted one) landed on LoginPage with "Your session has expired" and an infinite Sign in loop. The IdP session was valid so the ALB never re-prompted; the SPA 401'd on `/users/current` and rendered the wrong copy.

This PR adds a `NO_ACCOUNT` sign-in reason driven by a `403 + ACCOUNT_NOT_PROVISIONED` signal (delivered by the paired BE PR), renders a terminal "contact your administrator" state with no retry CTA, and preserves the existing `EXPIRED` handling for genuine 401s.

## Backend dependency

Pairs with the BE middleware change: CMS-Enterprise/ztmf#360. The `NO_ACCOUNT` terminal state only renders once the BE starts emitting the new `code` field.

**Deploy order: FE first, BE second.** This PR is forward-compatible: with old BE deployed, every new code path stays dormant and behavior matches today. The reverse order (BE first) is worse than the current bug: unprovisioned users see a confusing toast on a stuck page instead of the familiar (if misleading) loop. Coordinated single-deploy is best.

## Changes

* **`utils/authCodes.ts`** (new) — mirrors the BE auth-package constants (`UNAUTHORIZED`, `ACCOUNT_NOT_PROVISIONED`, `FORBIDDEN_ORIGIN`) plus FE-side `SignInReasons` (`NO_ACCOUNT`, `EXPIRED`). Single source of truth on the FE side.
* **`utils/authInterceptor.ts`** — branches on `response.data.code`. 403 with `ACCOUNT_NOT_PROVISIONED` redirects to `/signin` with `reason=NO_ACCOUNT` and suppresses the OOS toast. `FORBIDDEN_ORIGIN` logs and shows a defensive toast. 401 carries `reason=EXPIRED` on its existing redirect. Controller-level 403 (no code) path unchanged.
* **`router/authLoader.ts`** — discriminated return: `NO_ACCOUNT` and `EXPIRED` for the two auth-failure shapes. `NO_ACCOUNT` surfaces the BE `data.error` body as `message` so LoginPage can render it verbatim (the BE distinguishes unprovisioned vs soft-deleted via different message text under the same code). `EXPIRED` stays silent because the loader can't tell an expired session from a first-time visit. `serverError` path unchanged.
* **`views/LoginPage/LoginPage.tsx`** — `NoAccountTerminal` component renders the BE message verbatim with no retry affordance on `NO_ACCOUNT`. Otherwise the existing legacy / IdP-lookup variants render. Hedged placeholder copy from the earlier Path A commit removed.
* **`utils/apiErrors.ts`** — `parseApiError` surfaces the `code` field for callers that need to branch.
* **`views/Title/Title.tsx`** — useEffect gate, swap local `PromiseType` for the shared `AuthLoaderData`, and a header-gate follow-up (see below).

### Header gate fix (incidental, #399 follow-up)

The branded header now hides whenever LoginPage is the body (`loaderData.status !== 200`), not only on the `/signin` URL. Matches the datacall sub-bar's existing gate. Cold-load LoginPage at `/` was rendering under the branded chrome, which contradicted the "please sign in" prompt. Caught while smoke-testing #403; bundled here because Title.tsx was already in the diff.

## Test plan

Local-dev verification — no extra tooling required, only Vite dev server + DevTools console.

### Interceptor message rendering (DevTools console)

These exercise the exact same code path the interceptor uses in production: `router.navigate('/signin', {state})`. Paste in the console (Vite dev mode serves the router module via dynamic import):

```js
const router = (await import('/src/router/router.tsx')).default

// EXPIRED — what the interceptor sends on 401
router.navigate('/signin', { replace: true, state: {
  message: 'Your session has expired. Please log in again.',
  reason: 'EXPIRED',
}})

// NO_ACCOUNT — unprovisioned user
router.navigate('/signin', { replace: true, state: {
  message: 'Your ZTMF account is not set up. Contact your administrator to request access.',
  reason: 'NO_ACCOUNT',
}})

// Soft-deleted variant (same reason, different BE copy)
router.navigate('/signin', { replace: true, state: {
  message: 'Your ZTMF account is no longer active. Contact your administrator.',
  reason: 'NO_ACCOUNT',
}})
```

* [ ] EXPIRED — URL becomes /#/signin; "Your session has expired. Please log in again." renders in red above the email form.
* [ ] NO_ACCOUNT — URL becomes /#/signin; terminal state renders the BE message verbatim with no retry CTA, no email form, no branded header.
* [ ] Soft-deleted variant — same terminal state, different BE copy ("no longer active") → confirms FE renders BE message verbatim rather than a hardcoded FE string.

### Real-scenario checks (no mocking, no console)

* [ ] Cold-load EXPIRED — with no bearer token configured in env → reload → email form renders with NO "session expired" copy above it. Intentional: loader path stays silent because it can't distinguish an expired session from a first-time visit.
* [ ] Active-session redirect — with a valid bearer token, manually visit /#/signin → bounces to /.
* [ ] 5xx — stop the BE container (docker compose stop api or equivalent) → reload → ServerErrorPage renders.
* [ ] Header gate — with no bearer token, reload → branded ZTMF header is hidden above the LoginPage email form.

### Unit tests

* authInterceptor.test.ts - all code branches (UNAUTHORIZED, ACCOUNT_NOT_PROVISIONED, FORBIDDEN_ORIGIN, controller-level 403, skipAuthHandling bypass, 5xx pass-through, network error pass-through).
* LoginPage.test.tsx (new) - active-session redirect, NO_ACCOUNT terminal state from location.state and from the loader, fallback message when none provided, EXPIRED state for both Legacy and IDP_ENABLED variants, regression check that cold-load EXPIRED shows no session-expired copy.
* EmailModal.test.tsx - updated assertion for the new 401 state shape.

make check and make test green (163 passing).

## Notes for reviewers

Loader path stays silent on 401; interceptor path carries the message. The loader (cold-load 401) can't distinguish "expired session" from "first-time visit," so it doesn't pass a message — the BE's expiry-specific copy ("Your session has expired. Please sign in again.") would lie to a first-time visitor. The interceptor (mid-session 401) has ground truth that a session existed, so it carries ERROR_MESSAGES.expired via location.state. Both surface via the same <SessionMessage> component in LoginPage when the message is present. 