### PR TITLE
Enhancement/batch opdiv grants

### DIFF
--- a/src/utils/userOpdivs.ts
+++ b/src/utils/userOpdivs.ts
@@ -3,19 +3,13 @@ import axiosInstance from '@/axiosConfig'
 /**
  * OpDiv grant management for a single user (users_opdivs membership).
  *
- * All three operations hit the dedicated /users/{userid}/assignedopdivs
- * endpoints, whose shape mirrors the existing assignedfismasystems endpoints
- * (GET returns { data: number[] }; POST body { opdiv_id }; DELETE by id).
- * Granting/revoking recomputes the user's derived identity_provider server-side.
+ * fetchUserOpDivs reads the current grant set for a user (used for post-save
+ * refresh and as a fallback for older backends that omit assignedopdivids inline
+ * on the list response).
  *
- * The list endpoint (GET /users) returns each row's grants inline as
- * assignedopdivids, so the users table reads them off the row directly.
- * fetchUserOpDivs is for single-user refresh (e.g. after the grant modal) and
- * as a fallback for older backends that omit the field.
- *
- * NOTE: these endpoints are built on the backend RBAC branch
- * (feature/opdiv-rbac-enforcement) but are not yet in backend/openapi.yaml, so
- * this is built to the documented contract and may 404 until that branch ships.
+ * setUserOpDivs replaces the full grant set in one batch request. The backend
+ * reconciles the desired set against current grants (adds missing, removes extra)
+ * in one transaction and re-derives identity_provider once.
  */
 
 export async function fetchUserOpDivs(userid: string): Promise<number[]> {
@@ -25,18 +19,9 @@ export async function fetchUserOpDivs(userid: string): Promise<number[]> {
   return response.data.data ?? []
 }
 
-export async function grantOpDiv(
+export async function setUserOpDivs(
   userid: string,
-  opdivId: number
+  opdivIds: number[]
 ): Promise<void> {
-  await axiosInstance.post(`/users/${userid}/assignedopdivs`, {
-    opdiv_id: opdivId,
-  })
-}
-
-export async function revokeOpDiv(
-  userid: string,
-  opdivId: number
-): Promise<void> {
-  await axiosInstance.delete(`/users/${userid}/assignedopdivs/${opdivId}`)
+  await axiosInstance.put(`/users/${userid}/opdivs`, { opdiv_ids: opdivIds })
 }

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -1,0 +1,169 @@
+// jest.mock calls must precede all imports that reference the mocked modules.
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  const { handleAuthError } = require('@/utils/authInterceptor')
+  const instance = axios.create({ baseURL: '/api/v1/' })
+  instance.interceptors.response.use(
+    (response: unknown) => response,
+    handleAuthError
+  )
+  return { __esModule: true, default: instance }
+})
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MockAdapter from 'axios-mock-adapter'
+import axiosInstance from '@/axiosConfig'
+import router from '@/router/router'
+import OpDivGrantModal from './OpDivGrantModal'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { ERROR_MESSAGES } from '@/constants'
+import { Routes } from '@/router/constants'
+import type { OpDiv } from '@/types'
+
+const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
+const mock = new MockAdapter(axiosInstance)
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+// Represents the caller's grantable scope (children, active, and — for an
+// OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
+// so scope-filter tests can verify it is stripped from the PUT body.
+const opdivOptions: OpDiv[] = [
+  {
+    opdiv_id: 1,
+    code: 'AAA',
+    name: 'Division A',
+    is_parent: false,
+    active: true,
+  },
+  {
+    opdiv_id: 2,
+    code: 'BBB',
+    name: 'Division B',
+    is_parent: false,
+    active: true,
+  },
+]
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
+) {
+  return renderWithProviders(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+      {...overrides}
+    />
+  )
+}
+
+beforeEach(() => {
+  mock.reset()
+  mockedNavigate.mockReset()
+})
+
+// The most important test: verifies the scopedIds filter strips out-of-scope
+// grants before the PUT so an OPDIV_ADMIN never triggers a backend 403.
+test('PUT body excludes grants the target user holds outside the caller scope', async () => {
+  // Target user holds [1, 2, 99]. OpDiv 99 is absent from opdivOptions
+  // (out of caller scope), so only [1, 2] must reach the batch endpoint.
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(200, { data: [1, 2, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  renderModal()
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toHaveLength(2)
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2]))
+  expect(body.opdiv_ids).not.toContain(99)
+})
+
+test('success: modal closes and onChanged fires after save', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  const handleClose = jest.fn()
+  const onChanged = jest.fn()
+  renderModal({ handleClose, onChanged })
+
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => {
+    expect(handleClose).toHaveBeenCalledTimes(1)
+    expect(onChanged).toHaveBeenCalledWith(USER_ID)
+  })
+})
+
+test('modal stays open on save error and does not call onChanged', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(500)
+
+  const handleClose = jest.fn()
+  const onChanged = jest.fn()
+  renderModal({ handleClose, onChanged })
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
+  expect(handleClose).not.toHaveBeenCalled()
+  expect(onChanged).not.toHaveBeenCalled()
+})
+
+test('403 shows the permission snackbar and does not close the modal', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(403)
+
+  const handleClose = jest.fn()
+  renderModal({ handleClose })
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
+  expect(handleClose).not.toHaveBeenCalled()
+})
+
+test('401 redirects to sign-in without firing a generic error snackbar', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
+
+  renderModal()
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
+})
+
+test('save button is disabled while the request is in flight', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+  // Never resolves — keeps the request in-flight so we can assert the disabled state.
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(() => new Promise(() => {}))
+
+  renderModal()
+  const saveButton = screen.getByRole('button', { name: /^save$/i })
+
+  await userEvent.click(saveButton)
+
+  expect(saveButton).toBeDisabled()
+})

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -11,16 +11,10 @@ import { GridRowId } from '@mui/x-data-grid'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
 import Autocomplete from '@mui/material/Autocomplete'
