### PR TITLE
Data Call Progress column on the dashboard

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,19 @@ export type SystemScoreEntry = {
   tier?: ScoreTier
 }
 
+// One system's questionnaire progress within a data call, as returned by
+// GET /scores/progress. "Updated" counts answers genuinely touched this
+// cycle - answers pre-populated from the previous data call do not count
+// until a user saves them, so a carried-over untouched questionnaire reads
+// as not updated (ztmf#299).
+export type ScoreProgress = {
+  fismasystemid: number
+  questionsexpected: number
+  questionsupdated: number
+  lastupdatedat?: string | null
+  updatedsincestart: boolean
+}
+
 export type QuestionChoice = {
   label: string
   value: number
@@ -274,6 +287,10 @@ export type FormValidHelperText = {
 
 export type FismaTableProps = {
   scores: Record<number, SystemScoreEntry>
+  // Per-system questionnaire progress for the active data call, keyed by
+  // fismasystemid. Optional so the table degrades to an em-dash column if
+  // the progress fetch fails - score display must not depend on it.
+  progress?: Record<number, ScoreProgress>
 }
 
 export type ThemeColor =

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -374,6 +374,10 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
       // systems first, then by completion fraction.
       field: 'datacallprogress',
       headerName: 'Data Call Progress',
+      // valueGetter returns a numeric sort key, so the column must sort as a
+      // number - otherwise the grid string-compares and "1.5" sorts before
+      // "-1". type: 'number' also right-aligns by default, overridden below.
+      type: 'number',
       width: 190,
       align: 'center',
       headerAlign: 'center',

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -35,6 +35,8 @@ import { FismaTableProps } from '@/types'
 import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 import { hasSystemAccess } from '@/utils/userRoles'
 import { cellStyleForTier } from '@/utils/tierStyles'
+import { ProgressCell } from './progressColumn'
+import { progressSortValue } from './progressHelpers'
 type selectedRowsType = GridRowId[]
 declare module '@mui/x-data-grid' {
   interface FooterPropsOverrides {
@@ -210,7 +212,7 @@ interface CachedScore {
 }
 const pillarScoresCache = new Map<number, CachedScore>()
 
-export default function FismaTable({ scores }: FismaTableProps) {
+export default function FismaTable({ scores, progress }: FismaTableProps) {
   const apiRef = useGridApiRef()
   const { fismaSystems, latestDataCallId, selectedDatacall, userInfo } =
     useContextProp()
@@ -363,6 +365,23 @@ export default function FismaTable({ scores }: FismaTableProps) {
           </Box>
         )
       },
+    },
+    {
+      // Questionnaire progress for the active data call (ztmf#299). The
+      // fraction counts answers genuinely edited this cycle - answers
+      // pre-populated from the previous data call do not count until a
+      // user saves them. Ascending sort is the triage order: not-updated
+      // systems first, then by completion fraction.
+      field: 'datacallprogress',
+      headerName: 'Data Call Progress',
+      width: 190,
+      align: 'center',
+      headerAlign: 'center',
+      valueGetter: (value) =>
+        progressSortValue(progress?.[value.row.fismasystemid]),
+      renderCell: (params) => (
+        <ProgressCell entry={progress?.[params.row.fismasystemid]} />
+      ),
     },
     {
       field: 'datacenterenvironment',

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import type { ScoreProgress } from '@/types'
+import { ProgressCell } from './progressColumn'
+import { progressSortValue, progressTooltip } from './progressHelpers'
+
+const updatedEntry: ScoreProgress = {
+  fismasystemid: 1,
+  questionsexpected: 41,
+  questionsupdated: 12,
+  lastupdatedat: '2026-07-01T15:30:00Z',
+  updatedsincestart: true,
+}
+
+const untouchedEntry: ScoreProgress = {
+  fismasystemid: 2,
+  questionsexpected: 41,
+  questionsupdated: 0,
+  lastupdatedat: null,
+  updatedsincestart: false,
+}
+
+describe('progressSortValue', () => {
+  // Ascending sort is the OpDiv Admin triage order: not-updated systems
+  // first, then partial progress by fraction, complete last, and systems
+  // with no progress data at the very end.
+  it('ranks not-updated before any updated system', () => {
+    expect(progressSortValue(untouchedEntry)).toBeLessThan(
+      progressSortValue(updatedEntry)
+    )
+  })
+
+  it('ranks partial progress below complete', () => {
+    const complete: ScoreProgress = {
+      ...updatedEntry,
+      questionsupdated: 41,
+    }
+    expect(progressSortValue(updatedEntry)).toBeLessThan(
+      progressSortValue(complete)
+    )
+  })
+
+  it('ranks missing progress data last', () => {
+    expect(progressSortValue(undefined)).toBeGreaterThan(
+      progressSortValue({ ...updatedEntry, questionsupdated: 41 })
+    )
+  })
+
+  it('does not divide by zero when a system has no applicable questions', () => {
+    const empty: ScoreProgress = {
+      fismasystemid: 3,
+      questionsexpected: 0,
+      questionsupdated: 0,
+      updatedsincestart: true,
+    }
+    expect(progressSortValue(empty)).toBe(0)
+  })
+})
+
+describe('progressTooltip', () => {
+  it('describes the last update time when present', () => {
+    expect(progressTooltip(updatedEntry)).toMatch(/^Last updated /)
+  })
+
+  it('states no updates for an untouched system', () => {
+    expect(progressTooltip(untouchedEntry)).toBe('No updates this data call')
+  })
+
+  it('states no data when the entry is missing', () => {
+    expect(progressTooltip(undefined)).toBe(
+      'No progress data for this data call'
+    )
+  })
+
+  it('falls back to no-updates on an unparseable timestamp', () => {
+    expect(
+      progressTooltip({ ...updatedEntry, lastupdatedat: 'not-a-date' })
+    ).toBe('No updates this data call')
+  })
+})
+
+describe('ProgressCell', () => {
+  it('renders the fraction and an Updated chip for an edited system', () => {
+    render(<ProgressCell entry={updatedEntry} />)
+    expect(screen.getByText('12/41')).toBeInTheDocument()
+    expect(screen.getByText('Updated')).toBeInTheDocument()
+  })
+
+  it('renders the fraction and a Not updated chip for a carried-over system', () => {
+    // A pre-populated questionnaire has answers but no edits this cycle -
+    // the whole point of ztmf#299 is that this renders as NOT updated.
+    render(<ProgressCell entry={untouchedEntry} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Not updated')).toBeInTheDocument()
+  })
+
+  it('renders an em-dash when progress data is missing', () => {
+    render(<ProgressCell entry={undefined} />)
+    expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
+  })
+})

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -45,14 +45,36 @@ describe('progressSortValue', () => {
     )
   })
 
-  it('does not divide by zero when a system has no applicable questions', () => {
+  it('ranks a no-questionnaire system after complete but before missing data', () => {
+    // A 0/0 system is technically "not updated" but has nothing to update, so
+    // it must sort with the done pile, not the triage top - and ahead of a
+    // genuine no-data row.
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
       questionsupdated: 0,
-      updatedsincestart: true,
+      updatedsincestart: false,
     }
-    expect(progressSortValue(empty)).toBe(0)
+    const complete: ScoreProgress = { ...updatedEntry, questionsupdated: 41 }
+    expect(progressSortValue(empty)).toBeGreaterThan(
+      progressSortValue(complete)
+    )
+    expect(progressSortValue(empty)).toBeLessThan(progressSortValue(undefined))
+  })
+
+  it('does not sort a no-questionnaire system to the triage top', () => {
+    // Regression: the guard for 0 expected must be checked BEFORE the
+    // not-updated branch, or a 0/0 system lands at the very top next to real
+    // laggards.
+    const empty: ScoreProgress = {
+      fismasystemid: 3,
+      questionsexpected: 0,
+      questionsupdated: 0,
+      updatedsincestart: false,
+    }
+    expect(progressSortValue(empty)).toBeGreaterThan(
+      progressSortValue(untouchedEntry)
+    )
   })
 })
 
@@ -71,10 +93,24 @@ describe('progressTooltip', () => {
     )
   })
 
-  it('falls back to no-updates on an unparseable timestamp', () => {
+  it('does not contradict the chip on an unparseable timestamp', () => {
+    // An updated system with a bad timestamp must not read "No updates" - that
+    // would disagree with its green Updated chip. It reports the state instead.
     expect(
       progressTooltip({ ...updatedEntry, lastupdatedat: 'not-a-date' })
-    ).toBe('No updates this data call')
+    ).toBe('Updated (time unavailable)')
+  })
+
+  it('describes a no-questionnaire system', () => {
+    const empty: ScoreProgress = {
+      fismasystemid: 3,
+      questionsexpected: 0,
+      questionsupdated: 0,
+      updatedsincestart: false,
+    }
+    expect(progressTooltip(empty)).toBe(
+      'No questionnaire applies to this system'
+    )
   })
 })
 
@@ -96,5 +132,20 @@ describe('ProgressCell', () => {
   it('renders an em-dash when progress data is missing', () => {
     render(<ProgressCell entry={undefined} />)
     expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
+  })
+
+  it('renders a neutral N/A chip when no questionnaire applies', () => {
+    // A 0/0 system is not a laggard - it must not wear the orange "Not
+    // updated" chip, and it shows no misleading fraction.
+    const empty: ScoreProgress = {
+      fismasystemid: 3,
+      questionsexpected: 0,
+      questionsupdated: 0,
+      updatedsincestart: false,
+    }
+    render(<ProgressCell entry={empty} />)
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 })

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -1,0 +1,44 @@
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Tooltip from '@mui/material/Tooltip'
+import type { ScoreProgress } from '@/types'
+import { progressTooltip } from './progressHelpers'
+
+/**
+ * Cell body for the Data Call Progress column: an updated-count fraction
+ * ("12/41") next to an Updated / Not updated chip, wrapped in a tooltip
+ * carrying the last-activity time. Pre-populated answers carried over from
+ * the previous data call do not count as updated - the fraction reflects
+ * genuine edits this cycle (ztmf#299).
+ * @param {object} props - Component props.
+ * @param {ScoreProgress | undefined} props.entry - The system's progress row;
+ *   undefined renders an em-dash (progress fetch failed or not covered).
+ * @returns {JSX.Element} The progress cell.
+ */
+export function ProgressCell({ entry }: { entry: ScoreProgress | undefined }) {
+  if (!entry) {
+    return <span aria-label="No progress data">—</span>
+  }
+  const updated = entry.updatedsincestart
+  return (
+    <Tooltip title={progressTooltip(entry)}>
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <span>
+          {entry.questionsupdated}/{entry.questionsexpected}
+        </span>
+        <Chip
+          size="small"
+          label={updated ? 'Updated' : 'Not updated'}
+          color={updated ? 'success' : 'warning'}
+          variant="outlined"
+        />
+      </Box>
+    </Tooltip>
+  )
+}

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -2,14 +2,22 @@ import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import Tooltip from '@mui/material/Tooltip'
 import type { ScoreProgress } from '@/types'
-import { progressTooltip } from './progressHelpers'
+import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
 
 /**
  * Cell body for the Data Call Progress column: an updated-count fraction
- * ("12/41") next to an Updated / Not updated chip, wrapped in a tooltip
- * carrying the last-activity time. Pre-populated answers carried over from
- * the previous data call do not count as updated - the fraction reflects
- * genuine edits this cycle (ztmf#299).
+ * ("12/41") next to a status chip, wrapped in a tooltip carrying the
+ * last-activity time. Pre-populated answers carried over from the previous
+ * data call do not count as updated - the fraction reflects genuine edits
+ * this cycle (ztmf#299).
+ *
+ * Three states:
+ *   - a system with no applicable questionnaire (0/0) renders a neutral
+ *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
+ *     there is nothing to nudge;
+ *   - a system with any genuine edit reads "Updated" (green);
+ *   - otherwise "Not updated" (orange). The chip is derived from
+ *     questionsupdated so it can never disagree with the fraction.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -19,7 +27,14 @@ export function ProgressCell({ entry }: { entry: ScoreProgress | undefined }) {
   if (!entry) {
     return <span aria-label="No progress data">—</span>
   }
-  const updated = entry.updatedsincestart
+  if (hasNoQuestionnaire(entry)) {
+    return (
+      <Tooltip title={progressTooltip(entry)}>
+        <Chip size="small" label="N/A" variant="outlined" />
+      </Tooltip>
+    )
+  }
+  const updated = entry.questionsupdated > 0
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -1,0 +1,32 @@
+import type { ScoreProgress } from '@/types'
+
+/**
+ * Sort key for the Data Call Progress column. Ascending sort is the triage
+ * order OpDiv Admins want: systems with no update this cycle come first
+ * (-1), then partially updated systems by completion fraction, then fully
+ * updated ones. Systems with no progress data (fetch failed, or a system
+ * not covered by the response) sort last (+2) so unknowns never crowd the
+ * top of the triage view.
+ * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @returns {number} Sortable rank: -1 not updated, 0..1 fraction, 2 unknown.
+ */
+export function progressSortValue(entry: ScoreProgress | undefined): number {
+  if (!entry) return 2
+  if (!entry.updatedsincestart) return -1
+  if (entry.questionsexpected <= 0) return 0
+  return entry.questionsupdated / entry.questionsexpected
+}
+
+/**
+ * Tooltip line for the progress cell: when the last update happened, or an
+ * explicit "no updates" statement so an empty tooltip never renders.
+ * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @returns {string} Human-readable last-activity description.
+ */
+export function progressTooltip(entry: ScoreProgress | undefined): string {
+  if (!entry) return 'No progress data for this data call'
+  if (!entry.lastupdatedat) return 'No updates this data call'
+  const at = new Date(entry.lastupdatedat)
+  if (isNaN(at.getTime())) return 'No updates this data call'
+  return `Last updated ${at.toLocaleString()}`
+}

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -1,32 +1,56 @@
 import type { ScoreProgress } from '@/types'
 
 /**
- * Sort key for the Data Call Progress column. Ascending sort is the triage
- * order OpDiv Admins want: systems with no update this cycle come first
- * (-1), then partially updated systems by completion fraction, then fully
- * updated ones. Systems with no progress data (fetch failed, or a system
- * not covered by the response) sort last (+2) so unknowns never crowd the
- * top of the triage view.
+ * True when the system has no questionnaire this data call (no functions apply
+ * to its environment). The backend intentionally returns these systems as
+ * `0/0`; the frontend owns the display decision, and they are not actionable
+ * triage items — there is nothing to nudge.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
- * @returns {number} Sortable rank: -1 not updated, 0..1 fraction, 2 unknown.
+ * @returns {boolean} True when the system has zero applicable questions.
+ */
+export function hasNoQuestionnaire(entry: ScoreProgress | undefined): boolean {
+  return !!entry && entry.questionsexpected <= 0
+}
+
+/**
+ * Sort key for the Data Call Progress column. Ascending sort is the triage
+ * order OpDiv Admins want, most-urgent first:
+ *
+ *   -1  not updated but HAS a questionnaire  (needs a nudge — top of the list)
+ *   0..1 partially updated, by completion fraction
+ *   1   fully updated (a complete system lands at exactly 1)
+ *   1.5 no questionnaire applies (0/0 — nothing to do, not a laggard)
+ *   2   no progress data (fetch failed or system not covered — unknown, last)
+ *
+ * The 0/0 (no-questionnaire) case is classified BEFORE the not-updated branch:
+ * such a system is technically "not updated," but it has nothing to update, so
+ * it must not sort to the triage top alongside genuine laggards.
+ * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @returns {number} Sortable rank (see above).
  */
 export function progressSortValue(entry: ScoreProgress | undefined): number {
   if (!entry) return 2
-  if (!entry.updatedsincestart) return -1
-  if (entry.questionsexpected <= 0) return 0
+  if (entry.questionsexpected <= 0) return 1.5
+  if (entry.questionsupdated <= 0) return -1
   return entry.questionsupdated / entry.questionsexpected
 }
 
 /**
- * Tooltip line for the progress cell: when the last update happened, or an
- * explicit "no updates" statement so an empty tooltip never renders.
+ * Tooltip line for the progress cell: the last-update time when there is one,
+ * otherwise a state description that never contradicts the chip (an "Updated"
+ * system with an unusable timestamp reads "time unavailable," not "no updates").
  * @param {ScoreProgress | undefined} entry - The system's progress row.
- * @returns {string} Human-readable last-activity description.
+ * @returns {string} Human-readable description of the cell's state.
  */
 export function progressTooltip(entry: ScoreProgress | undefined): string {
   if (!entry) return 'No progress data for this data call'
-  if (!entry.lastupdatedat) return 'No updates this data call'
-  const at = new Date(entry.lastupdatedat)
-  if (isNaN(at.getTime())) return 'No updates this data call'
-  return `Last updated ${at.toLocaleString()}`
+  if (entry.lastupdatedat) {
+    const at = new Date(entry.lastupdatedat)
+    if (!isNaN(at.getTime())) return `Last updated ${at.toLocaleString()}`
+  }
+  // No usable timestamp: describe the state without contradicting the chip.
+  if (hasNoQuestionnaire(entry))
+    return 'No questionnaire applies to this system'
+  if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
+  return 'No updates this data call'
 }

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -5,7 +5,7 @@ import axiosInstance from '@/axiosConfig'
 import { useContextProp } from '../Title/Context'
 import { Box, CircularProgress } from '@mui/material'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
-import type { ScoreAggregate, SystemScoreEntry } from '@/types'
+import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 /**
  * Component that renders the contents of the Home view.
  * @returns {JSX.Element} Component that renders the home contents.
@@ -14,6 +14,9 @@ import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 export default function HomePageContainer() {
   const [loading, setLoading] = useState<boolean>(true)
   const [scoreMap, setScoreMap] = useState<Record<number, SystemScoreEntry>>({})
+  const [progressMap, setProgressMap] = useState<Record<number, ScoreProgress>>(
+    {}
+  )
   const { latestDataCallId, selectedDatacall } = useContextProp()
   const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   useEffect(() => {
@@ -41,7 +44,31 @@ export default function HomePageContainer() {
         }
       }
     }
+    // Questionnaire progress for the active data call (ztmf#299). Fetched
+    // alongside the aggregate but independent of it: a failure here leaves
+    // the progress column as em-dashes without blocking the score display,
+    // so it neither gates `loading` nor shares the aggregate's try/catch.
+    async function fetchProgress() {
+      if (activeDataCallId !== 0) {
+        try {
+          const res = await axiosInstance.get(
+            `/scores/progress?datacallid=${activeDataCallId}`,
+            { signal: controller.signal }
+          )
+          const map: Record<number, ScoreProgress> = {}
+          for (const obj of res.data.data as ScoreProgress[]) {
+            map[obj.fismasystemid] = obj
+          }
+          setProgressMap(map)
+        } catch (error) {
+          if (controller.signal.aborted) return
+          console.error('Error fetching data call progress:', error)
+          setProgressMap({})
+        }
+      }
+    }
     fetchScores()
+    fetchProgress()
     return () => {
       controller.abort()
     }
@@ -65,7 +92,7 @@ export default function HomePageContainer() {
     <Box>
       <StatisticsBlocks scores={scoreMap} />
       <BreadCrumbs />
-      <FismaTable scores={scoreMap} />
+      <FismaTable scores={scoreMap} progress={progressMap} />
     </Box>
   )
 }


### PR DESCRIPTION
### Summary

Adds a **Data Call Progress** column to the dashboard system list so OpDiv Admins can see, at a glance, which systems have actually updated their questionnaires this data call. This is the frontend half of `ztmf#299`; it consumes the new `GET /api/v1/scores/progress` endpoint from the companion backend PR, `CMS-Enterprise/ztmf#404`.

### What it shows

For each system, a fraction plus a status chip:

* `12/41 · Updated` — 12 questions genuinely edited this cycle
* `0/41 · Not updated` — answers carried over from last data call, nobody has touched it
* `—` — no progress data (fetch failed, or the system isn't covered)

Each cell carries a tooltip with the last-activity time. The column **sorts not-updated systems first**, so an admin with hundreds of systems sees the ones needing a nudge at the top without scrolling.

### Why "Not updated" isn't "0 answered"

The backend pre-populates every system's answers from the previous data call, so "has answers" is true for everyone on day one. The endpoint counts only answers *genuinely edited this cycle* (those with an audit event), so a fully carried-over questionnaire correctly reads `0/N · Not updated` even though it has a complete set of answers. The column reflects that faithfully — see `CMS-Enterprise/ztmf#404` for the mechanic.

### How it's wired

* `Home.tsx` fetches `/scores/progress?datacallid=${act existing aggregate fetch, on the same `activeDataCallId` dependency — so switching the active data call refetches progress automatically.
* The progress fetch is **independent of the score fetch map and the column falls back to em-dashes, without blocking score display or the page's loading gate.**
* Sort logic and tooltip text live in `progressHelpers.ts` so `progressColumn.tsx` stays a component-only module (FastRefresh).

### Testing

`progressColumn.test.tsx` (11 tests) covers:

* Triage sort ordering — not-updated first, then partial by fraction, complete last, unknowns last, with a divide-by-zero guard for systems with no applicable questions
* Tooltip states — last-activity line, explicit "no updates," missing-data, and unparseable-timestamp fallback
* Cell rendering — the `Updated` / `Not updated` / em-dash layouts, specifically checking the core `ztmf#299` case (a carried-over system renders `0/N · Not updated`)

### Files

| Area | File |
| --- | --- |
| Types | `src/types.ts` (`ScoreProgress`, `FismaTableProps.progress`) |
| Cell component | `src/views/FismaTable/progressColumn.tsx` |
| Sort + tooltip helpers | `src/views/FismaTable/progressHelpers.ts` |
| Column wiring | `src/views/FismaTable/FismaTable.tsx` |
| Data fetch | `src/views/Home/Home.tsx` |
| Tests | `src/views/FismaTable/progressColumn.test.tsx` |

2 commits, +242 / 6 files.

### Notes for reviewers

* Built in main's existing table idiom (plain MUI `Chip` layout) rather than reaching for the redesign's design-system components — this ships on `main` ahead of the redesign, which will restyle the column when it absorbs this commit.
* `progress` is an optional prop, so the table degrades gracefully if the progress array is unavailable; score display never depends on it.
* **Requires CMS-Enterprise/ztmf#404** to be deployed — until then the column renders all em-dashes.