### PR TITLE
Enhancement/batch opdiv grants

### DIFF
--- a/src/utils/userOpdivs.ts
+++ b/src/utils/userOpdivs.ts
@@ -3,19 +3,13 @@ import axiosInstance from '@/axiosConfig'
 /**
  * OpDiv grant management for a single user (users_opdivs membership).
  *
- * All three operations hit the dedicated /users/{userid}/assignedopdivs
- * endpoints, whose shape mirrors the existing assignedfismasystems endpoints
- * (GET returns { data: number[] }; POST body { opdiv_id }; DELETE by id).
- * Granting/revoking recomputes the user's derived identity_provider server-side.
+ * fetchUserOpDivs reads the current grant set for a user (used for post-save
+ * refresh and as a fallback for older backends that omit assignedopdivids inline
+ * on the list response).
  *
- * The list endpoint (GET /users) returns each row's grants inline as
- * assignedopdivids, so the users table reads them off the row directly.
- * fetchUserOpDivs is for single-user refresh (e.g. after the grant modal) and
- * as a fallback for older backends that omit the field.
- *
- * NOTE: these endpoints are built on the backend RBAC branch
- * (feature/opdiv-rbac-enforcement) but are not yet in backend/openapi.yaml, so
- * this is built to the documented contract and may 404 until that branch ships.
+ * setUserOpDivs replaces the full grant set in one batch request. The backend
+ * reconciles the desired set against current grants (adds missing, removes extra)
+ * in one transaction and re-derives identity_provider once.
  */
 
 export async function fetchUserOpDivs(userid: string): Promise<number[]> {
@@ -25,18 +19,9 @@ export async function fetchUserOpDivs(userid: string): Promise<number[]> {
   return response.data.data ?? []
 }
 
-export async function grantOpDiv(
+export async function setUserOpDivs(
   userid: string,
-  opdivId: number
+  opdivIds: number[]
 ): Promise<void> {
-  await axiosInstance.post(`/users/${userid}/assignedopdivs`, {
-    opdiv_id: opdivId,
-  })
-}
-
-export async function revokeOpDiv(
-  userid: string,
-  opdivId: number
-): Promise<void> {
-  await axiosInstance.delete(`/users/${userid}/assignedopdivs/${opdivId}`)
+  await axiosInstance.put(`/users/${userid}/opdivs`, { opdiv_ids: opdivIds })
 }

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -1,0 +1,169 @@
+// jest.mock calls must precede all imports that reference the mocked modules.
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  const { handleAuthError } = require('@/utils/authInterceptor')
+  const instance = axios.create({ baseURL: '/api/v1/' })
+  instance.interceptors.response.use(
+    (response: unknown) => response,
+    handleAuthError
+  )
+  return { __esModule: true, default: instance }
+})
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MockAdapter from 'axios-mock-adapter'
+import axiosInstance from '@/axiosConfig'
+import router from '@/router/router'
+import OpDivGrantModal from './OpDivGrantModal'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { ERROR_MESSAGES } from '@/constants'
+import { Routes } from '@/router/constants'
+import type { OpDiv } from '@/types'
+
+const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
+const mock = new MockAdapter(axiosInstance)
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+// Represents the caller's grantable scope (children, active, and — for an
+// OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
+// so scope-filter tests can verify it is stripped from the PUT body.
+const opdivOptions: OpDiv[] = [
+  {
+    opdiv_id: 1,
+    code: 'AAA',
+    name: 'Division A',
+    is_parent: false,
+    active: true,
+  },
+  {
+    opdiv_id: 2,
+    code: 'BBB',
+    name: 'Division B',
+    is_parent: false,
+    active: true,
+  },
+]
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
+) {
+  return renderWithProviders(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+      {...overrides}
+    />
+  )
+}
+
+beforeEach(() => {
+  mock.reset()
+  mockedNavigate.mockReset()
+})
+
+// The most important test: verifies the scopedIds filter strips out-of-scope
+// grants before the PUT so an OPDIV_ADMIN never triggers a backend 403.
+test('PUT body excludes grants the target user holds outside the caller scope', async () => {
+  // Target user holds [1, 2, 99]. OpDiv 99 is absent from opdivOptions
+  // (out of caller scope), so only [1, 2] must reach the batch endpoint.
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(200, { data: [1, 2, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  renderModal()
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toHaveLength(2)
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2]))
+  expect(body.opdiv_ids).not.toContain(99)
+})
+
+test('success: modal closes and onChanged fires after save', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  const handleClose = jest.fn()
+  const onChanged = jest.fn()
+  renderModal({ handleClose, onChanged })
+
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => {
+    expect(handleClose).toHaveBeenCalledTimes(1)
+    expect(onChanged).toHaveBeenCalledWith(USER_ID)
+  })
+})
+
+test('modal stays open on save error and does not call onChanged', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(500)
+
+  const handleClose = jest.fn()
+  const onChanged = jest.fn()
+  renderModal({ handleClose, onChanged })
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
+  expect(handleClose).not.toHaveBeenCalled()
+  expect(onChanged).not.toHaveBeenCalled()
+})
+
+test('403 shows the permission snackbar and does not close the modal', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(403)
+
+  const handleClose = jest.fn()
+  renderModal({ handleClose })
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
+  expect(handleClose).not.toHaveBeenCalled()
+})
+
+test('401 redirects to sign-in without firing a generic error snackbar', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
+
+  renderModal()
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
+})
+
+test('save button is disabled while the request is in flight', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  // Never resolves — keeps the request in-flight so we can assert the disabled state.
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(() => new Promise(() => {}))
+
+  renderModal()
+  const saveButton = screen.getByRole('button', { name: /^save$/i })
+
+  await userEvent.click(saveButton)
+
+  expect(saveButton).toBeDisabled()
+})

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -11,16 +11,10 @@ import { GridRowId } from '@mui/x-data-grid'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
-import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
-import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
-import { fetchUserOpDivs, grantOpDiv, revokeOpDiv } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import type { OpDiv } from '@/types'
-
-const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
-const checkedIcon = <CheckBoxIcon fontSize="small" />
 
 type Props = {
   open: boolean
@@ -34,9 +28,8 @@ type Props = {
    */
   opdivOptions: OpDiv[]
   /**
-   * Fired after a confirmed grant or revoke so the caller can refresh the
-   * user's row (grants + derived identity_provider) against post-mutation
-   * server state.
+   * Fired after a successful save so the caller can refresh the user's row
+   * (grants + derived identity_provider) against post-mutation server state.
    */
   onChanged?: (userid: string) => void
 }
@@ -49,10 +42,8 @@ export default function OpDivGrantModal({
   opdivOptions,
   onChanged,
 }: Props) {
-  const [assignedOpDivs, setAssignedOpDivs] = React.useState<number[]>([])
-  const [pendingRevoke, setPendingRevoke] = React.useState<{
-    opdivId: number
-  } | null>(null)
+  const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
+  const [saving, setSaving] = React.useState(false)
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -81,120 +72,82 @@ export default function OpDivGrantModal({
   React.useEffect(() => {
     if (open && userid) {
       fetchUserOpDivs(String(userid))
-        .then((grants) => setAssignedOpDivs(grants))
+        .then((grants) => setLocalOpDivs(grants))
         .catch((error) => handleError(error))
     }
   }, [open, userid])
-
-  const handleConfirmRevoke = (confirm: boolean) => {
-    const target = pendingRevoke
-    setPendingRevoke(null)
-    if (!confirm || !target) return
-    revokeOpDiv(String(userid), target.opdivId)
-      .then(() => {
-        // Functional update so a grant that resolved while the confirm was
-        // open is not dropped by a stale snapshot.
-        setAssignedOpDivs((prev) => prev.filter((id) => id !== target.opdivId))
-        notify('Saved - revoked OpDiv', 'success')
-        onChanged?.(String(userid))
-      })
-      .catch((error) => handleError(error))
-  }
 
   const optionLabel = (opdivId: number) => {
     const od = opdivMap[opdivId]
     return od ? `${od.code} - ${od.name}` : ''
   }
 
+  const handleSave = () => {
+    setSaving(true)
+    // An OPDIV_ADMIN's scope is already encoded in sortedOptionIds (only their
+    // own OpDivs appear as options). Filter localOpDivs to that set so the
+    // batch request never includes out-of-scope IDs the target user holds from
+    // another admin — the backend scope gate rejects any desired set that
+    // contains an ID the caller doesn't hold, even if they didn't add it.
+    const scopedIds = localOpDivs.filter((id) => sortedOptionIds.includes(id))
+    setUserOpDivs(String(userid), scopedIds)
+      .then(() => {
+        notify('Saved', 'success')
+        onChanged?.(String(userid))
+        handleClose()
+      })
+      .catch((error) => handleError(error))
+      .finally(() => setSaving(false))
+  }
+
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        maxWidth="lg"
-        fullWidth
-        aria-label="Assign OpDivs"
-      >
-        <DialogTitle align="center">
-          <div>
-            <Typography variant="h3">Assign OpDivs</Typography>
-          </div>
-        </DialogTitle>
-        <DialogContent sx={{ height: 500 }}>
-          <Autocomplete
-            multiple
-            disableCloseOnSelect
-            limitTags={3}
-            options={sortedOptionIds}
-            disableClearable
-            getOptionLabel={optionLabel}
-            renderOption={(props, option, { selected }) => (
-              <li {...props} key={option}>
-                <Checkbox
-                  icon={icon}
-                  checkedIcon={checkedIcon}
-                  style={{ marginRight: 8 }}
-                  checked={selected}
-                />
-                {optionLabel(option)}
-              </li>
-            )}
-            value={assignedOpDivs}
-            onChange={(_event, newValue) => {
-              const added = newValue.filter(
-                (item) => !assignedOpDivs.includes(item)
-              )
-              const removed = assignedOpDivs.filter(
-                (item) => !newValue.includes(item)
-              )
-              // Grant every added OpDiv and reflect only what the server
-              // confirms - never trust the optimistic newValue wholesale.
-              added.forEach((opdivId) => {
-                grantOpDiv(String(userid), opdivId)
-                  .then(() => {
-                    setAssignedOpDivs((prev) =>
-                      prev.includes(opdivId) ? prev : [...prev, opdivId]
-                    )
-                    notify('Saved - granted OpDiv', 'success')
-                    onChanged?.(String(userid))
-                  })
-                  .catch((error) => handleError(error))
-              })
-              // Revocations confirm one at a time; the revoke handler computes
-              // the next value functionally from the id being removed.
-              if (removed.length) {
-                setPendingRevoke({ opdivId: removed[0] })
-              }
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Assign OpDivs"
-                variant="filled"
-                placeholder="OpDivs"
-                InputLabelProps={{ sx: { marginTop: 0 } }}
-              />
-            )}
-          />
-        </DialogContent>
-        <DialogActions>
-          <CmsButton onClick={handleClose}>Close</CmsButton>
-        </DialogActions>
-      </Dialog>
-      <ConfirmDialog
-        title="Confirm Revoke OpDiv"
-        confirmationText={
-          pendingRevoke
-            ? `Are you sure you want to revoke ${
-                optionLabel(pendingRevoke.opdivId) || 'this OpDiv'
-              } from ${userName || 'this user'}?`
-            : ''
-        }
-        open={pendingRevoke !== null}
-        onClose={() => setPendingRevoke(null)}
-        confirmClick={handleConfirmRevoke}
-        confirmLabel="Revoke"
-      />
-    </>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="lg"
+      fullWidth
+      aria-label={`Assign OpDivs for ${userName}`}
+    >
+      <DialogTitle align="center">
+        <div>
+          <Typography variant="h3">Assign OpDivs</Typography>
+        </div>
+      </DialogTitle>
+      <DialogContent sx={{ height: 500 }}>
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          limitTags={3}
+          options={sortedOptionIds}
+          disableClearable
+          getOptionLabel={optionLabel}
+          renderOption={(props, option, { selected }) => (
+            <li {...props} key={option}>
+              <Checkbox style={{ marginRight: 8 }} checked={selected} />
+              {optionLabel(option)}
+            </li>
+          )}
+          value={localOpDivs}
+          onChange={(_event, newValue) => setLocalOpDivs(newValue)}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Assign OpDivs"
+              variant="filled"
+              placeholder="OpDivs"
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+            />
+          )}
+        />
+      </DialogContent>
+      <DialogActions>
+        <CmsButton onClick={handleClose} variation="ghost">
+          Cancel
+        </CmsButton>
+        <CmsButton onClick={handleSave} disabled={saving}>
+          Save
+        </CmsButton>
+      </DialogActions>
+    </Dialog>
   )
 }

