### PR TITLE
feat(system-detail): Target Maturity Level card (#398 MVP)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,10 @@ export type FismaSystemType = {
   system_owner?: string | null
   system_owner_email?: string | null
   legacy?: string | null
+  // Risk-based target maturity (ztmf#398). null = no target asserted yet;
+  // the UI presents the Advanced default.
+  target_maturity_tier?: string | null
+  target_maturity_justification?: string | null
 }
 export type FismaSystems = {
   fismaSystems: FismaSystemType[]

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -86,6 +86,15 @@ export const hasAdminRead = (user: UserLike): boolean =>
 export const hasUnscopedRead = (user: UserLike): boolean =>
   !!user && UNSCOPED_READ_ROLES.has(user.role as UserRole)
 
+// System-scoped tiers (ISSO / ISSM) - the users whose write scope is their
+// per-system assignment rather than an OpDiv or admin tier. Like the other
+// gates here this is display-only: the backend narrows the fismaSystems list
+// to the user's assignments and re-checks IsAssignedFismaSystem on write, so
+// the frontend only needs the tier. Read-only admins are deliberately excluded
+// (they are neither admin-writers nor system-scoped).
+export const isSystemScoped = (user: UserLike): boolean =>
+  !!user && SYSTEM_SCOPED_ROLES.has(user.role as UserRole)
+
 // Row-level OpDiv scoping is server-enforced - the backend narrows the
 // fismaSystems list before it reaches the frontend, so this gate only needs
 // to decide whether the user belongs to a tier that gets system-detail UI at

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -63,6 +63,9 @@ interface SystemDetailEditViewProps {
   // Datacenter-environment vocabulary for the select field, passed down from
   // SystemDetailPage (which reads it from the outlet context).
   datacenterEnvironments: DataCenterEnvironment[]
+  // Rendered in the right column between Data Lake Export and Organization,
+  // matching the read view's placement (ztmf#398).
+  targetMaturitySlot?: React.ReactNode
 }
 
 function renderEditField(
@@ -284,6 +287,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
     onReactivateRequest,
     validateDecommissionDate,
     onSdlSyncToggle,
+    targetMaturitySlot,
   } = props
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
@@ -505,6 +509,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             />
           </CardContent>
         </Card>
+        {targetMaturitySlot}
         <Card variant="outlined" sx={{ flex: 1 }}>
           <CardHeader
             title="Organization"

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -5,7 +5,9 @@ import { useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
-  isAdmin: boolean
+  /** Admins edit the whole form; an assigned ISSO gets the same Edit button
+   * but only the target-maturity card unlocks for them (ztmf#398). */
+  canEdit: boolean
   isEditing: boolean
   isSaving: boolean
   isFormValid: boolean
@@ -16,7 +18,7 @@ interface SystemDetailHeaderProps {
 
 export default function SystemDetailHeader({
   systemName,
-  isAdmin,
+  canEdit,
   isEditing,
   isSaving,
   isFormValid,
@@ -59,7 +61,7 @@ export default function SystemDetailHeader({
             </CmsButton>
           </>
         ) : (
-          isAdmin && (
+          canEdit && (
             <CmsButton variation="solid" onClick={onEdit}>
               Edit
             </CmsButton>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -17,11 +17,16 @@ import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import { getTodayISO, truncateNotes } from '@/utils/decommission'
-import { isAdmin as checkIsAdmin } from '@/utils/userRoles'
+import { isAdmin as checkIsAdmin, isSystemScoped } from '@/utils/userRoles'
 
 import SystemDetailHeader from './SystemDetailHeader'
 import SystemDetailReadView from './SystemDetailReadView'
 import SystemDetailEditView from './SystemDetailEditView'
+import TargetMaturityCard from './TargetMaturityCard'
+import {
+  DEFAULT_TARGET_TIER,
+  TARGET_JUSTIFICATION_MAX,
+} from './targetMaturityConfig'
 import { EXTENDED_METADATA_KEYS } from './fieldConfig'
 import CfactsRecordCard from './CfactsRecordCard'
 
@@ -32,6 +37,14 @@ export default function SystemDetailPage() {
 
   const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
+  // Target maturity is the one field pair an assigned ISSO may write
+  // (ztmf#398); the backend enforces assignment/OpDiv scope - this only
+  // gates display. Gate by tier, matching the app convention (the backend
+  // scopes an ISSO's fismaSystems list to their assignments, so a
+  // system-scoped user on this page is by definition assigned; the endpoint
+  // re-checks on write). An ISSO gets the page Edit button, but only the
+  // target card unlocks for them; the system form stays admin-only.
+  const canEditTarget = isAdmin || isSystemScoped(userInfo)
 
   const system = useMemo(
     () => fismaSystems.find((s) => s.fismasystemid === systemId) ?? null,
@@ -73,6 +86,9 @@ export default function SystemDetailPage() {
 
   const [isEditing, setIsEditing] = useState(false)
   const [editedSystem, setEditedSystem] = useState<FismaSystemType | null>(null)
+  // Draft target maturity, edited via the shared page Edit/Save flow
+  const [editedTargetTier, setEditedTargetTier] = useState(DEFAULT_TARGET_TIER)
+  const [editedTargetJustification, setEditedTargetJustification] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
   const [openDecommissionDialog, setOpenDecommissionDialog] = useState(false)
@@ -133,6 +149,8 @@ export default function SystemDetailPage() {
       setShowDecommissionForm(false)
       setReactivationNotes('')
       setShowReactivateForm(false)
+      setEditedTargetTier(system.target_maturity_tier ?? DEFAULT_TARGET_TIER)
+      setEditedTargetJustification(system.target_maturity_justification ?? '')
     }
   }, [isEditing, system])
 
@@ -207,11 +225,37 @@ export default function SystemDetailPage() {
     return true
   }
 
+  // The target draft counts as touched when it differs from what's stored
+  // (NULL stored renders as the Advanced default with empty justification).
+  const targetTouched = (): boolean => {
+    if (!system) return false
+    return (
+      editedTargetTier !==
+        (system.target_maturity_tier ?? DEFAULT_TARGET_TIER) ||
+      editedTargetJustification.trim() !==
+        (system.target_maturity_justification ?? '')
+    )
+  }
+
+  // Justification is required on every explicit target save (it's the GAO
+  // deliverable); an untouched draft is always valid because it won't be sent.
+  const isTargetValid = (): boolean => {
+    if (!targetTouched()) return true
+    const trimmed = editedTargetJustification.trim()
+    return trimmed.length > 0 && trimmed.length <= TARGET_JUSTIFICATION_MAX
+  }
+
   const isFormValid = (): boolean => {
-    return Object.values(formValid).every((v) => v === true)
+    // Non-admin (assigned ISSO) edit sessions only touch the target card, so
+    // the system-form field validity doesn't apply to them.
+    const systemFormValid = isAdmin
+      ? Object.values(formValid).every((v) => v === true)
+      : true
+    return systemFormValid && isTargetValid()
   }
 
   const hasUnsavedChanges = (): boolean => {
+    if (targetTouched()) return true
     if (!editedSystem || !system) return false
     return !_.isEqual(system, editedSystem)
   }
@@ -271,45 +315,81 @@ export default function SystemDetailPage() {
     if (!editedSystem) return
     setIsSaving(true)
     try {
-      const putBody: Record<string, unknown> = {
-        fismauid: editedSystem.fismauid,
-        fismaacronym: editedSystem.fismaacronym,
-        fismaname: editedSystem.fismaname,
-        fismasubsystem: editedSystem.fismasubsystem,
-        component: editedSystem.component,
-        groupacronym: editedSystem.groupacronym,
-        groupname: editedSystem.groupname,
-        divisionname: editedSystem.divisionname,
-        datacenterenvironment: editedSystem.datacenterenvironment,
-        datacallcontact: editedSystem.datacallcontact,
-        issoemail: editedSystem.issoemail,
-        sdl_sync_enabled: editedSystem.sdl_sync_enabled,
-        opdiv_id: editedSystem.opdiv_id,
+      // The full-system PUT is admin-only on the backend; an assigned ISSO's
+      // edit session can only have touched the target card below.
+      if (isAdmin) {
+        const putBody: Record<string, unknown> = {
+          fismauid: editedSystem.fismauid,
+          fismaacronym: editedSystem.fismaacronym,
+          fismaname: editedSystem.fismaname,
+          fismasubsystem: editedSystem.fismasubsystem,
+          component: editedSystem.component,
+          groupacronym: editedSystem.groupacronym,
+          groupname: editedSystem.groupname,
+          divisionname: editedSystem.divisionname,
+          datacenterenvironment: editedSystem.datacenterenvironment,
+          datacallcontact: editedSystem.datacallcontact,
+          issoemail: editedSystem.issoemail,
+          sdl_sync_enabled: editedSystem.sdl_sync_enabled,
+          opdiv_id: editedSystem.opdiv_id,
+        }
+        // Extended metadata fields are editable across all OpDivs; send each,
+        // using null to leave a value unchanged (the backend writes only
+        // non-null fields, so imported data isn't clobbered).
+        for (const key of EXTENDED_METADATA_KEYS) {
+          putBody[key] = editedSystem[key] ?? null
+        }
+        await axiosInstance.put(
+          `fismasystems/${editedSystem.fismasystemid}`,
+          putBody
+        )
       }
-      // Extended metadata fields are editable across all OpDivs; send each,
-      // using null to leave a value unchanged (the backend writes only
-      // non-null fields, so imported data isn't clobbered).
-      for (const key of EXTENDED_METADATA_KEYS) {
-        putBody[key] = editedSystem[key] ?? null
+
+      // Target maturity rides the same Save but goes to its dedicated,
+      // ISSO-writable endpoint. Only sent when actually changed so an
+      // untouched save doesn't record a spurious audit event.
+      let savedTarget: FismaSystemType | null = null
+      if (canEditTarget && targetTouched()) {
+        const res = await axiosInstance.put(
+          `fismasystems/${editedSystem.fismasystemid}/target-maturity`,
+          {
+            target_maturity_tier: editedTargetTier,
+            target_maturity_justification: editedTargetJustification.trim(),
+          }
+        )
+        savedTarget = res.data?.data ?? null
       }
-      await axiosInstance.put(
-        `fismasystems/${editedSystem.fismasystemid}`,
-        putBody
-      )
+
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
       setFismaSystems((prev) =>
-        prev.map((s) =>
-          s.fismasystemid === editedSystem.fismasystemid ? editedSystem : s
-        )
+        prev.map((s) => {
+          if (s.fismasystemid !== editedSystem.fismasystemid) return s
+          // editedSystem carries the target values from when edit began, so
+          // overlay the endpoint's response last.
+          const base = isAdmin ? editedSystem : s
+          return savedTarget
+            ? {
+                ...base,
+                target_maturity_tier: savedTarget.target_maturity_tier,
+                target_maturity_justification:
+                  savedTarget.target_maturity_justification,
+              }
+            : base
+        })
       )
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)
       // Backend 400 with a field map: render each reason inline under its
       // input via formValid + formValidErrorText. The 'Not Saved' toast
-      // is a status flag, not the detail.
-      if (parsed.fieldErrors) {
-        Object.entries(parsed.fieldErrors).forEach(([key, message]) => {
+      // is a status flag, not the detail. Only keys the system form owns are
+      // routed inline; target-maturity field errors fall through to the toast
+      // (they're client-validated, so a 400 here is unexpected).
+      const knownFieldErrors = Object.entries(parsed.fieldErrors ?? {}).filter(
+        ([key]) => key in formValid
+      )
+      if (knownFieldErrors.length > 0) {
+        knownFieldErrors.forEach(([key, message]) => {
           setFormValid((prev) => ({ ...prev, [key]: false }))
           setFormValidErrorText((prev) => ({ ...prev, [key]: message }))
         })
@@ -507,13 +587,28 @@ export default function SystemDetailPage() {
     )
   }
 
+  // Target maturity edits ride the page-level Edit/Save flow above, but save to
+  // the dedicated ISSO-writable endpoint. The card is slotted into the right
+  // column of whichever view renders (between Data Lake Export and
+  // Organization); for a non-admin assigned ISSO only this card unlocks.
+  const targetMaturityCard = (
+    <TargetMaturityCard
+      system={system}
+      isEditing={isEditing && canEditTarget}
+      tier={editedTargetTier}
+      justification={editedTargetJustification}
+      onTierChange={setEditedTargetTier}
+      onJustificationChange={setEditedTargetJustification}
+    />
+  )
+
   return (
     <Box sx={{ mt: 1, mb: 4 }}>
       <BreadCrumbs segmentLabels={{ [fismasystemid!]: system.fismaname }} />
 
       <SystemDetailHeader
         systemName={system.fismaname}
-        isAdmin={isAdmin}
+        canEdit={canEditTarget}
         isEditing={isEditing}
         isSaving={isSaving}
         isFormValid={isFormValid()}
@@ -522,7 +617,7 @@ export default function SystemDetailPage() {
         onCancel={handleCancel}
       />
 
-      {isEditing && editedSystem ? (
+      {isEditing && editedSystem && isAdmin ? (
         <SystemDetailEditView
           system={system}
           editedSystem={editedSystem}
@@ -553,11 +648,13 @@ export default function SystemDetailPage() {
               prev ? { ...prev, sdl_sync_enabled: checked } : prev
             )
           }
+          targetMaturitySlot={targetMaturityCard}
         />
       ) : (
         <SystemDetailReadView
           system={system}
           decommissionedByName={decommissionedByName}
+          targetMaturitySlot={targetMaturityCard}
         />
       )}
 

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import {
   Card,
   CardContent,
@@ -19,6 +20,10 @@ import { getFieldsBySection, FieldConfig } from './fieldConfig'
 interface SystemDetailReadViewProps {
   system: FismaSystemType
   decommissionedByName: string
+  // Rendered in the right column between Data Lake Export and Organization.
+  // The page owns it (its edit state is independent of this view) and slots it
+  // here so it sits with the other system cards (ztmf#398).
+  targetMaturitySlot?: ReactNode
 }
 
 function FieldDisplay({
@@ -51,6 +56,7 @@ function renderFields(fields: FieldConfig[], system: FismaSystemType) {
 export default function SystemDetailReadView({
   system,
   decommissionedByName,
+  targetMaturitySlot,
 }: SystemDetailReadViewProps) {
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
@@ -181,6 +187,7 @@ export default function SystemDetailReadView({
             </Typography>
           </CardContent>
         </Card>
+        {targetMaturitySlot}
         <Card variant="outlined" sx={{ flex: 1 }}>
           <CardHeader
             title="Organization"

--- a/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
@@ -1,0 +1,108 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+import TargetMaturityCard from './TargetMaturityCard'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType } from '@/types'
+
+const BASE_SYSTEM = {
+  fismasystemid: 1001,
+  fismaname: 'Death Star',
+  fismaacronym: 'DS-1',
+  target_maturity_tier: null,
+  target_maturity_justification: null,
+} as unknown as FismaSystemType
+
+const noop = () => {}
+
+function renderCard(
+  overrides: Partial<Parameters<typeof TargetMaturityCard>[0]> = {}
+) {
+  const props = {
+    system: BASE_SYSTEM,
+    isEditing: false,
+    tier: 'Advanced',
+    justification: '',
+    onTierChange: noop,
+    onJustificationChange: noop,
+    ...overrides,
+  }
+  return renderWithProviders(<TargetMaturityCard {...props} />)
+}
+
+test('no target set renders the Advanced default with the default caption', () => {
+  renderCard()
+  expect(screen.getByText('3 — Advanced (default)')).toBeInTheDocument()
+  expect(
+    screen.getByText(/Default — no target has been set/)
+  ).toBeInTheDocument()
+  // Read mode: no form controls, no justification block
+  expect(screen.queryByLabelText('Target level')).not.toBeInTheDocument()
+  expect(screen.queryByText('Justification')).not.toBeInTheDocument()
+})
+
+test('explicit target renders tier chip and justification', () => {
+  renderCard({
+    system: {
+      ...BASE_SYSTEM,
+      target_maturity_tier: 'Optimal',
+      target_maturity_justification: 'Internet-facing HVA.',
+    },
+  })
+  expect(screen.getByText('4 — Optimal')).toBeInTheDocument()
+  expect(screen.getByText('Internet-facing HVA.')).toBeInTheDocument()
+  expect(screen.queryByText(/Default — no target/)).not.toBeInTheDocument()
+})
+
+test('isEditing renders the controlled tier select and justification field', async () => {
+  const user = userEvent.setup()
+  const onTierChange = jest.fn()
+  const onJustificationChange = jest.fn()
+  renderCard({
+    isEditing: true,
+    tier: 'Advanced',
+    justification: '',
+    onTierChange,
+    onJustificationChange,
+  })
+
+  // Empty justification is flagged as required while editing
+  expect(screen.getByLabelText('Justification')).toBeInvalid()
+
+  // Selecting a tier lifts the change to the page
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  expect(onTierChange).toHaveBeenCalledWith('Optimal')
+
+  // Typing lifts justification changes to the page
+  await user.type(screen.getByLabelText('Justification'), 'B')
+  expect(onJustificationChange).toHaveBeenCalledWith('B')
+})
+
+test('only Initial, Advanced, and Optimal are offered - no Traditional', async () => {
+  const user = userEvent.setup()
+  renderCard({ isEditing: true })
+  await user.click(screen.getByLabelText('Target level'))
+  const options = await screen.findAllByRole('option')
+  expect(options.map((o) => o.textContent)).toEqual([
+    '2 — Initial',
+    '3 — Advanced (default)',
+    '4 — Optimal',
+  ])
+})
+
+test('over-limit justification shows the length error', () => {
+  renderCard({
+    isEditing: true,
+    justification: 'x'.repeat(1001),
+  })
+  expect(
+    screen.getByText('Must be 1000 characters or fewer')
+  ).toBeInTheDocument()
+  expect(screen.getByLabelText('Justification')).toBeInvalid()
+})

--- a/src/views/SystemDetailPage/TargetMaturityCard.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.tsx
@@ -1,0 +1,145 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  MenuItem,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { FismaSystemType } from '@/types'
+import {
+  TIER_OPTIONS,
+  DEFAULT_TARGET_TIER,
+  TARGET_JUSTIFICATION_MAX,
+} from './targetMaturityConfig'
+
+const JUSTIFICATION_HELPER =
+  'In one sentence, explain why this target level is appropriate for this system.'
+
+function tierLabel(tier: string): string {
+  return TIER_OPTIONS.find((o) => o.value === tier)?.label ?? tier
+}
+
+interface TargetMaturityCardProps {
+  system: FismaSystemType
+  /** Controlled by the page-level Edit button (ztmf#398 change request):
+   * true only while the page is in edit mode AND the user may write the
+   * target (admin or assigned ISSO). */
+  isEditing: boolean
+  tier: string
+  justification: string
+  onTierChange: (tier: string) => void
+  onJustificationChange: (justification: string) => void
+}
+
+/**
+ * Card for the system's risk-based target maturity level (ztmf#398).
+ * Fully controlled: edit state and the Save action live with the page's
+ * single Edit/Save flow. The page decides who may edit (assigned ISSOs get
+ * only this card unlocked; admins get the full form as well) and PUTs to
+ * the dedicated /target-maturity endpoint on save.
+ */
+export default function TargetMaturityCard({
+  system,
+  isEditing,
+  tier,
+  justification,
+  onTierChange,
+  onJustificationChange,
+}: TargetMaturityCardProps) {
+  const hasExplicitTarget = !!system.target_maturity_tier
+  const justificationTooLong = justification.length > TARGET_JUSTIFICATION_MAX
+  // Required once the draft differs from what's stored; the page-level
+  // isFormValid applies the same rule to gate Save.
+  const justificationMissing = isEditing && justification.trim().length === 0
+
+  return (
+    <Card variant="outlined" sx={{ mb: 3 }}>
+      <CardHeader
+        title="Target Maturity Level"
+        titleTypographyProps={{ variant: 'h6' }}
+        subheader="Risk-based target this system's answers are compared against"
+        sx={{ pb: 0 }}
+      />
+      <CardContent sx={{ pt: 0 }}>
+        {isEditing ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              maxWidth: 640,
+            }}
+          >
+            {/* variant="standard" + marginTop:0 on the label matches
+                SystemDetailEditView: the CMS design-system global CSS breaks
+                MUI's outlined floating label (it overlays the value). */}
+            <TextField
+              select
+              label="Target level"
+              variant="standard"
+              value={tier}
+              onChange={(e) => onTierChange(e.target.value)}
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+              inputProps={{ 'aria-label': 'Target level' }}
+            >
+              {TIER_OPTIONS.map((o) => (
+                <MenuItem key={o.value} value={o.value}>
+                  {o.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Justification"
+              variant="standard"
+              required
+              multiline
+              minRows={2}
+              value={justification}
+              onChange={(e) => onJustificationChange(e.target.value)}
+              helperText={
+                justificationTooLong
+                  ? `Must be ${TARGET_JUSTIFICATION_MAX} characters or fewer`
+                  : JUSTIFICATION_HELPER
+              }
+              error={justificationTooLong || justificationMissing}
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+              inputProps={{ 'aria-label': 'Justification' }}
+            />
+          </Box>
+        ) : (
+          <Box>
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2.5 }}
+            >
+              <Chip
+                label={tierLabel(
+                  system.target_maturity_tier ?? DEFAULT_TARGET_TIER
+                )}
+                color="primary"
+                size="small"
+              />
+              {!hasExplicitTarget && (
+                <Typography variant="caption" color="text.secondary">
+                  Default — no target has been set for this system yet
+                </Typography>
+              )}
+            </Box>
+            {hasExplicitTarget && (
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Justification
+                </Typography>
+                <Typography variant="body1">
+                  {system.target_maturity_justification || '—'}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/views/SystemDetailPage/targetMaturityConfig.ts
+++ b/src/views/SystemDetailPage/targetMaturityConfig.ts
@@ -1,0 +1,12 @@
+// Target-maturity vocabulary shared by the card and the page save flow
+// (ztmf#398). Mirrors the backend's validTargetMaturityTiers: the tier NAME is
+// the stored value; the CISA stage number is display-only. Traditional (1) is
+// deliberately not offered.
+export const TIER_OPTIONS = [
+  { value: 'Initial', label: '2 — Initial' },
+  { value: 'Advanced', label: '3 — Advanced (default)' },
+  { value: 'Optimal', label: '4 — Optimal' },
+]
+
+export const DEFAULT_TARGET_TIER = 'Advanced'
+export const TARGET_JUSTIFICATION_MAX = 1000


### PR DESCRIPTION
Frontend half of CMS-Enterprise/ztmf#398 (paired with backend PR CMS-Enterprise/ztmf#400 — merge that first; this UI calls its `PUT /fismasystems/{id}/target-maturity` endpoint).

## What

A **Target Maturity Level** card on the system detail page (right column, between Data Lake Export and Organization) showing the risk-based target tier and its justification, editable through the existing page-level Edit/Save flow.

## Behavior

- Options: **2 — Initial / 3 — Advanced (default) / 4 — Optimal** (tier NAME is the stored value; numerals are display-only; Traditional deliberately not offered).
- **No stored default**: a system with no asserted target renders the Advanced default explicitly labeled (`(default)` chip + "no target has been set" caption); the DB stays NULL until someone saves.
- **Single edit flow**: no card-level buttons — the page Edit unlocks the card, page Save persists it. The target PUT fires **only when the draft changed**, so untouched saves record no spurious audit event. Changing the tier requires a justification before Save enables; Cancel prompts on a dirty target.
- **ISSO/ISSM support**: the page Edit button now shows for system-scoped users (new `isSystemScoped` helper) — for them only the target card unlocks; the system form stays admin-only. Display gating is by tier per the app convention (the backend scopes an ISSO's system list and re-checks assignment on write).
- Fields use `variant="standard"` matching `SystemDetailEditView` (the CMS design-system CSS breaks MUI's outlined floating label).

## Test plan

- [x] `tsc --noEmit`, `eslint` clean
- [x] Jest: card read/edit states, option vocabulary, required + over-limit justification (plus full SystemDetailPage suite green)
- [x] Validated in the local stack against the backend branch: admin full-edit, ISSO target-only edit on an assigned system, no Edit button on unassigned systems, persistence across refresh

## Screenshots

<img width="2055" height="1096" alt="Screenshot 2026-07-08 at 4 53 24 PM" src="https://github.com/user-attachments/assets/3e7d6a07-da77-4ca8-8dc5-952199614908" />
<img width="2056" height="1103" alt="Screenshot 2026-07-08 at 4 54 41 PM" src="https://github.com/user-attachments/assets/1dd305d2-abdc-46f6-ac7c-5c55a2332fce" />


Refs CMS-Enterprise/ztmf#398
