### PR TITLE
Hide unrelated Pillars on SaaS environments.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,17 @@ export const CONFIRMATION_MESSAGE_QUESTION =
   'Your changes will not be saved! Are you sure you want to leave question without saving your changes?'
 
 /**
+ * Pillars hidden on the questionnaire for SaaS systems. Names must match the API's
+ * `question.pillar.pillar` value exactly.
+ */
+export const SAAS_EXCLUDED_PILLARS = ['Devices', 'Applications'] as const
+
+// If we wanted to filter out some pillars for other environments, we could add them here.
+// For now, only SaaS triggers any filtering.
+
+// ---------
+
+/**
  * The fixed order for pillars on the questionnaire, no matter what order the
  * API returns them in. Each name has to match the API's
  * `question.pillar.pillar` value exactly (same keys as {@link PILLAR_FUNCTION_MAP}).

--- a/src/utils/filterPillarsForSystem.test.ts
+++ b/src/utils/filterPillarsForSystem.test.ts
@@ -1,0 +1,69 @@
+import { filterPillarsForSystem } from './filterPillarsForSystem'
+
+const FULL_PILLARS = [
+  'Identity',
+  'Devices',
+  'Networks',
+  'Applications',
+  'Data',
+  'CrossCutting',
+]
+
+describe('filterPillarsForSystem', () => {
+  it('passes through when datacenterenvironment is null', () => {
+    expect(filterPillarsForSystem(FULL_PILLARS, null)).toEqual(FULL_PILLARS)
+  })
+
+  it('passes through when datacenterenvironment is undefined', () => {
+    expect(filterPillarsForSystem(FULL_PILLARS, undefined)).toEqual(
+      FULL_PILLARS
+    )
+  })
+
+  it('passes through when datacenterenvironment is not SaaS', () => {
+    expect(filterPillarsForSystem(FULL_PILLARS, 'On-Prem')).toEqual(
+      FULL_PILLARS
+    )
+    expect(filterPillarsForSystem(FULL_PILLARS, 'Imperial-Fleet')).toEqual(
+      FULL_PILLARS
+    )
+    expect(filterPillarsForSystem(FULL_PILLARS, '')).toEqual(FULL_PILLARS)
+  })
+
+  it('drops Devices and Applications when datacenterenvironment === SaaS', () => {
+    expect(filterPillarsForSystem(FULL_PILLARS, 'SaaS')).toEqual([
+      'Identity',
+      'Networks',
+      'Data',
+      'CrossCutting',
+    ])
+  })
+
+  it('is case-sensitive on the SaaS check (matches BE convention exactly)', () => {
+    // BE returns 'SaaS' exactly; anything else is treated as a different
+    // environment and not filtered. Guards against silent breakage if the
+    // BE ever ships a typo or a casing change.
+    expect(filterPillarsForSystem(FULL_PILLARS, 'saas')).toEqual(FULL_PILLARS)
+    expect(filterPillarsForSystem(FULL_PILLARS, 'SAAS')).toEqual(FULL_PILLARS)
+  })
+
+  it('preserves input order of the surviving pillars', () => {
+    const reordered = ['Data', 'Identity', 'Devices', 'CrossCutting']
+    expect(filterPillarsForSystem(reordered, 'SaaS')).toEqual([
+      'Data',
+      'Identity',
+      'CrossCutting',
+    ])
+  })
+
+  it('returns an empty array when given an empty input', () => {
+    expect(filterPillarsForSystem([], 'SaaS')).toEqual([])
+    expect(filterPillarsForSystem([], null)).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [...FULL_PILLARS]
+    filterPillarsForSystem(input, 'SaaS')
+    expect(input).toEqual(FULL_PILLARS)
+  })
+})

--- a/src/utils/filterPillarsForSystem.ts
+++ b/src/utils/filterPillarsForSystem.ts
@@ -1,0 +1,32 @@
+import { SAAS_EXCLUDED_PILLARS } from '@/constants'
+
+/**
+ * Hides pillars that aren't relevant to a system's datacenter
+ * environment. Today only 'SaaS' triggers any filtering - Devices and
+ * Applications are scored at the provider rather than the consumer for
+ * SaaS systems (see {@link SAAS_EXCLUDED_PILLARS}). Every other
+ * environment passes through unchanged.
+ *
+ * Takes the env string directly (rather than the whole system object)
+ * so callers can pass a stable primitive into a React effect's
+ * dependency array without churn.
+ *
+ * Returns a new array and preserves the input order. Pass-through on
+ * null/undefined/empty env so callers don't have to short-circuit
+ * themselves while the system info is still loading.
+ *
+ * @param pillars - The pillar names to filter (typically the output of
+ *   {@link sortPillars}).
+ * @param datacenterenvironment - The system's
+ *   `datacenterenvironment` value, or null/undefined while loading.
+ * @returns A new array with environment-irrelevant pillars removed.
+ */
+export function filterPillarsForSystem(
+  pillars: string[],
+  datacenterenvironment: string | null | undefined
+): string[] {
+  if (datacenterenvironment !== 'SaaS') return [...pillars]
+  return pillars.filter(
+    (p) => !(SAAS_EXCLUDED_PILLARS as readonly string[]).includes(p)
+  )
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
+import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
@@ -300,7 +301,10 @@ export default function QuestionnarePage() {
                 organizedData[question.pillar.pillar].push(question)
               })
               setQuestions(questionData)
