### PR TITLE
Dashboard filters, stat card sizing, and header alignment

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -13,8 +13,18 @@ import {
   GridRowParams,
 } from '@mui/x-data-grid'
 import Tooltip from '@mui/material/Tooltip'
-import { Box, IconButton } from '@mui/material'
-import { useState } from 'react'
+import {
+  Box,
+  IconButton,
+  Checkbox,
+  FormControl,
+  Select,
+  MenuItem,
+  ListItemText,
+  Button,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import { useState, useEffect, useMemo } from 'react'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
 import FileDownloadSharpIcon from '@mui/icons-material/FileDownloadSharp'
@@ -37,13 +47,31 @@ import { hasSystemAccess } from '@/utils/userRoles'
 import { cellStyleForTier } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
+import { fetchOpDivs } from '@/utils/opdivs'
+import { toCategoryMap } from '@/utils/dataCenterEnvironments'
+import type { OpDiv } from '@/types'
+import {
+  applyDashboardFilters,
+  hasNoActiveFilters,
+  EMPTY_DASHBOARD_FILTERS,
+  type DashboardFilterState,
+} from './dashboardFilters'
 type selectedRowsType = GridRowId[]
+type OpDivOption = { id: number; label: string }
 declare module '@mui/x-data-grid' {
   interface FooterPropsOverrides {
     selectedRows: selectedRowsType
     fismaSystems: FismaSystemType[]
     activeDataCallId: number
     scores: Record<number, SystemScoreEntry>
+  }
+  interface ToolbarPropsOverrides {
+    filters: DashboardFilterState
+    onFiltersChange: (next: DashboardFilterState) => void
+    envOptions: string[]
+    opdivOptions: OpDivOption[]
+    showEnvFilter: boolean
+    showOpDivFilter: boolean
   }
 }
 
@@ -152,15 +180,46 @@ export function CustomFooterSaveComponent(
   )
 }
 
