### PR TITLE
only renders datacall selector where needed

### DIFF
--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -162,6 +162,10 @@ export default function Title() {
   const isAdmin = checkIsAdmin(userInfo)
   const hasAdminRead = checkHasAdminRead(userInfo)
   const isSystemDetail = location.pathname.startsWith('/systems/')
+  const isHomeRoute = location.pathname === '/'
+  const isQuestionnaireRoute = location.pathname.startsWith('/questionnaire/')
+  const datacallContextNeeded =
+    isHomeRoute || isQuestionnaireRoute || isSystemDetail
   // Single source of truth for header logo sizing; divider scales with it
   // so the mark, divider, and wordmark stay vertically centered on resize.
   const LOGO_HEIGHT = 55
@@ -341,8 +345,8 @@ export default function Title() {
           )}
         </Box>
       )}
-      {/* Datacall sub-bar (shown when logged in, hidden on signin) */}
-      {loaderData.status == 200 && !isSignInRoute && (
+      {/* Datacall sub-bar (shown when datacall context needed, hidden everywhere else) */}
+      {loaderData.status == 200 && datacallContextNeeded && (
         <Box
           sx={{
             display: 'flex',


### PR DESCRIPTION
## Summary

Fixes #421.

The datacall selector was rendering on every authenticated route because Title.tsx only excluded the sign-in page (!isSignInRoute), so it leaked onto admin, user management, and any future routes added to the app.

This PR flips to an **allowlist**: the datacall sub-bar only renders on the three routes where it is meaningful.

| Route | Datacall bar |
|---|---|
| `/` (dashboard) | Full selector |
| `/questionnaire/*` | Full selector |
| `/systems/:id` | Read-only text (existing behavior, unchanged) |
| Everything else | Hidden |

**Why allowlist instead of denylist:** The issue notes "and any future settings/admin routes" — a denylist requires updating every time a new admin/settings route is added. An allowlist is self-closing: new routes get no datacall bar by default.

## Changes

- `src/views/Title/Title.tsx` — replaced `isSignInRoute` denylist with `isHomeRoute || isQuestionnaireRoute || isSystemDetail` allowlist

## UI
1. Dashboard still shows selector
<img width="1728" height="868" alt="image" src="https://github.com/user-attachments/assets/35e0ddad-09b0-4b44-ab3c-bdc4fc86fe31" />

2. Questionnaire still shows selector
<img width="1725" height="849" alt="image" src="https://github.com/user-attachments/assets/94e77a6c-4b1c-450a-89c8-64c7f9639372" />

3. System Detail still shows read-only text of the datacall
<img width="1728" height="899" alt="image" src="https://github.com/user-attachments/assets/a28ac7d2-2cfa-432d-a287-51c2ca266f6e" />

4. Hidden on admin routes
<img width="1725" height="853" alt="image" src="https://github.com/user-attachments/assets/2924f1f8-21be-457a-91b3-57f3f23388ff" />

5. Hidden on user routes
<img width="1728" height="827" alt="image" src="https://github.com/user-attachments/assets/7be8a8bf-43c3-413d-9f10-9e41cbca39b9" />

## Test Plan

- [ ] Sign in as admin, navigate to `/admin/opdivs` — datacall bar should not appear
- [ ] Navigate to `/users` — datacall bar should not appear
- [ ] Navigate to `/` (dashboard) — datacall selector should appear
- [ ] Navigate to a questionnaire page — datacall selector should appear
- [ ] Navigate to a system detail page (`/systems/:id`) — datacall read-only text should appear (no regression)

closes #421 