### PR TITLE
fix(user table): prevent admins from deleting their own accounts

### DIFF
--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -354,6 +354,14 @@ export default function UserTable() {
     const target = pendingDeleteRow
     setPendingDeleteRow(null)
     if (!confirm || !target) return
+    // Backstop: the row-action icon for the current user is already
+    // disabled, but guard the handler in case it's invoked some other
+    // way (programmatic call, future refactor wiring a new entry point).
+    // Self-delete locks the user out of the app with no recovery path.
+    if (target.userid === userInfo.userid) {
+      notify("You can't delete your own account.", 'error')
+      return
+    }
     try {
       await axiosInstance.delete(`/users/${target.userid}`)
       setRows((prev) => prev.filter((row) => row.userid !== target.userid))
@@ -677,13 +685,37 @@ export default function UserTable() {
               color="inherit"
             />
           </Tooltip>,
-          <GridActionsCellItem
-            key={`delete-${params.id}`}
-            icon={<DeleteIcon sx={{ color: 'black' }} />}
-            label="Delete"
-            onClick={handleDeleteClick(params.id)}
-            color="inherit"
-          />,
+          <Tooltip
+            title={
+              params.row.userid === userInfo.userid
+                ? "You can't delete your own account"
+                : 'Delete User'
+            }
+            key={`tooltip-delete-${params.id}`}
+            placement="right-start"
+          >
+            {/* span wrapper lets Tooltip listen to events even when the
+                child is disabled (MUI requirement). */}
+            <span>
+              <GridActionsCellItem
+                key={`delete-${params.id}`}
+                icon={
+                  <DeleteIcon
+                    sx={{
+                      color:
+                        params.row.userid === userInfo.userid
+                          ? 'gray'
+                          : 'black',
+                    }}
+                  />
+                }
+                label="Delete"
+                onClick={handleDeleteClick(params.id)}
+                color="inherit"
+                disabled={params.row.userid === userInfo.userid}
+              />
+            </span>
+          </Tooltip>,
         ]
       },
     },

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -650,6 +650,8 @@ export default function UserTable() {
           ]
         }
 
+        const isSelf = params.row.userid === userInfo.userid
+
         return [
           <GridActionsCellItem
             icon={<EditIcon />}
@@ -686,11 +688,7 @@ export default function UserTable() {
             />
           </Tooltip>,
           <Tooltip
-            title={
-              params.row.userid === userInfo.userid
-                ? "You can't delete your own account"
-                : 'Delete User'
-            }
+            title={isSelf ? "You can't delete your own account" : 'Delete User'}
             key={`tooltip-delete-${params.id}`}
             placement="right-start"
           >
@@ -699,20 +697,11 @@ export default function UserTable() {
             <span>
               <GridActionsCellItem
                 key={`delete-${params.id}`}
-                icon={
-                  <DeleteIcon
-                    sx={{
-                      color:
-                        params.row.userid === userInfo.userid
-                          ? 'gray'
-                          : 'black',
-                    }}
-                  />
-                }
+                icon={<DeleteIcon sx={{ color: isSelf ? 'gray' : 'black' }} />}
                 label="Delete"
                 onClick={handleDeleteClick(params.id)}
                 color="inherit"
-                disabled={params.row.userid === userInfo.userid}
+                disabled={isSelf}
               />
             </span>
           </Tooltip>,


### PR DESCRIPTION
## Summary

Closes #433.

Two-layer defense against an admin self-deleting:

1. **Visible**: the Delete row-action icon on the current user's own row is disabled, with a tooltip explaining why ("You can't delete your own account"). Icon color shifts black → gray to reinforce the disabled state. Other rows render the Delete icon as today with a new "Delete User" tooltip for consistency with the other row actions.
2. **Backstop**: `handleConfirmDelete` short-circuits with a notify toast if invoked against the current user's id. This catches programmatic invocation or future refactors that wire a new entry point to the handler.

## Why two layers

Self-delete locks the admin out of the app with no FE-recoverable path (no other admin nearby = locked out until a sibling admin runs `PUT /users/<id>/restore`). The visible affordance prevents the accidental click; the backstop catches everything else.

## Test plan

Manual verification (UserTable has no trivial equality checks; not worth standing up MUI DataGrid + outlet context + axios mocking just for this PR):

* [ ] Log in as admin, visit `/users`, hover own Delete icon → tooltip reads "You can't delete your own account", icon is greyed.
* [ ] Hover another user's Delete icon → tooltip reads "Delete User", icon is black, click → delete modal opens normally.
* [ ] Trigger `handleConfirmDelete` programmatically against own user id via the console → notify toast fires, network call is blocked.

## Follow-ups (out of scope)

* BE companion: reject `DELETE` where target id === caller id (defense in depth). Separate ticket: https://github.com/CMS-Enterprise/ztmf/issues/366.
* Restore self-guarding and last-admin protections, per the #433 out-of-scope section.