-function QuickSearchToolbar() {
+function QuickSearchToolbar(props: {
+  filters?: DashboardFilterState
+  onFiltersChange?: (next: DashboardFilterState) => void
+  envOptions?: string[]
+  opdivOptions?: OpDivOption[]
+  showEnvFilter?: boolean
+  showOpDivFilter?: boolean
+}) {
   const { showDecommissioned, setShowDecommissioned } = useContextProp()
+  const filters = props.filters ?? EMPTY_DASHBOARD_FILTERS
+  const onFiltersChange = props.onFiltersChange ?? (() => {})
+  const envOptions = props.envOptions ?? []
+  const opdivOptions = props.opdivOptions ?? []
+  const showEnvFilter = props.showEnvFilter ?? false
+  const showOpDivFilter = props.showOpDivFilter ?? false
+
+  const switchSx = {
+    '& .MuiSwitch-switchBase.Mui-checked': { color: '#004297' },
+    '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+      backgroundColor: '#004297',
+    },
+  }
+  // Keep the collapsed value on a single line so a multi-select never grows the
+  // control's height — the summary ellipsizes instead of wrapping into chips.
+  const selectValueSx = {
+    '& .MuiSelect-select': {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+  }
 
   return (
     <Box
       sx={{
-        py: 0.5,
-        pl: 1,
+        py: 1,
+        px: 1,
         display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1.5,
         justifyContent: 'space-between',
         alignItems: 'center',
       }}
@@ -168,40 +227,138 @@ function QuickSearchToolbar() {
       <GridToolbarQuickFilter
         debounceMs={250}
         sx={{
-          // '& .MuiInputBase-root:before': {
-          //   borderBottomColor: '#5666b8',
-          //   borderBottomWidth: 2,
-          // },
           '& .MuiInputBase-input::placeholder': {
-            color: '#404040', // Change placeholder color to red
-            opacity: 0.8, // Ensure it is fully visible (MUI reduces opacity by default)
+            color: '#404040',
+            opacity: 0.8,
           },
           '& .MuiInputBase-root:after': {
-            borderBottomColor: '#5666b8', // Changes the underline color when active
+            borderBottomColor: '#5666b8',
           },
           '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
-            borderBottomColor: '#5666b8', // Changes the underline color on hover
+            borderBottomColor: '#5666b8',
           },
         }}
       />
-      <FormControlLabel
-        control={
-          <Switch
-            checked={showDecommissioned}
-            onChange={(e) => setShowDecommissioned(e.target.checked)}
-            sx={{
-              '& .MuiSwitch-switchBase.Mui-checked': {
-                color: '#004297',
-              },
-              '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-                backgroundColor: '#004297',
-              },
-            }}
-          />
-        }
-        label="Show Decommissioned"
-        sx={{ mr: 2 }}
-      />
+      {/* All facet filters live in one right-aligned cluster next to the
+          Show Decommissioned toggle. */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 1.5,
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+        }}
+      >
+        {showEnvFilter && (
+          <FormControl size="small" sx={{ width: 200 }}>
+            <Select
+              multiple
+              displayEmpty
+              value={filters.environments}
+              onChange={(e) =>
+                onFiltersChange({
+                  ...filters,
+                  environments: e.target.value as string[],
+                })
+              }
+              inputProps={{ 'aria-label': 'Filter by environment' }}
+              renderValue={(selected) => {
+                const vals = selected as string[]
+                if (vals.length === 0)
+                  return <span style={{ color: '#6b6b6b' }}>Environment</span>
+                if (vals.length === 1) return vals[0]
+                return `${vals.length} environments`
+              }}
+              sx={selectValueSx}
+            >
+              {envOptions.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  <Checkbox
+                    checked={filters.environments.includes(opt)}
+                    size="small"
+                  />
+                  <ListItemText primary={opt} />
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+        {showOpDivFilter && (
+          <FormControl size="small" sx={{ width: 200 }}>
+            <Select
+              multiple
+              displayEmpty
+              value={filters.opdivIds}
+              onChange={(e) =>
+                onFiltersChange({
+                  ...filters,
+                  opdivIds: e.target.value as number[],
+                })
+              }
+              inputProps={{ 'aria-label': 'Filter by OpDiv' }}
+              renderValue={(selected) => {
+                const ids = selected as number[]
+                if (ids.length === 0)
+                  return <span style={{ color: '#6b6b6b' }}>OpDiv</span>
+                if (ids.length === 1)
+                  return (
+                    opdivOptions.find((o) => o.id === ids[0])?.label ??
+                    String(ids[0])
+                  )
+                return `${ids.length} OpDivs`
+              }}
+              sx={selectValueSx}
+            >
+              {opdivOptions.map((o) => (
+                <MenuItem key={o.id} value={o.id}>
+                  <Checkbox
+                    checked={filters.opdivIds.includes(o.id)}
+                    size="small"
+                  />
+                  <ListItemText primary={o.label} />
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+        <FormControlLabel
+          control={
+            <Switch
+              checked={filters.notUpdatedOnly}
+              onChange={(e) =>
+                onFiltersChange({
+                  ...filters,
+                  notUpdatedOnly: e.target.checked,
+                })
+              }
+              sx={switchSx}
+            />
+          }
+          label="Not updated only"
+          sx={{ m: 0 }}
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={showDecommissioned}
+              onChange={(e) => setShowDecommissioned(e.target.checked)}
+              sx={switchSx}
+            />
+          }
+          label="Show Decommissioned"
+          sx={{ m: 0 }}
+        />
+        <Button
+          size="small"
+          startIcon={<CloseIcon />}
+          onClick={() => onFiltersChange(EMPTY_DASHBOARD_FILTERS)}
+          disabled={hasNoActiveFilters(filters)}
+          sx={{ color: '#004297', textTransform: 'none', mr: 2, flexShrink: 0 }}
+        >
+          Clear filters
+        </Button>
+      </Box>
     </Box>
   )
 }
@@ -214,14 +371,111 @@ const pillarScoresCache = new Map<number, CachedScore>()
 
 export default function FismaTable({ scores, progress }: FismaTableProps) {
   const apiRef = useGridApiRef()
-  const { fismaSystems, latestDataCallId, selectedDatacall, userInfo } =
-    useContextProp()
+  const {
+    fismaSystems,
+    latestDataCallId,
+    selectedDatacall,
+    userInfo,
+    datacenterEnvironments,
+  } = useContextProp()
   const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
   const [selectedRows, setSelectedRows] = useState<GridRowId[]>([])
+  const [filters, setFilters] = useState<DashboardFilterState>(
+    EMPTY_DASHBOARD_FILTERS
+  )
+  const [opdivs, setOpDivs] = useState<OpDiv[]>([])
   const navigate = useNavigate()
+
+  // OpDiv list is only needed to label the OpDiv filter. Include inactive
+  // OpDivs so a system tied to a since-deactivated OpDiv still shows a name,
+  // not a bare id. Fetched once; failure is non-fatal.
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchOpDivs(true, controller.signal)
+      .then(setOpDivs)
+      .catch((error) => {
+        if (controller.signal.aborted) return
+        console.error('Fetch opdivs error:', error)
+      })
+    return () => controller.abort()
+  }, [])
+
+  // Raw datacenterenvironment -> category label, from the vocabulary already in
+  // context. Drives both the Environment filter options and row matching.
+  const categoryMap = useMemo(
+    () => toCategoryMap(datacenterEnvironments),
+    [datacenterEnvironments]
+  )
+
+  // Only offer facet values that actually appear in the current rows, in the
+  // vocabulary's curated order (datacenterEnvironments arrives sorted by `ordr`)
+  // so the filter matches the system-form dropdown order rather than alphabetical.
+  const envOptions = useMemo(() => {
+    const present = new Set<string>()
+    for (const system of fismaSystems) {
+      const category = categoryMap[system.datacenterenvironment]
+      if (category) present.add(category)
+    }
+    const ordered: string[] = []
+    const seen = new Set<string>()
+    for (const dce of datacenterEnvironments) {
+      if (present.has(dce.category) && !seen.has(dce.category)) {
+        seen.add(dce.category)
+        ordered.push(dce.category)
+      }
+    }
+    return ordered
+  }, [fismaSystems, categoryMap, datacenterEnvironments])
+
+  const opdivOptions = useMemo<OpDivOption[]>(() => {
+    const byId = new Map(opdivs.map((o) => [o.opdiv_id, o]))
+    const present = new Set<number>()
+    for (const system of fismaSystems) {
+      if (system.opdiv_id != null) present.add(system.opdiv_id)
+    }
+    return Array.from(present)
+      .map((id) => {
+        const od = byId.get(id)
+        return { id, label: od ? `${od.code} — ${od.name}` : String(id) }
+      })
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [fismaSystems, opdivs])
+
+  // Hide a facet filter when the visible systems span a single value — the
+  // control gains nothing and only costs toolbar width (and an empty menu).
+  const showEnvFilter = envOptions.length > 1
+  const showOpDivFilter = opdivOptions.length > 1
+
+  // Keep selections valid as the option sets change (e.g. Show Decommissioned
+  // refetches the rows, or a filter hides). Drop any selected value no longer
+  // offered so the grid never over-filters via an invisible control and MUI
+  // never warns about a value outside its options.
+  useEffect(() => {
+    setFilters((prev) => {
+      const environments = showEnvFilter
+        ? prev.environments.filter((e) => envOptions.includes(e))
+        : []
+      const opdivIds = showOpDivFilter
+        ? prev.opdivIds.filter((id) => opdivOptions.some((o) => o.id === id))
+        : []
+      if (
+        environments.length === prev.environments.length &&
+        opdivIds.length === prev.opdivIds.length
+      ) {
+        return prev
+      }
+      return { ...prev, environments, opdivIds }
+    })
+  }, [envOptions, opdivOptions, showEnvFilter, showOpDivFilter])
+
+  const filteredRows = useMemo(
+    () =>
+      applyDashboardFilters(fismaSystems, progress ?? {}, categoryMap, filters),
+    [fismaSystems, progress, categoryMap, filters]
+  )
   const [pillarScoresModal, setPillarScoresModal] = useState<{
     open: boolean
     systemName: string
@@ -469,7 +723,7 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
   return (
     <Box sx={{ height: 600, width: '100%', mb: 2 }}>
       <DataGrid
-        rows={fismaSystems}
+        rows={filteredRows}
         isRowSelectable={(params: GridRowParams) =>
           params.row.fismasystemid in scores
         }
@@ -483,6 +737,14 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
         }}
         slotProps={{
           footer: { selectedRows, fismaSystems, activeDataCallId, scores },
+          toolbar: {
+            filters,
+            onFiltersChange: setFilters,
+            envOptions,
+            opdivOptions,
+            showEnvFilter,
+            showOpDivFilter,
+          },
           filterPanel: {
             sx: {
               '& .MuiFormLabel-root': {

--- a/src/views/FismaTable/dashboardFilters.test.ts
+++ b/src/views/FismaTable/dashboardFilters.test.ts
@@ -1,0 +1,118 @@
+import type { FismaSystemType, ScoreProgress } from '@/types'
+import {
+  applyDashboardFilters,
+  isNotUpdated,
+  hasNoActiveFilters,
+  EMPTY_DASHBOARD_FILTERS,
+} from './dashboardFilters'
+
+// Minimal rows — only the fields the filter reads. Cast through unknown, the
+// repo's pattern for grid-row fixtures.
+const ROWS = [
+  { fismasystemid: 1, datacenterenvironment: 'aws', opdiv_id: 10 },
+  { fismasystemid: 2, datacenterenvironment: 'onprem', opdiv_id: 20 },
+  { fismasystemid: 3, datacenterenvironment: 'saas', opdiv_id: 10 },
+  { fismasystemid: 4, datacenterenvironment: 'aws', opdiv_id: null },
+] as unknown as FismaSystemType[]
+
+// raw datacenterenvironment -> category label
+const CATEGORY_MAP: Record<string, string> = {
+  aws: 'Cloud',
+  saas: 'Cloud',
+  onprem: 'On-Premises',
+}
+
+const prog = (
+  fismasystemid: number,
+  questionsexpected: number,
+  questionsupdated: number
+): ScoreProgress =>
+  ({
+    fismasystemid,
+    questionsexpected,
+    questionsupdated,
+    updatedsincestart: questionsupdated > 0,
+  }) as ScoreProgress
+
+// sys1 not updated, sys2 partial, sys3 fully updated, sys4 N/A (no questionnaire)
+const PROGRESS: Record<number, ScoreProgress> = {
+  1: prog(1, 40, 0),
+  2: prog(2, 40, 30),
+  3: prog(3, 40, 40),
+  4: prog(4, 0, 0),
+}
+
+const filters = (over: Partial<typeof EMPTY_DASHBOARD_FILTERS> = {}) => ({
+  ...EMPTY_DASHBOARD_FILTERS,
+  ...over,
+})
+
+test('empty filters return the input rows unchanged', () => {
+  expect(hasNoActiveFilters(EMPTY_DASHBOARD_FILTERS)).toBe(true)
+  expect(applyDashboardFilters(ROWS, PROGRESS, CATEGORY_MAP, filters())).toBe(
+    ROWS
+  )
+})
+
+test('environment filter matches by resolved category', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ environments: ['Cloud'] })
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1, 3, 4]) // aws, saas, aws
+})
+
+test('opdiv filter matches by opdiv_id and drops null opdivs', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ opdivIds: [10] })
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1, 3])
+})
+
+test('not-updated filter keeps only laggards with a questionnaire', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ notUpdatedOnly: true })
+  )
+  // sys1 only: sys2 partial, sys3 full, sys4 is 0/0 N/A (excluded)
+  expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
+test('isNotUpdated classifies each progress bucket correctly', () => {
+  expect(isNotUpdated(prog(1, 40, 0))).toBe(true) // not updated
+  expect(isNotUpdated(prog(2, 40, 30))).toBe(false) // partial
+  expect(isNotUpdated(prog(3, 40, 40))).toBe(false) // full
+  expect(isNotUpdated(prog(4, 0, 0))).toBe(false) // N/A 0/0
+  expect(isNotUpdated(undefined)).toBe(false) // no data
+})
+
+test('facets combine with AND', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ environments: ['Cloud'], opdivIds: [10], notUpdatedOnly: true })
+  )
+  // Cloud ∩ opdiv 10 = {1,3}; not-updated of those = {1}
+  expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
+test('a row whose environment is not in the category map is excluded when env filter is active', () => {
+  const rows = [
+    { fismasystemid: 9, datacenterenvironment: 'unknown-env', opdiv_id: 10 },
+  ] as unknown as FismaSystemType[]
+  const out = applyDashboardFilters(
+    rows,
+    {},
+    CATEGORY_MAP,
+    filters({ environments: ['Cloud'] })
+  )
+  expect(out).toHaveLength(0)
+})

