### PR TITLE
fix(#421): render datacall selector only where needed

### DIFF
--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -162,6 +162,10 @@ export default function Title() {
   const isAdmin = checkIsAdmin(userInfo)
   const hasAdminRead = checkHasAdminRead(userInfo)
   const isSystemDetail = location.pathname.startsWith('/systems/')
+  const isHomeRoute = location.pathname === '/'
+  const isQuestionnaireRoute = location.pathname.startsWith('/questionnaire/')
+  const datacallContextNeeded =
+    isHomeRoute || isQuestionnaireRoute || isSystemDetail
   // Single source of truth for header logo sizing; divider scales with it
   // so the mark, divider, and wordmark stay vertically centered on resize.
   const LOGO_HEIGHT = 55
@@ -341,8 +345,8 @@ export default function Title() {
           )}
         </Box>
       )}
-      {/* Datacall sub-bar (shown when logged in, hidden on signin) */}
-      {loaderData.status == 200 && !isSignInRoute && (
+      {/* Datacall sub-bar (shown when datacall context needed, hidden everywhere else) */}
+      {loaderData.status == 200 && datacallContextNeeded && (
         <Box
           sx={{
             display: 'flex',


### PR DESCRIPTION
## Summary

Fixes #421. Rehomed from #424 by @costacalvin (Calvin Costa) onto an internal branch so CI can run with secrets; original authorship is preserved on the commit. Rebased onto current `main` (picks up #423, which was merged after #424 was opened).

The datacall sub-bar previously rendered on every authenticated route because `Title.tsx` only excluded the sign-in page (`!isSignInRoute`), so it leaked onto admin, user management, and any future routes.

This flips to an allowlist: the sub-bar renders only on the three routes where datacall context is meaningful.

| Route | Datacall bar |
|---|---|
| `/` (dashboard) | Full selector |
| `/questionnaire/*` | Full selector |
| `/systems/:id` | Read-only text (unchanged) |
| Everything else | Hidden |

An allowlist is self-closing: new admin/settings routes get no datacall bar by default, so this does not need revisiting each time a route is added.

## Changes

- `src/views/Title/Title.tsx` — replace `!isSignInRoute` denylist with `isHomeRoute || isQuestionnaireRoute || isSystemDetail` allowlist

## Verification

- typecheck, lint, full test suite (172 passed) green locally on the rebased branch
- Route prefixes confirmed against `src/router/constants.ts` (`/`, `/questionnaire/:fismaacronym/...`, `/systems/:fismasystemid`)
- `isSignInRoute` still used for the header block, no dead code

Credit: @costacalvin. Supersedes #424.