--- a/src/views/UserTable/EditOpDivCell.tsx
+++ b/src/views/UserTable/EditOpDivCell.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid'
+import { Autocomplete, Checkbox, TextField } from '@mui/material'
+import { OpDiv } from '@/types'
+
+interface EditOpDivCellProps extends GridRenderEditCellParams {
+  opdivOptions: OpDiv[]
+}
+
+export default function EditOpDivCell(props: EditOpDivCellProps) {
+  const { id, value, field, opdivOptions } = props
+  const apiRef = useGridApiContext()
+
+  const selectedIds = (value as number[] | undefined) ?? []
+  const selectedOptions = opdivOptions.filter((od) =>
+    selectedIds.includes(od.opdiv_id)
+  )
+
+  const handleChange = (_: React.SyntheticEvent, newValue: OpDiv[]) => {
+    apiRef.current.setEditCellValue({
+      id,
+      field,
+      value: newValue.map((od) => od.opdiv_id),
+    })
+  }
+
+  return (
+    <Autocomplete
+      multiple
+      size="small"
+      options={opdivOptions}
+      getOptionLabel={(od) => od.code}
+      value={selectedOptions}
+      onChange={handleChange}
+      disableCloseOnSelect
+      disablePortal
+      limitTags={2}
+      renderOption={(props, option, { selected }) => {
+        const { key, ...rest } = props
+        return (
+          <li key={key} {...rest}>
+            <Checkbox checked={selected} size="small" sx={{ mr: 0.5 }} />
+            {option.code}
+          </li>
+        )
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          size="small"
+          variant="standard"
+          sx={{
+            '& .MuiInput-underline:before': { border: 'none' },
+            '& .MuiInput-underline:after': { border: 'none' },
+            '& .MuiInput-underline:hover:before': { border: 'none !important' },
+          }}
+        />
+      )}
+      sx={{ width: '100%' }}
+    />
+  )
+}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -38,7 +38,7 @@ import {
   selectableRoles,
 } from '@/utils/userRoles'
 import { fetchOpDivs } from '@/utils/opdivs'
