### PR TITLE
add drafts for questionnaire

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -508,19 +508,28 @@ export default function QuestionnarePage() {
             !isReadOnly && sys && questionId && datacallID > 0
               ? loadDraft(sys, questionId, datacallID)
               : null
-          if (
-            draft &&
-            choices.some((c) => c.value === draft.selectQuestionOption)
-          ) {
-            choices.forEach(
-              (c) => (c.defaultChecked = c.value === draft.selectQuestionOption)
-            )
-            setSelectQuestionOption(draft.selectQuestionOption)
-            setNotes(draft.notes)
-            setDraftStatus('restored')
+          if (draft) {
+            if (draft.selectQuestionOption === -1) {
+              // Notes-only draft — restore notes without pre-selecting an answer.
+              setNotes(draft.notes)
+              setDraftStatus('restored')
+            } else if (
+              choices.some((c) => c.value === draft.selectQuestionOption)
+            ) {
+              choices.forEach(
+                (c) =>
+                  (c.defaultChecked = c.value === draft.selectQuestionOption)
+              )
+              setSelectQuestionOption(draft.selectQuestionOption)
+              setNotes(draft.notes)
+              setDraftStatus('restored')
+            } else {
+              // Draft references an option that no longer exists — evict it.
+              if (sys && questionId && datacallID > 0)
+                clearDraft(sys, questionId, datacallID)
+              setDraftStatus('idle')
+            }
           } else {
-            if (draft && sys && questionId && datacallID > 0)
-              clearDraft(sys, questionId, datacallID)
             setDraftStatus('idle')
           }
           setOptions(choices)
@@ -553,10 +562,6 @@ export default function QuestionnarePage() {
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
-    // Never draft-save when no answer is selected: -1 is the "no answer"
-    // sentinel that shouldPersistResponse rejects, so a draft with -1 could
-    // never be promoted to a real save, leaving a permanent orphan in storage.
-    if (selectQuestionOption === -1) return
     if (selectQuestionOption === initQuestionChoice && notes === initNotes)
       return
     const timer = setTimeout(() => {
@@ -581,7 +586,14 @@ export default function QuestionnarePage() {
   React.useEffect(() => {
     if (isReadOnly) return
     const handle = (e: BeforeUnloadEvent) => {
-      if (shouldPersistResponse(unsavedRef.current)) e.preventDefault()
+      const s = unsavedRef.current
+      const hasPendingEdits =
+        shouldPersistResponse(s) ||
+        (s.selectQuestionOption === -1 && s.notes !== s.initNotes)
+      if (hasPendingEdits) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
     }
     window.addEventListener('beforeunload', handle)
     return () => window.removeEventListener('beforeunload', handle)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -47,6 +47,7 @@ import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
+import { saveDraft, loadDraft, clearDraft } from './draftStore'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -140,6 +141,25 @@ export default function QuestionnarePage() {
   const [stepId, setStepId] = React.useState<number>(0)
   const [selectQuestionOption, setSelectQuestionOption] =
     React.useState<number>(-1)
+  const [draftStatus, setDraftStatus] = React.useState<
+    'idle' | 'restored' | 'saved'
+  >('idle')
+  // Refs read inside setTimeout/event callbacks to get the current value
+  // without enrolling the effects in those deps (prevents extra re-runs).
+  const draftStatusRef = React.useRef(draftStatus)
+  draftStatusRef.current = draftStatus
+  const unsavedRef = React.useRef({
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+  })
+  unsavedRef.current = {
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+  }
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
@@ -162,6 +182,7 @@ export default function QuestionnarePage() {
   }
   const handleChoiceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectQuestionOption(Number(event.target.value))
+    if (draftStatus === 'restored') setDraftStatus('idle')
   }
   const renderRadioGroup = (options: QuestionChoice[]) => {
     return (
@@ -194,6 +215,8 @@ export default function QuestionnarePage() {
   // location.state. Optional-chain instead of crashing on first render; the
   // missing-system path is handled by an early render guard below.
   const system = location.state?.fismasystemid as number | undefined
+  const systemRef = React.useRef(system)
+  systemRef.current = system
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
   // Resolve the system's raw datacenter environment to its scoring category
@@ -206,6 +229,9 @@ export default function QuestionnarePage() {
   const [selectedIndex, setSelectedIndex] = React.useState(1)
   const handleConfirmReturn = (confirm: boolean) => {
     if (confirm) {
+      // User explicitly chose to abandon unsaved edits — clear the draft so it
+      // doesn't reappear if they navigate back to this question.
+      clearCurrentDraft()
       setLoadingQuestion(true)
       setSelectedIndex(stepId)
       setQuestionId(stepId)
@@ -217,6 +243,13 @@ export default function QuestionnarePage() {
     setQuestionId(index)
   }
 
+  const clearCurrentDraft = () => {
+    if (system && questionId && datacallID > 0) {
+      clearDraft(system, questionId, datacallID)
+    }
+    setDraftStatus('idle')
+  }
+
   const saveResponse = async () => {
     if (
       !shouldPersistResponse({
@@ -226,6 +259,7 @@ export default function QuestionnarePage() {
         initNotes,
       })
     ) {
+      clearCurrentDraft()
       return
     }
     // Backstop: the Next button is disabled when this fires, but a future
@@ -262,6 +296,7 @@ export default function QuestionnarePage() {
         })
       }
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      clearCurrentDraft()
       fetchQuestionScores(system, setQuestionScores)
     } catch (error) {
       if (isAuthHandled(error)) return
@@ -426,8 +461,10 @@ export default function QuestionnarePage() {
       const controller = new AbortController()
       // Clear saved-state markers before async load so the last-edited
       // footer does not flash the previous question's editor during the
-      // refetch window.
+      // refetch window. Also resets draft indicators so stale status from
+      // a previous question or datacall doesn't bleed into the next render.
       setInitQuestionChoice(-1)
+      setDraftStatus('idle')
       const choices: QuestionChoice[] = []
       let funcOptId: number = 0
       async function fetchOptions() {
@@ -460,7 +497,33 @@ export default function QuestionnarePage() {
           setSelectQuestionOption(funcOptId ? funcOptId : -1)
           setInitQuestionChoice(funcOptId ? funcOptId : -1)
           setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
-          setOptions(choices ? choices : [])
+
+          // Restore any in-progress draft from localStorage, overriding the
+          // server-side values set above. Skipped for read-only sessions.
+          const sys = systemRef.current
+          // Eagerly evict any stale draft when the session is now read-only.
+          if (isReadOnly && sys && questionId && datacallID > 0)
+            clearDraft(sys, questionId, datacallID)
+          const draft =
+            !isReadOnly && sys && questionId && datacallID > 0
+              ? loadDraft(sys, questionId, datacallID)
+              : null
+          if (
+            draft &&
+            choices.some((c) => c.value === draft.selectQuestionOption)
+          ) {
+            choices.forEach(
+              (c) => (c.defaultChecked = c.value === draft.selectQuestionOption)
+            )
+            setSelectQuestionOption(draft.selectQuestionOption)
+            setNotes(draft.notes)
+            setDraftStatus('restored')
+          } else {
+            if (draft && sys && questionId && datacallID > 0)
+              clearDraft(sys, questionId, datacallID)
+            setDraftStatus('idle')
+          }
+          setOptions(choices)
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
@@ -472,7 +535,64 @@ export default function QuestionnarePage() {
       fetchOptions()
       return () => controller.abort()
     }
-  }, [questionId, questionScores, questions])
+  }, [questionId, questionScores, questions, isReadOnly, datacallID])
+
+  // Debounced draft save: 1 second after the user pauses editing, persist
+  // the current answer and notes to localStorage so a reload can recover them.
+  // Only fires when the user has actually changed something from the server-side
+  // initial values — prevents question-load state transitions from being
+  // mistakenly recorded as drafts on questions the user never touched.
+  React.useEffect(() => {
+    if (
+      isReadOnly ||
+      !system ||
+      !questionId ||
+      datacallID <= 0 ||
+      loadingQuestion
+    ) {
+      if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
+      return
+    }
+    // Never draft-save when no answer is selected: -1 is the "no answer"
+    // sentinel that shouldPersistResponse rejects, so a draft with -1 could
+    // never be promoted to a real save, leaving a permanent orphan in storage.
+    if (selectQuestionOption === -1) return
+    if (selectQuestionOption === initQuestionChoice && notes === initNotes)
+      return
+    const timer = setTimeout(() => {
+      saveDraft(system, questionId, datacallID, { selectQuestionOption, notes })
+      if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+    }, 1000)
+    return () => clearTimeout(timer)
+  }, [
+    selectQuestionOption,
+    notes,
+    isReadOnly,
+    system,
+    questionId,
+    datacallID,
+    initQuestionChoice,
+    initNotes,
+    loadingQuestion,
+  ])
+
+  // Warn before tab close or hard refresh when the active question has edits
+  // that haven't been committed to the backend yet.
+  React.useEffect(() => {
+    if (isReadOnly) return
+    const handle = (e: BeforeUnloadEvent) => {
+      const s = unsavedRef.current
+      if (
+        s.selectQuestionOption !== s.initQuestionChoice ||
+        s.notes !== s.initNotes
+      ) {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('beforeunload', handle)
+    return () => window.removeEventListener('beforeunload', handle)
+  }, [isReadOnly])
+
   const breadcrumbSegmentLabels = fismaacronym
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
     : undefined
@@ -662,6 +782,7 @@ export default function QuestionnarePage() {
                     inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => {
                       setNotes(e.target.value)
+                      if (draftStatus === 'restored') setDraftStatus('idle')
                     }}
                   />
                   <Box
@@ -758,13 +879,12 @@ export default function QuestionnarePage() {
                             }
                           )
                         }
-                        setLoadingQuestion(true)
+                        if (id !== questionId) setLoadingQuestion(true)
                         setQuestionId(id)
                         setSelectedIndex(id)
                         if (!isReadOnly) {
                           saveResponse()
                         }
-                        setLoadingQuestion(false)
                       }}
                       disabled={needsNotesUpdate}
                       style={{ marginBottom: '8px', marginTop: '8px' }}
@@ -780,6 +900,17 @@ export default function QuestionnarePage() {
                       {/* <NavigateNextIcon sx={{ pt: '2px' }} /> */}
                     </CmsButton>
                   </Box>
+                  {draftStatus !== 'idle' && !isReadOnly && (
+                    <Alert
+                      severity={draftStatus === 'saved' ? 'success' : 'warning'}
+                      icon={false}
+                      sx={{ mt: 1, py: 0.5 }}
+                    >
+                      {draftStatus === 'saved'
+                        ? 'Draft saved — click Next or Complete to save permanently.'
+                        : 'Draft restored — click Next or Complete to save permanently.'}
+                    </Alert>
+                  )}
                   <LastEditedFooter
                     lastEditedAt={
                       initQuestionChoice !== -1 &&

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -581,13 +581,7 @@ export default function QuestionnarePage() {
   React.useEffect(() => {
     if (isReadOnly) return
     const handle = (e: BeforeUnloadEvent) => {
-      const s = unsavedRef.current
-      if (
-        s.selectQuestionOption !== s.initQuestionChoice ||
-        s.notes !== s.initNotes
-      ) {
-        e.preventDefault()
-      }
+      if (shouldPersistResponse(unsavedRef.current)) e.preventDefault()
     }
     window.addEventListener('beforeunload', handle)
     return () => window.removeEventListener('beforeunload', handle)

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -1,0 +1,166 @@
+import { saveDraft, loadDraft, clearDraft, QuestionDraft } from './draftStore'
+
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
+
+const IDS = { fismasystemid: 1, functionid: 2, datacallid: 3 } as const
+const EXPECTED_KEY = 'ztmf_draft_1_2_3'
+const DRAFT: QuestionDraft = { selectQuestionOption: 5, notes: 'test notes' }
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('key format', () => {
+  it('generates ztmf_draft_{system}_{function}_{datacall}', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    expect(localStorage.getItem(EXPECTED_KEY)).not.toBeNull()
+  })
+
+  it('different IDs produce different keys', () => {
+    saveDraft(1, 2, 3, DRAFT)
+    saveDraft(1, 2, 4, DRAFT)
+    expect(Object.keys(localStorage)).toHaveLength(2)
+  })
+})
+
+describe('saveDraft', () => {
+  it('writes JSON to the correct key', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const raw = localStorage.getItem(EXPECTED_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.selectQuestionOption).toBe(5)
+    expect(parsed.notes).toBe('test notes')
+  })
+
+  it('includes a numeric savedAt timestamp', () => {
+    const before = Date.now()
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const after = Date.now()
+    const { savedAt } = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
+    expect(typeof savedAt).toBe('number')
+    expect(savedAt).toBeGreaterThanOrEqual(before)
+    expect(savedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('does not expose savedAt to the QuestionDraft type (internal only)', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    // loadDraft strips savedAt before returning
+    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(result).not.toHaveProperty('savedAt')
+  })
+
+  it('does not throw when localStorage is unavailable', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError')
+    })
+    expect(() =>
+      saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    ).not.toThrow()
+  })
+})
+
+describe('loadDraft', () => {
+  it('returns null for a missing key', () => {
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+
+  it('returns the draft fields (without savedAt) for a valid fresh entry', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(result).toEqual(DRAFT)
+  })
+
+  it('returns null and removes the key when the entry is older than 14 days', () => {
+    const savedAt = 1000
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS + 1)
+
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns a valid draft exactly at the TTL boundary (not yet expired)', () => {
+    const savedAt = 1000
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS)
+
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toEqual(DRAFT)
+  })
+
+  it('returns null and removes the key when savedAt is missing (pre-TTL entry)', () => {
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify(DRAFT))
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null and removes the key when savedAt is 0', () => {
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt: 0 }))
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null when the stored value is malformed JSON', () => {
+    localStorage.setItem(EXPECTED_KEY, 'not-json{{{')
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+
+  it('does not throw when localStorage.getItem throws', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('SecurityError')
+    })
+    expect(() =>
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+})
+
+describe('clearDraft', () => {
+  it('removes the entry at the correct key', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('does not throw when the key does not exist', () => {
+    expect(() =>
+      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+  })
+
+  it('does not throw when localStorage.removeItem throws', () => {
+    jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('SecurityError')
+    })
+    expect(() =>
+      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+  })
+
+  it('only removes the targeted key, leaving others intact', () => {
+    saveDraft(1, 2, 3, DRAFT)
+    saveDraft(1, 2, 4, DRAFT)
+    clearDraft(1, 2, 3)
+    expect(localStorage.getItem('ztmf_draft_1_2_3')).toBeNull()
+    expect(localStorage.getItem('ztmf_draft_1_2_4')).not.toBeNull()
+  })
+})

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -1,0 +1,66 @@
+export type QuestionDraft = {
+  selectQuestionOption: number
+  notes: string
+}
+
+// Internal shape written to localStorage — callers only see QuestionDraft.
+type StoredDraft = QuestionDraft & { savedAt: number }
+
+const DRAFT_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+
+const draftKey = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+) => `ztmf_draft_${fismasystemid}_${functionid}_${datacallid}`
+
+export const saveDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number,
+  draft: QuestionDraft
+): void => {
+  try {
+    const stored: StoredDraft = { ...draft, savedAt: Date.now() }
+    localStorage.setItem(
+      draftKey(fismasystemid, functionid, datacallid),
+      JSON.stringify(stored)
+    )
+  } catch {
+    // localStorage unavailable (private browsing, quota exceeded) — degrade silently
+  }
+}
+
+export const loadDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+): QuestionDraft | null => {
+  try {
+    const raw = localStorage.getItem(
+      draftKey(fismasystemid, functionid, datacallid)
+    )
+    if (!raw) return null
+    const stored = JSON.parse(raw) as StoredDraft
+    if (!stored.savedAt || Date.now() - stored.savedAt > DRAFT_TTL_MS) {
+      clearDraft(fismasystemid, functionid, datacallid)
+      return null
+    }
+    const { savedAt: _, ...draft } = stored
+    return draft
+  } catch {
+    return null
+  }
+}
+
+export const clearDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+): void => {
+  try {
+    localStorage.removeItem(draftKey(fismasystemid, functionid, datacallid))
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
> **Note:** In-repo copy of #464 by @costacalvin. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #464

---

## Summary
Closes #457 
Implements localStorage-based draft persistence for questionnaire responses. Answers and notes are autosaved locally so a hard reload, crash, or accidental navigation no longer loses in-progress work.

- **Debounced autosave** — 1 second after the user pauses editing, the current answer and notes are written to `localStorage` keyed by `ztmf_draft_{fismasystemid}_{functionid}_{datacallid}`
- **14-day TTL** — stale drafts are evicted automatically on load
- **Draft restoration** — on return to a question, any saved draft is reapplied and a banner prompts the user to save permanently via Next/Complete
- **Auto-clear on save** — draft is removed from `localStorage` after a successful backend save, or when the user clicks Next/Complete with no changes
- **`beforeunload` guard** — browser warns before tab close or hard refresh when there are unsaved edits
- **Read-only sessions excluded** — no drafts are saved, restored, or shown when `isReadOnly` is true; existing stale drafts are eagerly evicted on read-only load
- **Option validation** — a restored draft referencing a `functionoptionid` that no longer exists is silently evicted rather than applied, preventing a stale value from reaching the backend

## Files Changed

- `src/views/QuestionnairePage/draftStore.ts` *(new)* — thin `localStorage` wrapper (`saveDraft`, `loadDraft`, `clearDraft`) with TTL handling; all operations are try/catch-wrapped for private-browsing/quota resilience
- `src/views/QuestionnairePage/draftStore.test.ts` *(new)* — 18 unit tests covering key format, TTL boundary, expiry eviction, malformed JSON, and `localStorage` unavailability
- `src/views/QuestionnairePage/QuestionnairePage.tsx` — debounce effect, restoration logic in `fetchOptions`, draft banner, `beforeunload` effect, and draft eviction on save/navigation

## UI
Original
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/91c1cf30-1d96-4415-b101-7b849ac63f41" />

Draft saved after edits
<img width="1727" height="958" alt="image" src="https://github.com/user-attachments/assets/3afb8879-1ed5-4790-a03a-65640aebc3f5" />

Refresh triggers popup
<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/c3696a4a-8061-451e-b03f-c832c3ad0041" />

Draft restored on reload
<img width="1728" height="956" alt="image" src="https://github.com/user-attachments/assets/cb0c1f4f-4298-4eb8-b2b4-4a3ca8a98bad" />

Changing questions through sidebar brings up confirm modal
<img width="1727" height="959" alt="image" src="https://github.com/user-attachments/assets/b54f1844-a24e-4895-bfb5-047c2a3e0e95" />

If confirmed the draft is cleared, and reverted to original state.
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/91c1cf30-1d96-4415-b101-7b849ac63f41" />

## Test Plan

- [ ] Open a question, select an answer, type notes — wait 1 second then hard reload (`Cmd+Shift+R`). Banner should show "Draft restored" with fields pre-filled
- [ ] Click Next/Complete after restoring a draft — banner disappears and the response is saved to the server
- [ ] Click Next/Complete with no changes from the server state — draft is cleared, no banner on next visit
- [ ] Restore a draft and attempt to close the tab before clicking Next — browser should show the "Leave site?" dialog
- [ ] Open a question in a closed (read-only) datacall — no draft banner, no autosave, existing drafts for that question are evicted
- [ ] Run unit tests: `npx jest --testPathPattern="draftStore"`
