### PR TITLE
Add non-production environment warning banner

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -23,6 +23,14 @@ VITE_AUTH_TOKEN3=your-jwt-token-here
 # Set to 'false' for local dev, 'true' for AWS environments
 VITE_IDP_ENABLED=false
 
+# Development banner overrides (all optional; leave empty to use built-in copy)
+# The banner shows in every non-production environment regardless of these.
+# Set these locally only to preview testing-window copy; real values for the
+# deployed dev environment are injected from CI secrets, never committed.
+VITE_DEV_BANNER_MESSAGE=
+VITE_DEV_FEEDBACK_URL=
+VITE_DEV_CONTACT_EMAIL=
+
 # Legacy proxy configuration (leave empty for default setup)
 TOKEN=
 PROXY_URI=

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,10 @@
 
 TOKEN = ''
 PROXY_URI = ''
+
+# Development banner overrides (optional). Blank by design in the repo; the
+# deployed dev environment injects real values from CI secrets during a testing
+# window and clears them afterward. See .github/workflows/ui.yml.
+VITE_DEV_BANNER_MESSAGE = ''
+VITE_DEV_FEEDBACK_URL = ''
+VITE_DEV_CONTACT_EMAIL = ''

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -58,6 +58,12 @@ jobs:
         # Default off; flip per environment as IdP rollout progresses.
         env:
           VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
+          # Dev-only banner overrides. Sourced from secrets so the feedback form
+          # URL and contact address stay out of the repo. Clear these secrets
+          # when the testing window ends and the banner reverts to default copy.
+          VITE_DEV_BANNER_MESSAGE: ${{ inputs.environment == 'dev' && secrets.DEV_BANNER_MESSAGE || '' }}
+          VITE_DEV_FEEDBACK_URL: ${{ inputs.environment == 'dev' && secrets.DEV_FEEDBACK_URL || '' }}
+          VITE_DEV_CONTACT_EMAIL: ${{ inputs.environment == 'dev' && secrets.DEV_CONTACT_EMAIL || '' }}
         run: yarn build:${{ inputs.environment }}
 
       - name: Get AWS Creds

--- a/src/components/DevEnvironmentBanner/DevEnvironmentBanner.test.tsx
+++ b/src/components/DevEnvironmentBanner/DevEnvironmentBanner.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DevEnvironmentBanner from './DevEnvironmentBanner'
+import CONFIG from '@/utils/config'
+
+// The component reads build-time config derived from import.meta.env, which
+// throws under @swc/jest. Mock the resolved CONFIG object (created inside the
+// hoisted factory to avoid a TDZ error) so tests can drive each
+// environment/override combination by mutating the imported reference.
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: {
+    IS_NONPROD: true,
+    DEV_BANNER_MESSAGE: '',
+    DEV_FEEDBACK_URL: '',
+    DEV_CONTACT_EMAIL: '',
+  },
+}))
+
+const mockConfig = CONFIG
+
+beforeEach(() => {
+  mockConfig.IS_NONPROD = true
+  mockConfig.DEV_BANNER_MESSAGE = ''
+  mockConfig.DEV_FEEDBACK_URL = ''
+  mockConfig.DEV_CONTACT_EMAIL = ''
+})
+
+test('renders nothing in production', () => {
+  mockConfig.IS_NONPROD = false
+  const { container } = render(<DevEnvironmentBanner />)
+  expect(container).toBeEmptyDOMElement()
+})
+
+test('shows the default notice in a non-production environment', () => {
+  render(<DevEnvironmentBanner />)
+  expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
+})
+
+test('uses the injected override message when provided', () => {
+  mockConfig.DEV_BANNER_MESSAGE = 'OpDiv data loaded for testing.'
+  render(<DevEnvironmentBanner />)
+  expect(screen.getByText('OpDiv data loaded for testing.')).toBeInTheDocument()
+})
+
+test('falls back to the default when the override is whitespace only', () => {
+  mockConfig.DEV_BANNER_MESSAGE = '   '
+  render(<DevEnvironmentBanner />)
+  expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
+})
+
+test('renders feedback and contact links only when configured', () => {
+  mockConfig.DEV_FEEDBACK_URL = 'https://forms.example.gov/feedback'
+  mockConfig.DEV_CONTACT_EMAIL = 'zerotrust@example.gov'
+  render(<DevEnvironmentBanner />)
+  expect(
+    screen.getByRole('link', { name: /share testing feedback/i })
+  ).toHaveAttribute('href', 'https://forms.example.gov/feedback')
+  expect(screen.getByRole('link', { name: /contact us/i })).toHaveAttribute(
+    'href',
+    'mailto:zerotrust@example.gov'
+  )
+})
+
+test('rejects a non-https feedback URL', () => {
+  mockConfig.DEV_FEEDBACK_URL = 'javascript:alert(1)'
+  render(<DevEnvironmentBanner />)
+  expect(
+    screen.queryByRole('link', { name: /share testing feedback/i })
+  ).not.toBeInTheDocument()
+})
+
+test('can be dismissed', async () => {
+  const user = userEvent.setup()
+  render(<DevEnvironmentBanner />)
+  expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
+  await user.click(screen.getByRole('button', { name: /close/i }))
+  expect(
+    screen.queryByText(/non-production environment/i)
+  ).not.toBeInTheDocument()
+})

