### PR TITLE
fix(login): distinguish lookup outages from unknown-email; enable withCredentials

### DIFF
--- a/src/axiosConfig.ts
+++ b/src/axiosConfig.ts
@@ -25,7 +25,11 @@ const axiosInstance: AxiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  // withCredentials: true,
+  // Same-origin requests to /api/v1/ already carry cookies, so this has no
+  // effect while the API shares the app's origin. It is set explicitly so
+  // credentialed requests keep working if the API is served from a
+  // separate origin.
+  withCredentials: true,
 })
 
 // Local development only: bypass auth with token from .env

--- a/src/utils/authLookup.test.ts
+++ b/src/utils/authLookup.test.ts
@@ -87,4 +87,11 @@ describe('lookupIdpForEmail - malformed 2xx is not a genuine null', () => {
       unavailable: true,
     })
   })
+
+  it('treats a present envelope with an absent idp marker as unavailable', async () => {
+    mock.onGet('/auth/lookup').reply(200, { data: {} })
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
 })

--- a/src/utils/authLookup.test.ts
+++ b/src/utils/authLookup.test.ts
@@ -1,0 +1,90 @@
+import MockAdapter from 'axios-mock-adapter'
+
+// Replace @/axiosConfig with a fresh axios instance. The production module
+// reads import.meta.env at top level and swc/jest leaves that literal in
+// the CommonJS output, which throws "Cannot use 'import.meta' outside a
+// module" on load. No interceptor is registered: every lookup call passes
+// skipAuthHandling: true, so the interceptor would rethrow untouched and
+// its absence does not change the behavior under test.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+
+import axiosInstance from '@/axiosConfig'
+import { lookupIdpForEmail } from './authLookup'
+
+const mock = new MockAdapter(axiosInstance)
+
+afterEach(() => {
+  mock.reset()
+})
+
+describe('lookupIdpForEmail - clean backend answers', () => {
+  it('returns { idp: "okta" } for an Okta-routed email', async () => {
+    mock.onGet('/auth/lookup').reply(200, { data: { idp: 'okta' } })
+    await expect(lookupIdpForEmail('user@okta.example')).resolves.toEqual({
+      idp: 'okta',
+    })
+  })
+
+  it('returns { idp: "entra" } for an Entra-routed email', async () => {
+    mock.onGet('/auth/lookup').reply(200, { data: { idp: 'entra' } })
+    await expect(lookupIdpForEmail('user@entra.example')).resolves.toEqual({
+      idp: 'entra',
+    })
+  })
+
+  it('returns { idp: null } for the non-enumeration "no IdP" response', async () => {
+    mock.onGet('/auth/lookup').reply(200, { data: { idp: null } })
+    await expect(lookupIdpForEmail('nobody@example.com')).resolves.toEqual({
+      idp: null,
+    })
+  })
+})
+
+describe('lookupIdpForEmail - transport/server failures surface as unavailable', () => {
+  it('maps a request timeout to { unavailable: true }', async () => {
+    mock.onGet('/auth/lookup').timeout()
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+
+  it('maps a network error to { unavailable: true }', async () => {
+    mock.onGet('/auth/lookup').networkError()
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+
+  it('maps a 5xx to { unavailable: true }', async () => {
+    mock.onGet('/auth/lookup').reply(500, { error: 'boom' })
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+
+  it('maps a 4xx to { unavailable: true }', async () => {
+    mock.onGet('/auth/lookup').reply(429, { error: 'slow down' })
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+})
+
+describe('lookupIdpForEmail - malformed 2xx is not a genuine null', () => {
+  it('treats an unknown idp marker as unavailable, not as null', async () => {
+    mock.onGet('/auth/lookup').reply(200, { data: { idp: 'bogus' } })
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+
+  it('treats a missing data envelope as unavailable', async () => {
+    mock.onGet('/auth/lookup').reply(200, {})
+    await expect(lookupIdpForEmail('user@example.com')).resolves.toEqual({
+      unavailable: true,
+    })
+  })
+})

--- a/src/utils/authLookup.ts
+++ b/src/utils/authLookup.ts
@@ -17,6 +17,21 @@ type LookupResponse = {
 }
 
 /**
+ * Discriminated result of the pre-auth lookup.
+ *
+ * - `{ idp }` - the backend answered cleanly. `idp` is `'okta'`/`'entra'`
+ *   for a routed identity, or `null` for the deliberate non-enumeration
+ *   "no IdP" response (unknown / unprovisioned / soft-deleted - all
+ *   indistinguishable by contract).
+ * - `{ unavailable: true }` - a transport or server failure (timeout,
+ *   network error, 4xx/5xx, or a 2xx whose body did not carry a known
+ *   `idp` marker). This is the ONLY state the landing page may surface
+ *   distinctly; it is independent of whether the email maps to an
+ *   account, so it carries no enumeration signal.
+ */
+export type LookupResult = { idp: IdpRouting } | { unavailable: true }
+
+/**
  * 5-second cap on the unauthenticated lookup call so the Continue button
  * does not hang indefinitely if the endpoint is slow or unreachable. The
  * landing page treats a timeout the same as any other failure: show the
@@ -42,24 +57,35 @@ const LOOKUP_TIMEOUT_MS = 5000
  *
  * @param email - The email entered on the landing page. Not validated
  *   here; the caller is expected to gate on format before calling.
- * @returns The resolved IdP marker, or null when the email is not
- *   provisioned (deliberately indistinguishable from "unknown email" per
- *   the non-enumeration contract).
+ * @returns A {@link LookupResult}: `{ idp }` for a clean backend answer
+ *   (including the non-enumeration `null`), or `{ unavailable: true }`
+ *   when the call failed at the transport/server level. The two are kept
+ *   separate so the landing page can offer a retry on an outage without
+ *   ever revealing whether an email maps to an account.
  */
-export async function lookupIdpForEmail(email: string): Promise<IdpRouting> {
+export async function lookupIdpForEmail(email: string): Promise<LookupResult> {
   try {
     const response = await axiosInstance.get<LookupResponse>('/auth/lookup', {
       params: { email },
       timeout: LOOKUP_TIMEOUT_MS,
       // The lookup is unauthenticated; the interceptor's 401/403 redirect
-      // would be wrong here. Caller treats any failure as a null result.
+      // would be wrong here. Caller owns the failure handling below.
       skipAuthHandling: true,
     })
-    return response.data.data.idp
+    const idp = response.data?.data?.idp
+    // Only accept the known markers. A 2xx whose body is not one of these
+    // (missing field, unexpected value) is a malformed response, not a
+    // genuine "no IdP" - treat it as unavailable so it is never conflated
+    // with the deliberate null.
+    if (idp === 'okta' || idp === 'entra' || idp === null) {
+      return { idp }
+    }
+    return { unavailable: true }
   } catch {
-    // Timeout, network error, 4xx, 5xx all collapse to null. The landing
-    // page renders the same generic message either way; that is the
-    // non-enumeration contract.
-    return null
+    // Timeout (ECONNABORTED), network error, 4xx, 5xx. Distinct from the
+    // 200 {idp:null} handled above: a transport/server failure is the one
+    // state the landing page may surface separately (a retry prompt),
+    // because it does not depend on whether the email exists.
+    return { unavailable: true }
   }
 }

--- a/src/views/LoginPage/LoginPage.test.tsx
+++ b/src/views/LoginPage/LoginPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { SignInReasons } from '@/utils/authCodes'
 import { Routes } from '@/router/constants'
 
@@ -37,10 +38,12 @@ jest.mock('@/assets/ztmf-logo-login.png', () => 'ztmf-logo-login.png', {
 
 import { useLocation, useRouteLoaderData } from 'react-router-dom'
 import CONFIG from '@/utils/config'
+import { lookupIdpForEmail } from '@/utils/authLookup'
 import LoginPage from './LoginPage'
 
 const mockedUseLocation = useLocation as jest.Mock
 const mockedUseRouteLoaderData = useRouteLoaderData as jest.Mock
+const mockedLookup = lookupIdpForEmail as jest.Mock
 const mutableConfig = CONFIG as unknown as { IDP_ENABLED: boolean }
 
 beforeEach(() => {
@@ -179,5 +182,84 @@ describe('LoginPage EXPIRED / default state', () => {
     expect(
       screen.queryByText(/your session is missing/i)
     ).not.toBeInTheDocument()
+  })
+})
+
+describe('IdpLookupLogin submit: routing and error mapping', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    // Outer beforeEach sets IDP_ENABLED false and resets the router mocks;
+    // drive the email-lookup variant with a signed-out session here.
+    mutableConfig.IDP_ENABLED = true
+    mockedUseLocation.mockReturnValue({ pathname: '/signin', state: null })
+    mockedUseRouteLoaderData.mockReturnValue(undefined)
+    mockedLookup.mockReset()
+    // jsdom rejects an href assignment on the real window.location; swap in
+    // a writable stub so the redirect target is observable and no real
+    // navigation is attempted.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { href: '' },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  async function submitEmail(email: string) {
+    const user = userEvent.setup()
+    render(<LoginPage />)
+    await user.type(screen.getByLabelText(/enter your email/i), email)
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+  }
+
+  it('redirects to /login when the lookup resolves to okta', async () => {
+    mockedLookup.mockResolvedValue({ idp: 'okta' })
+    await submitEmail('user@okta.example')
+    await waitFor(() => expect(window.location.href).toBe('/login'))
+  })
+
+  it('redirects to /login/entra when the lookup resolves to entra', async () => {
+    mockedLookup.mockResolvedValue({ idp: 'entra' })
+    await submitEmail('user@entra.example')
+    await waitFor(() => expect(window.location.href).toBe('/login/entra'))
+  })
+
+  it('shows the generic message and does not navigate on a null result', async () => {
+    mockedLookup.mockResolvedValue({ idp: null })
+    await submitEmail('nobody@example.com')
+    expect(
+      await screen.findByText(/can't determine an identity provider/i)
+    ).toBeInTheDocument()
+    expect(window.location.href).toBe('')
+  })
+
+  it('shows the retry message and does not navigate when unavailable', async () => {
+    mockedLookup.mockResolvedValue({ unavailable: true })
+    await submitEmail('user@example.com')
+    expect(
+      await screen.findByText(/temporarily unavailable/i)
+    ).toBeInTheDocument()
+    expect(window.location.href).toBe('')
+  })
+
+  it('keeps a genuine null and an outage on distinct messages (non-enumeration lock)', async () => {
+    // A no-IdP answer must read as the generic "contact your admin" copy,
+    // never as the outage retry copy, so an outage can never be mistaken
+    // for - or reveal - a real account. Assert the null branch shows the
+    // generic message and NOT the outage message.
+    mockedLookup.mockResolvedValue({ idp: null })
+    await submitEmail('nobody@example.com')
+    expect(
+      await screen.findByText(/can't determine an identity provider/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/temporarily unavailable/i)).toBeNull()
   })
 })

--- a/src/views/LoginPage/LoginPage.test.tsx
+++ b/src/views/LoginPage/LoginPage.test.tsx
@@ -241,12 +241,17 @@ describe('IdpLookupLogin submit: routing and error mapping', () => {
     expect(window.location.href).toBe('')
   })
 
-  it('shows the retry message and does not navigate when unavailable', async () => {
+  it('shows the retry message (and not the generic message) and does not navigate when unavailable', async () => {
     mockedLookup.mockResolvedValue({ unavailable: true })
     await submitEmail('user@example.com')
     expect(
       await screen.findByText(/temporarily unavailable/i)
     ).toBeInTheDocument()
+    // Other half of the non-enumeration lock: an outage must not fall back
+    // to the generic "no IdP" copy, so the two states stay distinguishable.
+    expect(
+      screen.queryByText(/can't determine an identity provider/i)
+    ).toBeNull()
     expect(window.location.href).toBe('')
   })
 

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -12,6 +12,14 @@ import ztmfLogo from '@/assets/ztmf-logo-login.png'
 const UNKNOWN_EMAIL_MESSAGE =
   "We can't determine an identity provider for that email. Contact your ZTMF administrator."
 
+// Shown only when the lookup fails at the transport/server level (timeout,
+// network, 4xx/5xx, malformed response) - never for a genuine "no IdP"
+// result. Keeping this distinct from UNKNOWN_EMAIL_MESSAGE lets a user
+// retry through a transient outage; because it fires independently of
+// whether the email exists, it leaks no enumeration signal.
+const LOOKUP_UNAVAILABLE_MESSAGE =
+  'The sign-in service is temporarily unavailable. Please try again in a moment.'
+
 // Fallback copy when the BE didn't send a message body (or the user
 // landed here without one passing through). The BE message is preferred
 // because it differentiates "no account" from "account deactivated" -
@@ -139,21 +147,28 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
     setIsSubmitting(true)
     setLookupError('')
 
-    const idp = await lookupIdpForEmail(trimmedEmail)
+    const result = await lookupIdpForEmail(trimmedEmail)
 
-    if (idp === 'okta') {
-      // Full-page navigation. /login is an ALB rule, not a router route.
-      window.location.href = '/login'
-      return
+    if ('idp' in result) {
+      if (result.idp === 'okta') {
+        // Full-page navigation. /login is an ALB rule, not a router route.
+        window.location.href = '/login'
+        return
+      }
+      if (result.idp === 'entra') {
+        window.location.href = '/login/entra'
+        return
+      }
+      // result.idp === null: the deliberate non-enumeration response.
+      // Unknown, unprovisioned, and soft-deleted emails all land here with
+      // the same generic message, so none can be told apart.
+      setLookupError(UNKNOWN_EMAIL_MESSAGE)
+    } else {
+      // result.unavailable: a transport/server failure. Distinct retryable
+      // copy - the only branch that differs from the generic message, and
+      // it does not depend on whether the email exists.
+      setLookupError(LOOKUP_UNAVAILABLE_MESSAGE)
     }
-    if (idp === 'entra') {
-      window.location.href = '/login/entra'
-      return
-    }
-
-    // idp === null collapses every failure mode (unknown email, error,
-    // timeout) into the same generic message. No enumeration signal.
-    setLookupError(UNKNOWN_EMAIL_MESSAGE)
     setIsSubmitting(false)
     // Return focus to the field so keyboard/SR users land on the input the
     // error refers to, not the now-disabled submit button.

--- a/src/views/LoginPage/LoginPage.tsx
+++ b/src/views/LoginPage/LoginPage.tsx
@@ -147,28 +147,37 @@ function IdpLookupLogin({ sessionMessage }: { sessionMessage: string }) {
     setIsSubmitting(true)
     setLookupError('')
 
-    const result = await lookupIdpForEmail(trimmedEmail)
+    try {
+      const result = await lookupIdpForEmail(trimmedEmail)
 
-    if ('idp' in result) {
-      if (result.idp === 'okta') {
-        // Full-page navigation. /login is an ALB rule, not a router route.
-        window.location.href = '/login'
-        return
+      if ('idp' in result) {
+        if (result.idp === 'okta') {
+          // Full-page navigation. /login is an ALB rule, not a router route.
+          window.location.href = '/login'
+          return
+        }
+        if (result.idp === 'entra') {
+          window.location.href = '/login/entra'
+          return
+        }
+        // result.idp === null: the deliberate non-enumeration response.
+        // Unknown, unprovisioned, and soft-deleted emails all land here with
+        // the same generic message, so none can be told apart.
+        setLookupError(UNKNOWN_EMAIL_MESSAGE)
+      } else {
+        // result.unavailable: a transport/server failure. Distinct retryable
+        // copy - the only branch that differs from the generic message, and
+        // it does not depend on whether the email exists.
+        setLookupError(LOOKUP_UNAVAILABLE_MESSAGE)
       }
-      if (result.idp === 'entra') {
-        window.location.href = '/login/entra'
-        return
-      }
-      // result.idp === null: the deliberate non-enumeration response.
-      // Unknown, unprovisioned, and soft-deleted emails all land here with
-      // the same generic message, so none can be told apart.
-      setLookupError(UNKNOWN_EMAIL_MESSAGE)
-    } else {
-      // result.unavailable: a transport/server failure. Distinct retryable
-      // copy - the only branch that differs from the generic message, and
-      // it does not depend on whether the email exists.
+    } catch {
+      // lookupIdpForEmail resolves rather than throws, so this is not
+      // reachable today. It guards a future change that throws before the
+      // lookup's own catch, which would otherwise leave the form stuck in
+      // the submitting state with no error shown.
       setLookupError(LOOKUP_UNAVAILABLE_MESSAGE)
     }
+
     setIsSubmitting(false)
     // Return focus to the field so keyboard/SR users land on the input the
     // error refers to, not the now-disabled submit button.


### PR DESCRIPTION
## Summary

Hardens how the pre-auth login page handles the email→IdP lookup. Today a transport or server failure (timeout, network error, 4xx/5xx, or a malformed response) is folded into the same `null` as a genuine "no IdP" answer, so an outage is indistinguishable from a not-found and the user gets no retry signal. This splits the lookup into a discriminated result so an outage shows a distinct "temporarily unavailable, please try again" message, while unknown, unprovisioned, and soft-deleted emails keep the single generic message — preserving the non-enumeration contract. It also enables `withCredentials` on the axios instance defensively.

These changes are independent of the backend Entra 401 under investigation; they harden the login UX regardless of why a given login fails.

## Changes

- `src/utils/authLookup.ts` — `lookupIdpForEmail` now returns `{ idp } | { unavailable: true }`. A clean backend answer (including the deliberate `null`) returns `{ idp }`; a transport/server failure or a malformed 2xx body returns `{ unavailable: true }`.
- `src/views/LoginPage/LoginPage.tsx` — branch on the result: the Okta/Entra redirects are unchanged; `null` keeps the existing generic message; `unavailable` shows the new retry message. The `unavailable` state fires independently of whether an email exists, so it carries no enumeration signal.
- `src/axiosConfig.ts` — set `withCredentials: true` explicitly. Defensive only: same-origin `/api/v1/` already sends cookies, so this has no effect today; it guards a future separate-origin API.
- Tests — new `src/utils/authLookup.test.ts` (okta/entra/null, timeout, network error, 4xx/5xx, malformed body) and added `LoginPage` submit cases that assert a genuine `null` and an outage stay on distinct messages.

## Non-enumeration contract

Unknown email, unprovisioned, soft-deleted, and a genuine `null` all render identically. Only a transport/server failure surfaces a distinct, retryable state, and that state does not depend on whether the email maps to an account. The tests lock this so a later change can't quietly reintroduce an enumeration oracle.

## Deploy note

Opened as a draft on purpose. `orchestration-dev.yml` deploys to dev on a non-draft PR, and we don't want a UI change landing on dev while the backend Entra 401 verification is still in flight — a half-verified fix could mask that signal. Mark this ready for review once the backend verification is complete, at which point the dev deploy runs.

**Rebase onto `main` before marking ready / merging.** This branch was cut from `7b32b30` (#434), one commit before #438 (batch OpDiv grants) landed on main, so its tree still carries the pre-#438 `OpDivGrantModal`/`userOpdivs`/`UserTable`. Without the rebase, marking ready would deploy a tree missing #438 to dev (and the eventual merge would ship it stale). The changed files are disjoint — #438 touches `userOpdivs`/`OpDivGrantModal`/`UserTable`, this PR touches `axiosConfig`/`authLookup`/`LoginPage` — so the rebase is conflict-free.

## Follow-up

Client-side outage telemetry — a fire-and-forget beacon on the `unavailable` branch plus a backend sink and alarm — is tracked in CMS-Enterprise/ztmf#378 and intentionally left out of this PR so the UX fix is not blocked on the backend piece. Refs CMS-Enterprise/ztmf#378.

## Test plan

- [x] Rebase onto `main` to pick up #438 (batch OpDiv grants) before marking ready / merging — branch predates #438; disjoint files, so conflict-free
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:ci` — `authLookup` and `LoginPage` suites green, existing suites unaffected
- [ ] Manual: a healthy lookup still redirects to `/login` or `/login/entra`; a forced failure shows the "temporarily unavailable" message; an unknown email still shows the generic message

<details>
<summary>Background: dev Entra login RCA (excerpt)</summary>

Entra login on dev broke in two distinct ways, both obscured by a logging blind spot. The first was an Entra-side block — the test user was not assigned to the Entra enterprise application, so Microsoft stopped the sign-in at its own page and never redirected back; removing the assignment requirement cleared that block. The second is a backend 401: after the ALB completes the OIDC handshake and forwards the request, the backend rejects the Entra token. Infrastructure, the ALB↔IdP handshake, and the UI all checked out healthy.

What was ruled out on the frontend: the live lookup returned the correct shape; the deployed UI had the Entra path enabled (`VITE_IDP_ENABLED=true`); the redirect was a correct full-page navigation. Okta login succeeded end-to-end, proving the ALB OIDC → backend session-mint → session path works. In other words, the UI was not the cause — which is why the changes in this PR are hardening, not a fix for the outage.

Leading backend hypothesis (handled separately in CMS-Enterprise/ztmf): the Entra branch pins the `tid` claim, which the ALB-forwarded userinfo-derived token does not carry, so the tenant check rejects it. That work is staged in the backend repo and awaiting a real Entra login to confirm.

This PR is the frontend follow-up: it does not depend on the backend cause, and it makes a lookup outage legible to the user instead of silently collapsing into "no IdP".

</details>

