### PR TITLE
feat(datacall): sort by deadline; deadline-driven Current/Latest chip (#393)

### DIFF
--- a/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.test.tsx
@@ -183,6 +183,48 @@ describe('ScoreDiffModal', () => {
     expect(screen.getByLabelText('From datacall')).toHaveValue('FY2024')
   })
 
+  // #393 regression: a re-imported historical call can carry a higher
+  // datacallid than the real current call, so "latest" must follow the
+  // furthest-out deadline, not the id.
+  it('treats the furthest-out deadline as latest even when another call has a higher datacallid', async () => {
+    const OUT_OF_ORDER: datacall[] = [
+      // highest id but an already-passed deadline (the historical hijacker)
+      {
+        datacallid: 7,
+        datacall: 'FY23 ZTM',
+        datecreated: '2026-01-01T00:00:00Z',
+        deadline: '2023-06-30T00:00:00Z',
+      },
+      // lower id but the furthest-out deadline (the real current call)
+      {
+        datacallid: 6,
+        datacall: 'FY2025 Q3',
+        datecreated: '2025-01-01T00:00:00Z',
+        deadline: '2099-09-30T00:00:00Z',
+      },
+      {
+        datacallid: 2,
+        datacall: 'FY2022',
+        datecreated: '2022-01-01T00:00:00Z',
+        deadline: '2022-12-31T00:00:00Z',
+      },
+    ]
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/datacalls')
+        return Promise.resolve({ data: { data: OUT_OF_ORDER } })
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: QUESTIONS } })
+      if (url.includes('/scores/diff'))
+        return Promise.resolve({ data: { data: [] } })
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+    render(<ScoreDiffModal {...DEFAULT_PROPS} selectedDataCallId={undefined} />)
+    // To defaults to the max-deadline call (FY2025 Q3), not the higher-id FY23 ZTM.
+    expect(await screen.findByLabelText('To datacall')).toHaveValue('FY2025 Q3')
+    // From is the next-older call by deadline (FY23 ZTM), not by id.
+    expect(screen.getByLabelText('From datacall')).toHaveValue('FY23 ZTM')
+  })
+
   it('fetches the diff with the correct query params', async () => {
     setupMocks()
     render(<ScoreDiffModal {...DEFAULT_PROPS} />)

--- a/src/components/ScoreDiffModal/ScoreDiffModal.tsx
+++ b/src/components/ScoreDiffModal/ScoreDiffModal.tsx
@@ -111,8 +111,12 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
           sorted = datacallsCache.data
         } else {
           const res = await axiosInstance.get('/datacalls')
+          // Order by deadline (furthest-out first), datacallid only as a
+          // tiebreak: historical loads can out-id the real current call (#393).
           sorted = [...res.data.data].sort(
-            (a: datacall, b: datacall) => b.datacallid - a.datacallid
+            (a: datacall, b: datacall) =>
+              new Date(b.deadline).getTime() - new Date(a.deadline).getTime() ||
+              b.datacallid - a.datacallid
           )
           datacallsCache.data = sorted
           datacallsCache.timestamp = now
@@ -121,9 +125,12 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
         const toId = selectedDataCallId
         const toDefault =
           sorted.find((dc) => dc.datacallid === toId) ?? sorted[0] ?? null
-        const fromDefault =
-          sorted.find((dc) => dc.datacallid < (toDefault?.datacallid ?? 0)) ??
-          null
+        // The default "from" is the call immediately older than "to" - i.e. the
+        // next entry in the deadline-sorted list, not the next-lower datacallid.
+        const toIndex = sorted.findIndex(
+          (dc) => dc.datacallid === toDefault?.datacallid
+        )
+        const fromDefault = toIndex >= 0 ? sorted[toIndex + 1] ?? null : null
         setToDatacall(toDefault)
         setFromDatacall(fromDefault)
       } catch (err) {
@@ -253,7 +260,7 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
     option: datacall,
     latestId: number
   ) => {
-    const isCurrent = option.datacallid === latestId
+    const isLatest = option.datacallid === latestId
     const isClosed = new Date() > new Date(option.deadline)
     const { key, ...rest } = props
     const deadlineLabel = new Date(option.deadline).toLocaleDateString(
@@ -273,12 +280,14 @@ const ScoreDiffModal: React.FC<ScoreDiffModalProps> = ({
             }}
           >
             <Typography variant="body2">{option.datacall}</Typography>
-            {isCurrent && (
+            {/* Latest-by-deadline call: "Current" while open, "Latest" once
+                its deadline has passed (#393). */}
+            {isLatest && (
               <Chip
-                label="Current"
+                label={isClosed ? 'Latest' : 'Current'}
                 size="small"
                 variant="outlined"
-                color="primary"
+                color={isClosed ? 'default' : 'primary'}
                 sx={{ height: 18, fontSize: '0.65rem' }}
               />
             )}

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -110,8 +110,13 @@ export default function Title() {
         const res = await axiosInstance.get('/datacalls', {
           signal: controller.signal,
         })
+        // "Latest"/"current" is the call with the furthest-out deadline, not
+        // the highest datacallid: historical loads can carry a higher id than
+        // the real current call (#393). datacallid is only a tiebreak.
         const sorted: datacall[] = [...res.data.data].sort(
-          (a: datacall, b: datacall) => b.datacallid - a.datacallid
+          (a: datacall, b: datacall) =>
+            new Date(b.deadline).getTime() - new Date(a.deadline).getTime() ||
+            b.datacallid - a.datacallid
         )
         setDatacalls(sorted)
         if (sorted.length > 0) {
@@ -390,7 +395,7 @@ export default function Title() {
                     if (dc) setSelectedDatacall(dc)
                   }}
                   renderOption={(props, option) => {
-                    const isCurrent = option.datacallid === latestDataCallId
+                    const isLatest = option.datacallid === latestDataCallId
                     const isClosed = new Date() > new Date(option.deadline)
                     const { key, ...rest } = props
                     const deadlineLabel = new Date(
@@ -415,12 +420,15 @@ export default function Title() {
                             <Typography variant="body2">
                               {option.datacall}
                             </Typography>
-                            {isCurrent && (
+                            {/* Only the latest-by-deadline call is badged:
+                                "Current" while still open, "Latest" once its
+                                deadline has passed (#393). */}
+                            {isLatest && (
                               <Chip
-                                label="Current"
+                                label={isClosed ? 'Latest' : 'Current'}
                                 size="small"
                                 variant="outlined"
-                                color="primary"
+                                color={isClosed ? 'default' : 'primary'}
                                 sx={{ height: 18, fontSize: '0.65rem' }}
                               />
                             )}


### PR DESCRIPTION
Part of CMS-Enterprise/ztmf#393 (the frontend half; paired with the backend PR CMS-Enterprise/ztmf#396).

## Problem
The datacall picker sorted by `datacallid` descending, so a re-imported historical call (higher serial id, older deadline) would out-sort the real current call and become the default selection once the HHS historical load lands.

## Changes
- `Title.tsx`: sort datacalls by `deadline` descending (`datacallid` only as a tiebreak); `sorted[0]` — the default selection and the badged call — is now the furthest-out deadline. All downstream consumers read this via Outlet context, so they inherit the fix.
- `ScoreDiffModal.tsx`: same deadline sort; the default "from" is now the next-older call by list order rather than by next-lower `datacallid`.
- Chip on the latest call now reads **"Current"** only while it is open and **"Latest"** once its deadline has passed (was always "Current").
- Added a `ScoreDiffModal` test asserting the furthest-out deadline is treated as latest even when another call has a higher `datacallid`.

## Testing
- `tsc --noEmit` and `eslint` clean; full changed-file jest suite green (incl. the new regression test).
- Verified end-to-end in the running local stack (vite dev server + dev API rebuilt from the backend branch, driven with Playwright): with a high-`datacallid`/past-deadline call injected, the picker defaults to the open furthest-out call badged "Current" and sorts the historical call into its deadline position; when the furthest-out call's deadline is in the past, its badge reads "Latest".

Refs CMS-Enterprise/ztmf#393
