### PR TITLE
fix(OpDivGrantModal): block save during and after fetch to prevent grant data loss

### DIFF
--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -196,6 +196,64 @@ test('save button stays disabled when the initial grant fetch fails', async () =
   expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
 })
 
+test('autocomplete picker is disabled while the initial grant fetch is in flight', async () => {
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(() => new Promise(() => {}))
+
+  renderModal()
+
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('autocomplete picker is disabled when the initial grant fetch fails', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+
+  renderModal()
+
+  // Snackbar proves .catch ran and setFetchFailed(true) has committed.
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('closing after a fetch failure resets error state so Save re-enables on reopen', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).replyOnce(500)
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+
+  const { rerender } = renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+
+  rerender(
+    <OpDivGrantModal
+      open={false}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+  rerender(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // Second GET resolves successfully — Save must re-enable.
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  )
+})
+
 test('401 on the initial grant fetch redirects to sign-in without a generic error snackbar', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(401)
 

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -30,6 +30,7 @@ const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
 const mock = new MockAdapter(axiosInstance)
 
 const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 // Represents the caller's grantable scope (children, active, and — for an
 // OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
@@ -119,6 +120,7 @@ test('modal stays open on save error and does not call onChanged', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
@@ -133,6 +135,7 @@ test('403 shows the permission snackbar and does not close the modal', async () 
   const handleClose = jest.fn()
   renderModal({ handleClose })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
@@ -144,6 +147,7 @@ test('401 redirects to sign-in without firing a generic error snackbar', async (
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
 
   renderModal()
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -163,7 +167,70 @@ test('save button is disabled while the request is in flight', async () => {
   renderModal()
   const saveButton = screen.getByRole('button', { name: /^save$/i })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(saveButton)
 
   expect(saveButton).toBeDisabled()
+})
+
+test('save button is disabled until the initial grant fetch resolves', async () => {
+  // GET never resolves — keeps the modal in loading state indefinitely.
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(() => new Promise(() => {}))
+
+  renderModal()
+  const saveButton = screen.getByRole('button', { name: /^save$/i })
+
+  expect(saveButton).toBeDisabled()
+})
+
+test('save button stays disabled when the initial grant fetch fails', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+
+  renderModal()
+
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('stale fetch from a prior user is discarded when userid changes', async () => {
+  // User A's fetch is intentionally slow — held until we manually release it.
+  let resolveUserA!: () => void
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(
+    () =>
+      new Promise((res) => {
+        resolveUserA = () => res([200, { data: [1] }])
+      })
+  )
+  // User B's fetch resolves immediately with a different grant set.
+  mock.onGet(`/users/${USER_ID_B}/assignedopdivs`).reply(200, { data: [2] })
+  mock.onPut(`/users/${USER_ID_B}/opdivs`).reply(204)
+
+  const { rerender } = renderModal()
+
+  // Switch to user B before user A's fetch resolves — triggers effect cleanup.
+  rerender(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID_B}
+      userName="Test User B"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // Both GETs have been sent; user B's has already resolved.
+  await waitFor(() => expect(mock.history.get).toHaveLength(2))
+
+  // Release user A's stale fetch — the cancelled flag should swallow the result.
+  resolveUserA()
+
+  // Save must send user B's grant (opdiv 2), not user A's stale grant (opdiv 1).
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toEqual([2])
+  expect(body.opdiv_ids).not.toContain(1)
 })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -224,6 +224,7 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
   mock.onGet(`/users/${USER_ID_B}/assignedopdivs`).reply(200, { data: [2] })
   mock.onPut(`/users/${USER_ID_B}/opdivs`).reply(204)
 
+  const onChanged = jest.fn()
   const { rerender } = renderModal()
 
   // Switch to user B before user A's fetch resolves — triggers effect cleanup.
@@ -234,7 +235,7 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       userid={USER_ID_B}
       userName="Test User B"
       opdivOptions={opdivOptions}
-      onChanged={jest.fn()}
+      onChanged={onChanged}
     />
   )
 
@@ -250,4 +251,6 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
   const body = JSON.parse(mock.history.put[0].data)
   expect(body.opdiv_ids).toEqual([2])
   expect(body.opdiv_ids).not.toContain(1)
+  expect(onChanged).toHaveBeenCalledWith(USER_ID_B)
+  expect(onChanged).not.toHaveBeenCalledWith(USER_ID)
 })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -190,7 +190,24 @@ test('save button stays disabled when the initial grant fetch fails', async () =
 
   renderModal()
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  // Wait for the full error path to settle — snackbar proves .catch ran and
+  // setFetchFailed(true) has committed, not just that the GET was sent.
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('401 on the initial grant fetch redirects to sign-in without a generic error snackbar', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(401)
+
+  renderModal()
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
   expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
 })
 

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -44,6 +44,8 @@ export default function OpDivGrantModal({
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
   const [saving, setSaving] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [fetchFailed, setFetchFailed] = React.useState(false)
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -71,9 +73,26 @@ export default function OpDivGrantModal({
 
   React.useEffect(() => {
     if (open && userid) {
+      let cancelled = false
+      setLoading(true)
+      setFetchFailed(false)
+      setLocalOpDivs([])
       fetchUserOpDivs(String(userid))
-        .then((grants) => setLocalOpDivs(grants))
-        .catch((error) => handleError(error))
+        .then((grants) => {
+          if (!cancelled) setLocalOpDivs(grants)
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            handleError(error)
+            setFetchFailed(true)
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+      return () => {
+        cancelled = true
+      }
     }
   }, [open, userid])
 
@@ -144,7 +163,10 @@ export default function OpDivGrantModal({
         <CmsButton onClick={handleClose} variation="ghost">
           Cancel
         </CmsButton>
-        <CmsButton onClick={handleSave} disabled={saving}>
+        <CmsButton
+          onClick={handleSave}
+          disabled={saving || loading || fetchFailed}
+        >
           Save
         </CmsButton>
       </DialogActions>

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -65,11 +65,11 @@ export default function OpDivGrantModal({
     [opdivOptions, opdivMap]
   )
 
-  const handleError = (error: unknown) => {
+  const handleError = React.useCallback((error: unknown) => {
     if (isAuthHandled(error)) return
     const parsed = parseApiError(error)
     notify(parsed.message, 'error')
-  }
+  }, [])
 
   React.useEffect(() => {
     if (open && userid) {
@@ -93,8 +93,11 @@ export default function OpDivGrantModal({
       return () => {
         cancelled = true
       }
+    } else {
+      setFetchFailed(false)
+      setLoading(false)
     }
-  }, [open, userid])
+  }, [open, userid, handleError])
 
   const optionLabel = (opdivId: number) => {
     const od = opdivMap[opdivId]
@@ -138,7 +141,7 @@ export default function OpDivGrantModal({
           disableCloseOnSelect
           limitTags={3}
           options={sortedOptionIds}
-          disabled={loading}
+          disabled={loading || fetchFailed}
           disableClearable
           getOptionLabel={optionLabel}
           renderOption={(props, option, { selected }) => (

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -138,6 +138,7 @@ export default function OpDivGrantModal({
           disableCloseOnSelect
           limitTags={3}
           options={sortedOptionIds}
+          disabled={loading}
           disableClearable
           getOptionLabel={optionLabel}
           renderOption={(props, option, { selected }) => (

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -96,6 +96,7 @@ export default function OpDivGrantModal({
     } else {
       setFetchFailed(false)
       setLoading(false)
+      setLocalOpDivs([])
     }
   }, [open, userid, handleError])
 


### PR DESCRIPTION
## Summary
Closes #440. Pairs with the original modal addition in #438 where this bug was introduced.

Pre-existing bug: `OpDivGrantModal` enabled the Save button immediately on modal open. `localOpDivs` initializes to `[]` and is only populated when `GET /users/{userid}/assignedopdivs` resolves. A Save click before that completes — or after it errors — sends `PUT /users/{userid}/opdivs` with `{ "opdiv_ids": [] }`, which the backend reconciles as "remove every in-scope OpDiv grant from this user." Silent data loss with no warning.

## Dependencies

| PR | Repo | Status | Notes |
|----|------|--------|-------|
| #438 | `ztmf-ui` | ✅ Merged | Introduced `OpDivGrantModal` and the `PUT /users/{userid}/opdivs` batch endpoint this fix targets |

No downstream dependencies — this PR is self-contained and unblocks nothing.

## Changes

**`OpDivGrantModal.tsx`**

- Added `loading` and `fetchFailed` boolean states.
- `useEffect` now: resets `localOpDivs` and `fetchFailed`, sets `loading = true` before the fetch, sets `fetchFailed = true` on error (in addition to the existing toast), clears `loading` in `.finally`.
- Added a `cancelled` boolean flag in the `useEffect` cleanup to guard against stale fetches (e.g., userid changes mid-flight) overwriting state for the current render.
- Save button: `disabled={saving || loading || fetchFailed}` — blocked during load, and kept blocked after a fetch failure so a transient network error cannot trigger a destructive empty PUT. The user must close and reopen the modal to retry.
- Autocomplete: `disabled={loading}` — blocks interaction with the grant picker while the current grants are still loading, preventing a state-overwrite race where user changes are silently stomped when the fetch resolves.

**`OpDivGrantModal.test.tsx`**

- Added `await waitFor(() => expect(mock.history.get).toHaveLength(1))` before Save clicks in existing tests — without this, post-fix tests would silently pass by clicking a now-disabled button and never reaching the PUT.
- Added `USER_ID_B` constant for multi-user scenarios.
- Four new tests:
  1. **`save button is disabled until the initial grant fetch resolves`** — GET never resolves; asserts Save is disabled on mount.
  2. **`save button stays disabled when the initial grant fetch fails`** — GET returns 500; anchors on the error snackbar text to confirm `.catch` has run before asserting the button state.
  3. **`401 on the initial grant fetch redirects to sign-in without a generic error snackbar`** — GET returns 401; verifies the auth redirect fires and no `tryAgain` toast appears.
  4. **`stale fetch from a prior user is discarded when userid changes`** — opens for user A with a held GET, switches to user B (whose GET resolves immediately), releases user A's fetch after the rerender, then saves and verifies the PUT body contains only user B's grants.

## UI
When fetch is in flight, Autocomplete and Save button are disabled.
<img width="1512" height="820" alt="image" src="https://github.com/user-attachments/assets/6e307f55-68b4-49cd-b9d5-0536d4fd0ba2" />

## Test plan

Unit tests — `npm test -- --testPathPattern OpDivGrantModal`:

- [x] `PUT body excludes grants the target user holds outside the caller scope`
- [x] `success: modal closes and onChanged fires after save`
- [x] `modal stays open on save error and does not call onChanged`
- [x] `403 shows the permission snackbar and does not close the modal`
- [x] `401 redirects to sign-in without firing a generic error snackbar`
- [x] `save button is disabled while the request is in flight`
- [x] `save button is disabled until the initial grant fetch resolves`
- [x] `save button stays disabled when the initial grant fetch fails`
- [x] `401 on the initial grant fetch redirects to sign-in without a generic error snackbar`
- [x] `stale fetch from a prior user is discarded when userid changes`

Manual smoke test against a running dev environment:

* [ ] **Normal flow** — open the modal for any user, wait for the spinner to clear, verify Save becomes enabled. Click Save and confirm the PUT fires with the correct grant set.
* [ ] **Early Save click (the bug path)** — throttle the network in DevTools (Slow 3G), open the modal, and immediately click Save before the spinner clears. Save must remain disabled and no PUT must be sent.
* [ ] **Fetch failure** — use DevTools request blocking to drop the initial GET; open the modal. Verify the error toast appears and Save stays permanently disabled (close + reopen to retry).
* [ ] **Rapid user switch** — open the modal for user A, switch to user B via the data grid before the fetch resolves, verify the Autocomplete reflects user B's grants and the subsequent Save sends user B's grant set only.