-import { fetchUserOpDivs, grantOpDiv } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
 import { parseApiError } from '@/utils/apiErrors'
@@ -277,7 +277,6 @@ export default function UserTable() {
   }
   const handleCloseOpDivModal = () => {
     setOpenOpDivModal(false)
-    refreshUserRow(String(opdivModalUserId))
   }
   const handleCancelClick = (id: GridRowId) => () => {
     setRowModesModel({
@@ -316,45 +315,39 @@ export default function UserTable() {
         updatedRow.userid = createdUser.userid
 
         const opdivIdsToGrant = (newRow.opdivs as number[] | undefined) ?? []
-        const grantResults = await Promise.allSettled(
-          opdivIdsToGrant.map((opdivId) =>
-            grantOpDiv(createdUser.userid, opdivId)
-          )
-        )
-
-        if (
-          grantResults.some(
-            (r) => r.status === 'rejected' && isAuthHandled(r.reason)
-          )
-        ) {
-          return updatedRow
-        }
-
-        const succeededIds = opdivIdsToGrant.filter(
-          (_, i) => grantResults[i].status === 'fulfilled'
-        )
-        setUserOpDivMap((prev) => ({
-          ...prev,
-          [createdUser.userid]: succeededIds,
-        }))
-        updatedRow.assignedopdivids = succeededIds
+        let grantsFailed = false
 
         if (opdivIdsToGrant.length > 0) {
-          // Backend recomputes identity_provider after OpDiv grants — leave blank
-          // until refreshUserRow returns the authoritative value.
-          refreshUserRow(createdUser.userid)
+          try {
+            await setUserOpDivs(createdUser.userid, opdivIdsToGrant)
+            setUserOpDivMap((prev) => ({
+              ...prev,
+              [createdUser.userid]: opdivIdsToGrant,
+            }))
+            updatedRow.assignedopdivids = opdivIdsToGrant
+            // Backend recomputes identity_provider after OpDiv grants — leave blank
+            // until refreshUserRow returns the authoritative value.
+            refreshUserRow(createdUser.userid)
+          } catch (grantError) {
+            if (isAuthHandled(grantError)) {
+              apiRef.current.updateRows([
+                { userid: curRowUserId, _action: 'delete' },
+              ])
+              return updatedRow
+            }
+            grantsFailed = true
+            updatedRow.identity_provider = createdUser.identity_provider ?? ''
+          }
         } else {
           updatedRow.identity_provider = createdUser.identity_provider ?? ''
         }
 
         apiRef.current.updateRows([{ userid: curRowUserId, _action: 'delete' }])
         apiRef.current.updateRows([updatedRow])
-
-        const failCount = opdivIdsToGrant.length - succeededIds.length
-        setSnackBarSeverity(failCount > 0 ? 'warning' : 'success')
+        setSnackBarSeverity(grantsFailed ? 'warning' : 'success')
         setSnackBarText(
-          failCount > 0
-            ? `User created, but ${failCount} OpDiv grant(s) failed. Use Assign OpDivs to retry.`
+          grantsFailed
+            ? 'User created, but OpDiv grants failed. Use Assign OpDivs to retry.'
             : STATUS_MESSAGES.saved
         )
         setOpen(true)
@@ -787,11 +780,11 @@ export default function UserTable() {
                 assignableRoles.includes(params.row.role)
               )
             }
-            if (
-              params.field === 'opdivs' ||
-              params.field === 'identity_provider'
-            ) {
+            if (params.field === 'opdivs') {
               return !!params.row.isNew
+            }
+            if (params.field === 'identity_provider') {
+              return !!params.row.isNew && showIdpSelector
             }
             return true
           }}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -33,11 +33,14 @@ import { users, OpDiv } from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead,
+  hasUnscopedRead,
   isOpDivTier,
   selectableRoles,
 } from '@/utils/userRoles'
 import { fetchOpDivs } from '@/utils/opdivs'
-import { fetchUserOpDivs } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, grantOpDiv } from '@/utils/userOpdivs'
+import CONFIG from '@/utils/config'
+import EditOpDivCell from './EditOpDivCell'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
@@ -67,7 +70,13 @@ function EditToolbar(props: EditToolbarProps) {
     const userid = Math.floor(Math.random() * 1000) + 1
     setRows((oldRows) => [
       ...oldRows,
-      { userid, fullname: '', email: '', role: '', isNew: true },
+      {
+        userid,
+        fullname: '',
+        email: '',
+        role: '',
+        isNew: true,
+      },
     ])
     setRowModesModel((oldModel) => ({
       ...oldModel,
@@ -137,6 +146,7 @@ export default function UserTable() {
   const canRead = hasAdminRead(userInfo)
   // Roles this admin may assign; also the valid option set for the role editor.
   const assignableRoles = selectableRoles(userInfo.role)
+  const showIdpSelector = CONFIG.IDP_ENABLED && hasUnscopedRead(userInfo)
   useEffect(() => {
     if (userInfo.role && !canRead) {
       navigate(Routes.ROOT, { replace: true })
@@ -290,21 +300,67 @@ export default function UserTable() {
     const curRowUserId = updatedRow.userid
     if (newRow.isNew) {
       try {
-        const res = await axiosInstance.post('/users', {
+        const idpValue = newRow.identity_provider
+        const body = {
           email: updatedRow.email,
           fullname: updatedRow.fullname,
           role: updatedRow.role,
-        })
-        newRow = res.data.data
-        updatedRow.userid = newRow.userid
+          ...(showIdpSelector &&
+            (idpValue === 'okta' || idpValue === 'entra') && {
+              identity_provider: idpValue,
+            }),
+        }
+
+        const res = await axiosInstance.post('/users', body)
+        const createdUser = res.data.data
+        updatedRow.userid = createdUser.userid
+
+        const opdivIdsToGrant = (newRow.opdivs as number[] | undefined) ?? []
+        const grantResults = await Promise.allSettled(
+          opdivIdsToGrant.map((opdivId) =>
+            grantOpDiv(createdUser.userid, opdivId)
+          )
+        )
+
+        if (
+          grantResults.some(
+            (r) => r.status === 'rejected' && isAuthHandled(r.reason)
+          )
+        ) {
+          return updatedRow
+        }
+
+        const succeededIds = opdivIdsToGrant.filter(
+          (_, i) => grantResults[i].status === 'fulfilled'
+        )
+        setUserOpDivMap((prev) => ({
+          ...prev,
+          [createdUser.userid]: succeededIds,
+        }))
+        updatedRow.assignedopdivids = succeededIds
+
+        if (opdivIdsToGrant.length > 0) {
+          // Backend recomputes identity_provider after OpDiv grants — leave blank
+          // until refreshUserRow returns the authoritative value.
+          refreshUserRow(createdUser.userid)
+        } else {
+          updatedRow.identity_provider = createdUser.identity_provider ?? ''
+        }
+
         apiRef.current.updateRows([{ userid: curRowUserId, _action: 'delete' }])
         apiRef.current.updateRows([updatedRow])
-        setSnackBarSeverity('success')
-        setSnackBarText(STATUS_MESSAGES.saved)
+
+        const failCount = opdivIdsToGrant.length - succeededIds.length
+        setSnackBarSeverity(failCount > 0 ? 'warning' : 'success')
+        setSnackBarText(
+          failCount > 0
+            ? `User created, but ${failCount} OpDiv grant(s) failed. Use Assign OpDivs to retry.`
+            : STATUS_MESSAGES.saved
+        )
         setOpen(true)
       } catch (error) {
         if (isAuthHandled(error)) return updatedRow
-        console.error('Error updating score:', error)
+        console.error('Error creating user:', error)
         setSaveError(error)
       }
     } else {
@@ -319,6 +375,7 @@ export default function UserTable() {
         setOpen(true)
       } catch (error) {
         if (isAuthHandled(error)) return updatedRow
+        console.error('Error saving user:', error)
         setSaveError(error)
       }
     }
@@ -553,6 +610,10 @@ export default function UserTable() {
       flex: 1,
       sortable: false,
       filterable: false,
+      editable: isAdmin,
+      renderEditCell: (params) => (
+        <EditOpDivCell {...params} opdivOptions={opdivOptions} />
+      ),
       renderCell: (params) => {
         // Refresh override (post grant-modal) wins; otherwise use the grants the
         // list returned inline on the row.
@@ -578,11 +639,13 @@ export default function UserTable() {
       field: 'identity_provider',
       headerName: 'IdP',
       flex: 0.5,
-      editable: false,
-      // Display-only. The backend derives this from the user's OpDiv, with an
-      // OWNER-only override handled server-side; the UI never sends it. Show
-      // the resolved value, or '—' until the backend has populated it.
-      valueGetter: (params) => params.row.identity_provider ?? '—',
+      editable: showIdpSelector,
+      type: 'singleSelect',
+      valueOptions: ['okta', 'entra'],
+      // renderCell controls view-mode display; shows '—' for unset values.
+      // HHS-wide admins can set this on new rows; for existing rows the backend
+      // derives it from OpDiv membership.
+      renderCell: (params) => params.row.identity_provider || '—',
     },
     {
       field: 'actions',
@@ -710,17 +773,28 @@ export default function UserTable() {
           rows={rows}
           apiRef={apiRef}
           columns={columns}
-          // Don't let an admin edit a role they can't assign: if a row's
-          // current role is above this admin's tier, lock the role cell so it
-          // can't be blanked or downgraded on save. New rows (blank role,
-          // mid-create) stay editable - valueOptions already limits the choices
-          // to the admin's assignable set. The server enforces this too.
-          isCellEditable={(params) =>
-            params.field !== 'role' ||
-            params.row.isNew ||
-            !params.row.role ||
-            assignableRoles.includes(params.row.role)
-          }
+          // Cell-level edit gates (defense-in-depth; server enforces the same rules):
+          // - role: locked on existing rows whose current role is outside this
+          //   admin's assignable tier, preventing unauthorized role changes.
+          // - opdivs / identity_provider: locked to new rows only — existing
+          //   users' OpDiv memberships and derived IdP are managed via the
+          //   Assign OpDivs action, not inline editing.
+          isCellEditable={(params) => {
+            if (params.field === 'role') {
+              return (
+                params.row.isNew ||
+                !params.row.role ||
+                assignableRoles.includes(params.row.role)
+              )
+            }
+            if (
+              params.field === 'opdivs' ||
+              params.field === 'identity_provider'
+            ) {
+              return !!params.row.isNew
+            }
+            return true
+          }}
           editMode="row"
           getRowId={(row) => row.userid}
           initialState={{


### PR DESCRIPTION
## Summary

Closes #395. Depends on #432 (must merge first — this branch is rebased onto `enhancement/opdiv-idp-fields-selectable`).

Replaces the per-OpDiv POST/DELETE loop in `OpDivGrantModal` with a single `PUT /users/{userid}/opdivs` batch request. The backend reconciles the full desired set against current grants in one transaction and re-derives `identity_provider` once.

- **`userOpdivs.ts`**: removes `grantOpDiv` and `revokeOpDiv`; adds `setUserOpDivs(userid, opdivIds[])` → `PUT /users/{userid}/opdivs`
- **`OpDivGrantModal`**: replaces immediate per-toggle writes with local state + Save/Cancel buttons; modal only closes on success; OPDIV_ADMIN scope filter strips out-of-scope grants from the PUT body before sending (prevents backend 403 when the target user holds grants from another admin outside the caller's scope)
- **`UserTable`**: wires `setUserOpDivs` into the new-user create flow (replaces per-item `Promise.allSettled` loop from #432); fixes `handleCloseOpDivModal` to not trigger a redundant refresh on cancel

## Acceptance criteria

- [x] `OpDivGrantModal` has Save and Cancel buttons replacing the old single Close button
- [x] Changes are applied in one batch request on Save, not on each toggle
- [x] Modal stays open on error; closes only on success
- [x] OPDIV_ADMIN cannot trigger a 403 by saving a user who holds out-of-scope grants from another admin
- [x] Creating a new user with OpDivs selected uses the batch endpoint (one PUT)
- [x] Cancelling the modal fires no network requests
- [x] OpDivGrantModal saves all grant add/remove changes in one request via the new batch endpoint
- [x] Resulting grants and the post-save identity_provider refresh are unchanged from today
- [x] No per-OpDiv request loop remains in the modal

## UI
OpDivGrantModal now uses a save button in conjunction with the batch OpDiv grant network call.

<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/78c79cbd-e236-40f5-ac7d-f2804576aa05" />

Network request + payload `{"opdiv_ids":[7,14,21]}`

<img width="534" height="160" alt="image" src="https://github.com/user-attachments/assets/96accbbe-9f6a-4d3c-993c-089f8a2b0d33" />



## Test plan

- [ ] Open Assign OpDivs modal for a user, toggle several OpDivs, click Save — verify single `PUT /opdivs` in network tab (204)
- [ ] Open modal, make no changes, click Cancel — verify no network requests fire
- [ ] Open modal, click Save — verify modal closes on success and the OpDivs column updates
- [ ] Verify error state: if PUT fails, modal stays open and shows error snackbar
- [ ] As OPDIV_ADMIN: verify only your own OpDivs appear as options and Save succeeds without 403
- [ ] Create a new user with multiple OpDivs selected — verify single PUT (not N POSTs) in network tab, followed by GET assignedopdivs + GET user refresh
