### PR TITLE
feat(questionnaire): encrypt saved drafts (AES-256-GCM)

### DIFF
--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -1,7 +1,15 @@
 import '@testing-library/jest-dom'
 import 'jest-fetch-mock'
 import { TextEncoder, TextDecoder } from 'util'
+import { webcrypto } from 'crypto'
 
 // Polyfill for React Router 7 which requires TextEncoder/TextDecoder
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder as typeof global.TextDecoder
+
+// Polyfill Web Crypto API — JSDOM does not expose crypto.subtle
+Object.defineProperty(globalThis, 'crypto', {
+  value: webcrypto,
+  configurable: true,
+  writable: true,
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -245,7 +245,7 @@ export default function QuestionnarePage() {
 
   const clearCurrentDraft = () => {
     if (system && questionId && datacallID > 0) {
-      clearDraft(system, questionId, datacallID)
+      clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
   }
@@ -502,11 +502,12 @@ export default function QuestionnarePage() {
           // server-side values set above. Skipped for read-only sessions.
           const sys = systemRef.current
           // Eagerly evict any stale draft when the session is now read-only.
+          const uid = userInfo.userid
           if (isReadOnly && sys && questionId && datacallID > 0)
-            clearDraft(sys, questionId, datacallID)
+            clearDraft(uid, sys, questionId, datacallID)
           const draft =
             !isReadOnly && sys && questionId && datacallID > 0
-              ? loadDraft(sys, questionId, datacallID)
+              ? await loadDraft(uid, sys, questionId, datacallID)
               : null
           if (draft) {
             if (draft.selectQuestionOption === -1) {
@@ -526,7 +527,7 @@ export default function QuestionnarePage() {
             } else {
               // Draft references an option that no longer exists — evict it.
               if (sys && questionId && datacallID > 0)
-                clearDraft(sys, questionId, datacallID)
+                clearDraft(uid, sys, questionId, datacallID)
               setDraftStatus('idle')
             }
           } else {
@@ -544,7 +545,14 @@ export default function QuestionnarePage() {
       fetchOptions()
       return () => controller.abort()
     }
-  }, [questionId, questionScores, questions, isReadOnly, datacallID])
+  }, [
+    questionId,
+    questionScores,
+    questions,
+    isReadOnly,
+    datacallID,
+    userInfo.userid,
+  ])
 
   // Debounced draft save: 1 second after the user pauses editing, persist
   // the current answer and notes to localStorage so a reload can recover them.
@@ -565,8 +573,12 @@ export default function QuestionnarePage() {
     if (selectQuestionOption === initQuestionChoice && notes === initNotes)
       return
     const timer = setTimeout(() => {
-      saveDraft(system, questionId, datacallID, { selectQuestionOption, notes })
-      if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+      saveDraft(userInfo.userid, system, questionId, datacallID, {
+        selectQuestionOption,
+        notes,
+      }).then(() => {
+        if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+      })
     }, 1000)
     return () => clearTimeout(timer)
   }, [
@@ -579,6 +591,7 @@ export default function QuestionnarePage() {
     initQuestionChoice,
     initNotes,
     loadingQuestion,
+    userInfo.userid,
   ])
 
   // Warn before tab close or hard refresh when the active question has edits

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -508,19 +508,28 @@ export default function QuestionnarePage() {
             !isReadOnly && sys && questionId && datacallID > 0
               ? loadDraft(sys, questionId, datacallID)
               : null
-          if (
-            draft &&
-            choices.some((c) => c.value === draft.selectQuestionOption)
-          ) {
-            choices.forEach(
-              (c) => (c.defaultChecked = c.value === draft.selectQuestionOption)
-            )
-            setSelectQuestionOption(draft.selectQuestionOption)
-            setNotes(draft.notes)
-            setDraftStatus('restored')
+          if (draft) {
+            if (draft.selectQuestionOption === -1) {
+              // Notes-only draft — restore notes without pre-selecting an answer.
+              setNotes(draft.notes)
+              setDraftStatus('restored')
+            } else if (
+              choices.some((c) => c.value === draft.selectQuestionOption)
+            ) {
+              choices.forEach(
+                (c) =>
+                  (c.defaultChecked = c.value === draft.selectQuestionOption)
+              )
+              setSelectQuestionOption(draft.selectQuestionOption)
+              setNotes(draft.notes)
+              setDraftStatus('restored')
+            } else {
+              // Draft references an option that no longer exists — evict it.
+              if (sys && questionId && datacallID > 0)
+                clearDraft(sys, questionId, datacallID)
+              setDraftStatus('idle')
+            }
           } else {
-            if (draft && sys && questionId && datacallID > 0)
-              clearDraft(sys, questionId, datacallID)
             setDraftStatus('idle')
           }
           setOptions(choices)
@@ -553,10 +562,6 @@ export default function QuestionnarePage() {
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
-    // Never draft-save when no answer is selected: -1 is the "no answer"
-    // sentinel that shouldPersistResponse rejects, so a draft with -1 could
-    // never be promoted to a real save, leaving a permanent orphan in storage.
-    if (selectQuestionOption === -1) return
     if (selectQuestionOption === initQuestionChoice && notes === initNotes)
       return
     const timer = setTimeout(() => {
@@ -581,7 +586,14 @@ export default function QuestionnarePage() {
   React.useEffect(() => {
     if (isReadOnly) return
     const handle = (e: BeforeUnloadEvent) => {
-      if (shouldPersistResponse(unsavedRef.current)) e.preventDefault()
+      const s = unsavedRef.current
+      const hasPendingEdits =
+        shouldPersistResponse(s) ||
+        (s.selectQuestionOption === -1 && s.notes !== s.initNotes)
+      if (hasPendingEdits) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
     }
     window.addEventListener('beforeunload', handle)
     return () => window.removeEventListener('beforeunload', handle)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -47,6 +47,7 @@ import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
+import { saveDraft, loadDraft, clearDraft } from './draftStore'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -140,6 +141,25 @@ export default function QuestionnarePage() {
   const [stepId, setStepId] = React.useState<number>(0)
   const [selectQuestionOption, setSelectQuestionOption] =
     React.useState<number>(-1)
+  const [draftStatus, setDraftStatus] = React.useState<
+    'idle' | 'restored' | 'saved'
+  >('idle')
+  // Refs read inside setTimeout/event callbacks to get the current value
+  // without enrolling the effects in those deps (prevents extra re-runs).
+  const draftStatusRef = React.useRef(draftStatus)
+  draftStatusRef.current = draftStatus
+  const unsavedRef = React.useRef({
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+  })
+  unsavedRef.current = {
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+  }
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
@@ -162,6 +182,7 @@ export default function QuestionnarePage() {
   }
   const handleChoiceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectQuestionOption(Number(event.target.value))
+    if (draftStatus === 'restored') setDraftStatus('idle')
   }
   const renderRadioGroup = (options: QuestionChoice[]) => {
     return (
@@ -194,6 +215,8 @@ export default function QuestionnarePage() {
   // location.state. Optional-chain instead of crashing on first render; the
   // missing-system path is handled by an early render guard below.
   const system = location.state?.fismasystemid as number | undefined
+  const systemRef = React.useRef(system)
+  systemRef.current = system
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
   // Resolve the system's raw datacenter environment to its scoring category
@@ -206,6 +229,9 @@ export default function QuestionnarePage() {
   const [selectedIndex, setSelectedIndex] = React.useState(1)
   const handleConfirmReturn = (confirm: boolean) => {
     if (confirm) {
+      // User explicitly chose to abandon unsaved edits — clear the draft so it
+      // doesn't reappear if they navigate back to this question.
+      clearCurrentDraft()
       setLoadingQuestion(true)
       setSelectedIndex(stepId)
       setQuestionId(stepId)
@@ -217,6 +243,13 @@ export default function QuestionnarePage() {
     setQuestionId(index)
   }
 
+  const clearCurrentDraft = () => {
+    if (system && questionId && datacallID > 0) {
+      clearDraft(system, questionId, datacallID)
+    }
+    setDraftStatus('idle')
+  }
+
   const saveResponse = async () => {
     if (
       !shouldPersistResponse({
@@ -226,6 +259,7 @@ export default function QuestionnarePage() {
         initNotes,
       })
     ) {
+      clearCurrentDraft()
       return
     }
     // Backstop: the Next button is disabled when this fires, but a future
@@ -262,6 +296,7 @@ export default function QuestionnarePage() {
         })
       }
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      clearCurrentDraft()
       fetchQuestionScores(system, setQuestionScores)
     } catch (error) {
       if (isAuthHandled(error)) return
@@ -426,8 +461,10 @@ export default function QuestionnarePage() {
       const controller = new AbortController()
       // Clear saved-state markers before async load so the last-edited
       // footer does not flash the previous question's editor during the
-      // refetch window.
+      // refetch window. Also resets draft indicators so stale status from
+      // a previous question or datacall doesn't bleed into the next render.
       setInitQuestionChoice(-1)
+      setDraftStatus('idle')
       const choices: QuestionChoice[] = []
       let funcOptId: number = 0
       async function fetchOptions() {
@@ -460,7 +497,33 @@ export default function QuestionnarePage() {
           setSelectQuestionOption(funcOptId ? funcOptId : -1)
           setInitQuestionChoice(funcOptId ? funcOptId : -1)
           setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
-          setOptions(choices ? choices : [])
+
+          // Restore any in-progress draft from localStorage, overriding the
+          // server-side values set above. Skipped for read-only sessions.
+          const sys = systemRef.current
+          // Eagerly evict any stale draft when the session is now read-only.
+          if (isReadOnly && sys && questionId && datacallID > 0)
+            clearDraft(sys, questionId, datacallID)
+          const draft =
+            !isReadOnly && sys && questionId && datacallID > 0
+              ? loadDraft(sys, questionId, datacallID)
+              : null
+          if (
+            draft &&
+            choices.some((c) => c.value === draft.selectQuestionOption)
+          ) {
+            choices.forEach(
+              (c) => (c.defaultChecked = c.value === draft.selectQuestionOption)
+            )
+            setSelectQuestionOption(draft.selectQuestionOption)
+            setNotes(draft.notes)
+            setDraftStatus('restored')
+          } else {
+            if (draft && sys && questionId && datacallID > 0)
+              clearDraft(sys, questionId, datacallID)
+            setDraftStatus('idle')
+          }
+          setOptions(choices)
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
@@ -472,7 +535,64 @@ export default function QuestionnarePage() {
       fetchOptions()
       return () => controller.abort()
     }
-  }, [questionId, questionScores, questions])
+  }, [questionId, questionScores, questions, isReadOnly, datacallID])
+
+  // Debounced draft save: 1 second after the user pauses editing, persist
+  // the current answer and notes to localStorage so a reload can recover them.
+  // Only fires when the user has actually changed something from the server-side
+  // initial values — prevents question-load state transitions from being
+  // mistakenly recorded as drafts on questions the user never touched.
+  React.useEffect(() => {
+    if (
+      isReadOnly ||
+      !system ||
+      !questionId ||
+      datacallID <= 0 ||
+      loadingQuestion
+    ) {
+      if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
+      return
+    }
+    // Never draft-save when no answer is selected: -1 is the "no answer"
+    // sentinel that shouldPersistResponse rejects, so a draft with -1 could
+    // never be promoted to a real save, leaving a permanent orphan in storage.
+    if (selectQuestionOption === -1) return
+    if (selectQuestionOption === initQuestionChoice && notes === initNotes)
+      return
+    const timer = setTimeout(() => {
+      saveDraft(system, questionId, datacallID, { selectQuestionOption, notes })
+      if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+    }, 1000)
+    return () => clearTimeout(timer)
+  }, [
+    selectQuestionOption,
+    notes,
+    isReadOnly,
+    system,
+    questionId,
+    datacallID,
+    initQuestionChoice,
+    initNotes,
+    loadingQuestion,
+  ])
+
+  // Warn before tab close or hard refresh when the active question has edits
+  // that haven't been committed to the backend yet.
+  React.useEffect(() => {
+    if (isReadOnly) return
+    const handle = (e: BeforeUnloadEvent) => {
+      const s = unsavedRef.current
+      if (
+        s.selectQuestionOption !== s.initQuestionChoice ||
+        s.notes !== s.initNotes
+      ) {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener('beforeunload', handle)
+    return () => window.removeEventListener('beforeunload', handle)
+  }, [isReadOnly])
+
   const breadcrumbSegmentLabels = fismaacronym
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
     : undefined
@@ -662,6 +782,7 @@ export default function QuestionnarePage() {
                     inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
                     onChange={(e) => {
                       setNotes(e.target.value)
+                      if (draftStatus === 'restored') setDraftStatus('idle')
                     }}
                   />
                   <Box
@@ -758,13 +879,12 @@ export default function QuestionnarePage() {
                             }
                           )
                         }
-                        setLoadingQuestion(true)
+                        if (id !== questionId) setLoadingQuestion(true)
                         setQuestionId(id)
                         setSelectedIndex(id)
                         if (!isReadOnly) {
                           saveResponse()
                         }
-                        setLoadingQuestion(false)
                       }}
                       disabled={needsNotesUpdate}
                       style={{ marginBottom: '8px', marginTop: '8px' }}
@@ -780,6 +900,17 @@ export default function QuestionnarePage() {
                       {/* <NavigateNextIcon sx={{ pt: '2px' }} /> */}
                     </CmsButton>
                   </Box>
+                  {draftStatus !== 'idle' && !isReadOnly && (
+                    <Alert
+                      severity={draftStatus === 'saved' ? 'success' : 'warning'}
+                      icon={false}
+                      sx={{ mt: 1, py: 0.5 }}
+                    >
+                      {draftStatus === 'saved'
+                        ? 'Draft saved — click Next or Complete to save permanently.'
+                        : 'Draft restored — click Next or Complete to save permanently.'}
+                    </Alert>
+                  )}
                   <LastEditedFooter
                     lastEditedAt={
                       initQuestionChoice !== -1 &&

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -581,13 +581,7 @@ export default function QuestionnarePage() {
   React.useEffect(() => {
     if (isReadOnly) return
     const handle = (e: BeforeUnloadEvent) => {
-      const s = unsavedRef.current
-      if (
-        s.selectQuestionOption !== s.initQuestionChoice ||
-        s.notes !== s.initNotes
-      ) {
-        e.preventDefault()
-      }
+      if (shouldPersistResponse(unsavedRef.current)) e.preventDefault()
     }
     window.addEventListener('beforeunload', handle)
     return () => window.removeEventListener('beforeunload', handle)

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -1,0 +1,166 @@
+import { saveDraft, loadDraft, clearDraft, QuestionDraft } from './draftStore'
+
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
+
+const IDS = { fismasystemid: 1, functionid: 2, datacallid: 3 } as const
+const EXPECTED_KEY = 'ztmf_draft_1_2_3'
+const DRAFT: QuestionDraft = { selectQuestionOption: 5, notes: 'test notes' }
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('key format', () => {
+  it('generates ztmf_draft_{system}_{function}_{datacall}', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    expect(localStorage.getItem(EXPECTED_KEY)).not.toBeNull()
+  })
+
+  it('different IDs produce different keys', () => {
+    saveDraft(1, 2, 3, DRAFT)
+    saveDraft(1, 2, 4, DRAFT)
+    expect(Object.keys(localStorage)).toHaveLength(2)
+  })
+})
+
+describe('saveDraft', () => {
+  it('writes JSON to the correct key', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const raw = localStorage.getItem(EXPECTED_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.selectQuestionOption).toBe(5)
+    expect(parsed.notes).toBe('test notes')
+  })
+
+  it('includes a numeric savedAt timestamp', () => {
+    const before = Date.now()
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const after = Date.now()
+    const { savedAt } = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
+    expect(typeof savedAt).toBe('number')
+    expect(savedAt).toBeGreaterThanOrEqual(before)
+    expect(savedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('does not expose savedAt to the QuestionDraft type (internal only)', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    // loadDraft strips savedAt before returning
+    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(result).not.toHaveProperty('savedAt')
+  })
+
+  it('does not throw when localStorage is unavailable', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError')
+    })
+    expect(() =>
+      saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    ).not.toThrow()
+  })
+})
+
+describe('loadDraft', () => {
+  it('returns null for a missing key', () => {
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+
+  it('returns the draft fields (without savedAt) for a valid fresh entry', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(result).toEqual(DRAFT)
+  })
+
+  it('returns null and removes the key when the entry is older than 14 days', () => {
+    const savedAt = 1000
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS + 1)
+
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns a valid draft exactly at the TTL boundary (not yet expired)', () => {
+    const savedAt = 1000
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
+    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS)
+
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toEqual(DRAFT)
+  })
+
+  it('returns null and removes the key when savedAt is missing (pre-TTL entry)', () => {
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify(DRAFT))
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null and removes the key when savedAt is 0', () => {
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt: 0 }))
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null when the stored value is malformed JSON', () => {
+    localStorage.setItem(EXPECTED_KEY, 'not-json{{{')
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+
+  it('does not throw when localStorage.getItem throws', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('SecurityError')
+    })
+    expect(() =>
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+    expect(
+      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+  })
+})
+
+describe('clearDraft', () => {
+  it('removes the entry at the correct key', () => {
+    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('does not throw when the key does not exist', () => {
+    expect(() =>
+      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+  })
+
+  it('does not throw when localStorage.removeItem throws', () => {
+    jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('SecurityError')
+    })
+    expect(() =>
+      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).not.toThrow()
+  })
+
+  it('only removes the targeted key, leaving others intact', () => {
+    saveDraft(1, 2, 3, DRAFT)
+    saveDraft(1, 2, 4, DRAFT)
+    clearDraft(1, 2, 3)
+    expect(localStorage.getItem('ztmf_draft_1_2_3')).toBeNull()
+    expect(localStorage.getItem('ztmf_draft_1_2_4')).not.toBeNull()
+  })
+})

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -1,9 +1,16 @@
-import { saveDraft, loadDraft, clearDraft, QuestionDraft } from './draftStore'
+import {
+  saveDraft,
+  loadDraft,
+  clearDraft,
+  clearStaleUserDrafts,
+  QuestionDraft,
+} from './draftStore'
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
 
+const USER = 'user-abc'
 const IDS = { fismasystemid: 1, functionid: 2, datacallid: 3 } as const
-const EXPECTED_KEY = 'ztmf_draft_1_2_3'
+const EXPECTED_KEY = 'ztmf_draft_user-abc_1_2_3'
 const DRAFT: QuestionDraft = { selectQuestionOption: 5, notes: 'test notes' }
 
 beforeEach(() => {
@@ -15,31 +22,59 @@ afterEach(() => {
 })
 
 describe('key format', () => {
-  it('generates ztmf_draft_{system}_{function}_{datacall}', () => {
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+  it('generates ztmf_draft_{userid}_{system}_{function}_{datacall}', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
     expect(localStorage.getItem(EXPECTED_KEY)).not.toBeNull()
   })
 
-  it('different IDs produce different keys', () => {
-    saveDraft(1, 2, 3, DRAFT)
-    saveDraft(1, 2, 4, DRAFT)
+  it('different IDs produce different keys', async () => {
+    await saveDraft(USER, 1, 2, 3, DRAFT)
+    await saveDraft(USER, 1, 2, 4, DRAFT)
+    expect(Object.keys(localStorage)).toHaveLength(2)
+  })
+
+  it('different userids produce different keys', async () => {
+    await saveDraft('user-a', 1, 2, 3, DRAFT)
+    await saveDraft('user-b', 1, 2, 3, DRAFT)
     expect(Object.keys(localStorage)).toHaveLength(2)
   })
 })
 
 describe('saveDraft', () => {
-  it('writes JSON to the correct key', () => {
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+  it('writes encrypted JSON to the correct key', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
     const raw = localStorage.getItem(EXPECTED_KEY)
     expect(raw).not.toBeNull()
     const parsed = JSON.parse(raw!)
-    expect(parsed.selectQuestionOption).toBe(5)
-    expect(parsed.notes).toBe('test notes')
+    expect(parsed).toHaveProperty('iv')
+    expect(parsed).toHaveProperty('ciphertext')
+    expect(parsed).toHaveProperty('savedAt')
+    // Stored value must not contain plaintext fields
+    expect(parsed).not.toHaveProperty('selectQuestionOption')
+    expect(parsed).not.toHaveProperty('notes')
   })
 
-  it('includes a numeric savedAt timestamp', () => {
+  it('includes a numeric savedAt timestamp', async () => {
     const before = Date.now()
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
     const after = Date.now()
     const { savedAt } = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
     expect(typeof savedAt).toBe('number')
@@ -47,103 +82,170 @@ describe('saveDraft', () => {
     expect(savedAt).toBeLessThanOrEqual(after)
   })
 
-  it('does not expose savedAt to the QuestionDraft type (internal only)', () => {
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
-    // loadDraft strips savedAt before returning
-    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+  it('does not expose savedAt in the decrypted QuestionDraft', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const result = await loadDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
     expect(result).not.toHaveProperty('savedAt')
   })
 
-  it('does not throw when localStorage is unavailable', () => {
+  it('does not throw when localStorage is unavailable', async () => {
     jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new DOMException('QuotaExceededError')
     })
-    expect(() =>
-      saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
-    ).not.toThrow()
+    await expect(
+      saveDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
+    ).resolves.not.toThrow()
   })
 })
 
 describe('loadDraft', () => {
-  it('returns null for a missing key', () => {
+  it('returns null for a missing key', async () => {
     expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
   })
 
-  it('returns the draft fields (without savedAt) for a valid fresh entry', () => {
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
-    const result = loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+  it('decrypts and returns the original draft fields', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const result = await loadDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
     expect(result).toEqual(DRAFT)
   })
 
-  it('returns null and removes the key when the entry is older than 14 days', () => {
-    const savedAt = 1000
-    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
-    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS + 1)
+  it('returns null for a draft decrypted with the wrong user key', async () => {
+    await saveDraft(
+      'user-a',
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    // Copy user-a ciphertext into user-b key slot to test key isolation
+    const raw = localStorage.getItem('ztmf_draft_user-a_1_2_3')!
+    localStorage.setItem('ztmf_draft_user-b_1_2_3', raw)
+    const result = await loadDraft(
+      'user-b',
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
+    expect(result).toBeNull()
+  })
+
+  it('returns null and removes the key when the entry is older than 14 days', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const raw = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
+    localStorage.setItem(
+      EXPECTED_KEY,
+      JSON.stringify({ ...raw, savedAt: 1000 })
+    )
+    jest.spyOn(Date, 'now').mockReturnValue(1000 + FOURTEEN_DAYS_MS + 1)
 
     expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
     expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
-  it('returns a valid draft exactly at the TTL boundary (not yet expired)', () => {
-    const savedAt = 1000
-    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt }))
-    jest.spyOn(Date, 'now').mockReturnValue(savedAt + FOURTEEN_DAYS_MS)
+  it('returns a valid draft exactly at the TTL boundary (not yet expired)', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const raw = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
+    localStorage.setItem(
+      EXPECTED_KEY,
+      JSON.stringify({ ...raw, savedAt: 1000 })
+    )
+    jest.spyOn(Date, 'now').mockReturnValue(1000 + FOURTEEN_DAYS_MS)
 
     expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toEqual(DRAFT)
   })
 
-  it('returns null and removes the key when savedAt is missing (pre-TTL entry)', () => {
-    localStorage.setItem(EXPECTED_KEY, JSON.stringify(DRAFT))
+  it('returns null and removes the key when savedAt is missing', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const { savedAt: _, ...withoutSavedAt } = JSON.parse(
+      localStorage.getItem(EXPECTED_KEY)!
+    )
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify(withoutSavedAt))
+
     expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
     expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
-  it('returns null and removes the key when savedAt is 0', () => {
-    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...DRAFT, savedAt: 0 }))
-    expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
-    ).toBeNull()
-    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
-  })
-
-  it('returns null when the stored value is malformed JSON', () => {
+  it('returns null when the stored value is malformed JSON', async () => {
     localStorage.setItem(EXPECTED_KEY, 'not-json{{{')
     expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
   })
 
-  it('does not throw when localStorage.getItem throws', () => {
+  it('does not throw when localStorage.getItem throws', async () => {
     jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('SecurityError')
     })
-    expect(() =>
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
-    ).not.toThrow()
-    expect(
-      loadDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
-    ).toBeNull()
+    await expect(
+      loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).resolves.toBeNull()
   })
 })
 
 describe('clearDraft', () => {
-  it('removes the entry at the correct key', () => {
-    saveDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
-    clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+  it('removes the entry at the correct key', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
   it('does not throw when the key does not exist', () => {
     expect(() =>
-      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).not.toThrow()
   })
 
@@ -152,15 +254,53 @@ describe('clearDraft', () => {
       throw new DOMException('SecurityError')
     })
     expect(() =>
-      clearDraft(IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+      clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).not.toThrow()
   })
 
-  it('only removes the targeted key, leaving others intact', () => {
-    saveDraft(1, 2, 3, DRAFT)
-    saveDraft(1, 2, 4, DRAFT)
-    clearDraft(1, 2, 3)
-    expect(localStorage.getItem('ztmf_draft_1_2_3')).toBeNull()
-    expect(localStorage.getItem('ztmf_draft_1_2_4')).not.toBeNull()
+  it('only removes the targeted key, leaving others intact', async () => {
+    await saveDraft(USER, 1, 2, 3, DRAFT)
+    await saveDraft(USER, 1, 2, 4, DRAFT)
+    clearDraft(USER, 1, 2, 3)
+    expect(localStorage.getItem('ztmf_draft_user-abc_1_2_3')).toBeNull()
+    expect(localStorage.getItem('ztmf_draft_user-abc_1_2_4')).not.toBeNull()
+  })
+})
+
+describe('clearStaleUserDrafts', () => {
+  it('removes drafts belonging to other users', async () => {
+    await saveDraft('user-a', 1, 2, 3, DRAFT)
+    await saveDraft('user-b', 1, 2, 3, DRAFT)
+    clearStaleUserDrafts('user-a')
+    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
+    expect(localStorage.getItem('ztmf_draft_user-b_1_2_3')).toBeNull()
+  })
+
+  it('preserves all drafts belonging to the current user', async () => {
+    await saveDraft('user-a', 1, 2, 3, DRAFT)
+    await saveDraft('user-a', 1, 2, 4, DRAFT)
+    clearStaleUserDrafts('user-a')
+    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
+    expect(localStorage.getItem('ztmf_draft_user-a_1_2_4')).not.toBeNull()
+  })
+
+  it('does not remove unrelated localStorage keys', async () => {
+    localStorage.setItem('some_other_key', 'value')
+    await saveDraft('user-b', 1, 2, 3, DRAFT)
+    clearStaleUserDrafts('user-a')
+    expect(localStorage.getItem('some_other_key')).toBe('value')
+  })
+
+  it('does nothing when userid is empty', async () => {
+    await saveDraft('user-a', 1, 2, 3, DRAFT)
+    clearStaleUserDrafts('')
+    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
+  })
+
+  it('does not throw when localStorage throws', () => {
+    jest.spyOn(Storage.prototype, 'key').mockImplementation(() => {
+      throw new DOMException('SecurityError')
+    })
+    expect(() => clearStaleUserDrafts('user-a')).not.toThrow()
   })
 })

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -3,63 +3,162 @@ export type QuestionDraft = {
   notes: string
 }
 
-// Internal shape written to localStorage — callers only see QuestionDraft.
-type StoredDraft = QuestionDraft & { savedAt: number }
+// Shape written to localStorage — callers only see QuestionDraft.
+type StoredDraft = {
+  iv: string
+  ciphertext: string
+  savedAt: number
+}
 
 const DRAFT_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+const DRAFT_PREFIX = 'ztmf_draft_'
+const PBKDF2_SALT = new TextEncoder().encode('ztmf-draft-v1')
+const PBKDF2_ITERATIONS = 100_000
 
 const draftKey = (
+  userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number
-) => `ztmf_draft_${fismasystemid}_${functionid}_${datacallid}`
+) => `${DRAFT_PREFIX}${userid}_${fismasystemid}_${functionid}_${datacallid}`
 
-export const saveDraft = (
+// Cache derived keys by userid — PBKDF2 is intentionally slow at 100k
+// iterations; re-deriving on every read/write would add ~100ms per call.
+const keyCache = new Map<string, CryptoKey>()
+
+async function deriveKey(userid: string): Promise<CryptoKey> {
+  const cached = keyCache.get(userid)
+  if (cached) return cached
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(userid),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  )
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: PBKDF2_SALT,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+  keyCache.set(userid, key)
+  return key
+}
+
+async function encryptDraft(
+  key: CryptoKey,
+  draft: QuestionDraft
+): Promise<{ iv: string; ciphertext: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const plaintext = new TextEncoder().encode(JSON.stringify(draft))
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    plaintext
+  )
+  return {
+    iv: btoa(String.fromCharCode(...iv)),
+    ciphertext: btoa(String.fromCharCode(...new Uint8Array(encrypted))),
+  }
+}
+
+async function decryptDraft(
+  key: CryptoKey,
+  iv: string,
+  ciphertext: string
+): Promise<QuestionDraft> {
+  const ivBytes = Uint8Array.from(atob(iv), (c) => c.charCodeAt(0))
+  const ciphertextBytes = Uint8Array.from(atob(ciphertext), (c) =>
+    c.charCodeAt(0)
+  )
+  const decrypted = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: ivBytes },
+    key,
+    ciphertextBytes
+  )
+  return JSON.parse(new TextDecoder().decode(decrypted)) as QuestionDraft
+}
+
+export const saveDraft = async (
+  userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number,
   draft: QuestionDraft
-): void => {
+): Promise<void> => {
   try {
-    const stored: StoredDraft = { ...draft, savedAt: Date.now() }
+    const key = await deriveKey(userid)
+    const { iv, ciphertext } = await encryptDraft(key, draft)
+    const stored: StoredDraft = { iv, ciphertext, savedAt: Date.now() }
     localStorage.setItem(
-      draftKey(fismasystemid, functionid, datacallid),
+      draftKey(userid, fismasystemid, functionid, datacallid),
       JSON.stringify(stored)
     )
   } catch {
-    // localStorage unavailable (private browsing, quota exceeded) — degrade silently
+    // localStorage unavailable or crypto unsupported — degrade silently
   }
 }
 
-export const loadDraft = (
+export const loadDraft = async (
+  userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number
-): QuestionDraft | null => {
+): Promise<QuestionDraft | null> => {
   try {
     const raw = localStorage.getItem(
-      draftKey(fismasystemid, functionid, datacallid)
+      draftKey(userid, fismasystemid, functionid, datacallid)
     )
     if (!raw) return null
     const stored = JSON.parse(raw) as StoredDraft
     if (!stored.savedAt || Date.now() - stored.savedAt > DRAFT_TTL_MS) {
-      clearDraft(fismasystemid, functionid, datacallid)
+      clearDraft(userid, fismasystemid, functionid, datacallid)
       return null
     }
-    const { savedAt: _, ...draft } = stored
-    return draft
+    const key = await deriveKey(userid)
+    return await decryptDraft(key, stored.iv, stored.ciphertext)
   } catch {
     return null
   }
 }
 
 export const clearDraft = (
+  userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number
 ): void => {
   try {
-    localStorage.removeItem(draftKey(fismasystemid, functionid, datacallid))
+    localStorage.removeItem(
+      draftKey(userid, fismasystemid, functionid, datacallid)
+    )
+  } catch {
+    // ignore
+  }
+}
+
+// Removes all drafts in localStorage saved under a different user account.
+// Called on app mount so a shared-machine login switch doesn't expose one
+// user's notes to another.
+export const clearStaleUserDrafts = (currentUserid: string): void => {
+  if (!currentUserid) return
+  try {
+    const userPrefix = `${DRAFT_PREFIX}${currentUserid}_`
+    const toRemove: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key && key.startsWith(DRAFT_PREFIX) && !key.startsWith(userPrefix)) {
+        toRemove.push(key)
+      }
+    }
+    toRemove.forEach((key) => localStorage.removeItem(key))
   } catch {
     // ignore
   }

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -1,0 +1,66 @@
+export type QuestionDraft = {
+  selectQuestionOption: number
+  notes: string
+}
+
+// Internal shape written to localStorage — callers only see QuestionDraft.
+type StoredDraft = QuestionDraft & { savedAt: number }
+
+const DRAFT_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+
+const draftKey = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+) => `ztmf_draft_${fismasystemid}_${functionid}_${datacallid}`
+
+export const saveDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number,
+  draft: QuestionDraft
+): void => {
+  try {
+    const stored: StoredDraft = { ...draft, savedAt: Date.now() }
+    localStorage.setItem(
+      draftKey(fismasystemid, functionid, datacallid),
+      JSON.stringify(stored)
+    )
+  } catch {
+    // localStorage unavailable (private browsing, quota exceeded) — degrade silently
+  }
+}
+
+export const loadDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+): QuestionDraft | null => {
+  try {
+    const raw = localStorage.getItem(
+      draftKey(fismasystemid, functionid, datacallid)
+    )
+    if (!raw) return null
+    const stored = JSON.parse(raw) as StoredDraft
+    if (!stored.savedAt || Date.now() - stored.savedAt > DRAFT_TTL_MS) {
+      clearDraft(fismasystemid, functionid, datacallid)
+      return null
+    }
+    const { savedAt: _, ...draft } = stored
+    return draft
+  } catch {
+    return null
+  }
+}
+
+export const clearDraft = (
+  fismasystemid: number,
+  functionid: number,
+  datacallid: number
+): void => {
+  try {
+    localStorage.removeItem(draftKey(fismasystemid, functionid, datacallid))
+  } catch {
+    // ignore
+  }
+}

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -37,6 +37,7 @@ import _ from 'lodash'
 import DataCallModal from '../DatacallModal/DataCallModal'
 import Footer from '@/components/Footer/Footer'
 import ztmfLogo from '@/assets/ztmf-logo-color.png'
+import { clearStaleUserDrafts } from '../QuestionnairePage/draftStore'
 /**
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
@@ -106,6 +107,10 @@ export default function Title() {
   useEffect(() => {
     if (loaderData.status === 200) fetchFismaSystems(showDecommissioned)
   }, [showDecommissioned, fetchFismaSystems, loaderData.status])
+
+  useEffect(() => {
+    if (loaderData.status === 200) clearStaleUserDrafts(userInfo.userid)
+  }, [loaderData.status, userInfo.userid])
 
   useEffect(() => {
     if (loaderData.status !== 200) return


### PR DESCRIPTION
> **Note:** In-repo copy of #472 by @costacalvin, moved off the fork so the Snyk and deploy CI gates can run, which need org secrets unavailable to fork PRs. Commits and authorship are unchanged.
>
> Refs #472

---

## Summary

Adds an initial encrypted-drafts feature for the questionnaire. Drafts persist in the browser (from #469) and are encrypted at rest with AES-256-GCM via the Web Crypto API (from #472). This is a first cut: it obfuscates drafts at rest, and the confidentiality hardening plus persistence fixes are tracked in #475.

Delivers the initial version requested in CMS-Enterprise/ztmf#399. That issue closes in favor of the ztmf-ui successor #475, which tracks the remaining confidentiality hardening and persistence fixes, when this merges.

## Supersedes #469

This branch carries #469's commits (questionnaire draft persistence, @MackOverflow) with the AES-256-GCM layer (@costacalvin) on top, confirmed against git history (#469's head is an ancestor of this branch). Close #469 in its favor once this is accepted (it is a PR, so the `Closes` keyword will not auto-close it; close it by hand).

## What's included

- **Questionnaire draft persistence**, from #469, @MackOverflow.
- **AES-256-GCM draft encryption** via `crypto.subtle`, from #472, @costacalvin: new `draftStore.ts`, wiring in `QuestionnairePage.tsx` and `Title.tsx`, jest crypto setup in `config/jest/setupTests.ts`, and `draftStore.test.ts`.

## Known limitations (tracked in #475)

Pre-merge review found blockers that ship in this initial version. They are tracked in #475 rather than gating the first cut:

- Key derivation uses the user id (a non-secret) plus a fixed salt, so the encryption obfuscates rather than protects against device access.
- A failed save still reports "Draft saved," which can lose data silently.
- A malformed stored draft can crash the questionnaire view.
- Draft keys omit the user, so a shared browser can leak drafts across users.
- Reverting an answer to its original value does not clear the saved draft.

## Test plan

- [x] `yarn typecheck` clean
- [ ] `yarn test` green (includes `draftStore.test.ts`)
- [ ] Enter answers and notes, reload, the draft restores
- [ ] Inspect the stored draft in DevTools, it shows ciphertext, not plaintext
- [ ] Snyk and deploy CI gates pass (the reason for the rehome)

## Notes

- Authorship preserved. The ref-based rehome points at the exact commit stack, so both authors' commits are unchanged.
- The original fork #472 stays a draft and closes when this merges.
