### PR TITLE
Bug/disable grant save button

### DIFF
--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -196,6 +196,64 @@ test('save button stays disabled when the initial grant fetch fails', async () =
   expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
 })
 
+test('autocomplete picker is disabled while the initial grant fetch is in flight', async () => {
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(() => new Promise(() => {}))
+
+  renderModal()
+
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('autocomplete picker is disabled when the initial grant fetch fails', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+
+  renderModal()
+
+  // Snackbar proves .catch ran and setFetchFailed(true) has committed.
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('closing after a fetch failure resets error state so Save re-enables on reopen', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).replyOnce(500)
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [] })
+
+  const { rerender } = renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+
+  rerender(
+    <OpDivGrantModal
+      open={false}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+  rerender(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // Second GET resolves successfully — Save must re-enable.
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /^save$/i })).not.toBeDisabled()
+  )
+})
+
 test('401 on the initial grant fetch redirects to sign-in without a generic error snackbar', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(401)
 

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -30,6 +30,7 @@ const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
 const mock = new MockAdapter(axiosInstance)
 
 const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const USER_ID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 // Represents the caller's grantable scope (children, active, and — for an
 // OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
@@ -119,6 +120,7 @@ test('modal stays open on save error and does not call onChanged', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
@@ -133,6 +135,7 @@ test('403 shows the permission snackbar and does not close the modal', async () 
   const handleClose = jest.fn()
   renderModal({ handleClose })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
@@ -144,6 +147,7 @@ test('401 redirects to sign-in without firing a generic error snackbar', async (
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
 
   renderModal()
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -163,7 +167,70 @@ test('save button is disabled while the request is in flight', async () => {
   renderModal()
   const saveButton = screen.getByRole('button', { name: /^save$/i })
 
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
   await userEvent.click(saveButton)
 
   expect(saveButton).toBeDisabled()
+})
+
+test('save button is disabled until the initial grant fetch resolves', async () => {
+  // GET never resolves — keeps the modal in loading state indefinitely.
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(() => new Promise(() => {}))
+
+  renderModal()
+  const saveButton = screen.getByRole('button', { name: /^save$/i })
+
+  expect(saveButton).toBeDisabled()
+})
+
+test('save button stays disabled when the initial grant fetch fails', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+
+  renderModal()
+
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('stale fetch from a prior user is discarded when userid changes', async () => {
+  // User A's fetch is intentionally slow — held until we manually release it.
+  let resolveUserA!: () => void
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(
+    () =>
+      new Promise((res) => {
+        resolveUserA = () => res([200, { data: [1] }])
+      })
+  )
+  // User B's fetch resolves immediately with a different grant set.
+  mock.onGet(`/users/${USER_ID_B}/assignedopdivs`).reply(200, { data: [2] })
+  mock.onPut(`/users/${USER_ID_B}/opdivs`).reply(204)
+
+  const { rerender } = renderModal()
+
+  // Switch to user B before user A's fetch resolves — triggers effect cleanup.
+  rerender(
+    <OpDivGrantModal
+      open={true}
+      handleClose={jest.fn()}
+      userid={USER_ID_B}
+      userName="Test User B"
+      opdivOptions={opdivOptions}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // Both GETs have been sent; user B's has already resolved.
+  await waitFor(() => expect(mock.history.get).toHaveLength(2))
+
+  // Release user A's stale fetch — the cancelled flag should swallow the result.
+  resolveUserA()
+
+  // Save must send user B's grant (opdiv 2), not user A's stale grant (opdiv 1).
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toEqual([2])
+  expect(body.opdiv_ids).not.toContain(1)
 })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -224,6 +224,7 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
   mock.onGet(`/users/${USER_ID_B}/assignedopdivs`).reply(200, { data: [2] })
   mock.onPut(`/users/${USER_ID_B}/opdivs`).reply(204)
 
+  const onChanged = jest.fn()
   const { rerender } = renderModal()
 
   // Switch to user B before user A's fetch resolves — triggers effect cleanup.
@@ -234,7 +235,7 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       userid={USER_ID_B}
       userName="Test User B"
       opdivOptions={opdivOptions}
-      onChanged={jest.fn()}
+      onChanged={onChanged}
     />
   )
 
@@ -250,4 +251,6 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
   const body = JSON.parse(mock.history.put[0].data)
   expect(body.opdiv_ids).toEqual([2])
   expect(body.opdiv_ids).not.toContain(1)
+  expect(onChanged).toHaveBeenCalledWith(USER_ID_B)
+  expect(onChanged).not.toHaveBeenCalledWith(USER_ID)
 })

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -190,7 +190,24 @@ test('save button stays disabled when the initial grant fetch fails', async () =
 
   renderModal()
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  // Wait for the full error path to settle — snackbar proves .catch ran and
+  // setFetchFailed(true) has committed, not just that the GET was sent.
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('401 on the initial grant fetch redirects to sign-in without a generic error snackbar', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(401)
+
+  renderModal()
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
   expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
 })
 

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -44,6 +44,8 @@ export default function OpDivGrantModal({
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
   const [saving, setSaving] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [fetchFailed, setFetchFailed] = React.useState(false)
 
   const opdivMap = React.useMemo(() => {
     const map: Record<number, { code: string; name: string }> = {}
@@ -71,9 +73,26 @@ export default function OpDivGrantModal({
 
   React.useEffect(() => {
     if (open && userid) {
+      let cancelled = false
+      setLoading(true)
+      setFetchFailed(false)
+      setLocalOpDivs([])
       fetchUserOpDivs(String(userid))
-        .then((grants) => setLocalOpDivs(grants))
-        .catch((error) => handleError(error))
+        .then((grants) => {
+          if (!cancelled) setLocalOpDivs(grants)
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            handleError(error)
+            setFetchFailed(true)
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+      return () => {
+        cancelled = true
+      }
     }
   }, [open, userid])
 
@@ -144,7 +163,10 @@ export default function OpDivGrantModal({
         <CmsButton onClick={handleClose} variation="ghost">
           Cancel
         </CmsButton>
-        <CmsButton onClick={handleSave} disabled={saving}>
+        <CmsButton
+          onClick={handleSave}
+          disabled={saving || loading || fetchFailed}
+        >
           Save
         </CmsButton>
       </DialogActions>

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -65,11 +65,11 @@ export default function OpDivGrantModal({
     [opdivOptions, opdivMap]
   )
 
-  const handleError = (error: unknown) => {
+  const handleError = React.useCallback((error: unknown) => {
     if (isAuthHandled(error)) return
     const parsed = parseApiError(error)
     notify(parsed.message, 'error')
-  }
+  }, [])
 
   React.useEffect(() => {
     if (open && userid) {
@@ -93,8 +93,11 @@ export default function OpDivGrantModal({
       return () => {
         cancelled = true
       }
+    } else {
+      setFetchFailed(false)
+      setLoading(false)
     }
-  }, [open, userid])
+  }, [open, userid, handleError])
 
   const optionLabel = (opdivId: number) => {
     const od = opdivMap[opdivId]
@@ -138,7 +141,7 @@ export default function OpDivGrantModal({
           disableCloseOnSelect
           limitTags={3}
           options={sortedOptionIds}
-          disabled={loading}
+          disabled={loading || fetchFailed}
           disableClearable
           getOptionLabel={optionLabel}
           renderOption={(props, option, { selected }) => (

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -138,6 +138,7 @@ export default function OpDivGrantModal({
           disableCloseOnSelect
           limitTags={3}
           options={sortedOptionIds}
+          disabled={loading}
           disableClearable
           getOptionLabel={optionLabel}
           renderOption={(props, option, { selected }) => (

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -96,6 +96,7 @@ export default function OpDivGrantModal({
     } else {
       setFetchFailed(false)
       setLoading(false)
+      setLocalOpDivs([])
     }
   }, [open, userid, handleError])
 


### PR DESCRIPTION
In-repo version of #441 by @costacalvin, moved so the org-secret CI gates (Snyk,
Infrastructure/Deploy) can run — they can't on a fork PR. Commits pushed unchanged;
authorship preserved.

Closes #440. Pairs with the original modal addition in #438 where this bug was introduced.

## Summary
Pre-existing bug: `OpDivGrantModal` enabled the Save button immediately on modal open.
`localOpDivs` initializes to `[]` and is only populated when `GET /users/{userid}/assignedopdivs`
resolves. A Save click before that completes — or after it errors — sends
`PUT /users/{userid}/opdivs` with `{ "opdiv_ids": [] }`, which the backend reconciles as
"remove every in-scope OpDiv grant from this user." Silent data loss with no warning.

## Dependencies
- #438 (ztmf-ui, merged) — introduced `OpDivGrantModal` and the `PUT /users/{userid}/opdivs`
  batch endpoint this fix targets.

No downstream dependencies — self-contained.

## Changes
**`OpDivGrantModal.tsx`**
- Added `loading` and `fetchFailed` boolean states.
- `useEffect` now resets `localOpDivs` and `fetchFailed`, sets `loading = true` before the
  fetch, sets `fetchFailed = true` on error (in addition to the existing toast), clears
  `loading` in `.finally`.
- Added a `cancelled` flag in the `useEffect` cleanup to guard against stale fetches (e.g.
  `userid` changes mid-flight) overwriting state for the current render.
- Save button: `disabled={saving || loading || fetchFailed}` — blocked during load, and kept
  blocked after a fetch failure so a transient network error can't trigger a destructive empty
  PUT. User must close and reopen to retry.
- Autocomplete: `disabled={loading}` — blocks the grant picker while current grants load,
  preventing a state-overwrite race.

**`OpDivGrantModal.test.tsx`**
- Added `await waitFor(() => expect(mock.history.get).toHaveLength(1))` before Save clicks in
  existing tests (otherwise post-fix tests would silently pass by clicking a now-disabled
  button and never reaching the PUT).
- Added `USER_ID_B` constant for multi-user scenarios.
- Four new tests: Save disabled until initial grant fetch resolves; Save stays disabled when
  the fetch fails (500); 401 on the fetch redirects to sign-in without a generic snackbar;
  stale fetch from a prior user is discarded when `userid` changes.

## Test plan
Unit tests (`npm test -- --testPathPattern OpDivGrantModal`) — all listed cases green,
including the four new guards. Manual smoke against dev: normal flow enables Save after the
spinner clears; early Save click on throttled network stays disabled with no PUT; dropped
initial GET keeps Save permanently disabled until reopen; rapid user switch sends only the
second user's grant set.

Refs #441