### PR TITLE
fix visual overrun on Add Fisma System modal

### DIFF
--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -505,6 +505,11 @@ export default function EditSystemModal({
                   !formValid.opdiv_id ? formValidErrorText.opdiv_id : ''
                 }
                 sx={{ mb: 2 }}
+                InputLabelProps={{
+                  sx: {
+                    marginTop: 0,
+                  },
+                }}
                 onChange={(e) => {
                   const val =
                     e.target.value === '' ? null : Number(e.target.value)


### PR DESCRIPTION
> **Note:** In-repo copy of #473 by @costacalvin. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #473

---

## Summary

Closes #465 — the `OpDiv` label on the "Add FISMA System" modal was visually overrunning the input underline (appearing at or below the line instead of floating above it).

Every other `variant="standard"` TextField in `EditSystemModal` already had `InputLabelProps={{ sx: { marginTop: 0 } }}` to pin the label above the underline. The `opdiv_id` select field was the only one missing it.

## Changes

- Added `InputLabelProps={{ sx: { marginTop: 0 } }}` to the `opdiv_id` TextField in `EditSystemModal.tsx` to match the pattern used by all other fields in the form.

## UI
Before
<img width="1341" height="940" alt="image" src="https://github.com/user-attachments/assets/63667103-f772-4524-8870-18bb142a4fd0" />

After
<img width="1680" height="949" alt="image" src="https://github.com/user-attachments/assets/a96a3144-69ba-4f22-b990-c8689c33db2b" />

## Testing

1. Navigate to the app and click **Add FISMA System**
2. Confirm the `OpDiv` label floats above the underline, consistent with all other fields
3. Confirm no regression in edit mode (OpDiv renders correctly with a pre-selected value)
