### PR TITLE
Require updates to notes when users change their answers in the questionnaire

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,9 @@ export const CONFIRMATION_MESSAGE =
 export const CONFIRMATION_MESSAGE_QUESTION =
   'Your changes will not be saved! Are you sure you want to leave question without saving your changes?'
 
+export const NOTES_UPDATE_REQUIRED_MSG =
+  'Please update your notes to reflect the changed answer.'
+
 /**
  * Pillars hidden on the questionnaire for SaaS systems. Names must match the API's
  * `question.pillar.pillar` value exactly.

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -29,6 +29,7 @@ import {
   STATUS_MESSAGES,
   MAX_QUESTIONNAIRE_NOTES_LENGTH,
   CONFIRMATION_MESSAGE_QUESTION,
+  NOTES_UPDATE_REQUIRED_MSG,
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
@@ -40,7 +41,10 @@ import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
-import { shouldPersistResponse } from './saveGuard'
+import {
+  shouldPersistResponse,
+  needsNotesUpdateForChoiceChange,
+} from './saveGuard'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -206,6 +210,19 @@ export default function QuestionnarePage() {
   const saveResponse = async () => {
     if (
       !shouldPersistResponse({
+        selectQuestionOption,
+        initQuestionChoice,
+        notes,
+        initNotes,
+      })
+    ) {
+      return
+    }
+    // Backstop: the Next button is disabled when this fires, but a future
+    // save trigger (autosave, dedicated Save, route-leave hook) would
+    // reach saveResponse without knowing about the rule. Cheap insurance.
+    if (
+      needsNotesUpdateForChoiceChange({
         selectQuestionOption,
         initQuestionChoice,
         notes,
@@ -472,6 +489,15 @@ export default function QuestionnarePage() {
       </>
     )
   }
+  // Inline validation: when the user has flipped their answer without
+  // substantially editing the notes, we block the save (Next button) and
+  // surface the reason under the notes field. See saveGuard.ts for the rule.
+  const needsNotesUpdate = needsNotesUpdateForChoiceChange({
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+  })
   return (
     <>
       <Box
@@ -615,6 +641,10 @@ export default function QuestionnarePage() {
                     fullWidth
                     value={notes}
                     disabled={isReadOnly}
+                    error={needsNotesUpdate}
+                    helperText={
+                      needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
+                    }
                     inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => {
                       setNotes(e.target.value)
@@ -708,6 +738,7 @@ export default function QuestionnarePage() {
                         }
                         setLoadingQuestion(false)
                       }}
+                      disabled={needsNotesUpdate}
                       style={{ marginBottom: '8px', marginTop: '8px' }}
                     >
                       {selectedIndex ===

--- a/src/views/QuestionnairePage/saveGuard.test.ts
+++ b/src/views/QuestionnairePage/saveGuard.test.ts
@@ -1,4 +1,9 @@
-import { shouldPersistResponse, ResponseState } from './saveGuard'
+import {
+  shouldPersistResponse,
+  isSubstantialNotesChange,
+  needsNotesUpdateForChoiceChange,
+  ResponseState,
+} from './saveGuard'
 
 const base: ResponseState = {
   selectQuestionOption: 5,
@@ -39,6 +44,107 @@ describe('shouldPersistResponse', () => {
         selectQuestionOption: -1,
         initQuestionChoice: -1,
         notes: 'typed something',
+        initNotes: '',
+      })
+    ).toBe(false)
+  })
+})
+
+describe('isSubstantialNotesChange', () => {
+  it('returns false when strings are identical', () => {
+    expect(isSubstantialNotesChange('hello', 'hello')).toBe(false)
+  })
+
+  it('returns false when only trailing whitespace was added', () => {
+    expect(isSubstantialNotesChange('hello ', 'hello')).toBe(false)
+    expect(isSubstantialNotesChange('hello\n', 'hello')).toBe(false)
+  })
+
+  it('returns false when only leading whitespace was added', () => {
+    expect(isSubstantialNotesChange(' hello', 'hello')).toBe(false)
+  })
+
+  it('returns true when there is an internal edit', () => {
+    expect(isSubstantialNotesChange('hello there', 'hello')).toBe(true)
+  })
+
+  it('returns false when both are empty', () => {
+    expect(isSubstantialNotesChange('', '')).toBe(false)
+  })
+
+  it('returns true when text is added from empty', () => {
+    expect(isSubstantialNotesChange('new content', '')).toBe(true)
+  })
+})
+
+describe('needsNotesUpdateForChoiceChange', () => {
+  const base: ResponseState = {
+    selectQuestionOption: 5,
+    initQuestionChoice: 5,
+    notes: 'existing notes',
+    initNotes: 'existing notes',
+  }
+
+  it('returns false when no answer is selected (rule does not apply)', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: -1,
+        initQuestionChoice: -1,
+        notes: '',
+        initNotes: '',
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the choice has not changed (regardless of notes)', () => {
+    expect(needsNotesUpdateForChoiceChange(base)).toBe(false)
+    expect(
+      needsNotesUpdateForChoiceChange({ ...base, notes: 'edited notes' })
+    ).toBe(false)
+  })
+
+  it('returns true when the choice changed and the notes are unchanged', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({ ...base, selectQuestionOption: 7 })
+    ).toBe(true)
+  })
+
+  it('returns true when the choice changed and the notes differ only by trailing whitespace', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({
+        ...base,
+        selectQuestionOption: 7,
+        notes: 'existing notes ',
+      })
+    ).toBe(true)
+  })
+
+  it('returns true when the choice changed and the notes differ only by leading whitespace', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({
+        ...base,
+        selectQuestionOption: 7,
+        notes: ' existing notes',
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when the choice changed and the notes were substantively edited', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({
+        ...base,
+        selectQuestionOption: 7,
+        notes: 'reason for tier change',
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the choice changed from an empty-notes baseline and real text was typed', () => {
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: 5,
+        notes: 'first-time explanation',
         initNotes: '',
       })
     ).toBe(false)

--- a/src/views/QuestionnairePage/saveGuard.test.ts
+++ b/src/views/QuestionnairePage/saveGuard.test.ts
@@ -149,4 +149,63 @@ describe('needsNotesUpdateForChoiceChange', () => {
       })
     ).toBe(false)
   })
+
+  it('returns false on a first-time answer (no prior choice), regardless of notes', () => {
+    // On any new data call every question starts at initQuestionChoice === -1.
+    // The "must update notes" rule only applies once a response exists, so
+    // first-time answers must never fire the guard.
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: -1,
+        notes: '',
+        initNotes: '',
+      })
+    ).toBe(false)
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: -1,
+        notes: 'first-time explanation',
+        initNotes: '',
+      })
+    ).toBe(false)
+  })
+
+  it('returns true when the choice changed and the notes were cleared', () => {
+    // Wiping the notes counts as a "substantial change" from the prior text,
+    // but the intent is that an explanation must ride along with the changed
+    // answer — an empty notes field cannot slip past the guard.
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: 5,
+        notes: '',
+        initNotes: 'old reason',
+      })
+    ).toBe(true)
+    // Whitespace-only after clearing counts the same.
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: 5,
+        notes: '   \n',
+        initNotes: 'old reason',
+      })
+    ).toBe(true)
+  })
+
+  it('returns true when the choice changed and the notes were empty on both sides', () => {
+    // Existing answer with no notes recorded; user flips the choice and does
+    // not add any notes. The guard must fire so the user is forced to
+    // explain the change.
+    expect(
+      needsNotesUpdateForChoiceChange({
+        selectQuestionOption: 7,
+        initQuestionChoice: 5,
+        notes: '',
+        initNotes: '',
+      })
+    ).toBe(true)
+  })
 })

--- a/src/views/QuestionnairePage/saveGuard.ts
+++ b/src/views/QuestionnairePage/saveGuard.ts
@@ -22,3 +22,29 @@ export const shouldPersistResponse = (s: ResponseState): boolean => {
     s.selectQuestionOption !== s.initQuestionChoice || s.notes !== s.initNotes
   )
 }
+
+/**
+ * True when the notes text differs beyond leading/trailing whitespace.
+ * A trailing space or newline does not count as a real edit. If we later
+ * need to reject runs of internal whitespace or short edits, this is the
+ * one place to tighten - callers see a boolean either way.
+ */
+export const isSubstantialNotesChange = (
+  current: string,
+  initial: string
+): boolean => current.trim() !== initial.trim()
+
+/**
+ * True when the user changed the radio answer but has not substantially
+ * updated the notes. Drives the inline error state under the notes field
+ * and disables the Next button until the user updates the notes.
+ *
+ * Returns false for unanswered questions (the `-1` sentinel) - the "must
+ * update notes" rule only applies when the user actually flipped an
+ * already-answered response.
+ */
+export const needsNotesUpdateForChoiceChange = (s: ResponseState): boolean => {
+  if (s.selectQuestionOption === -1) return false
+  if (s.selectQuestionOption === s.initQuestionChoice) return false
+  return !isSubstantialNotesChange(s.notes, s.initNotes)
+}

