### PR TITLE
fix(system-detail): parse timestamp-format ATO dates

### DIFF
--- a/src/views/SystemDetailPage/CfactsRecordCard.test.tsx
+++ b/src/views/SystemDetailPage/CfactsRecordCard.test.tsx
@@ -94,3 +94,40 @@ test('500 renders the failed-to-load message', async () => {
     await screen.findByText(/failed to load ztmf insights data/i)
   ).toBeInTheDocument()
 })
+
+test('formats a timestamp-format ATO expiration date instead of "Invalid Date"', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+        ato_expiration_date: '2026-12-13 00:00:00.000',
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+
+  expect(await screen.findByText('Test Package')).toBeInTheDocument()
+  expect(screen.getByText('12/13/2026')).toBeInTheDocument()
+  expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument()
+})
+
+test('renders the placeholder when no ATO expiration date is present', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+        ato_expiration_date: null,
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+
+  expect(await screen.findByText('Test Package')).toBeInTheDocument()
+  expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/CfactsRecordCard.tsx
+++ b/src/views/SystemDetailPage/CfactsRecordCard.tsx
@@ -55,7 +55,7 @@ function BooleanChip({
 }
 
 function parseDateOnly(dateStr: string): Date {
-  const [year, month, day] = dateStr.split('-').map(Number)
+  const [year, month, day] = dateStr.split(/[ T]/)[0].split('-').map(Number)
   return new Date(year, month - 1, day)
 }
 
@@ -79,7 +79,9 @@ function parseDate(dateStr: string): Date {
 
 function formatDate(dateStr: string | null): string | null {
   if (!dateStr) return null
-  return parseDate(dateStr).toLocaleDateString()
+  const date = parseDate(dateStr)
+  if (isNaN(date.getTime())) return null
+  return date.toLocaleDateString()
 }
 
 export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {


### PR DESCRIPTION
Closes #419.

ATO Expiration on the System Detail page rendered the literal "Invalid Date" for systems whose enrichment ATO date is stored as a full timestamp like `2026-12-13 00:00:00.000` instead of a bare `YYYY-MM-DD`. The value is valid data, the parsing was the problem.

`parseDateOnly` split the whole string on `-`, so the day token came back as `13 00:00:00.000` and the Date was invalid. `parseDate` only routed to `new Date()` when the string contained `T`, and these use a space separator, so they fell through. `formatDate` then returned the string "Invalid Date", which is truthy, so the existing `|| "—"` placeholder never kicked in. The same parse path feeds `getAtoColor`, so the expired/expiring color highlight was silently broken for these values too.

Changes in `src/views/SystemDetailPage/CfactsRecordCard.tsx`:
- `parseDateOnly` takes only the date portion before a space or `T` before splitting on `-`.
- `formatDate` guards `isNaN(date.getTime())` and returns null so the placeholder shows.

Added two tests to `CfactsRecordCard.test.tsx`: one asserting a timestamp-format ATO date renders a formatted date and not "Invalid Date", and one asserting a missing date still renders the placeholder.

Shared component, so this affects dev and prod and targets main.

Verify: `npx tsc --noEmit` clean, and `yarn test --watchAll=false src/views/SystemDetailPage/CfactsRecordCard.test.tsx` (6 passing).