-              const sortedPillars = sortPillars(Object.keys(organizedData))
+              const sortedPillars = filterPillarsForSystem(
+                sortPillars(Object.keys(organizedData)),
+                systemInfo?.datacenterenvironment
+              )
               let sortedFuncId: number[] = []
               const categoriesData: Category[] = sortedPillars.map((pillar) => {
                 const sortedSteps = sortFunctions(pillar, organizedData[pillar])
@@ -384,6 +388,7 @@ export default function QuestionnarePage() {
     latestDataCallId,
     latestDatacall,
     latestDeadline,
+    systemInfo?.datacenterenvironment,
   ])
   React.useEffect(() => {
     if (questionId) {

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -33,6 +33,7 @@ import Tooltip from '@mui/material/Tooltip'
 import { MAX_QUESTIONNAIRE_NOTES_LENGTH, STATUS_MESSAGES } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
+import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { sortFunctions } from '@/utils/sortFunctions'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
@@ -280,7 +281,10 @@ export default function QuestionnareModal({
             }
             organizedData[question.pillar.pillar].push(question)
           })
-          const sortedPillars = sortPillars(Object.keys(organizedData))
+          const sortedPillars = filterPillarsForSystem(
+            sortPillars(Object.keys(organizedData)),
+            system?.datacenterenvironment
+          )
           const categoriesData: Category[] = sortedPillars.map((pillar) => ({
             name: pillar,
             steps: sortFunctions(pillar, organizedData[pillar]),


### PR DESCRIPTION
## Summary

Closes #426.

For SaaS-typed systems, Devices and Applications pillars are scored at the provider rather than the consumer, so showing those pillars on the questionnaire asks the wrong audience. This PR hides them on the FE for any system whose `datacenterenvironment === 'SaaS'`. Every other environment renders unchanged.

## Changes

* **`src/constants.ts`** — new `SAAS_EXCLUDED_PILLARS = ['Devices', 'Applications'] as const` constant, doc-commented alongside the existing `PILLAR_ORDER`. Names match the API's `question.pillar.pillar` value exactly.
* **`src/utils/filterPillarsForSystem.ts`** (new) — `filterPillarsForSystem(pillars, datacenterenvironment)`. Returns a new array; pass-through when env is anything other than `'SaaS'` (including null/undefined/empty); preserves input order.
* **`src/utils/filterPillarsForSystem.test.ts`** (new) — 8 unit tests covering: null/undefined env pass-through, non-SaaS env pass-through, SaaS dropping the two excluded pillars, case sensitivity on `'SaaS'` (saas / SAAS do not trigger), order preservation, empty input, non-mutation of the input array.
* **`src/views/QuestionnairePage/QuestionnairePage.tsx`** — wraps the existing `sortPillars(...)` call with `filterPillarsForSystem(..., systemInfo?.datacenterenvironment)`. Adds the env string to the fetch effect's dep array so a system change re-runs the question fetch with the right filter.
* **`src/views/QuestionnareModal/QuestionnareModal.tsx`** — same wrap, using `system?.datacenterenvironment`. Existing dep array already lists `system` so no dep-array change needed.

## Test plan

### Unit tests

`yarn jest src/utils/filterPillarsForSystem` — 8/8 passing locally.

`make check` and `make test` both green (191 passing).

### Regression checks (non-SaaS systems unchanged)

* [ ] Open the questionnaire for any non-SaaS seeded system (e.g., Imperial-Fleet, On-Prem, etc.) → all six pillars render as before.
* [ ] Open the modal for the same system → all six pillars present.
* [ ] Sort order unchanged across both flows (Identity → Devices → Networks → Applications → Data → CrossCutting on non-SaaS).

## Notes for reviewers

* Case-sensitive match on 'SaaS'. Anything else (case variants, null, empty, other envs) passes through. Guards against a silent break if the BE ever ships a typo or normalizes casing; we'd see pillars come back instead of disappear.
* Two pillars listed in SAAS_EXCLUDED_PILLARS today; if a future scope adds more environments or excludes different pillars, the helper's pass-through-by-default shape keeps the surface centralized.