### PR TITLE
test(ui): run frontend tests before commit and deploy

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -49,6 +49,9 @@ jobs:
       - name: LINT
         run: yarn lint
 
+      - name: TEST
+        run: yarn test:ci
+
       - name: BUILD
         # VITE_* vars are baked into the bundle at build time, so they must
         # be set on the build step itself, not on the deployed container.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+yarn test:ci

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+yarn lint:other
 yarn test:ci

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+set -e
+
 npx lint-staged
 yarn lint:other
 yarn test:ci

--- a/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
@@ -188,7 +188,8 @@ describe('ScoreDiffModal', () => {
     render(<ScoreDiffModal {...DEFAULT_PROPS} />)
     await waitFor(() =>
       expect(mockGet).toHaveBeenCalledWith(
-        '/scores/diff?from=4&to=5&fismasystemid=1001'
+        '/scores/diff?from=4&to=5&fismasystemid=1001',
+        expect.objectContaining({ signal: expect.anything() })
       )
     )
   })
@@ -267,7 +268,8 @@ describe('ScoreDiffModal', () => {
     const { rerender } = render(<ScoreDiffModal {...DEFAULT_PROPS} />)
     await waitFor(() =>
       expect(mockGet).toHaveBeenCalledWith(
-        expect.stringContaining('/scores/diff')
+        expect.stringContaining('/scores/diff'),
+        expect.objectContaining({ signal: expect.anything() })
       )
     )
     const firstCount = mockGet.mock.calls.filter(([u]: [string]) =>

--- a/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
@@ -197,7 +197,9 @@ describe('ScoreDiffModal', () => {
   it('shows empty-state message when diff returns no entries', async () => {
     setupMocks([])
     render(<ScoreDiffModal {...DEFAULT_PROPS} />)
-    await screen.findByText('No changes between these two datacalls.')
+    expect(
+      await screen.findByText('No changes between these two datacalls.')
+    ).toBeInTheDocument()
   })
 
   it('shows an error alert when the diff fetch fails', async () => {
@@ -209,7 +211,9 @@ describe('ScoreDiffModal', () => {
       return Promise.reject(new Error('Network error'))
     })
     render(<ScoreDiffModal {...DEFAULT_PROPS} />)
-    await screen.findByText('Failed to load diff. Please try again.')
+    expect(
+      await screen.findByText('Failed to load diff. Please try again.')
+    ).toBeInTheDocument()
   })
 
   it('renders function, question, both answer sides, and attribution', async () => {
@@ -229,7 +233,7 @@ describe('ScoreDiffModal', () => {
     setupMocks()
     render(<ScoreDiffModal {...DEFAULT_PROPS} />)
     // to.notes = 'Improved this cycle', from.notes = null → only one notes line
-    await screen.findByText('Improved this cycle')
+    expect(await screen.findByText('Improved this cycle')).toBeInTheDocument()
   })
 
   it('renders "No answer" for a null side', async () => {


### PR DESCRIPTION
Closes #422.

## Summary

The UI deploy workflow ran lint and build from a fresh checkout, but did not run Jest. Add local and CI gates so formatting and frontend unit test failures are caught before deployment.

## Fix

- Add a `TEST` step after `LINT` and before `BUILD` in `.github/workflows/ui.yml`.
- Run the existing `yarn test:ci` script in that step.
- Run `yarn lint:other` and `yarn test:ci` from `.husky/pre-commit` after `lint-staged`.
- Update `ScoreDiffModal` assertions to allow the axios `{ signal }` config passed by the AbortController fetch path.
- This runs Jest unit tests only. It does not run e2e tests or touch a seed database.

## Validation

- `yarn test:ci`: 17 passed, 1 skipped; 172 tests passed, 3 skipped
- `sh .husky/pre-commit`: passes
- `yarn lint:other`: passes
- `yarn lint`: passes
- Pre-push hook: typecheck, formatting verification, and linting verification pass
- Existing `jest/expect-expect` warnings remain in `ScoreDiffModal.test.tsx`; no lint errors