-import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
-import CheckBoxIcon from '@mui/icons-material/CheckBox'
-import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
-import { fetchUserOpDivs, grantOpDiv, revokeOpDiv } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import type { OpDiv } from '@/types'
-
-const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
-const checkedIcon = <CheckBoxIcon fontSize="small" />
 
 type Props = {
   open: boolean
@@ -34,9 +28,8 @@ type Props = {
    */
   opdivOptions: OpDiv[]
   /**
-   * Fired after a confirmed grant or revoke so the caller can refresh the
-   * user's row (grants + derived identity_provider) against post-mutation
-   * server state.
+   * Fired after a successful save so the caller can refresh the user's row
+   * (grants + derived identity_provider) against post-mutation server state.
    */
   onChanged?: (userid: string) => void
 }
@@ -49,10 +42,8 @@ export default function OpDivGrantModal({
   opdivOptions,
   onChanged,
 }: Props) {
-  const [assignedOpDivs, setAssignedOpDivs] = React.useState<number[]>([])
-  const [pendingRevoke, setPendingRevoke] = React.useState<{
-    opdivId: number
-  } | null>(null)
+  const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
+  const [saving, setSaving] = React.useState(false)
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -81,120 +72,82 @@ export default function OpDivGrantModal({
   React.useEffect(() => {
     if (open && userid) {
       fetchUserOpDivs(String(userid))
-        .then((grants) => setAssignedOpDivs(grants))
+        .then((grants) => setLocalOpDivs(grants))
         .catch((error) => handleError(error))
     }
   }, [open, userid])
-
-  const handleConfirmRevoke = (confirm: boolean) => {
-    const target = pendingRevoke
-    setPendingRevoke(null)
-    if (!confirm || !target) return
-    revokeOpDiv(String(userid), target.opdivId)
-      .then(() => {
-        // Functional update so a grant that resolved while the confirm was
-        // open is not dropped by a stale snapshot.
-        setAssignedOpDivs((prev) => prev.filter((id) => id !== target.opdivId))
-        notify('Saved - revoked OpDiv', 'success')
-        onChanged?.(String(userid))
-      })
-      .catch((error) => handleError(error))
-  }
 
   const optionLabel = (opdivId: number) => {
     const od = opdivMap[opdivId]
     return od ? `${od.code} - ${od.name}` : ''
   }
 
+  const handleSave = () => {
+    setSaving(true)
+    // An OPDIV_ADMIN's scope is already encoded in sortedOptionIds (only their
+    // own OpDivs appear as options). Filter localOpDivs to that set so the
+    // batch request never includes out-of-scope IDs the target user holds from
+    // another admin — the backend scope gate rejects any desired set that
+    // contains an ID the caller doesn't hold, even if they didn't add it.
+    const scopedIds = localOpDivs.filter((id) => sortedOptionIds.includes(id))
+    setUserOpDivs(String(userid), scopedIds)
+      .then(() => {
+        notify('Saved', 'success')
+        onChanged?.(String(userid))
+        handleClose()
+      })
+      .catch((error) => handleError(error))
+      .finally(() => setSaving(false))
+  }
+
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        maxWidth="lg"
-        fullWidth
-        aria-label="Assign OpDivs"
-      >
-        <DialogTitle align="center">
-          <div>
-            <Typography variant="h3">Assign OpDivs</Typography>
-          </div>
-        </DialogTitle>
-        <DialogContent sx={{ height: 500 }}>
-          <Autocomplete
-            multiple
-            disableCloseOnSelect
-            limitTags={3}
-            options={sortedOptionIds}
-            disableClearable
-            getOptionLabel={optionLabel}
-            renderOption={(props, option, { selected }) => (
-              <li {...props} key={option}>
-                <Checkbox
-                  icon={icon}
-                  checkedIcon={checkedIcon}
-                  style={{ marginRight: 8 }}
-                  checked={selected}
-                />
-                {optionLabel(option)}
-              </li>
-            )}
-            value={assignedOpDivs}
-            onChange={(_event, newValue) => {
-              const added = newValue.filter(
-                (item) => !assignedOpDivs.includes(item)
-              )
-              const removed = assignedOpDivs.filter(
-                (item) => !newValue.includes(item)
-              )
-              // Grant every added OpDiv and reflect only what the server
-              // confirms - never trust the optimistic newValue wholesale.
-              added.forEach((opdivId) => {
-                grantOpDiv(String(userid), opdivId)
-                  .then(() => {
-                    setAssignedOpDivs((prev) =>
-                      prev.includes(opdivId) ? prev : [...prev, opdivId]
-                    )
-                    notify('Saved - granted OpDiv', 'success')
-                    onChanged?.(String(userid))
-                  })
-                  .catch((error) => handleError(error))
-              })
-              // Revocations confirm one at a time; the revoke handler computes
-              // the next value functionally from the id being removed.
-              if (removed.length) {
-                setPendingRevoke({ opdivId: removed[0] })
-              }
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Assign OpDivs"
-                variant="filled"
-                placeholder="OpDivs"
-                InputLabelProps={{ sx: { marginTop: 0 } }}
-              />
-            )}
-          />
-        </DialogContent>
-        <DialogActions>
-          <CmsButton onClick={handleClose}>Close</CmsButton>
-        </DialogActions>
-      </Dialog>
-      <ConfirmDialog
-        title="Confirm Revoke OpDiv"
-        confirmationText={
-          pendingRevoke
-            ? `Are you sure you want to revoke ${
-                optionLabel(pendingRevoke.opdivId) || 'this OpDiv'
-              } from ${userName || 'this user'}?`
-            : ''
-        }
-        open={pendingRevoke !== null}
-        onClose={() => setPendingRevoke(null)}
-        confirmClick={handleConfirmRevoke}
-        confirmLabel="Revoke"
-      />
-    </>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="lg"
+      fullWidth
+      aria-label={`Assign OpDivs for ${userName}`}
+    >
+      <DialogTitle align="center">
+        <div>
+          <Typography variant="h3">Assign OpDivs</Typography>
+        </div>
+      </DialogTitle>
+      <DialogContent sx={{ height: 500 }}>
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          limitTags={3}
+          options={sortedOptionIds}
+          disableClearable
+          getOptionLabel={optionLabel}
+          renderOption={(props, option, { selected }) => (
+            <li {...props} key={option}>
+              <Checkbox style={{ marginRight: 8 }} checked={selected} />
+              {optionLabel(option)}
+            </li>
+          )}
+          value={localOpDivs}
+          onChange={(_event, newValue) => setLocalOpDivs(newValue)}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Assign OpDivs"
+              variant="filled"
+              placeholder="OpDivs"
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+            />
+          )}
+        />
+      </DialogContent>
+      <DialogActions>
+        <CmsButton onClick={handleClose} variation="ghost">
+          Cancel
+        </CmsButton>
+        <CmsButton onClick={handleSave} disabled={saving}>
+          Save
+        </CmsButton>
+      </DialogActions>
+    </Dialog>
   )
 }

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -38,7 +38,7 @@ import {
   selectableRoles,
 } from '@/utils/userRoles'
 import { fetchOpDivs } from '@/utils/opdivs'