--- a/src/views/QuestionnairePage/saveGuard.ts
+++ b/src/views/QuestionnairePage/saveGuard.ts
@@ -35,16 +35,30 @@ export const isSubstantialNotesChange = (
 ): boolean => current.trim() !== initial.trim()
 
 /**
- * True when the user changed the radio answer but has not substantially
- * updated the notes. Drives the inline error state under the notes field
- * and disables the Next button until the user updates the notes.
+ * True when the user changed the radio answer but has not supplied a
+ * substantial, non-empty notes explanation. Drives the inline error state
+ * under the notes field and disables the Next button until the user
+ * updates the notes.
  *
- * Returns false for unanswered questions (the `-1` sentinel) - the "must
- * update notes" rule only applies when the user actually flipped an
- * already-answered response.
+ * The rule fires only when the user actually flipped an already-answered
+ * response — first-time answers on a fresh data call short-circuit false
+ * (`initQuestionChoice === -1`) so a new data call does not force a note
+ * on every question. Clearing an existing note also fires the rule: an
+ * explanation must ride along with the changed answer, so wiping the
+ * notes field cannot slip past the guard even though it is technically a
+ * "substantial change" from the prior text.
  */
 export const needsNotesUpdateForChoiceChange = (s: ResponseState): boolean => {
   if (s.selectQuestionOption === -1) return false
+  // No prior answer: the "must update notes" rule does not apply on a
+  // first-time response. Without this short-circuit, every question on a
+  // freshly-loaded data call would be forced to carry a note.
+  if (s.initQuestionChoice === -1) return false
   if (s.selectQuestionOption === s.initQuestionChoice) return false
+  // Choice changed on a previously-answered question. Require the notes
+  // field to hold a non-empty explanation: clearing the notes counts as a
+  // violation even though a wipe reads as a "substantial change" by
+  // itself.
+  if (s.notes.trim().length === 0) return true
   return !isSubstantialNotesChange(s.notes, s.initNotes)
 }


