### PR TITLE
Gate the dev banner to signed-in users

### DIFF
--- a/src/components/DevEnvironmentBanner/DevEnvironmentBanner.test.tsx
+++ b/src/components/DevEnvironmentBanner/DevEnvironmentBanner.test.tsx
@@ -37,10 +37,28 @@ test('shows the default notice in a non-production environment', () => {
   expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
 })
 
-test('uses the injected override message when provided', () => {
+test('uses the injected override message for authenticated users', () => {
   mockConfig.DEV_BANNER_MESSAGE = 'OpDiv data loaded for testing.'
-  render(<DevEnvironmentBanner />)
+  render(<DevEnvironmentBanner authenticated />)
   expect(screen.getByText('OpDiv data loaded for testing.')).toBeInTheDocument()
+})
+
+test('hides override copy, feedback, and contact from pre-login visitors', () => {
+  mockConfig.DEV_BANNER_MESSAGE = 'OpDiv data loaded for testing.'
+  mockConfig.DEV_FEEDBACK_URL = 'https://forms.example.gov/feedback'
+  mockConfig.DEV_CONTACT_EMAIL = 'zerotrust@example.gov'
+  render(<DevEnvironmentBanner />)
+  // Generic marker shows, but nothing environment-specific leaks publicly.
+  expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
+  expect(
+    screen.queryByText('OpDiv data loaded for testing.')
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('link', { name: /share testing feedback/i })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('link', { name: /contact us/i })
+  ).not.toBeInTheDocument()
 })
 
 test('falls back to the default when the override is whitespace only', () => {
@@ -49,10 +67,10 @@ test('falls back to the default when the override is whitespace only', () => {
   expect(screen.getByText(/non-production environment/i)).toBeInTheDocument()
 })
 
-test('renders feedback and contact links only when configured', () => {
+test('renders feedback and contact links for authenticated users when configured', () => {
   mockConfig.DEV_FEEDBACK_URL = 'https://forms.example.gov/feedback'
   mockConfig.DEV_CONTACT_EMAIL = 'zerotrust@example.gov'
-  render(<DevEnvironmentBanner />)
+  render(<DevEnvironmentBanner authenticated />)
   expect(
     screen.getByRole('link', { name: /share testing feedback/i })
   ).toHaveAttribute('href', 'https://forms.example.gov/feedback')
@@ -64,7 +82,7 @@ test('renders feedback and contact links only when configured', () => {
 
 test('rejects a non-https feedback URL', () => {
   mockConfig.DEV_FEEDBACK_URL = 'javascript:alert(1)'
-  render(<DevEnvironmentBanner />)
+  render(<DevEnvironmentBanner authenticated />)
   expect(
     screen.queryByRole('link', { name: /share testing feedback/i })
   ).not.toBeInTheDocument()

--- a/src/components/DevEnvironmentBanner/DevEnvironmentBanner.tsx
+++ b/src/components/DevEnvironmentBanner/DevEnvironmentBanner.tsx
@@ -14,24 +14,40 @@ const DEFAULT_MESSAGE =
   'are for testing only. We deploy throughout the day, so if something looks ' +
   'off, pause and refresh.'
 
+type DevEnvironmentBannerProps = {
+  /**
+   * Whether an authenticated app session is active. The injected testing copy,
+   * feedback-form link, and contact address render only for signed-in users so
+   * they are never exposed on the public pre-login page; unauthenticated
+   * visitors see the generic marker with no links.
+   */
+  authenticated?: boolean
+}
+
 /**
  * Persistent warning banner that marks non-production environments so testers
  * do not mistake them for production or enter real data. Rendered once in the
  * app shell; hidden entirely in production and after a user dismisses it.
+ * @param {DevEnvironmentBannerProps} props Component props.
  * @returns {JSX.Element | null}
  */
-export default function DevEnvironmentBanner() {
+export default function DevEnvironmentBanner({
+  authenticated = false,
+}: DevEnvironmentBannerProps) {
   const [dismissed, setDismissed] = useState(false)
 
   if (!CONFIG.IS_NONPROD || dismissed) {
     return null
   }
 
-  // Trim guards against a whitespace-only override secret rendering a blank
-  // banner or an unusable link.
-  const message = CONFIG.DEV_BANNER_MESSAGE.trim() || DEFAULT_MESSAGE
-  const feedbackUrl = CONFIG.DEV_FEEDBACK_URL.trim()
-  const contactEmail = CONFIG.DEV_CONTACT_EMAIL.trim()
+  // Testing-specific copy and contact links are gated behind an authenticated
+  // session. Pre-login the banner falls back to the generic marker so the
+  // contact email, testing dates, and feedback URL are not shown publicly.
+  // Trim also guards against a whitespace-only override rendering blank.
+  const override = CONFIG.DEV_BANNER_MESSAGE.trim()
+  const message = authenticated && override ? override : DEFAULT_MESSAGE
+  const feedbackUrl = authenticated ? CONFIG.DEV_FEEDBACK_URL.trim() : ''
+  const contactEmail = authenticated ? CONFIG.DEV_CONTACT_EMAIL.trim() : ''
   // Only render an https link. The value comes from a trusted build-time
   // secret, but the allowlist forbids javascript:/data: hrefs as defense in
   // depth against a mis-set secret.

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -212,7 +212,7 @@ export default function Title() {
   return (
     <>
       <UsaBanner />
-      <DevEnvironmentBanner />
+      <DevEnvironmentBanner authenticated={loaderData.status === 200} />
       {/* Branded header bar. Hidden on the /signin route AND any time
           LoginPage is rendered as the body (loaderData.status !== 200),
           so the header never sits above a "please sign in" prompt at any


### PR DESCRIPTION
Follow-up to #482. That PR merged before this gate landed, so `main` currently mounts the banner unconditionally and it renders on the pre-login page.

## Change

Adds an `authenticated` prop to `DevEnvironmentBanner`. `Title.tsx` passes `loaderData.status === 200`: signed-in users see the full environment-specific copy, pre-login visitors see only the generic non-production marker.

## Testing note

There is no good way to catch this locally. Local dev auto-authenticates (`VITE_LOCAL_DEV`), so `loaderData.status` is always 200 and the pre-login state never renders on a dev machine. Issues in the pre-login path only surface once deployed, where real unauthenticated sessions exist.

Component tests extended to cover the pre-login state (8 total). Typecheck and lint clean.