--- a/src/views/FismaTable/dashboardFilters.ts
+++ b/src/views/FismaTable/dashboardFilters.ts
@@ -1,0 +1,84 @@
+import type { FismaSystemType, ScoreProgress } from '@/types'
+import { progressSortValue } from './progressHelpers'
+
+/**
+ * Client-side dashboard filter selections. Each facet is independent and
+ * combines with the others via AND; an empty/false facet is a no-op.
+ */
+export type DashboardFilterState = {
+  /** Selected Environment *category* labels (resolved from datacenterenvironment). */
+  environments: string[]
+  /** Selected opdiv_id values. */
+  opdivIds: number[]
+  /** When true, keep only systems that have a questionnaire but zero updates. */
+  notUpdatedOnly: boolean
+}
+
+/** An empty filter state — nothing selected, everything passes. */
+export const EMPTY_DASHBOARD_FILTERS: DashboardFilterState = {
+  environments: [],
+  opdivIds: [],
+  notUpdatedOnly: false,
+}
+
+/**
+ * True when no facet is active, so filtering can be skipped entirely.
+ * @param {DashboardFilterState} filters - The current selections.
+ * @returns {boolean} True when every facet is empty/false.
+ */
+export function hasNoActiveFilters(filters: DashboardFilterState): boolean {
+  return (
+    filters.environments.length === 0 &&
+    filters.opdivIds.length === 0 &&
+    !filters.notUpdatedOnly
+  )
+}
+
+/**
+ * True when a system is a genuine "Not updated" laggard for the active data
+ * call: it has a questionnaire but zero functions updated. Reuses the column's
+ * own classifier (`progressSortValue === -1`) so the filter and the Data Call
+ * Progress chip never disagree — the 0/0 "N/A" case and systems with no
+ * progress data are intentionally excluded.
+ * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @returns {boolean} True when the system is not updated but has a questionnaire.
+ */
+export function isNotUpdated(entry: ScoreProgress | undefined): boolean {
+  return progressSortValue(entry) === -1
+}
+
+/**
+ * Apply the dashboard filters to the system rows. Pure and side-effect free so
+ * it can be memoized in the component and unit-tested in isolation (the
+ * repo's established pattern for grid logic).
+ * @param {FismaSystemType[]} rows - All system rows currently in the grid.
+ * @param {Record<number, ScoreProgress>} progress - Progress keyed by fismasystemid.
+ * @param {Record<string, string>} categoryMap - Raw datacenterenvironment -> category.
+ * @param {DashboardFilterState} filters - The active selections.
+ * @returns {FismaSystemType[]} The subset of rows passing every active facet.
+ */
+export function applyDashboardFilters(
+  rows: FismaSystemType[],
+  progress: Record<number, ScoreProgress>,
+  categoryMap: Record<string, string>,
+  filters: DashboardFilterState
+): FismaSystemType[] {
+  if (hasNoActiveFilters(filters)) return rows
+
+  const envSet = new Set(filters.environments)
+  const opdivSet = new Set(filters.opdivIds)
+
+  return rows.filter((row) => {
+    if (envSet.size > 0) {
+      const category = categoryMap[row.datacenterenvironment]
+      if (!category || !envSet.has(category)) return false
+    }
+    if (opdivSet.size > 0) {
+      if (row.opdiv_id == null || !opdivSet.has(row.opdiv_id)) return false
+    }
+    if (filters.notUpdatedOnly && !isNotUpdated(progress[row.fismasystemid])) {
+      return false
+    }
+    return true
+  })
+}

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -6,13 +6,17 @@ import { styled } from '@mui/material/styles'
 import { useContextProp } from '../Title/Context'
 import type { SystemScoreEntry } from '@/types'
 const StatisticsPaper = styled(Paper)(({ theme }) => ({
-  width: 120,
-  height: 120,
   padding: theme.spacing(2),
   ...theme.typography.body2,
+  // Center the numeral + label and let the card grow with its content so long
+  // system names wrap instead of clipping past a fixed height. The wrapper's
+  // stretch + minHeight keeps every card the same size.
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
   textAlign: 'center',
   overflowWrap: 'break-word',
-  elevation: 3,
 }))
 export default function StatisticsBlocks({
   scores,
@@ -72,10 +76,11 @@ export default function StatisticsBlocks({
         display: 'flex',
         flexWrap: 'wrap',
         justifyContent: 'space-evenly',
+        alignItems: 'stretch',
         '& > :not(style)': {
           m: 1,
           width: 270,
-          height: 128,
+          minHeight: 128,
           borderWidth: 2,
         },
       }}

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -211,8 +211,30 @@ export default function Title() {
   const LOGO_OPTICAL_OFFSET = Math.round(LOGO_HEIGHT * 0.1)
   return (
     <>
-      <UsaBanner />
-      <DevEnvironmentBanner />
+      {/* Left-align the USA banner's content with the ZTMF logo below it by
+          dropping the CMSDS max-width centering and matching the header's
+          responsive horizontal padding. */}
+      <Box
+        sx={{
+          '& .ds-c-usa-banner__header, & .ds-c-usa-banner__guidance': {
+            maxWidth: 'none',
+            px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+          },
+        }}
+      >
+        <UsaBanner />
+      </Box>
+      {/* Match the dev banner's text start to the logo/USA-banner content
+          while the coloured bar stays full-bleed. */}
+      <Box
+        sx={{
+          '& .MuiAlert-root': {
+            px: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+          },
+        }}
+      >
+        <DevEnvironmentBanner />
+      </Box>
       {/* Branded header bar. Hidden on the /signin route AND any time
           LoginPage is rendered as the body (loaderData.status !== 200),
           so the header never sits above a "please sign in" prompt at any


### PR DESCRIPTION
Closes #489. Closes #463.

## Dashboard filters (#489)
<img width="1695" height="134" alt="image" src="https://github.com/user-attachments/assets/53a77071-1815-4615-8b93-3977ea34ba2f" />

Client-side filters on the dashboard system list so users can narrow the table without scrolling:

- **Environment** and **OpDiv** — compact multi-selects (fixed height; the collapsed control shows a short summary and never grows with selections).
- **Not updated only** — a toggle that isolates systems with a questionnaire but zero updates for the active data call. Reuses the Data Call Progress column's own classifier so the filter and the column chip always agree.
- **Clear filters** — resets the three facets; disabled when nothing is active.

A facet filter is hidden when the visible systems span a single value. The filter logic lives in a pure, unit-tested module (`src/views/FismaTable/dashboardFilters.ts`); selections auto-prune when the option sets change (e.g. after Show Decommissioned refetches).

## Summary card sizing (#463)

The dashboard summary cards clipped long system names against a fixed height. Switched to a min-height with `align-items: stretch` so cards grow to fit their content and stay equal size.

## Header alignment

The USA banner and the development-environment banner text now left-align with the ZTMF logo, while the bars stay full width.

## Testing

- New unit tests for the filter logic (7), full suite green (309 passing), typecheck and lint clean.
- Verified locally against dev data (the local backend was rebuilt so the Data Call Progress endpoint is present).

## Note

The development banner's pre-login gate is tracked separately in #485 (still open); this branch does not include it, so that PR and this one both touch the banner mount and will need a trivial reconcile whenever both land.