### PR TITLE
make idp and Opdiv fields editable

### DIFF
--- a/src/views/UserTable/EditOpDivCell.tsx
+++ b/src/views/UserTable/EditOpDivCell.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid'
+import { Autocomplete, Checkbox, TextField } from '@mui/material'
+import { OpDiv } from '@/types'
+
+interface EditOpDivCellProps extends GridRenderEditCellParams {
+  opdivOptions: OpDiv[]
+}
+
+export default function EditOpDivCell(props: EditOpDivCellProps) {
+  const { id, value, field, opdivOptions } = props
+  const apiRef = useGridApiContext()
+
+  const selectedIds = (value as number[] | undefined) ?? []
+  const selectedOptions = opdivOptions.filter((od) =>
+    selectedIds.includes(od.opdiv_id)
+  )
+
+  const handleChange = (_: React.SyntheticEvent, newValue: OpDiv[]) => {
+    apiRef.current.setEditCellValue({
+      id,
+      field,
+      value: newValue.map((od) => od.opdiv_id),
+    })
+  }
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={opdivOptions}
+      getOptionLabel={(od) => od.code}
+      value={selectedOptions}
+      onChange={handleChange}
+      disableCloseOnSelect
+      disablePortal
+      limitTags={2}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...rest } = props
+        return (
+          <li key={key} {...rest}>
+            <Checkbox checked={selected} size="small" sx={{ mr: 0.5 }} />
+            {option.code}
+          </li>
+        )
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          size="small"
+          variant="standard"
+          sx={{
+            '& .MuiInput-underline:before': { border: 'none' },
+            '& .MuiInput-underline:after': { border: 'none' },
+            '& .MuiInput-underline:hover:before': { border: 'none !important' },
+          }}
+        />
+      )}
+      sx={{ width: '100%' }}
+    />
+  )
+}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -33,11 +33,14 @@ import { users, OpDiv } from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead,
+  hasUnscopedRead,
   isOpDivTier,
   selectableRoles,
 } from '@/utils/userRoles'
 import { fetchOpDivs } from '@/utils/opdivs'
