### PR TITLE
ci: add Manual Deploy to DEV workflow

### DIFF
--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,8 +1,8 @@
 name: Manual Deploy to DEV
 
-# Manually deploy the current ref (run this on `main`) to the DEV environment.
-# DEV otherwise only deploys the head branch of an open PR, so `main` is never
-# auto-published to DEV. Use this to reset/redeploy DEV to main on demand.
+# Deploy main to DEV on demand.
+#   - orchestration-dev (open/sync a PR): preview a feature branch on DEV.
+#   - this workflow: (re)deploy main to DEV, e.g. to reset DEV after branch deploys.
 # Run: gh workflow run "Manual Deploy to DEV" --ref main
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-deploy-dev.yml
+++ b/.github/workflows/manual-deploy-dev.yml
@@ -1,0 +1,23 @@
+name: Manual Deploy to DEV
+
+# Manually deploy the current ref (run this on `main`) to the DEV environment.
+# DEV otherwise only deploys the head branch of an open PR, so `main` is never
+# auto-published to DEV. Use this to reset/redeploy DEV to main on demand.
+# Run: gh workflow run "Manual Deploy to DEV" --ref main
+on:
+  workflow_dispatch:
+
+jobs:
+  analysis:
+    name: Analysis
+    uses: ./.github/workflows/analysis.yml
+    secrets: inherit
+
+  ui:
+    name: ui
+    needs:
+      - analysis
+    uses: ./.github/workflows/ui.yml
+    with:
+      environment: dev
+    secrets: inherit


### PR DESCRIPTION
## What

Adds a `Manual Deploy to DEV` workflow (`workflow_dispatch`) so the current `main` can be published to the DEV environment on demand.

## Why

DEV only deploys via `orchestration-dev`, which triggers on `pull_request` to `main` and builds the **PR's head branch** — so `main` itself is never auto-deployed to DEV, and DEV ends up reflecting whichever PR last synced rather than the merged baseline. This adds a way to reset/redeploy DEV to `main` without opening a throwaway PR.

## How

Run from the Actions tab, or:

```
gh workflow run "Manual Deploy to DEV" --ref main
```

It reuses the existing reusable workflows (no deploy logic is duplicated): Analysis, then the deploy. The existing PR-triggered DEV behavior is unchanged — this is purely additive.

## Note

`workflow_dispatch` is only registered once the workflow file is on the default branch, so this has to merge before the manual trigger becomes available.