-import { fetchUserOpDivs, grantOpDiv } from '@/utils/userOpdivs'
+import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
 import { parseApiError } from '@/utils/apiErrors'
@@ -277,7 +277,6 @@ export default function UserTable() {
   }
   const handleCloseOpDivModal = () => {
     setOpenOpDivModal(false)
-    refreshUserRow(String(opdivModalUserId))
   }
   const handleCancelClick = (id: GridRowId) => () => {
     setRowModesModel({
@@ -316,48 +315,39 @@ export default function UserTable() {
         updatedRow.userid = createdUser.userid
 
         const opdivIdsToGrant = (newRow.opdivs as number[] | undefined) ?? []
-        const grantResults = await Promise.allSettled(
-          opdivIdsToGrant.map((opdivId) =>
-            grantOpDiv(createdUser.userid, opdivId)
-          )
-        )
-
-        if (
-          grantResults.some(
-            (r) => r.status === 'rejected' && isAuthHandled(r.reason)
-          )
-        ) {
-          apiRef.current.updateRows([
-            { userid: curRowUserId, _action: 'delete' },
-          ])
-          return updatedRow
-        }
-
-        const succeededIds = opdivIdsToGrant.filter(
-          (_, i) => grantResults[i].status === 'fulfilled'
-        )
-        setUserOpDivMap((prev) => ({
-          ...prev,
-          [createdUser.userid]: succeededIds,
-        }))
-        updatedRow.assignedopdivids = succeededIds
+        let grantsFailed = false
 
         if (opdivIdsToGrant.length > 0) {
-          // Backend recomputes identity_provider after OpDiv grants — leave blank
-          // until refreshUserRow returns the authoritative value.
-          refreshUserRow(createdUser.userid)
+          try {
+            await setUserOpDivs(createdUser.userid, opdivIdsToGrant)
+            setUserOpDivMap((prev) => ({
+              ...prev,
+              [createdUser.userid]: opdivIdsToGrant,
+            }))
+            updatedRow.assignedopdivids = opdivIdsToGrant
+            // Backend recomputes identity_provider after OpDiv grants — leave blank
+            // until refreshUserRow returns the authoritative value.
+            refreshUserRow(createdUser.userid)
+          } catch (grantError) {
+            if (isAuthHandled(grantError)) {
+              apiRef.current.updateRows([
+                { userid: curRowUserId, _action: 'delete' },
+              ])
+              return updatedRow
+            }
+            grantsFailed = true
+            updatedRow.identity_provider = createdUser.identity_provider ?? ''
+          }
         } else {
           updatedRow.identity_provider = createdUser.identity_provider ?? ''
         }
 
         apiRef.current.updateRows([{ userid: curRowUserId, _action: 'delete' }])
         apiRef.current.updateRows([updatedRow])
-
-        const failCount = opdivIdsToGrant.length - succeededIds.length
-        setSnackBarSeverity(failCount > 0 ? 'warning' : 'success')
+        setSnackBarSeverity(grantsFailed ? 'warning' : 'success')
         setSnackBarText(
-          failCount > 0
-            ? `User created, but ${failCount} OpDiv grant(s) failed. Use Assign OpDivs to retry.`
+          grantsFailed
+            ? 'User created, but OpDiv grants failed. Use Assign OpDivs to retry.'
             : STATUS_MESSAGES.saved
         )
         setOpen(true)
@@ -811,11 +801,11 @@ export default function UserTable() {
                 assignableRoles.includes(params.row.role)
               )
             }
-            if (
-              params.field === 'opdivs' ||
-              params.field === 'identity_provider'
-            ) {
+            if (params.field === 'opdivs') {
               return !!params.row.isNew
+            }
+            if (params.field === 'identity_provider') {
+              return !!params.row.isNew && showIdpSelector
             }
             return true
           }}


### PR DESCRIPTION
In-repo version of #437 by @costacalvin. Carries the full superset of #432 (`make idp and Opdiv fields editable`, commit `e709c76`) plus a second commit, `batch Opdiv grants` (`389230f`), so the org-secret-gated CI can run — Snyk and the dev deploy (via the AWS OIDC role) do not run on a fork PR. Both commits are unchanged and authorship is preserved (`Calvin Costa`); this repo is squash-merge-only, so please keep @costacalvin credited as the author on merge.

This PR currently carries #432's commit underneath the batch change. Per the author's note, #432 merges first; once it lands, this branch will be rebased down to the batch-only commit. Closes #395. Refs #406, #432, #437.

## Summary

The batch commit replaces the per-OpDiv POST/DELETE loop in `OpDivGrantModal` with a single `PUT /users/{userid}/opdivs` batch request. The backend reconciles the full desired set against current grants in one transaction and re-derives `identity_provider` once.

- **`userOpdivs.ts`** — removes `grantOpDiv`/`revokeOpDiv`; adds `setUserOpDivs(userid, opdivIds[])` → `PUT /users/{userid}/opdivs` with body `{ opdiv_ids: [...] }`.
- **`OpDivGrantModal`** — replaces immediate per-toggle writes with local state + Save/Cancel; the modal closes only on success. An OPDIV_ADMIN's scope is enforced by filtering the PUT body to the OpDivs they hold, which clears the backend's scope gate without revoking out-of-scope grants the target user holds from another admin (the backend only reconciles within the caller's scope).
- **`UserTable`** — wires `setUserOpDivs` into the new-user create flow (one PUT in place of the per-item loop) and stops a redundant refresh when the modal is cancelled.

The first commit (OpDiv/IdP fields editable at create) is the change previously carried by #432; see #432 / #431 for its screenshots and the "OpDiv grant derivation overrides explicit IdP" note.

## Depends on

- Backend CMS-Enterprise/ztmf#352 — widens the `identity_provider` override gate so HHS-wide admins can set Entra at create. Green in dev.
- Backend CMS-Enterprise/ztmf#369 — adds the `PUT /users/{userid}/opdivs` batch endpoint and its scope-aware reconciliation. Must be deployed to dev alongside this UI; until it is, the modal Save and new-user-with-OpDivs paths return 404 in dev.

## Test plan

- [ ] Open Assign OpDivs, toggle several OpDivs, Save — single `PUT /opdivs` (204) in the network tab; the OpDivs column updates
- [ ] Open the modal, make no changes, Cancel — no network requests fire
- [ ] Save with a failing PUT — modal stays open and shows an error
- [ ] As OPDIV_ADMIN: only your own OpDivs appear as options and Save succeeds without a 403; a target user's out-of-scope grants are preserved
- [ ] Create a new user with multiple OpDivs — single PUT (not N POSTs), followed by the assignedopdivs + user refresh
- [ ] HHS_ADMIN / OPDIV_ADMIN / existing-row gating from the first commit still holds (OpDiv + IdP editable only on new rows; IdP selector only when `showIdpSelector`)

## Follow-ups (non-blocking)

- **Guard Save against the initial load (recommended before prod reliance):** the modal enables Save before `fetchUserOpDivs` resolves. Opening the modal and clicking Save immediately sends `PUT { opdiv_ids: [] }`, which for an OPDIV_ADMIN reconciles to "remove all in-scope grants." Add a `loading` state and disable Save until the initial fetch resolves. (Cannot trigger in dev until ztmf#369 ships, since Save 404s until then.)
- Add `isOptionEqualToValue={(o, v) => o === v}` to the modal Autocomplete to suppress an MUI console warning when a user holds out-of-scope grants.
- Add a test asserting Cancel fires no PUT (the inverse of the scope-filter test).