-import { fetchUserOpDivs } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, grantOpDiv } from '@/utils/userOpdivs'
+import CONFIG from '@/utils/config'
+import EditOpDivCell from './EditOpDivCell'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
@@ -67,7 +70,13 @@ function EditToolbar(props: EditToolbarProps) {
     const userid = Math.floor(Math.random() * 1000) + 1
     setRows((oldRows) => [
       ...oldRows,
-      { userid, fullname: '', email: '', role: '', isNew: true },
+      {
+        userid,
+        fullname: '',
+        email: '',
+        role: '',
+        isNew: true,
+      },
     ])
     setRowModesModel((oldModel) => ({
       ...oldModel,
@@ -137,6 +146,7 @@ export default function UserTable() {
   const canRead = hasAdminRead(userInfo)
   // Roles this admin may assign; also the valid option set for the role editor.
   const assignableRoles = selectableRoles(userInfo.role)
+  const showIdpSelector = CONFIG.IDP_ENABLED && hasUnscopedRead(userInfo)
   useEffect(() => {
     if (userInfo.role && !canRead) {
       navigate(Routes.ROOT, { replace: true })
@@ -290,21 +300,67 @@ export default function UserTable() {
     const curRowUserId = updatedRow.userid
     if (newRow.isNew) {
       try {
-        const res = await axiosInstance.post('/users', {
+        const idpValue = newRow.identity_provider
+        const body = {
           email: updatedRow.email,
           fullname: updatedRow.fullname,
           role: updatedRow.role,
-        })
-        newRow = res.data.data
-        updatedRow.userid = newRow.userid
+          ...(showIdpSelector &&
+            (idpValue === 'okta' || idpValue === 'entra') && {
+              identity_provider: idpValue,
+            }),
+        }
+
+        const res = await axiosInstance.post('/users', body)
+        const createdUser = res.data.data
+        updatedRow.userid = createdUser.userid
+
+        const opdivIdsToGrant = (newRow.opdivs as number[] | undefined) ?? []
+        const grantResults = await Promise.allSettled(
+          opdivIdsToGrant.map((opdivId) =>
+            grantOpDiv(createdUser.userid, opdivId)
+          )
+        )
+
+        if (
+          grantResults.some(
+            (r) => r.status === 'rejected' && isAuthHandled(r.reason)
+          )
+        ) {
+          return updatedRow
+        }
+
+        const succeededIds = opdivIdsToGrant.filter(
+          (_, i) => grantResults[i].status === 'fulfilled'
+        )
+        setUserOpDivMap((prev) => ({
+          ...prev,
+          [createdUser.userid]: succeededIds,
+        }))
+        updatedRow.assignedopdivids = succeededIds
+
+        if (opdivIdsToGrant.length > 0) {
+          // Backend recomputes identity_provider after OpDiv grants — leave blank
+          // until refreshUserRow returns the authoritative value.
+          refreshUserRow(createdUser.userid)
+        } else {
+          updatedRow.identity_provider = createdUser.identity_provider ?? ''
+        }
+
         apiRef.current.updateRows([{ userid: curRowUserId, _action: 'delete' }])
         apiRef.current.updateRows([updatedRow])
-        setSnackBarSeverity('success')
-        setSnackBarText(STATUS_MESSAGES.saved)
+
+        const failCount = opdivIdsToGrant.length - succeededIds.length
+        setSnackBarSeverity(failCount > 0 ? 'warning' : 'success')
+        setSnackBarText(
+          failCount > 0
+            ? `User created, but ${failCount} OpDiv grant(s) failed. Use Assign OpDivs to retry.`
+            : STATUS_MESSAGES.saved
+        )
         setOpen(true)
       } catch (error) {
         if (isAuthHandled(error)) return updatedRow
-        console.error('Error updating score:', error)
+        console.error('Error creating user:', error)
         setSaveError(error)
       }
     } else {
@@ -319,6 +375,7 @@ export default function UserTable() {
         setOpen(true)
       } catch (error) {
         if (isAuthHandled(error)) return updatedRow
+        console.error('Error saving user:', error)
         setSaveError(error)
       }
     }
@@ -553,6 +610,10 @@ export default function UserTable() {
       flex: 1,
       sortable: false,
       filterable: false,
+      editable: isAdmin,
+      renderEditCell: (params) => (
+        <EditOpDivCell {...params} opdivOptions={opdivOptions} />
+      ),
       renderCell: (params) => {
         // Refresh override (post grant-modal) wins; otherwise use the grants the
         // list returned inline on the row.
@@ -578,11 +639,13 @@ export default function UserTable() {
       field: 'identity_provider',
       headerName: 'IdP',
       flex: 0.5,
-      editable: false,
-      // Display-only. The backend derives this from the user's OpDiv, with an
-      // OWNER-only override handled server-side; the UI never sends it. Show
-      // the resolved value, or '—' until the backend has populated it.
-      valueGetter: (params) => params.row.identity_provider ?? '—',
+      editable: showIdpSelector,
+      type: 'singleSelect',
+      valueOptions: ['okta', 'entra'],
+      // renderCell controls view-mode display; shows '—' for unset values.
+      // HHS-wide admins can set this on new rows; for existing rows the backend
+      // derives it from OpDiv membership.
+      renderCell: (params) => params.row.identity_provider || '—',
     },
     {
       field: 'actions',
@@ -710,17 +773,28 @@ export default function UserTable() {
           rows={rows}
           apiRef={apiRef}
           columns={columns}
-          // Don't let an admin edit a role they can't assign: if a row's
-          // current role is above this admin's tier, lock the role cell so it
-          // can't be blanked or downgraded on save. New rows (blank role,
-          // mid-create) stay editable - valueOptions already limits the choices
-          // to the admin's assignable set. The server enforces this too.
-          isCellEditable={(params) =>
-            params.field !== 'role' ||
-            params.row.isNew ||
-            !params.row.role ||
-            assignableRoles.includes(params.row.role)
-          }
+          // Cell-level edit gates (defense-in-depth; server enforces the same rules):
+          // - role: locked on existing rows whose current role is outside this
+          //   admin's assignable tier, preventing unauthorized role changes.
+          // - opdivs / identity_provider: locked to new rows only — existing
+          //   users' OpDiv memberships and derived IdP are managed via the
+          //   Assign OpDivs action, not inline editing.
+          isCellEditable={(params) => {
+            if (params.field === 'role') {
+              return (
+                params.row.isNew ||
+                !params.row.role ||
+                assignableRoles.includes(params.row.role)
+              )
+            }
+            if (
+              params.field === 'opdivs' ||
+              params.field === 'identity_provider'
+            ) {
+              return !!params.row.isNew
+            }
+            return true
+          }}
           editMode="row"
           getRowId={(row) => row.userid}
           initialState={{


### PR DESCRIPTION
## Summary

Closes #406. Makes the OpDiv and Auth (identity provider) fields in the add-user DataGrid row functional, so a new user can be assigned OpDiv(s) and an explicit IdP at create time instead of requiring follow-up actions.

- **OpDiv assignment at create** — the add-user row now includes a multi-select Autocomplete for OpDivs. Selections are sent as parallel grant requests after the user POST. The selectable set is scoped to the acting admin: OpDiv-scoped admins (OPDIV_ADMIN) see only their own OpDiv(s); HHS-wide admins (OWNER, HHS_ADMIN) see all active, non-parent OpDivs.
- **IdP selector at create** — a working `okta`/`entra` dropdown shown only to HHS-wide admins (`CONFIG.IDP_ENABLED && hasUnscopedRead`). Sent in the create body only when the selector is visible and a valid value is selected. Eliminates the add-then-remove-OpDiv workaround for HHS users who need Entra but have no OpDiv.
- **isCellEditable gates** — `opdivs` and `identity_provider` are editable only on new rows; existing users' OpDiv membership and derived IdP remain managed via the Assign OpDivs action.
- **Post-create IdP display** — when OpDivs are granted, `refreshUserRow` fetches the server-recomputed `identity_provider` after grants settle rather than showing a potentially stale value. When no OpDivs are granted, the POST response value is used directly.

### Note: OpDiv grant derivation overrides explicit IdP

If an HHS-wide admin selects an explicit IdP (e.g. `okta`) but also assigns an OpDiv, the backend's `deriveIdentityProvider` runs after the grants and overwrites the explicit value. The rule: if the user has the `CMS` OpDiv in their grants → `okta`; any other OpDiv → `entra`; if both `CMS` and a non-CMS OpDiv are granted → `okta` wins. The IdP selector is primarily intended for the no-OpDiv case (e.g. HHS leadership with no OpDiv assignment). This is expected backend behavior and is unchanged by this PR.


## Depends on

Backend: CMS-Enterprise/ztmf#352 — widens the `identity_provider` override gate from `IsOwner()` to `HasUnscopedRead()` so HHS_ADMIN can set Entra at create. This PR and #352 should deploy together.

## UI

Opdivs selector + Idp selector for HHS_ADMIN
<img width="1728" height="331" alt="image" src="https://github.com/user-attachments/assets/d6ae6b69-bc54-4532-8584-8600f2df65b7" />


Open OpDivs selector for HHS_ADMIN
<img width="1627" height="715" alt="image" src="https://github.com/user-attachments/assets/f136dbe3-4392-41eb-a150-f35e7bb3f84b" />

Open IDP selector for HHS_ADMIN
<img width="1530" height="451" alt="image" src="https://github.com/user-attachments/assets/0e50ef20-8db0-456d-ab95-4df379e947a7" />

Idp and Opdiv fields are read only after creation
<img width="1566" height="594" alt="image" src="https://github.com/user-attachments/assets/a56a34fe-459c-4a22-a0f3-2bf1091f446a" />


Idp selector not available for non-HHS wide admins
<img width="1527" height="345" alt="image" src="https://github.com/user-attachments/assets/458602d9-eb54-433a-9b8a-94a750d89c3b" />



## Test plan

- [ ] HHS_ADMIN: add-user row shows OpDiv multi-select and IdP selector; create user with no OpDiv + `entra` IdP → user created with `entra`
- [ ] HHS_ADMIN: create user with OpDiv that derives `entra` + explicit `okta` IdP → IdP resolves to `entra` after grants (expected — derivation wins)
- [ ] HHS_ADMIN: create user with OpDiv + no IdP selected → IdP derived from OpDiv after grants via `refreshUserRow`
- [ ] OPDIV_ADMIN (e.g. Thrawn/IMPNAVY): add-user row shows only their own OpDiv in selector; no IdP selector visible
- [ ] Existing rows: OpDiv and IdP cells are locked (not editable); changes go through Assign OpDivs action
- [ ] Partial grant failure: user is created, warning snackbar shown, successful grants reflected, failed grants noted for retry
- [ ] HHS_ADMIN: create user with no OpDiv and no IdP selected → user created with `okta` (backend default)

