### PR TITLE
feat(questionnaire): encrypt drafts at rest — non-extractable IDB key + lifecycle hardening (#475)

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -449,12 +449,16 @@ export default function QuestionnarePage() {
             )
           } catch (error) {
             if (controller.signal.aborted) return
-            if (isAuthHandled(error)) {
-              setLoadingQuestion(false)
-              return
+            if (!isAuthHandled(error)) {
+              console.error('Error fetching question scores:', error)
+              notify(ERROR_MESSAGES.tryAgain, 'error')
             }
-            console.error('Error fetching question scores:', error)
-            notify(ERROR_MESSAGES.tryAgain, 'error')
+            // Fall through to the batch below with an empty scores map so the
+            // sidebar/URL commit together with questions/datacallID/questionId,
+            // even when the scores call 403s without redirecting (auth-handled,
+            // component stays mounted). Returning here instead would leave the
+            // sidebar/URL on the new system while the content stayed on the old
+            // one. The [questionId] effect's finally clears the spinner.
           }
           // Batch questions + scores + datacallID + questionId so the questionId
           // effect fires exactly once with the correct scores already in
@@ -539,6 +543,15 @@ export default function QuestionnarePage() {
           const sys = systemRef.current
           const uid = userInfo.userid
           if (controller.signal.aborted) return
+          // Read-only sessions never load the draft again, so evict any lingering
+          // entry instead of letting it sit for the full TTL. Bump the save
+          // generation first: an autosave that fired just before isReadOnly
+          // flipped may still be mid-flight, and without the bump its isCurrent()
+          // checks would pass and rewrite the draft after this clear.
+          if (isReadOnly && sys && questionId && datacallID > 0) {
+            saveGenRef.current++
+            void clearDraft(uid, sys, questionId, datacallID)
+          }
           const draft =
             !isReadOnly && sys && questionId && datacallID > 0
               ? await loadDraft(uid, sys, questionId, datacallID)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -426,6 +426,7 @@ export default function QuestionnarePage() {
             if (controller.signal.aborted) return
             if (isAuthHandled(error)) return
             notify(ERROR_MESSAGES.tryAgain, 'error')
+            setLoadingQuestion(false)
             return
           }
           if (questionsEmpty) {
@@ -462,6 +463,7 @@ export default function QuestionnarePage() {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
           console.error('Error fetching data:', error)
+          setLoadingQuestion(false)
         }
       }
       fetchData()
@@ -567,7 +569,7 @@ export default function QuestionnarePage() {
           if (isAuthHandled(error)) return
           console.error('Error fetching data:', error)
         } finally {
-          setLoadingQuestion(false)
+          if (!controller.signal.aborted) setLoadingQuestion(false)
         }
       }
       fetchOptions()
@@ -610,10 +612,14 @@ export default function QuestionnarePage() {
     const currentGen = saveGenRef.current
     const timer = setTimeout(() => {
       if (saveGenRef.current !== currentGen) return
-      saveDraft(userInfo.userid, system, questionId, datacallID, {
-        selectQuestionOption,
-        notes,
-      }).then((saved) => {
+      saveDraft(
+        userInfo.userid,
+        system,
+        questionId,
+        datacallID,
+        { selectQuestionOption, notes },
+        () => saveGenRef.current === currentGen
+      ).then((saved) => {
         if (saveGenRef.current !== currentGen) return
         if (saved) {
           if (draftStatusRef.current !== 'restored') setDraftStatus('saved')

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -142,12 +142,20 @@ export default function QuestionnarePage() {
   const [selectQuestionOption, setSelectQuestionOption] =
     React.useState<number>(-1)
   const [draftStatus, setDraftStatus] = React.useState<
-    'idle' | 'restored' | 'saved'
+    'idle' | 'restored' | 'saved' | 'error'
   >('idle')
   // Refs read inside setTimeout/event callbacks to get the current value
   // without enrolling the effects in those deps (prevents extra re-runs).
   const draftStatusRef = React.useRef(draftStatus)
   draftStatusRef.current = draftStatus
+  // Stable ref so fetchOptions always reads the latest scores without enrolling
+  // questionScores as a dep of the questionId effect. Stale-closure-safe because
+  // the ref updates synchronously on every render before any effect runs.
+  const questionScoresRef = React.useRef(questionScores)
+  questionScoresRef.current = questionScores
+  // Incremented on every explicit draft clear so in-flight debounced saves
+  // that fire after a clear don't resurrect the just-removed draft.
+  const saveGenRef = React.useRef(0)
   const unsavedRef = React.useRef({
     selectQuestionOption,
     initQuestionChoice,
@@ -238,14 +246,16 @@ export default function QuestionnarePage() {
     }
   }
   const handleListItemClick = (index: number) => {
+    saveGenRef.current++
     setLoadingQuestion(true)
     setSelectedIndex(index)
     setQuestionId(index)
   }
 
   const clearCurrentDraft = () => {
+    saveGenRef.current++
     if (system && questionId && datacallID > 0) {
-      clearDraft(userInfo.userid, system, questionId, datacallID)
+      void clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
   }
@@ -312,6 +322,9 @@ export default function QuestionnarePage() {
       // view does not bleed into the next render when system changes.
       setNoQuestions(false)
       const fetchData = async () => {
+        // Gate the debounce effect during the entire system/datacall transition
+        // so stale pending saves don't fire while the question list reloads.
+        setLoadingQuestion(true)
         try {
           let questionsEmpty = false
           let datacall = ''
@@ -320,13 +333,11 @@ export default function QuestionnarePage() {
             selectedDatacall.datacallid !== latestDataCallId
           let activeDataCallId: number
           if (isHistorical && selectedDatacall) {
-            setDatacallID(selectedDatacall.datacallid)
             datacall = selectedDatacall.datacall.replaceAll(' ', '_')
             setDatacall(datacall)
             setIsPastDeadline(true)
             activeDataCallId = selectedDatacall.datacallid
           } else {
-            setDatacallID(latestDataCallId)
             datacall = latestDatacall.replaceAll(' ', '_')
             setDatacall(datacall)
             setIsPastDeadline(
@@ -334,6 +345,9 @@ export default function QuestionnarePage() {
             )
             activeDataCallId = latestDataCallId
           }
+          // Hoisted so both the questions block and the final batch can access them.
+          const questionData: Record<number, Question> = {}
+          let sortedFuncId: number[] = []
           try {
             const response = await axiosInstance.get(
               `/fismasystems/${system}/questions`,
@@ -352,7 +366,6 @@ export default function QuestionnarePage() {
               setLoadingQuestion(false)
             } else {
               const organizedData: Record<string, FismaQuestion[]> = {}
-              const questionData: Record<number, Question> = {}
               data.forEach((question: FismaQuestion) => {
                 if (!organizedData[question.pillar.pillar]) {
                   organizedData[question.pillar.pillar] = []
@@ -366,12 +379,10 @@ export default function QuestionnarePage() {
                 }
                 organizedData[question.pillar.pillar].push(question)
               })
-              setQuestions(questionData)
               const sortedPillars = filterPillarsForSystem(
                 sortPillars(Object.keys(organizedData)),
                 systemCategory
               )
-              let sortedFuncId: number[] = []
               const categoriesData: Category[] = sortedPillars.map((pillar) => {
                 const sortedSteps = sortFunctions(pillar, organizedData[pillar])
                 const sortedStepFuncId = sortedSteps.map(
@@ -394,9 +405,13 @@ export default function QuestionnarePage() {
                 },
                 {}
               )
-              setFunctionIdIdx(funcIdToIdx) // set a map of functionid -> index in sortedFunctId
-              setQuestionId(sortedFuncId[0]) // sets the questionid(functionid) to the first value in the array
-              setStepFunctionId(sortedFuncId) // contains an array of all functionid in order of render
+              // Update sidebar/nav state immediately so the question list
+              // renders while scores are still loading. setQuestions,
+              // setDatacallID, and setQuestionId are deferred to the batch
+              // below — after scores arrive — so the questionId effect fires
+              // exactly once with the correct scores already in the ref.
+              setFunctionIdIdx(funcIdToIdx)
+              setStepFunctionId(sortedFuncId)
               setCategories(categoriesData)
               navigate(
                 `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
@@ -405,10 +420,7 @@ export default function QuestionnarePage() {
                   replace: true,
                 }
               )
-              setSelectedIndex(sortedFuncId[0]) // set the first selected item in the list (rendered) to be selected(highlighted)
-              setQuestion(questionData[sortedFuncId[0]].question) // set the first question value to the page
-              setDescription(questionData[sortedFuncId[0]].description)
-              setNotePrompt(questionData[sortedFuncId[0]].notesprompt) // set the first note prompt to the page
+              setSelectedIndex(sortedFuncId[0])
             }
           } catch (error) {
             if (controller.signal.aborted) return
@@ -419,24 +431,33 @@ export default function QuestionnarePage() {
           if (questionsEmpty) {
             return
           }
+          let hashTable: questionScoreMap = {}
           try {
             const res = await axiosInstance.get(
               `scores?datacallid=${activeDataCallId}&fismasystemid=${system}&include=functionoption`,
               { signal: controller.signal }
             )
-            const hashTable: questionScoreMap = Object.assign(
+            hashTable = Object.assign(
               {},
               ...res.data.data.map((item: QuestionScores) => ({
                 [item.functionoptionid]: item,
               }))
             )
-            setQuestionScores(hashTable)
           } catch (error) {
             if (controller.signal.aborted) return
             if (isAuthHandled(error)) return
             console.error('Error fetching question scores:', error)
             notify(ERROR_MESSAGES.tryAgain, 'error')
           }
+          // Batch questions + scores + datacallID + questionId so the questionId
+          // effect fires exactly once with the correct scores already in
+          // questionScoresRef. This prevents a second effect run (and its
+          // accompanying draft-clearing race) that would occur if questionScores
+          // arrived as a separate update after questionId was already set.
+          setQuestions(questionData)
+          setQuestionScores(hashTable)
+          setDatacallID(activeDataCallId)
+          setQuestionId(sortedFuncId[0])
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
@@ -478,37 +499,43 @@ export default function QuestionnarePage() {
               label: item.description,
               value: item.functionoptionid,
             }
-            if (item.functionoptionid in questionScores) {
+            if (item.functionoptionid in questionScoresRef.current) {
               funcOptId = item.functionoptionid
               choiceOpt.defaultChecked = true
             }
             choices.push(choiceOpt)
           })
           // Foundation of question
-          setDescription(questionId ? questions[questionId].description : '')
-          setQuestion(questionId ? questions[questionId].question : '')
-          setNotePrompt(questionId ? questions[questionId].notesprompt : '')
+          setDescription(questions[questionId ?? 0]?.description ?? '')
+          setQuestion(questions[questionId ?? 0]?.question ?? '')
+          setNotePrompt(questions[questionId ?? 0]?.notesprompt ?? '')
 
           // Notes
-          setNotes(funcOptId ? questionScores[funcOptId].notes : '')
-          setInitNotes(funcOptId ? questionScores[funcOptId].notes : '')
+          setNotes(funcOptId ? questionScoresRef.current[funcOptId].notes : '')
+          setInitNotes(
+            funcOptId ? questionScoresRef.current[funcOptId].notes : ''
+          )
 
           // Question options
           setSelectQuestionOption(funcOptId ? funcOptId : -1)
           setInitQuestionChoice(funcOptId ? funcOptId : -1)
-          setScoreId(funcOptId ? questionScores[funcOptId].scoreid : 0)
+          setScoreId(
+            funcOptId ? questionScoresRef.current[funcOptId].scoreid : 0
+          )
 
           // Restore any in-progress draft from localStorage, overriding the
           // server-side values set above. Skipped for read-only sessions.
           const sys = systemRef.current
-          // Eagerly evict any stale draft when the session is now read-only.
           const uid = userInfo.userid
-          if (isReadOnly && sys && questionId && datacallID > 0)
-            clearDraft(uid, sys, questionId, datacallID)
+          if (controller.signal.aborted) return
           const draft =
             !isReadOnly && sys && questionId && datacallID > 0
               ? await loadDraft(uid, sys, questionId, datacallID)
               : null
+          // Guard: if the user navigated away while loadDraft was running
+          // (crypto.subtle.decrypt is genuinely async), discard its result
+          // rather than writing it into the now-active question's state.
+          if (controller.signal.aborted) return
           if (draft) {
             if (draft.selectQuestionOption === -1) {
               // Notes-only draft — restore notes without pre-selecting an answer.
@@ -527,7 +554,8 @@ export default function QuestionnarePage() {
             } else {
               // Draft references an option that no longer exists — evict it.
               if (sys && questionId && datacallID > 0)
-                clearDraft(uid, sys, questionId, datacallID)
+                await clearDraft(uid, sys, questionId, datacallID)
+              if (controller.signal.aborted) return
               setDraftStatus('idle')
             }
           } else {
@@ -545,14 +573,7 @@ export default function QuestionnarePage() {
       fetchOptions()
       return () => controller.abort()
     }
-  }, [
-    questionId,
-    questionScores,
-    questions,
-    isReadOnly,
-    datacallID,
-    userInfo.userid,
-  ])
+  }, [questionId, questions, isReadOnly, datacallID, userInfo.userid])
 
   // Debounced draft save: 1 second after the user pauses editing, persist
   // the current answer and notes to localStorage so a reload can recover them.
@@ -570,14 +591,35 @@ export default function QuestionnarePage() {
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
-    if (selectQuestionOption === initQuestionChoice && notes === initNotes)
+    if (selectQuestionOption === initQuestionChoice && notes === initNotes) {
+      saveGenRef.current++
+      // Skip clearDraft when a draft was just restored from storage — the draft
+      // values matching the server state does not mean the user reverted manually.
+      // Clearing it here would delete a valid in-progress draft on every page load
+      // when the server happens to be at the same state as the draft.
+      if (
+        system &&
+        questionId &&
+        datacallID > 0 &&
+        draftStatusRef.current !== 'restored'
+      )
+        void clearDraft(userInfo.userid, system, questionId, datacallID)
+      if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
+    }
+    const currentGen = saveGenRef.current
     const timer = setTimeout(() => {
+      if (saveGenRef.current !== currentGen) return
       saveDraft(userInfo.userid, system, questionId, datacallID, {
         selectQuestionOption,
         notes,
-      }).then(() => {
-        if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+      }).then((saved) => {
+        if (saveGenRef.current !== currentGen) return
+        if (saved) {
+          if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
+        } else {
+          setDraftStatus('error')
+        }
       })
     }, 1000)
     return () => clearTimeout(timer)
@@ -856,6 +898,7 @@ export default function QuestionnarePage() {
                           )
                           setOpenAlert(true)
                         } else {
+                          saveGenRef.current++
                           const id =
                             stepFunctionId[functionIdIdx[selectedIndex] - 1]
                           if (questions[id]) {
@@ -921,13 +964,21 @@ export default function QuestionnarePage() {
                   </Box>
                   {draftStatus !== 'idle' && !isReadOnly && (
                     <Alert
-                      severity={draftStatus === 'saved' ? 'success' : 'warning'}
+                      severity={
+                        draftStatus === 'saved'
+                          ? 'success'
+                          : draftStatus === 'error'
+                            ? 'error'
+                            : 'warning'
+                      }
                       icon={false}
                       sx={{ mt: 1, py: 0.5 }}
                     >
                       {draftStatus === 'saved'
                         ? 'Draft saved — click Next or Complete to save permanently.'
-                        : 'Draft restored — click Next or Complete to save permanently.'}
+                        : draftStatus === 'error'
+                          ? 'Draft could not be saved — click Next or Complete to save permanently.'
+                          : 'Draft restored — click Next or Complete to save permanently.'}
                     </Alert>
                   )}
                   <LastEditedFooter

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -48,6 +48,7 @@ import {
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
+import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -168,6 +169,16 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   }
+  // Refs so the out-of-band re-seed effect can read current options and loading
+  // state without enrolling them as effect dependencies.
+  const optionsRef = React.useRef(options)
+  optionsRef.current = options
+  const loadingQuestionRef = React.useRef(loadingQuestion)
+  loadingQuestionRef.current = loadingQuestion
+  // Bumped when a re-seed changes the answer so the uncontrolled radio ChoiceList
+  // (which only reflects defaultChecked on mount) remounts and shows the
+  // corrected selection.
+  const [radioKey, setRadioKey] = React.useState(0)
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
@@ -682,6 +693,47 @@ export default function QuestionnarePage() {
     return () => window.removeEventListener('beforeunload', handle)
   }, [isReadOnly])
 
+  // Re-seed the current question's answer when the scores map refreshes out of
+  // band — e.g. the user saves a question then navigates back before that save's
+  // scores GET resolves, so the questionId effect seeded from a stale snapshot.
+  // Only runs when idle (the questionId effect owns seeding while loading) with no
+  // unsaved edits and no restored draft, so an in-progress change is never
+  // overwritten. Without this the display can show a just-saved answer as
+  // unanswered, and re-answering it would POST a duplicate score.
+  React.useEffect(() => {
+    const u = unsavedRef.current
+    if (
+      !shouldReseedAnswer({
+        hasQuestion: !!questionId,
+        loadingQuestion: loadingQuestionRef.current,
+        hasUnsavedEdits:
+          u.selectQuestionOption !== u.initQuestionChoice ||
+          u.notes !== u.initNotes,
+        draftRestored: draftStatusRef.current === 'restored',
+      })
+    ) {
+      return
+    }
+    const sel = deriveScoreSelection(
+      optionsRef.current.map((o) => Number(o.value)),
+      questionScoresRef.current
+    )
+    // No change from the last-seeded state — nothing to correct.
+    if (sel.choice === u.initQuestionChoice && sel.notes === u.initNotes) return
+    setOptions((prev) =>
+      prev.map((o) => ({
+        ...o,
+        defaultChecked: Number(o.value) === sel.funcOptId,
+      }))
+    )
+    setSelectQuestionOption(sel.choice)
+    setInitQuestionChoice(sel.choice)
+    setNotes(sel.notes)
+    setInitNotes(sel.notes)
+    setScoreId(sel.scoreid)
+    setRadioKey((k) => k + 1)
+  }, [questionScores, questionId])
+
   const breadcrumbSegmentLabels = fismaacronym
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
     : undefined
@@ -854,7 +906,9 @@ export default function QuestionnarePage() {
                 </Box>
               ) : (
                 <Box>
-                  <Box sx={{ mb: 2 }}>{renderRadioGroup(options)}</Box>
+                  <Box key={radioKey} sx={{ mb: 2 }}>
+                    {renderRadioGroup(options)}
+                  </Box>
                   <Typography variant="h6" sx={{ mb: 1 }}>
                     {notePrompt || ''}
                   </Typography>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -424,7 +424,10 @@ export default function QuestionnarePage() {
             }
           } catch (error) {
             if (controller.signal.aborted) return
-            if (isAuthHandled(error)) return
+            if (isAuthHandled(error)) {
+              setLoadingQuestion(false)
+              return
+            }
             notify(ERROR_MESSAGES.tryAgain, 'error')
             setLoadingQuestion(false)
             return
@@ -446,7 +449,10 @@ export default function QuestionnarePage() {
             )
           } catch (error) {
             if (controller.signal.aborted) return
-            if (isAuthHandled(error)) return
+            if (isAuthHandled(error)) {
+              setLoadingQuestion(false)
+              return
+            }
             console.error('Error fetching question scores:', error)
             notify(ERROR_MESSAGES.tryAgain, 'error')
           }
@@ -461,7 +467,10 @@ export default function QuestionnarePage() {
           setQuestionId(sortedFuncId[0])
         } catch (error) {
           if (controller.signal.aborted) return
-          if (isAuthHandled(error)) return
+          if (isAuthHandled(error)) {
+            setLoadingQuestion(false)
+            return
+          }
           console.error('Error fetching data:', error)
           setLoadingQuestion(false)
         }
@@ -931,6 +940,7 @@ export default function QuestionnarePage() {
                     </CmsButton>
                     <CmsButton
                       onClick={() => {
+                        saveGenRef.current++
                         const id =
                           selectedIndex ===
                           stepFunctionId[stepFunctionId.length - 1]

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -2,19 +2,69 @@ import {
   saveDraft,
   loadDraft,
   clearDraft,
-  clearStaleUserDrafts,
+  clearOtherUserDrafts,
+  __resetKeyCache,
+  __setKeyForTesting,
+  __setHashedIdForTesting,
   QuestionDraft,
 } from './draftStore'
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
+const DRAFT_VERSION = 1
 
 const USER = 'user-abc'
+const USER_A = 'user-a'
+const USER_B = 'user-b'
 const IDS = { fismasystemid: 1, functionid: 2, datacallid: 3 } as const
-const EXPECTED_KEY = 'ztmf_draft_user-abc_1_2_3'
+
+// Predictable hashes injected via __setHashedIdForTesting so EXPECTED_KEY is stable.
+const H_USER = 'h-user-abc'
+const H_USER_A = 'h-user-a'
+const H_USER_B = 'h-user-b'
+const EXPECTED_KEY = `ztmf_draft_${H_USER}_1_2_3`
+
 const DRAFT: QuestionDraft = { selectQuestionOption: 5, notes: 'test notes' }
+
+// Two distinct keys so cross-user isolation tests behave correctly.
+let keyA: CryptoKey
+let keyB: CryptoKey
+
+beforeAll(async () => {
+  const params = { name: 'AES-GCM', length: 256 } as const
+  const uses: KeyUsage[] = ['encrypt', 'decrypt']
+  keyA = await crypto.subtle.generateKey(params, false, uses)
+  keyB = await crypto.subtle.generateKey(params, false, uses)
+})
+
+// Helper: encrypt an arbitrary payload with a given key (for shape/version tests).
+async function encryptRaw(
+  key: CryptoKey,
+  payload: unknown
+): Promise<{ iv: string; ciphertext: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload))
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    plaintext
+  )
+  return {
+    iv: btoa(String.fromCharCode(...iv)),
+    ciphertext: btoa(String.fromCharCode(...new Uint8Array(encrypted))),
+  }
+}
 
 beforeEach(() => {
   localStorage.clear()
+  // Reset and re-seed both caches so each test starts from known state without
+  // touching IndexedDB (unavailable in JSDOM) or SHA-256 digest.
+  __resetKeyCache()
+  __setKeyForTesting(USER, keyA)
+  __setKeyForTesting(USER_A, keyA)
+  __setKeyForTesting(USER_B, keyB)
+  __setHashedIdForTesting(USER, H_USER)
+  __setHashedIdForTesting(USER_A, H_USER_A)
+  __setHashedIdForTesting(USER_B, H_USER_B)
 })
 
 afterEach(() => {
@@ -22,7 +72,7 @@ afterEach(() => {
 })
 
 describe('key format', () => {
-  it('generates ztmf_draft_{userid}_{system}_{function}_{datacall}', async () => {
+  it('generates ztmf_draft_{hashedUserId}_{system}_{function}_{datacall}', async () => {
     await saveDraft(
       USER,
       IDS.fismasystemid,
@@ -40,14 +90,39 @@ describe('key format', () => {
   })
 
   it('different userids produce different keys', async () => {
-    await saveDraft('user-a', 1, 2, 3, DRAFT)
-    await saveDraft('user-b', 1, 2, 3, DRAFT)
+    await saveDraft(USER_A, 1, 2, 3, DRAFT)
+    await saveDraft(USER_B, 1, 2, 3, DRAFT)
     expect(Object.keys(localStorage)).toHaveLength(2)
   })
 })
 
 describe('saveDraft', () => {
-  it('writes encrypted JSON to the correct key', async () => {
+  it('returns true when save succeeds', async () => {
+    const result = await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false when localStorage is unavailable', async () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError')
+    })
+    const result = await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    expect(result).toBe(false)
+  })
+
+  it('writes encrypted JSON with version field to the correct key', async () => {
     await saveDraft(
       USER,
       IDS.fismasystemid,
@@ -58,6 +133,7 @@ describe('saveDraft', () => {
     const raw = localStorage.getItem(EXPECTED_KEY)
     expect(raw).not.toBeNull()
     const parsed = JSON.parse(raw!)
+    expect(parsed).toHaveProperty('v', DRAFT_VERSION)
     expect(parsed).toHaveProperty('iv')
     expect(parsed).toHaveProperty('ciphertext')
     expect(parsed).toHaveProperty('savedAt')
@@ -98,15 +174,6 @@ describe('saveDraft', () => {
     )
     expect(result).not.toHaveProperty('savedAt')
   })
-
-  it('does not throw when localStorage is unavailable', async () => {
-    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new DOMException('QuotaExceededError')
-    })
-    await expect(
-      saveDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid, DRAFT)
-    ).resolves.not.toThrow()
-  })
 })
 
 describe('loadDraft', () => {
@@ -114,6 +181,27 @@ describe('loadDraft', () => {
     expect(
       await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
+  })
+
+  it('round-trips a notes-only draft (selectQuestionOption = -1)', async () => {
+    const notesOnly: QuestionDraft = {
+      selectQuestionOption: -1,
+      notes: 'partial note',
+    }
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      notesOnly
+    )
+    const result = await loadDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
+    expect(result).toEqual(notesOnly)
   })
 
   it('decrypts and returns the original draft fields', async () => {
@@ -135,17 +223,18 @@ describe('loadDraft', () => {
 
   it('returns null for a draft decrypted with the wrong user key', async () => {
     await saveDraft(
-      'user-a',
+      USER_A,
       IDS.fismasystemid,
       IDS.functionid,
       IDS.datacallid,
       DRAFT
     )
-    // Copy user-a ciphertext into user-b key slot to test key isolation
-    const raw = localStorage.getItem('ztmf_draft_user-a_1_2_3')!
-    localStorage.setItem('ztmf_draft_user-b_1_2_3', raw)
+    // Copy user-a ciphertext (encrypted with keyA) into user-b slot.
+    // loadDraft for user-b will try keyB — decrypt fails → null.
+    const raw = localStorage.getItem(`ztmf_draft_${H_USER_A}_1_2_3`)!
+    localStorage.setItem(`ztmf_draft_${H_USER_B}_1_2_3`, raw)
     const result = await loadDraft(
-      'user-b',
+      USER_B,
       IDS.fismasystemid,
       IDS.functionid,
       IDS.datacallid
@@ -213,11 +302,92 @@ describe('loadDraft', () => {
     expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
+  it('returns null and evicts when the version field is wrong', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const raw = JSON.parse(localStorage.getItem(EXPECTED_KEY)!)
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify({ ...raw, v: 99 }))
+
+    expect(
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null and evicts when the version field is missing', async () => {
+    await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT
+    )
+    const { v: _, ...withoutV } = JSON.parse(
+      localStorage.getItem(EXPECTED_KEY)!
+    )
+    localStorage.setItem(EXPECTED_KEY, JSON.stringify(withoutV))
+
+    expect(
+      await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    ).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
   it('returns null when the stored value is malformed JSON', async () => {
     localStorage.setItem(EXPECTED_KEY, 'not-json{{{')
     expect(
       await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     ).toBeNull()
+  })
+
+  it('evicts the entry when the stored value is malformed JSON', async () => {
+    localStorage.setItem(EXPECTED_KEY, 'not-json{{{')
+    await loadDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null and evicts when decrypted payload is missing notes', async () => {
+    const { iv, ciphertext } = await encryptRaw(keyA, {
+      selectQuestionOption: 5,
+    })
+    localStorage.setItem(
+      EXPECTED_KEY,
+      JSON.stringify({ v: DRAFT_VERSION, iv, ciphertext, savedAt: Date.now() })
+    )
+
+    const result = await loadDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
+    expect(result).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns null and evicts when decrypted payload has wrong field types', async () => {
+    const { iv, ciphertext } = await encryptRaw(keyA, {
+      selectQuestionOption: 'not-a-number',
+      notes: 42,
+    })
+    localStorage.setItem(
+      EXPECTED_KEY,
+      JSON.stringify({ v: DRAFT_VERSION, iv, ciphertext, savedAt: Date.now() })
+    )
+
+    const result = await loadDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid
+    )
+    expect(result).toBeNull()
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
   it('does not throw when localStorage.getItem throws', async () => {
@@ -239,68 +409,68 @@ describe('clearDraft', () => {
       IDS.datacallid,
       DRAFT
     )
-    clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
+    await clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
     expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
-  it('does not throw when the key does not exist', () => {
-    expect(() =>
+  it('does not throw when the key does not exist', async () => {
+    await expect(
       clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
-    ).not.toThrow()
+    ).resolves.not.toThrow()
   })
 
-  it('does not throw when localStorage.removeItem throws', () => {
+  it('does not throw when localStorage.removeItem throws', async () => {
     jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
       throw new DOMException('SecurityError')
     })
-    expect(() =>
+    await expect(
       clearDraft(USER, IDS.fismasystemid, IDS.functionid, IDS.datacallid)
-    ).not.toThrow()
+    ).resolves.not.toThrow()
   })
 
   it('only removes the targeted key, leaving others intact', async () => {
     await saveDraft(USER, 1, 2, 3, DRAFT)
     await saveDraft(USER, 1, 2, 4, DRAFT)
-    clearDraft(USER, 1, 2, 3)
-    expect(localStorage.getItem('ztmf_draft_user-abc_1_2_3')).toBeNull()
-    expect(localStorage.getItem('ztmf_draft_user-abc_1_2_4')).not.toBeNull()
+    await clearDraft(USER, 1, 2, 3)
+    expect(localStorage.getItem(`ztmf_draft_${H_USER}_1_2_3`)).toBeNull()
+    expect(localStorage.getItem(`ztmf_draft_${H_USER}_1_2_4`)).not.toBeNull()
   })
 })
 
-describe('clearStaleUserDrafts', () => {
+describe('clearOtherUserDrafts', () => {
   it('removes drafts belonging to other users', async () => {
-    await saveDraft('user-a', 1, 2, 3, DRAFT)
-    await saveDraft('user-b', 1, 2, 3, DRAFT)
-    clearStaleUserDrafts('user-a')
-    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
-    expect(localStorage.getItem('ztmf_draft_user-b_1_2_3')).toBeNull()
+    await saveDraft(USER_A, 1, 2, 3, DRAFT)
+    await saveDraft(USER_B, 1, 2, 3, DRAFT)
+    await clearOtherUserDrafts(USER_A)
+    expect(localStorage.getItem(`ztmf_draft_${H_USER_A}_1_2_3`)).not.toBeNull()
+    expect(localStorage.getItem(`ztmf_draft_${H_USER_B}_1_2_3`)).toBeNull()
   })
 
   it('preserves all drafts belonging to the current user', async () => {
-    await saveDraft('user-a', 1, 2, 3, DRAFT)
-    await saveDraft('user-a', 1, 2, 4, DRAFT)
-    clearStaleUserDrafts('user-a')
-    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
-    expect(localStorage.getItem('ztmf_draft_user-a_1_2_4')).not.toBeNull()
+    await saveDraft(USER_A, 1, 2, 3, DRAFT)
+    await saveDraft(USER_A, 1, 2, 4, DRAFT)
+    await clearOtherUserDrafts(USER_A)
+    expect(localStorage.getItem(`ztmf_draft_${H_USER_A}_1_2_3`)).not.toBeNull()
+    expect(localStorage.getItem(`ztmf_draft_${H_USER_A}_1_2_4`)).not.toBeNull()
   })
 
   it('does not remove unrelated localStorage keys', async () => {
     localStorage.setItem('some_other_key', 'value')
-    await saveDraft('user-b', 1, 2, 3, DRAFT)
-    clearStaleUserDrafts('user-a')
+    await saveDraft(USER_B, 1, 2, 3, DRAFT)
+    await clearOtherUserDrafts(USER_A)
     expect(localStorage.getItem('some_other_key')).toBe('value')
   })
 
   it('does nothing when userid is empty', async () => {
-    await saveDraft('user-a', 1, 2, 3, DRAFT)
-    clearStaleUserDrafts('')
-    expect(localStorage.getItem('ztmf_draft_user-a_1_2_3')).not.toBeNull()
+    await saveDraft(USER_A, 1, 2, 3, DRAFT)
+    await clearOtherUserDrafts('')
+    expect(localStorage.getItem(`ztmf_draft_${H_USER_A}_1_2_3`)).not.toBeNull()
   })
 
-  it('does not throw when localStorage throws', () => {
+  it('does not throw when localStorage throws', async () => {
     jest.spyOn(Storage.prototype, 'key').mockImplementation(() => {
       throw new DOMException('SecurityError')
     })
-    expect(() => clearStaleUserDrafts('user-a')).not.toThrow()
+    await expect(clearOtherUserDrafts(USER_A)).resolves.not.toThrow()
   })
 })

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -501,3 +501,136 @@ describe('clearOtherUserDrafts', () => {
     await expect(clearOtherUserDrafts(USER_A)).resolves.not.toThrow()
   })
 })
+
+// Minimal in-memory IndexedDB for the device-key store. jsdom has no IndexedDB,
+// and the rest of this suite deliberately bypasses it via __setKeyForTesting, so
+// this stand-in lets the real getOrCreateDeviceKey path run for the concurrency
+// regression below. It stores values by reference (a CryptoKey round-trips
+// unchanged, as the browser's structured clone keeps it usable) and fires
+// callbacks on a later microtask so concurrent callers interleave the way they
+// would against a real database.
+type FakeRequest = {
+  result?: unknown
+  onsuccess?: (ev: { target: FakeRequest }) => void
+  onupgradeneeded?: (ev: { target: FakeRequest }) => void
+}
+
+function installMemoryIndexedDB(): () => void {
+  const stores = new Map<string, Map<IDBValidKey, unknown>>()
+  let created = false
+  const settle = (req: FakeRequest, result?: unknown) => {
+    queueMicrotask(() => {
+      req.result = result
+      req.onsuccess?.({ target: req })
+    })
+  }
+  const storeFor = (name: string) => {
+    if (!stores.has(name)) stores.set(name, new Map())
+    const data = stores.get(name)!
+    return {
+      get(key: IDBValidKey) {
+        const req: FakeRequest = {}
+        settle(req, data.get(key))
+        return req
+      },
+      put(value: unknown, key: IDBValidKey) {
+        const req: FakeRequest = {}
+        data.set(key, value)
+        settle(req, key)
+        return req
+      },
+    }
+  }
+  const db = {
+    createObjectStore: (name: string) => storeFor(name),
+    transaction: (name: string) => ({ objectStore: () => storeFor(name) }),
+    close: () => {},
+  }
+  const fake = {
+    open() {
+      const req: FakeRequest = {}
+      queueMicrotask(() => {
+        req.result = db
+        if (!created) {
+          created = true
+          req.onupgradeneeded?.({ target: req })
+        }
+        req.onsuccess?.({ target: req })
+      })
+      return req
+    },
+    deleteDatabase() {
+      stores.clear()
+      created = false
+      const req: FakeRequest = {}
+      settle(req)
+      return req
+    },
+  }
+  const holder = globalThis as { indexedDB?: unknown }
+  const original = holder.indexedDB
+  holder.indexedDB = fake as unknown as IDBFactory
+  return () => {
+    holder.indexedDB = original
+  }
+}
+
+describe('device key persistence (IndexedDB)', () => {
+  const IDB_USER = 'idb-user'
+  const SYS = 9
+  const DC = 7
+  let restoreIndexedDB: () => void
+
+  beforeAll(() => {
+    restoreIndexedDB = installMemoryIndexedDB()
+  })
+  afterAll(() => {
+    restoreIndexedDB()
+  })
+
+  beforeEach(async () => {
+    // Run the real create-key path (not a seeded key): empty the store and both
+    // in-memory caches so getOrCreateDeviceKey reaches IndexedDB.
+    localStorage.clear()
+    __resetKeyCache()
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('ztmf-draft-keys')
+      req.onsuccess = () => resolve()
+    })
+  })
+
+  it('concurrent first-use saves share one key and survive a reload', async () => {
+    // Fire concurrent saves for different questions before any key exists, so
+    // each save triggers key creation while the others are still resolving.
+    // Regression: previously each concurrent caller generated and persisted its
+    // own key, orphaning every draft not encrypted with the last-written key —
+    // they then failed to decrypt after reload and were silently evicted.
+    const fns = [1, 2, 3, 4]
+    const results = await Promise.all(
+      fns.map((functionid) =>
+        saveDraft(IDB_USER, SYS, functionid, DC, {
+          selectQuestionOption: functionid,
+          notes: `notes ${functionid}`,
+        })
+      )
+    )
+    expect(results).toEqual([true, true, true, true])
+
+    // Simulate a reload: in-memory cache is gone, IndexedDB persists. Every draft
+    // must still decrypt — i.e. the key that encrypted it is the one persisted.
+    __resetKeyCache()
+    for (const functionid of fns) {
+      await expect(loadDraft(IDB_USER, SYS, functionid, DC)).resolves.toEqual({
+        selectQuestionOption: functionid,
+        notes: `notes ${functionid}`,
+      })
+    }
+  })
+
+  it('reuses the persisted key across reloads for a returning user', async () => {
+    expect(await saveDraft(IDB_USER, SYS, 1, DC, DRAFT)).toBe(true)
+    // Reload: cache cleared, the key read back from IndexedDB must decrypt.
+    __resetKeyCache()
+    await expect(loadDraft(IDB_USER, SYS, 1, DC)).resolves.toEqual(DRAFT)
+  })
+})

--- a/src/views/QuestionnairePage/draftStore.test.ts
+++ b/src/views/QuestionnairePage/draftStore.test.ts
@@ -7,10 +7,10 @@ import {
   __setKeyForTesting,
   __setHashedIdForTesting,
   QuestionDraft,
+  DRAFT_VERSION,
 } from './draftStore'
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
-const DRAFT_VERSION = 1
 
 const USER = 'user-abc'
 const USER_A = 'user-a'
@@ -106,6 +106,33 @@ describe('saveDraft', () => {
       DRAFT
     )
     expect(result).toBe(true)
+  })
+
+  it('returns false without writing when isCurrent returns false before encryption', async () => {
+    const result = await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT,
+      () => false
+    )
+    expect(result).toBe(false)
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
+  })
+
+  it('returns false without writing when isCurrent returns false after encryption', async () => {
+    let calls = 0
+    const result = await saveDraft(
+      USER,
+      IDS.fismasystemid,
+      IDS.functionid,
+      IDS.datacallid,
+      DRAFT,
+      () => ++calls < 2 // true on first check (pre-encrypt), false on second (pre-write)
+    )
+    expect(result).toBe(false)
+    expect(localStorage.getItem(EXPECTED_KEY)).toBeNull()
   })
 
   it('returns false when localStorage is unavailable', async () => {

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -11,7 +11,7 @@ type StoredDraft = {
   savedAt: number
 }
 
-const DRAFT_VERSION = 1
+export const DRAFT_VERSION = 1
 const DRAFT_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
 const DRAFT_PREFIX = 'ztmf_draft_'
 
@@ -162,17 +162,24 @@ async function decryptDraft(
 // Returns true when the draft was successfully persisted, false on any failure
 // (storage quota, private browsing, crypto unavailable). The caller uses the
 // return value to decide whether to show a "saved" or "not saved" indicator.
+//
+// isCurrent is checked twice: once before async work begins and once before the
+// final write. This prevents a stale in-flight save from resurrecting a draft
+// that was explicitly cleared while encryption was running (~10 ms async window).
 export const saveDraft = async (
   userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number,
-  draft: QuestionDraft
+  draft: QuestionDraft,
+  isCurrent: () => boolean = () => true
 ): Promise<boolean> => {
   try {
+    if (!isCurrent()) return false
     const hashedId = await hashUserId(userid)
     const key = await getOrCreateDeviceKey(userid)
     const { iv, ciphertext } = await encryptDraft(key, draft)
+    if (!isCurrent()) return false
     const stored: StoredDraft = {
       v: DRAFT_VERSION,
       iv,

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -23,7 +23,10 @@ const DB_VERSION = 1
 const KEY_STORE = 'keys'
 
 // In-memory caches — avoids round-trips on repeated reads/writes within a session.
-const keyCache = new Map<string, CryptoKey>()
+// keyCache holds the in-flight key-resolution *promise* (not the resolved key) so
+// concurrent callers in one session share a single key instead of each racing to
+// generate and persist their own — see getOrCreateDeviceKey.
+const keyCache = new Map<string, Promise<CryptoKey>>()
 const hashedIdCache = new Map<string, string>()
 
 // Exported for test isolation only — clears both in-memory caches.
@@ -33,9 +36,10 @@ export function __resetKeyCache(): void {
 }
 
 // Exported for test isolation only — seeds the key cache directly, bypassing IDB
-// (IndexedDB is unavailable in JSDOM).
+// (IndexedDB is unavailable in JSDOM). Wrapped in a resolved promise to match the
+// cache's Promise<CryptoKey> shape.
 export function __setKeyForTesting(userid: string, key: CryptoKey): void {
-  keyCache.set(userid, key)
+  keyCache.set(userid, Promise.resolve(key))
 }
 
 // Exported for test isolation only — seeds the hash cache with a predictable value.
@@ -54,46 +58,67 @@ function openKeyDB(): Promise<IDBDatabase> {
   })
 }
 
+// Resolves the per-device key from IndexedDB, creating it on first use. Generate
+// the candidate before opening the transaction: awaiting generateKey mid-transaction
+// lets IDB auto-commit and throw on the put. The single readwrite transaction
+// re-checks for an existing key and keeps it if present — IndexedDB serializes
+// overlapping transactions on one store, so two tabs can't both persist a key and
+// clobber each other (the loser's drafts would fail to decrypt after reload and
+// be silently evicted). idbKey is the hashed userid, matching the localStorage
+// key format so the raw userid isn't exposed in DevTools.
+async function resolveDeviceKey(userid: string): Promise<CryptoKey> {
+  const idbKey = await hashUserId(userid)
+  const candidate = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    false, // non-extractable — cannot be exported as raw bytes via JS
+    ['encrypt', 'decrypt']
+  )
+  const db = await openKeyDB()
+  try {
+    return await new Promise<CryptoKey>((resolve, reject) => {
+      const store = db
+        .transaction(KEY_STORE, 'readwrite')
+        .objectStore(KEY_STORE)
+      const getReq = store.get(idbKey)
+      getReq.onerror = () => reject(getReq.error)
+      getReq.onsuccess = () => {
+        const found = getReq.result as CryptoKey | undefined
+        if (found) {
+          resolve(found)
+          return
+        }
+        // store.put can throw synchronously (e.g. DataCloneError, or an inactive
+        // transaction). This runs in an event callback after the executor
+        // returned, so an uncaught throw would leave the promise pending and hang
+        // saveDraft/loadDraft — reject explicitly instead.
+        try {
+          const putReq = store.put(candidate, idbKey)
+          putReq.onsuccess = () => resolve(candidate)
+          putReq.onerror = () => reject(putReq.error)
+        } catch (err) {
+          reject(err)
+        }
+      }
+    })
+  } finally {
+    db.close()
+  }
+}
+
+// Returns the per-user non-extractable AES-GCM key. The in-flight promise is
+// memoized (not just the resolved key) so concurrent callers in one session share
+// one resolution — otherwise each generates its own key and all but one are
+// orphaned, taking their encrypted drafts with them on the next reload.
 async function getOrCreateDeviceKey(userid: string): Promise<CryptoKey> {
   const cached = keyCache.get(userid)
   if (cached) return cached
-
-  // Hash the userid so the IDB key name is consistent with the localStorage
-  // key format and doesn't expose the raw userid in DevTools.
-  const idbKey = await hashUserId(userid)
-  const db = await openKeyDB()
+  const promise = resolveDeviceKey(userid)
+  keyCache.set(userid, promise)
   try {
-    const existing = await new Promise<CryptoKey | undefined>(
-      (resolve, reject) => {
-        const tx = db.transaction(KEY_STORE, 'readonly')
-        const req = tx.objectStore(KEY_STORE).get(idbKey)
-        req.onsuccess = () => resolve(req.result as CryptoKey | undefined)
-        req.onerror = () => reject(req.error)
-      }
-    )
-
-    if (existing) {
-      keyCache.set(userid, existing)
-      return existing
-    }
-
-    const key = await crypto.subtle.generateKey(
-      { name: 'AES-GCM', length: 256 },
-      false, // non-extractable — cannot be exported as raw bytes via JS
-      ['encrypt', 'decrypt']
-    )
-
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(KEY_STORE, 'readwrite')
-      const req = tx.objectStore(KEY_STORE).put(key, idbKey)
-      req.onsuccess = () => resolve()
-      req.onerror = () => reject(req.error)
-    })
-
-    keyCache.set(userid, key)
-    return key
-  } finally {
-    db.close()
+    return await promise
+  } catch (err) {
+    keyCache.delete(userid) // don't cache a rejection — let the next caller retry
+    throw err
   }
 }
 

--- a/src/views/QuestionnairePage/draftStore.ts
+++ b/src/views/QuestionnairePage/draftStore.ts
@@ -5,52 +5,125 @@ export type QuestionDraft = {
 
 // Shape written to localStorage — callers only see QuestionDraft.
 type StoredDraft = {
+  v: number // format version — entries with a mismatched version are evicted
   iv: string
   ciphertext: string
   savedAt: number
 }
 
+const DRAFT_VERSION = 1
 const DRAFT_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
 const DRAFT_PREFIX = 'ztmf_draft_'
-const PBKDF2_SALT = new TextEncoder().encode('ztmf-draft-v1')
-const PBKDF2_ITERATIONS = 100_000
+
+// IndexedDB database that holds one non-extractable CryptoKey per user.
+// Non-extractable keys cannot be exported via JS API — an attacker needs a
+// live browser session, not just a disk dump of the profile directory.
+const DB_NAME = 'ztmf-draft-keys'
+const DB_VERSION = 1
+const KEY_STORE = 'keys'
+
+// In-memory caches — avoids round-trips on repeated reads/writes within a session.
+const keyCache = new Map<string, CryptoKey>()
+const hashedIdCache = new Map<string, string>()
+
+// Exported for test isolation only — clears both in-memory caches.
+export function __resetKeyCache(): void {
+  keyCache.clear()
+  hashedIdCache.clear()
+}
+
+// Exported for test isolation only — seeds the key cache directly, bypassing IDB
+// (IndexedDB is unavailable in JSDOM).
+export function __setKeyForTesting(userid: string, key: CryptoKey): void {
+  keyCache.set(userid, key)
+}
+
+// Exported for test isolation only — seeds the hash cache with a predictable value.
+export function __setHashedIdForTesting(userid: string, hash: string): void {
+  hashedIdCache.set(userid, hash)
+}
+
+function openKeyDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(KEY_STORE)
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function getOrCreateDeviceKey(userid: string): Promise<CryptoKey> {
+  const cached = keyCache.get(userid)
+  if (cached) return cached
+
+  // Hash the userid so the IDB key name is consistent with the localStorage
+  // key format and doesn't expose the raw userid in DevTools.
+  const idbKey = await hashUserId(userid)
+  const db = await openKeyDB()
+  try {
+    const existing = await new Promise<CryptoKey | undefined>(
+      (resolve, reject) => {
+        const tx = db.transaction(KEY_STORE, 'readonly')
+        const req = tx.objectStore(KEY_STORE).get(idbKey)
+        req.onsuccess = () => resolve(req.result as CryptoKey | undefined)
+        req.onerror = () => reject(req.error)
+      }
+    )
+
+    if (existing) {
+      keyCache.set(userid, existing)
+      return existing
+    }
+
+    const key = await crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      false, // non-extractable — cannot be exported as raw bytes via JS
+      ['encrypt', 'decrypt']
+    )
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(KEY_STORE, 'readwrite')
+      const req = tx.objectStore(KEY_STORE).put(key, idbKey)
+      req.onsuccess = () => resolve()
+      req.onerror = () => reject(req.error)
+    })
+
+    keyCache.set(userid, key)
+    return key
+  } finally {
+    db.close()
+  }
+}
+
+// Hashes the userid with SHA-256 and returns the first 16 base64url characters
+// (~96 bits). Used as the user segment of localStorage key names so raw user
+// IDs are not visible in DevTools on a shared machine.
+async function hashUserId(userid: string): Promise<string> {
+  const cached = hashedIdCache.get(userid)
+  if (cached) return cached
+
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(userid)
+  )
+  const hash = btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+    .slice(0, 16)
+
+  hashedIdCache.set(userid, hash)
+  return hash
+}
 
 const draftKey = (
-  userid: string,
+  hashedId: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number
-) => `${DRAFT_PREFIX}${userid}_${fismasystemid}_${functionid}_${datacallid}`
-
-// Cache derived keys by userid — PBKDF2 is intentionally slow at 100k
-// iterations; re-deriving on every read/write would add ~100ms per call.
-const keyCache = new Map<string, CryptoKey>()
-
-async function deriveKey(userid: string): Promise<CryptoKey> {
-  const cached = keyCache.get(userid)
-  if (cached) return cached
-  const keyMaterial = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(userid),
-    'PBKDF2',
-    false,
-    ['deriveKey']
-  )
-  const key = await crypto.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      salt: PBKDF2_SALT,
-      iterations: PBKDF2_ITERATIONS,
-      hash: 'SHA-256',
-    },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  )
-  keyCache.set(userid, key)
-  return key
-}
+) => `${DRAFT_PREFIX}${hashedId}_${fismasystemid}_${functionid}_${datacallid}`
 
 async function encryptDraft(
   key: CryptoKey,
@@ -86,23 +159,33 @@ async function decryptDraft(
   return JSON.parse(new TextDecoder().decode(decrypted)) as QuestionDraft
 }
 
+// Returns true when the draft was successfully persisted, false on any failure
+// (storage quota, private browsing, crypto unavailable). The caller uses the
+// return value to decide whether to show a "saved" or "not saved" indicator.
 export const saveDraft = async (
   userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number,
   draft: QuestionDraft
-): Promise<void> => {
+): Promise<boolean> => {
   try {
-    const key = await deriveKey(userid)
+    const hashedId = await hashUserId(userid)
+    const key = await getOrCreateDeviceKey(userid)
     const { iv, ciphertext } = await encryptDraft(key, draft)
-    const stored: StoredDraft = { iv, ciphertext, savedAt: Date.now() }
+    const stored: StoredDraft = {
+      v: DRAFT_VERSION,
+      iv,
+      ciphertext,
+      savedAt: Date.now(),
+    }
     localStorage.setItem(
-      draftKey(userid, fismasystemid, functionid, datacallid),
+      draftKey(hashedId, fismasystemid, functionid, datacallid),
       JSON.stringify(stored)
     )
+    return true
   } catch {
-    // localStorage unavailable or crypto unsupported — degrade silently
+    return false
   }
 }
 
@@ -113,44 +196,71 @@ export const loadDraft = async (
   datacallid: number
 ): Promise<QuestionDraft | null> => {
   try {
+    const hashedId = await hashUserId(userid)
     const raw = localStorage.getItem(
-      draftKey(userid, fismasystemid, functionid, datacallid)
+      draftKey(hashedId, fismasystemid, functionid, datacallid)
     )
     if (!raw) return null
     const stored = JSON.parse(raw) as StoredDraft
-    if (!stored.savedAt || Date.now() - stored.savedAt > DRAFT_TTL_MS) {
-      clearDraft(userid, fismasystemid, functionid, datacallid)
+    // Evict entries from a different format version before any other checks.
+    if (stored.v !== DRAFT_VERSION) {
+      await clearDraft(userid, fismasystemid, functionid, datacallid)
       return null
     }
-    const key = await deriveKey(userid)
-    return await decryptDraft(key, stored.iv, stored.ciphertext)
+    if (!stored.savedAt || Date.now() - stored.savedAt > DRAFT_TTL_MS) {
+      await clearDraft(userid, fismasystemid, functionid, datacallid)
+      return null
+    }
+    const key = await getOrCreateDeviceKey(userid)
+    const draft = await decryptDraft(key, stored.iv, stored.ciphertext)
+    // Runtime shape guard — evict and ignore if the decrypted payload doesn't
+    // match the expected structure (format migration, bit-flip, schema change).
+    if (
+      typeof draft?.selectQuestionOption !== 'number' ||
+      typeof draft?.notes !== 'string'
+    ) {
+      await clearDraft(userid, fismasystemid, functionid, datacallid)
+      return null
+    }
+    return draft
   } catch {
+    // Evict the corrupt entry so it isn't retried on every question load
+    // for the remaining TTL. Ignore secondary storage failures.
+    try {
+      await clearDraft(userid, fismasystemid, functionid, datacallid)
+    } catch {
+      // ignore
+    }
     return null
   }
 }
 
-export const clearDraft = (
+export const clearDraft = async (
   userid: string,
   fismasystemid: number,
   functionid: number,
   datacallid: number
-): void => {
+): Promise<void> => {
   try {
+    const hashedId = await hashUserId(userid)
     localStorage.removeItem(
-      draftKey(userid, fismasystemid, functionid, datacallid)
+      draftKey(hashedId, fismasystemid, functionid, datacallid)
     )
   } catch {
     // ignore
   }
 }
 
-// Removes all drafts in localStorage saved under a different user account.
+// Removes localStorage draft entries that belong to a different user.
 // Called on app mount so a shared-machine login switch doesn't expose one
-// user's notes to another.
-export const clearStaleUserDrafts = (currentUserid: string): void => {
+// user's drafts to another.
+export const clearOtherUserDrafts = async (
+  currentUserid: string
+): Promise<void> => {
   if (!currentUserid) return
   try {
-    const userPrefix = `${DRAFT_PREFIX}${currentUserid}_`
+    const hashedId = await hashUserId(currentUserid)
+    const userPrefix = `${DRAFT_PREFIX}${hashedId}_`
     const toRemove: string[] = []
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)

--- a/src/views/QuestionnairePage/scoreSelection.test.ts
+++ b/src/views/QuestionnairePage/scoreSelection.test.ts
@@ -1,0 +1,86 @@
+import {
+  deriveScoreSelection,
+  shouldReseedAnswer,
+  ScoreMap,
+} from './scoreSelection'
+
+describe('deriveScoreSelection', () => {
+  it('returns the "no answer" sentinel when no option is in the scores map', () => {
+    const scores: ScoreMap = {}
+    expect(deriveScoreSelection([10, 11, 12], scores)).toEqual({
+      funcOptId: 0,
+      choice: -1,
+      notes: '',
+      scoreid: 0,
+    })
+  })
+
+  it('derives the answered option, its notes and scoreid', () => {
+    const scores: ScoreMap = { 11: { notes: 'because', scoreid: 42 } }
+    expect(deriveScoreSelection([10, 11, 12], scores)).toEqual({
+      funcOptId: 11,
+      choice: 11,
+      notes: 'because',
+      scoreid: 42,
+    })
+  })
+
+  it('picks the first matching option when several are present', () => {
+    const scores: ScoreMap = {
+      12: { notes: 'b', scoreid: 2 },
+      10: { notes: 'a', scoreid: 1 },
+    }
+    // Iteration order follows the option list, not the map.
+    expect(deriveScoreSelection([10, 11, 12], scores).funcOptId).toBe(10)
+  })
+
+  it('treats an empty-notes answer as answered (scoreid drives PUT vs POST)', () => {
+    const scores: ScoreMap = { 7: { notes: '', scoreid: 99 } }
+    expect(deriveScoreSelection([7], scores)).toEqual({
+      funcOptId: 7,
+      choice: 7,
+      notes: '',
+      scoreid: 99,
+    })
+  })
+
+  it('returns the sentinel for an empty option list', () => {
+    expect(deriveScoreSelection([], { 1: { notes: 'x', scoreid: 1 } })).toEqual(
+      {
+        funcOptId: 0,
+        choice: -1,
+        notes: '',
+        scoreid: 0,
+      }
+    )
+  })
+})
+
+describe('shouldReseedAnswer', () => {
+  const clean = {
+    hasQuestion: true,
+    loadingQuestion: false,
+    hasUnsavedEdits: false,
+    draftRestored: false,
+  }
+
+  it('allows a re-seed when idle on a question with no unsaved edits', () => {
+    expect(shouldReseedAnswer(clean)).toBe(true)
+  })
+
+  it('blocks while the question is loading (fetchOptions owns seeding)', () => {
+    expect(shouldReseedAnswer({ ...clean, loadingQuestion: true })).toBe(false)
+  })
+
+  it('blocks when there is no active question', () => {
+    expect(shouldReseedAnswer({ ...clean, hasQuestion: false })).toBe(false)
+  })
+
+  it('blocks when the user has unsaved edits (never clobber them)', () => {
+    expect(shouldReseedAnswer({ ...clean, hasUnsavedEdits: true })).toBe(false)
+  })
+
+  it('blocks when a draft was restored (the draft owns the fields)', () => {
+    expect(shouldReseedAnswer({ ...clean, draftRestored: true })).toBe(false)
+  })
+})

--- a/src/views/QuestionnairePage/scoreSelection.ts
+++ b/src/views/QuestionnairePage/scoreSelection.ts
@@ -1,0 +1,60 @@
+// Pure helpers extracted from QuestionnairePage so the out-of-band scores re-seed
+// and read-only draft eviction logic can be unit-tested in isolation, mirroring
+// the saveGuard.ts pattern in this directory.
+
+export interface ScoreEntry {
+  notes: string
+  scoreid: number
+}
+
+export type ScoreMap = Record<number, ScoreEntry>
+
+export interface ScoreSelection {
+  funcOptId: number // 0 when no option is answered
+  choice: number // funcOptId, or the -1 "no answer" sentinel
+  notes: string
+  scoreid: number
+}
+
+/**
+ * Derives the answered option for a question from its option values and the
+ * scores map: the first option value present in the map wins. Mirrors how the
+ * questionId effect seeds a question's answer, so the stale-scores re-seed and
+ * its tests share one definition.
+ */
+export const deriveScoreSelection = (
+  optionValues: number[],
+  scores: ScoreMap
+): ScoreSelection => {
+  let funcOptId = 0
+  for (const value of optionValues) {
+    if (value in scores) {
+      funcOptId = value
+      break
+    }
+  }
+  const entry = funcOptId ? scores[funcOptId] : undefined
+  return {
+    funcOptId,
+    choice: funcOptId || -1,
+    notes: entry ? entry.notes : '',
+    scoreid: entry ? entry.scoreid : 0,
+  }
+}
+
+export interface ReseedGuardState {
+  hasQuestion: boolean
+  loadingQuestion: boolean
+  hasUnsavedEdits: boolean
+  draftRestored: boolean
+}
+
+/**
+ * Whether an out-of-band scores refresh may re-seed the current question's
+ * answer. False while the question is loading (the questionId effect owns
+ * seeding then), when there is no active question, when the user has unsaved
+ * edits (never overwrite them), or when a draft was restored (the draft owns the
+ * fields).
+ */
+export const shouldReseedAnswer = (s: ReseedGuardState): boolean =>
+  s.hasQuestion && !s.loadingQuestion && !s.hasUnsavedEdits && !s.draftRestored

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -37,7 +37,7 @@ import _ from 'lodash'
 import DataCallModal from '../DatacallModal/DataCallModal'
 import Footer from '@/components/Footer/Footer'
 import ztmfLogo from '@/assets/ztmf-logo-color.png'
-import { clearStaleUserDrafts } from '../QuestionnairePage/draftStore'
+import { clearOtherUserDrafts } from '../QuestionnairePage/draftStore'
 /**
  * Component that renders the contents of the Dashboard view.
  * @returns {JSX.Element} Component that renders the dashboard contents.
@@ -109,7 +109,7 @@ export default function Title() {
   }, [showDecommissioned, fetchFismaSystems, loaderData.status])
 
   useEffect(() => {
-    if (loaderData.status === 200) clearStaleUserDrafts(userInfo.userid)
+    if (loaderData.status === 200) void clearOtherUserDrafts(userInfo.userid)
   }, [loaderData.status, userInfo.userid])
 
   useEffect(() => {


### PR DESCRIPTION
In-repo rehome of #478 by @costacalvin (Calvin Costa) so the org-secret CI gates (dev deployment + checks) can run against the branch. The head commit is identical to #478 (`7d77b62`); authorship is preserved. The original PR stays open as a draft until this one merges.

Closes #475. Supersedes #476.

## Summary

Resolves all five blocking items and the remaining non-blocking hardening items from the encrypted questionnaire drafts issue. Replaces the PBKDF2-derived key and initial encryption approach from #476 with a non-extractable per-device key in IndexedDB, and hardens the draft lifecycle wiring throughout `QuestionnairePage`.

## Dependencies / predecessors

- **ztmf#399** — Original "Encrypt Draft text of freeform box at rest" ticket. Answered the post-quantum question (AES-256 is CNSA 2.0 compliant for data at rest; PQC standards target asymmetric primitives not used here). Closed in favor of #475.
- **ztmf-ui#476** — First encryption cut (landed on main). Introduced `draftStore.ts`, basic draft wiring in `QuestionnairePage`, and the initial `draftStore.test.ts`. Used PBKDF2 key derivation from a non-secret userid; #475 tracks the blockers. This PR replaces the key approach and addresses all tracked gaps.

## Blocking items resolved (#475)

| # | Issue | Resolution |
|---|-------|------------|
| 1 | Key derived only from non-secret `userid` — anyone with profile disk access could re-derive and decrypt | Replaced with a **non-extractable `AES-256-GCM` key** generated via `crypto.subtle.generateKey({ extractable: false })` and stored in **IndexedDB**. The key cannot be exported via the JS API; an attacker needs a live authenticated browser session, not just a disk dump. |
| 2 | `saveDraft` swallowed errors — UI showed "Draft saved" even on quota/private-browsing failure | `saveDraft` now returns `Promise<boolean>`. The debounce effect checks the return value and sets `draftStatus = 'error'` on failure, surfacing a visible error state in the UI. |
| 3 | `loadDraft` cast without runtime check — `notes: undefined` would throw on `notes.length` and blank the questionnaire | Added a runtime shape guard after decrypt: evicts and returns `null` if either field is missing or has the wrong type. |
| 4 | Draft key omitted `userid` — one user's draft could restore into another user's session on a shared machine | localStorage key is now `ztmf_draft_{sha256(userid)[0:16]}_{fismasystemid}_{functionid}_{datacallid}`. The userid segment is SHA-256 hashed (base64url, 16 chars) so raw UUIDs are not visible in DevTools. `clearOtherUserDrafts` is called on every authenticated app load to evict entries not matching the current user's prefix. |
| 5 | Reverting A→B→A left the B draft in storage to resurface later | The debounce effect detects when `selectQuestionOption === initQuestionChoice && notes === initNotes` and calls `clearDraft` — unless the draft was just auto-restored (`draftStatus === 'restored'`), in which case matching the server state does not indicate a user revert and the draft is preserved. |

## Non-blocking hardening

- **Random per-entry IV** — `crypto.getRandomValues(new Uint8Array(12))` on every `encryptDraft` call. No static salt (eliminated by the IDB key approach).
- **Generation counter (`saveGenRef`)** — incremented on every explicit `clearCurrentDraft()` call and on every navigation (`handleListItemClick`, Back button, Next/Complete button onClick). Any in-flight debounce `.then()` that fires after a clear or navigation is a no-op (`saveGenRef.current !== capturedGen`).
- **`isCurrent` callback in `saveDraft`** — checked at two points inside the async function: before encryption begins, and again before the final `localStorage.setItem`. Prevents a stale in-flight save from resurrecting a draft that was cleared during the ~10 ms AES-GCM encryption window.
- **Schema/version field** — `StoredDraft.v` (`DRAFT_VERSION = 1`). Entries with a mismatched version are evicted on first load, enabling safe future format migrations.
- **`questionScoresRef`** — stable ref updated every render; `fetchOptions` reads scores through the ref instead of enrolling `questionScores` as an effect dep, which previously caused a double-run of the effect after every `saveResponse` call.

## Additional correctness fixes

- **Datacall-switch batching** — `setQuestions`, `setDatacallID`, `setQuestionId`, and `setQuestionScores` are now batched together after **both** the questions and scores APIs return. Previously `setQuestionId` fired after the questions API alone, causing the `questionId` effect to run with stale scores from the prior datacall and then run a second time when scores arrived — creating a window where the debounce could incorrectly clear a restored draft.
- **Abort guards in `fetchOptions`** — two `controller.signal.aborted` checks bracket the `loadDraft` call. `crypto.subtle.decrypt` is genuinely async (~10–50 ms); without the guard, rapid datacall switching could write a stale draft's values into the newly active question's state.
- **`setLoadingQuestion` debounce gate** — `loadingQuestion` is set to `true` at the start of `fetchData` and cleared only after `fetchOptions` finishes. The debounce effect returns early while `loadingQuestion` is true, preventing stale saves from firing during system or datacall transitions.
- **`setLoadingQuestion(false)` on non-redirect auth errors** — all three `fetchData` catch blocks (questions fetch, scores fetch, outer) now call `setLoadingQuestion(false)` before returning on auth-handled errors. For 403s that show a toast without redirecting (FORBIDDEN_ORIGIN, plain controller-level 403), the component stays mounted and the spinner would otherwise be stuck indefinitely.
- **`setLoadingQuestion(false)` guard in `fetchOptions` finally** — wrapped in `if (!controller.signal.aborted)` so a newer in-flight request owns the loading state after rapid navigation.

## Files changed

| File | What changed |
|------|-------------|
| `src/views/QuestionnairePage/draftStore.ts` | Rewritten — IDB key management replaces PBKDF2, AES-256-GCM encrypt/decrypt, `saveDraft` returns `Promise<boolean>`, `isCurrent` callback, hashed userid keys, `DRAFT_VERSION` schema field, test-only escape hatches |
| `src/views/QuestionnairePage/draftStore.test.ts` | Extended to 33 tests — adds coverage for `isCurrent` early-abort at both checkpoints, `'error'` status on quota failure, version mismatch eviction, corrupt ciphertext eviction, cross-user isolation with hashed keys |
| `src/views/QuestionnairePage/QuestionnairePage.tsx` | `saveGenRef` generation counter, `questionScoresRef`, `setLoadingQuestion` debounce gate, state batching, abort guards in `fetchOptions`, `isCurrent` passed to `saveDraft`, `setLoadingQuestion(false)` on all auth-handled and error paths |
| `src/views/Title/Title.tsx` | `clearOtherUserDrafts` updated to use hashed prefix format |

## Test plan

- [x] Open a questionnaire question, type in the notes field. Confirm "Draft saved" banner appears after ~1 second.
- [x] Refresh the page. Confirm the draft is restored and "Draft restored" banner appears.
- [x] Verify draft content in DevTools → Application → Local Storage is ciphertext, not plaintext.
- [x] Verify DevTools → Application → IndexedDB → `ztmf-draft-keys` contains an opaque `CryptoKey` entry.
- [x] Verify localStorage keys use the format `ztmf_draft_<16-char-opaque-string>_...` (no raw userid visible).
- [x] Select an answer, switch to a different datacall question, switch back. Confirm the draft is still present and the correct answer/notes are shown for each question.
- [x] Select an answer, revert to the original server value. Confirm the draft is cleared (no "Draft restored" on next page load for that question).
- [x] Fill in a question, click Next. Confirm the draft is cleared on the submitted question.
- [ ] Fill in a question and immediately click Next before the 1-second debounce fires. Confirm no stale draft reappears on re-navigation to that question.
- [x] Open the questionnaire in a private browsing window (IDB and localStorage may be limited). Confirm no crash — the error banner appears if the draft cannot be saved.
- [x] With drafts saved, log in as a different user. Verify DevTools → Local Storage contains no `ztmf_draft_` entries for the previous user.
- [x] `npx jest --no-coverage src/views/QuestionnairePage/draftStore.test.ts` — all 33 tests pass.

---

*Rehomed from #478 (@costacalvin). Original commit `7d77b62` preserved verbatim.*