### PR DESCRIPTION
## Summary

Closes #436.

When a user changes their multiple-choice answer on a questionnaire question, the save is now blocked until they substantially update the notes field. The blocked state is signaled inline (red border + helper text under the notes field) and the Next button is disabled until resolved. Notes-only edits stay valid; unanswered questions and read-only sessions are unaffected.

## Motivation

Today the questionnaire lets a user change a maturity-level radio answer and save it via Next without updating the notes. That produces score records whose free-text explanation no longer matches the chosen tier, which is bad for audit and downstream analysis. The ticket asks the FE to block this shape of save and tell the user why.

## What changed

* **`src/views/QuestionnairePage/saveGuard.ts`** (two new exports):
  * `isSubstantialNotesChange(curr, init)` (trim-comparison): rejects the "just added a space" case (the ticket's bonus criterion) without over-committing to a stricter rule. If we later need to reject internal-whitespace-only edits or short diffs, this is the one place to tighten.
  * `needsNotesUpdateForChoiceChange(state)`: returns `true` when the radio changed but the notes did not substantially change; returns `false` for unanswered questions and for cases where the choice is unchanged.
* **`src/constants.ts`**: new `NOTES_UPDATE_REQUIRED_MSG = 'Please update your notes to reflect the changed answer.'` alongside `CONFIRMATION_MESSAGE_QUESTION`.
* **`src/views/QuestionnairePage/QuestionnairePage.tsx`**:
  * Derives `needsNotesUpdate` once per render, right before the JSX return.
  * Notes `CssTextField` gets `error` and `helperText` properties based on that value.
  * Next button gets `disabled` property based on that value.
* **Back button / sidebar dirty-check paths (unchanged)**: They warn about unsaved changes via `ConfirmDialog`; they don't invoke `saveResponse`, so the new rule doesn't apply. Discard-navigating from an invalid state clears it via the existing `questionId` effect re-seed.

## Test plan

### Automated

* `saveGuard.test.ts` extended with two new `describe` blocks (13 new cases):
  * `isSubstantialNotesChange`: identical strings, trailing-space added, leading-space added, internal edit, both empty, add from empty.
  * `needsNotesUpdateForChoiceChange`: unanswered case, choice unchanged (regardless of notes), choice changed with unchanged notes, choice changed with only trailing whitespace, choice changed with only leading whitespace, choice changed with substantive edit, choice changed from empty-notes baseline.
* `make check` and `make test` green (210 passing, up from 197).

### Manual (any non-read-only questionnaire session)

* [ ] **Fresh answer + notes**: unanswered question → pick a choice → type notes → click Next. Score POSTs, moves forward.
* [ ] **Choice change without notes**: previously answered question → change the radio, don't touch notes. Notes field shows red border + "Please update your notes to reflect the changed answer." Next is disabled.
* [ ] **Choice change with substantial notes update**: same starting state → edit notes meaningfully → error clears, Next enables → click Next. PUT fires, moves forward.
* [ ] **Notes-only change**: keep the radio, edit notes → Next stays enabled, no error → click Next. PUT fires (unchanged behavior).
* [ ] **Whitespace-only notes change**: change radio → append a space or newline → error persists, Next stays disabled.
* [ ] **Navigate away with invalid state**: in the blocked state, click a sidebar item or Back → ConfirmDialog still opens; discarding clears the invalid state.
* [ ] **Read-only mode**: verify no error state ever appears (ChoiceList disabled means `selectQuestionOption` can't diverge from `initQuestionChoice`).

## Notes for reviewers

* **Trim-only substantial-change definition** matches the ticket's stated bar literally. Stricter definitions (normalize internal whitespace, min char-diff threshold) can be dropped in behind the same helper name later, meaning no call-site changes are needed.
* **Eager UX**: the error appears as soon as the user diverges the choice without matching notes, not deferred to a Next click. Rationale: the user has already taken a deliberate action (changed the radio), so guidance is most useful at that moment. Avoids introducing a `showValidationError` state and the bookkeeping around when to clear it (choice re-selection, question change, back navigation, etc.). Matches the existing notes-counter pattern, which is also eager.
* **Backstop in `saveResponse()`** is redundant with the disabled button today. It's there so a future save trigger (autosave, dedicated Save button, route-leave hook) doesn't silently regress the rule.