--- a/src/components/DevEnvironmentBanner/DevEnvironmentBanner.tsx
+++ b/src/components/DevEnvironmentBanner/DevEnvironmentBanner.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import Alert from '@mui/material/Alert'
+import Link from '@mui/material/Link'
+import CONFIG from '@/utils/config'
+
+/**
+ * Fallback copy shown in any non-production environment (dev, impl, local) when
+ * no override is supplied. Deliberately mode-neutral: the deployed dev
+ * environment layers on testing-specific wording via VITE_DEV_BANNER_MESSAGE,
+ * while impl and local fall back to this generic notice.
+ */
+const DEFAULT_MESSAGE =
+  "You're in a ZTMF non-production environment, not the live site. Records here " +
+  'are for testing only. We deploy throughout the day, so if something looks ' +
+  'off, pause and refresh.'
+
+/**
+ * Persistent warning banner that marks non-production environments so testers
+ * do not mistake them for production or enter real data. Rendered once in the
+ * app shell; hidden entirely in production and after a user dismisses it.
+ * @returns {JSX.Element | null}
+ */
+export default function DevEnvironmentBanner() {
+  const [dismissed, setDismissed] = useState(false)
+
+  if (!CONFIG.IS_NONPROD || dismissed) {
+    return null
+  }
+
+  // Trim guards against a whitespace-only override secret rendering a blank
+  // banner or an unusable link.
+  const message = CONFIG.DEV_BANNER_MESSAGE.trim() || DEFAULT_MESSAGE
+  const feedbackUrl = CONFIG.DEV_FEEDBACK_URL.trim()
+  const contactEmail = CONFIG.DEV_CONTACT_EMAIL.trim()
+  // Only render an https link. The value comes from a trusted build-time
+  // secret, but the allowlist forbids javascript:/data: hrefs as defense in
+  // depth against a mis-set secret.
+  const showFeedback = feedbackUrl.startsWith('https://')
+
+  return (
+    <Alert
+      severity="warning"
+      onClose={() => setDismissed(true)}
+      role="region"
+      aria-label="Non-production environment notice"
+      sx={{
+        borderRadius: 0,
+        py: 0.25,
+        '& .MuiAlert-message': {
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          columnGap: 1,
+          rowGap: 0.25,
+        },
+      }}
+    >
+      <span>{message}</span>
+      {showFeedback && (
+        <Link
+          href={feedbackUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="inherit"
+          aria-label="Share testing feedback (opens in a new tab)"
+          sx={{ fontWeight: 700 }}
+        >
+          Share testing feedback
+        </Link>
+      )}
+      {contactEmail && (
+        <Link
+          href={`mailto:${contactEmail}`}
+          color="inherit"
+          sx={{ fontWeight: 700 }}
+        >
+          Contact us
+        </Link>
+      )}
+    </Alert>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,11 +3,20 @@
  * @module types
  */
 
-// TODO: maybe provide environment and other things to log?
-export type AppConfig = AppFeatureFlags
+export type AppConfig = AppFeatureFlags & AppEnvironment
 
 export type AppFeatureFlags = {
   IDP_ENABLED: boolean
+}
+
+// Environment-derived settings. IS_NONPROD gates the development banner; the
+// DEV_* overrides let the deployed dev environment inject testing-specific copy
+// and contact links at build time without committing them to the repo.
+export type AppEnvironment = {
+  IS_NONPROD: boolean
+  DEV_BANNER_MESSAGE: string
+  DEV_FEEDBACK_URL: string
+  DEV_CONTACT_EMAIL: string
 }
 
 export type FormField = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,6 +8,18 @@ import type { AppConfig } from '@/types'
 const CONFIG = {
   //* Feature flags
   IDP_ENABLED: String(import.meta.env.VITE_IDP_ENABLED) === 'true',
+
+  //* Environment
+  // Vite's build mode is 'production' only for `yarn build:prod`; local dev,
+  // AWS dev, and impl all resolve to non-production modes.
+  IS_NONPROD: import.meta.env.MODE !== 'production',
+
+  //* Development banner overrides (blank in the repo by design)
+  // Set only on the deployed dev build during a testing window, then cleared.
+  // Empty values fall back to the banner's built-in default copy / hide links.
+  DEV_BANNER_MESSAGE: import.meta.env.VITE_DEV_BANNER_MESSAGE ?? '',
+  DEV_FEEDBACK_URL: import.meta.env.VITE_DEV_FEEDBACK_URL ?? '',
+  DEV_CONTACT_EMAIL: import.meta.env.VITE_DEV_CONTACT_EMAIL ?? '',
 } satisfies AppConfig
 
 export default CONFIG

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -35,6 +35,7 @@ import { EMPTY_SYSTEM } from '../EditSystemModal/emptySystem'
 import _ from 'lodash'
 import DataCallModal from '../DatacallModal/DataCallModal'
 import Footer from '@/components/Footer/Footer'
+import DevEnvironmentBanner from '@/components/DevEnvironmentBanner/DevEnvironmentBanner'
 import ztmfLogo from '@/assets/ztmf-logo-color.png'
 /**
  * Component that renders the contents of the Dashboard view.
@@ -202,6 +203,7 @@ export default function Title() {
   return (
     <>
       <UsaBanner />
+      <DevEnvironmentBanner />
       {/* Branded header bar. Hidden on the /signin route AND any time
           LoginPage is rendered as the body (loaderData.status !== 200),
           so the header never sits above a "please sign in" prompt at any


### PR DESCRIPTION
Closes #479.

## What
<img width="2118" height="198" alt="image" src="https://github.com/user-attachments/assets/4345f4f8-2bd4-4567-a90a-6bfe48d591ff" />

Adds a dismissible warning banner that renders in every non-production environment (dev, impl, local) and is hidden in production. It tells users they are not on the live site, warns that active deployments can cause brief glitches (pause and refresh), and surfaces a feedback form and contact link.

## How it works

- **Environment gate:** `CONFIG.IS_NONPROD` is derived from Vite's build mode (`import.meta.env.MODE !== 'production'`). `build:prod` uses `--mode production`, so the banner fails closed and never appears in prod.
- **Copy and links are build-time injected, not committed.** Three optional variables drive the testing-specific text and links:
  - `VITE_DEV_BANNER_MESSAGE` — overrides the default copy
  - `VITE_DEV_FEEDBACK_URL` — feedback form link (https-only; other schemes are ignored)
  - `VITE_DEV_CONTACT_EMAIL` — contact mailto
- When a variable is empty the banner falls back to a mode-neutral default and hides the corresponding link. The deployed dev build sources these from **dev GitHub Environment secrets** (wired in `ui.yml`), so the feedback URL and contact address stay out of the repo and can be cleared when a testing window ends. impl and local show the generic default.
- Mounted once in the app shell (`Title.tsx`), directly below the existing USA banner. Dismissal is in-memory by design, so it returns on reload.

## Testing

- New unit tests cover the production hide, the non-prod default, override copy, whitespace-only fallback, https-only link filtering, and dismissal.
- Full suite green (258 passing); typecheck and lint clean.

## Before this deploys to dev

- The dev Environment secrets (`DEV_BANNER_MESSAGE`, `DEV_CONTACT_EMAIL`, `DEV_FEEDBACK_URL`) still need to be set so the first dev deploy shows the full testing copy. The real feedback-form URL is still outstanding; until it is set, the feedback link stays hidden and everything else renders.

---

### Follow-up: only show once signed in

The banner first rendered on the pre-login page too. It is now gated to an active session (`loaderData.status === 200`): signed-in users see the full environment-specific copy, while pre-login visitors see only the generic non-production marker.

### Testing note

There is no good way to catch this locally. Local dev auto-authenticates (`VITE_LOCAL_DEV`), so `loaderData.status` is always 200 and the pre-login state never renders on a dev machine. Issues in the pre-login path only surface once deployed, where real unauthenticated sessions exist.
