### PR TITLE
feat(pillar-scores): label radar series with actual data-call names

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -125,8 +125,8 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
 
   // True whenever a comparison is active (default or user-chosen call),
   // false when the user explicitly picked "None" or there is no predecessor
-  // at all. Distinguishes "selected a call with no score → show No previous
-  // data" from "None / no comparison possible → hide entirely".
+  // at all. Distinguishes "selected a call with no score → show 'No data for <name>'"
+  // from "None / no comparison possible → hide entirely".
   const comparisonActive =
     selectedComparisonId !== null &&
     (selectedComparisonId !== undefined || previousDatacall !== null)
@@ -475,7 +475,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             mb: 0.3,
                           }}
                         >
-                          {`${comparisonDatacallName}: ${previousSystemScore.toFixed(2)}`}
+                          {`Compared with ${comparisonDatacallName}: ${previousSystemScore.toFixed(2)}`}
                         </Typography>
                         <Typography
                           variant="caption"
@@ -504,7 +504,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                           fontSize: '0.85rem',
                         }}
                       >
-                        No previous data
+                        No data for {comparisonDatacallName}
                       </Typography>
                     )
                   }
@@ -627,7 +627,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             fontSize: '0.75rem',
                           }}
                         >
-                          {`${comparisonDatacallName}: ${previousPillarScore.toFixed(2)}`}
+                          {`Compared with ${comparisonDatacallName}: ${previousPillarScore.toFixed(2)}`}
                         </Typography>
                       )}
 
@@ -641,7 +641,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                               fontSize: '0.75rem',
                             }}
                           >
-                            No previous data
+                            No data for {comparisonDatacallName}
                           </Typography>
                         )}
 

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -327,16 +327,18 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                   <FormControl size="small">
                     <Select
                       value={
-                        selectedComparisonId === undefined
-                          ? previousScoreEntry?.datacallid ?? ''
-                          : selectedComparisonId ?? ''
+                        sortedDatacalls.length === 0
+                          ? ''
+                          : selectedComparisonId === undefined
+                            ? previousScoreEntry?.datacallid ?? ''
+                            : selectedComparisonId ?? ''
                       }
                       onChange={(e) => {
                         const val = e.target.value
                         setSelectedComparisonId(val === '' ? null : Number(val))
                       }}
                       displayEmpty
-                      sx={{ minWidth: 160 }}
+                      sx={{ minWidth: 160, maxWidth: 260 }}
                     >
                       <MenuItem value="">None</MenuItem>
                       {sortedDatacalls
@@ -479,7 +481,11 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         </Typography>
                       </>
                     )
-                  } else if (latestScore.systemscore && !previousSystemScore) {
+                  } else if (
+                    latestScore.systemscore &&
+                    comparisonScoreEntry !== null &&
+                    !previousSystemScore
+                  ) {
                     return (
                       <Typography
                         variant="body2"
@@ -503,7 +509,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
               gutterBottom
               sx={{ mt: 3, mb: 1.5, textAlign: 'center', fontSize: '1.25rem' }}
             >
-              Pillar Scores - {getQuarterName(latestScore.datacallid)}
+              Pillar Scores - {currentDatacallName}
             </Typography>
             <Grid container spacing={2}>
               {(latestScore.pillarscores ?? []).map((pillar) => {
@@ -615,17 +621,19 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         </Typography>
                       )}
 
-                      {!previousPillarScore && currentScore > 0 && (
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: 'text.secondary',
-                            fontSize: '0.75rem',
-                          }}
-                        >
-                          No previous data
-                        </Typography>
-                      )}
+                      {comparisonScoreEntry !== null &&
+                        !previousPillarScore &&
+                        currentScore > 0 && (
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              color: 'text.secondary',
+                              fontSize: '0.75rem',
+                            }}
+                          >
+                            No previous data
+                          </Typography>
+                        )}
 
                       {trendInfo.text && currentScore > 0 && (
                         <Typography
@@ -730,7 +738,14 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                                 />
                                 <Typography
                                   variant="caption"
-                                  sx={{ fontSize: '0.875rem' }}
+                                  sx={{
+                                    fontSize: '0.875rem',
+                                    maxWidth: 200,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                  }}
+                                  title={entry.value}
                                 >
                                   {entry.value}
                                 </Typography>
@@ -741,10 +756,46 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       }}
                     />
                     <Tooltip
-                      formatter={(value: number, name: string) => [
-                        value.toFixed(2),
-                        name,
-                      ]}
+                      content={({ active, payload, label }) => {
+                        if (!active || !payload?.length) return null
+                        return (
+                          <Box
+                            sx={{
+                              backgroundColor: 'background.paper',
+                              border: '1px solid',
+                              borderColor: 'divider',
+                              borderRadius: 1,
+                              p: 1,
+                              maxWidth: 280,
+                            }}
+                          >
+                            <Typography
+                              variant="caption"
+                              display="block"
+                              fontWeight="bold"
+                              sx={{
+                                mb: 0.5,
+                                overflowWrap: 'anywhere',
+                              }}
+                            >
+                              {label}
+                            </Typography>
+                            {payload.map((entry, i) => (
+                              <Typography
+                                key={i}
+                                variant="caption"
+                                display="block"
+                                sx={{
+                                  color: entry.color,
+                                  overflowWrap: 'anywhere',
+                                }}
+                              >
+                                {entry.name}: {Number(entry.value).toFixed(2)}
+                              </Typography>
+                            ))}
+                          </Box>
+                        )
+                      }}
                     />
                   </RadarChart>
                 </ResponsiveContainer>

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -34,7 +34,7 @@ import {
   Tooltip,
 } from 'recharts'
 import axiosInstance from '@/axiosConfig'
-import type { ScoreAggregate } from '@/types'
+import type { ScoreAggregate, datacall as DataCall } from '@/types'
 import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
@@ -43,13 +43,6 @@ import { parseDatacallName } from '@/utils/datacallGrouping'
 const datacallsCache: { data: DataCall[] | null; timestamp: number | null } = {
   data: null,
   timestamp: null,
-}
-
-interface DataCall {
-  datacallid: number
-  datacall: string
-  datecreated: string
-  deadline: string
 }
 
 interface PillarScoresModalProps {
@@ -106,24 +99,21 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     [datacalls]
   )
 
-  // Deadline-ordered when datacalls have loaded; falls back to datacallid
-  // ordering during the async fetch so the comparison series doesn't disappear.
-  const previousScoreEntry = (() => {
-    if (!latestScore) return null
-    if (sortedDatacalls.length > 0) {
-      const idx = sortedDatacalls.findIndex(
-        (dc) => dc.datacallid === latestScore.datacallid
-      )
-      if (idx < 0) return null
-      const prevDcId = sortedDatacalls[idx + 1]?.datacallid
-      return prevDcId !== undefined
-        ? scores.find((s) => s.datacallid === prevDcId) ?? null
-        : null
-    }
-    const sorted = [...scores].sort((a, b) => b.datacallid - a.datacallid)
-    const idx = sorted.findIndex((s) => s.datacallid === latestScore.datacallid)
-    return idx >= 0 ? sorted[idx + 1] ?? null : null
+  // The datacall immediately preceding the current one by deadline order.
+  // Tracked separately from its score so we can still label the comparison
+  // when this system has no submission for that call.
+  const previousDatacall = (() => {
+    if (!latestScore || sortedDatacalls.length === 0) return null
+    const idx = sortedDatacalls.findIndex(
+      (dc) => dc.datacallid === latestScore.datacallid
+    )
+    return idx >= 0 ? sortedDatacalls[idx + 1] ?? null : null
   })()
+
+  // Score entry for the previous datacall; null if no submission for that call.
+  const previousScoreEntry = previousDatacall
+    ? scores.find((s) => s.datacallid === previousDatacall.datacallid) ?? null
+    : null
 
   // Effective comparison entry based on selection state.
   const comparisonScoreEntry =
@@ -132,6 +122,17 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
       : selectedComparisonId === null
         ? null
         : scores.find((s) => s.datacallid === selectedComparisonId) ?? null
+
+  // True whenever a comparison is active (default or user-chosen call),
+  // false when the user explicitly picked "None" or there is no predecessor
+  // at all. Distinguishes "selected a call with no score → show No previous
+  // data" from "None / no comparison possible → hide entirely".
+  const comparisonActive =
+    selectedComparisonId !== null &&
+    (selectedComparisonId !== undefined || previousDatacall !== null)
+
+  const hasComparisonPillarData =
+    (comparisonScoreEntry?.pillarscores?.length ?? 0) > 0
 
   // Prepare radar chart data
   const radarData = useMemo(() => {
@@ -198,10 +199,12 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     }
   }, [open])
 
-  // Reset to default (undefined) when the viewed call changes
+  // Reset to default whenever the modal opens or the target system/call changes.
+  // Depending on latestScore.datacallid alone misses the case where two different
+  // systems share the same active datacall — the stale comparison would persist.
   useEffect(() => {
-    setSelectedComparisonId(undefined)
-  }, [latestScore?.datacallid])
+    if (open) setSelectedComparisonId(undefined)
+  }, [open, selectedDataCallId])
 
   // Returns "{name} · {tenant}" to match the year-grouped selector styling.
   const getQuarterName = (datacallid: number) => {
@@ -217,9 +220,16 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     latestScore && datacalls.length > 0
       ? getQuarterName(latestScore.datacallid)
       : 'Current'
+  // Resolve which datacall id is being compared against — from explicit selection,
+  // the default predecessor call, or nothing (None selected).
+  const comparisonDatacallId =
+    selectedComparisonId === undefined
+      ? previousDatacall?.datacallid
+      : selectedComparisonId ?? undefined
+
   const comparisonDatacallName =
-    comparisonScoreEntry && datacalls.length > 0
-      ? getQuarterName(comparisonScoreEntry.datacallid)
+    comparisonDatacallId != null && datacalls.length > 0
+      ? getQuarterName(comparisonDatacallId)
       : 'Previous'
 
   // Helper function to get trend information
@@ -330,7 +340,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         sortedDatacalls.length === 0
                           ? ''
                           : selectedComparisonId === undefined
-                            ? previousScoreEntry?.datacallid ?? ''
+                            ? previousDatacall?.datacallid ?? ''
                             : selectedComparisonId ?? ''
                       }
                       onChange={(e) => {
@@ -347,7 +357,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         )
                         .map((dc) => (
                           <MenuItem key={dc.datacallid} value={dc.datacallid}>
-                            {`${dc.datacall} · ${parseDatacallName(dc.datacall).tenant}`}
+                            {getQuarterName(dc.datacallid)}
                           </MenuItem>
                         ))}
                     </Select>
@@ -483,7 +493,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                     )
                   } else if (
                     latestScore.systemscore &&
-                    comparisonScoreEntry !== null &&
+                    comparisonActive &&
                     !previousSystemScore
                   ) {
                     return (
@@ -621,7 +631,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         </Typography>
                       )}
 
-                      {comparisonScoreEntry !== null &&
+                      {comparisonActive &&
                         !previousPillarScore &&
                         currentScore > 0 && (
                           <Typography
@@ -693,7 +703,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       fillOpacity={0.3}
                       strokeWidth={2}
                     />
-                    {comparisonScoreEntry !== null && (
+                    {hasComparisonPillarData && (
                       <Radar
                         name={comparisonDatacallName}
                         dataKey="previous"
@@ -848,7 +858,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                           <TableCell align="right">
                             <strong>{currentDatacallName}</strong>
                           </TableCell>
-                          {comparisonScoreEntry !== null && (
+                          {hasComparisonPillarData && (
                             <TableCell align="right">
                               <strong>{comparisonDatacallName}</strong>
                             </TableCell>
@@ -893,7 +903,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                                   ? currentScore.toFixed(2)
                                   : 'N/A'}
                               </TableCell>
-                              {comparisonScoreEntry !== null && (
+                              {hasComparisonPillarData && (
                                 <TableCell align="right">
                                   {prevScore > 0 ? prevScore.toFixed(2) : 'N/A'}
                                 </TableCell>

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -33,6 +33,7 @@ import {
 import axiosInstance from '@/axiosConfig'
 import type { ScoreAggregate } from '@/types'
 import { tierStyle, TIERS } from '@/utils/tierStyles'
+import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 
 // Static cache for datacalls that persists across component instances
 const datacallsCache: { data: DataCall[] | null; timestamp: number | null } = {
@@ -94,12 +95,18 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   const radarData = useMemo(() => {
     if (!hasValidData || !latestScore?.pillarscores) return []
 
-    const previousDatacall = scores
-      .filter((s) => s.datacallid < latestScore.datacallid)
-      .sort((a, b) => b.datacallid - a.datacallid)[0]
+    const sortedDcs = sortDatacallsByDeadline(datacalls)
+    const currentIdx = sortedDcs.findIndex(
+      (dc) => dc.datacallid === latestScore.datacallid
+    )
+    const prevDcId = sortedDcs[currentIdx + 1]?.datacallid
+    const previousEntry =
+      prevDcId !== undefined
+        ? scores.find((s) => s.datacallid === prevDcId) ?? null
+        : null
 
     return latestScore.pillarscores.map((pillar) => {
-      const previousPillarScore = previousDatacall?.pillarscores?.find(
+      const previousPillarScore = previousEntry?.pillarscores?.find(
         (p) => p.pillarid === pillar.pillarid
       )?.score
 
@@ -109,7 +116,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
         previous: previousPillarScore ?? 0,
       }
     })
-  }, [scores, latestScore, hasValidData])
+  }, [scores, latestScore, hasValidData, datacalls])
 
   // Fetch datacalls when modal opens (with caching)
   useEffect(() => {
@@ -166,6 +173,27 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     const datacall = datacalls.find((dc) => dc.datacallid === datacallid)
     return datacall ? datacall.datacall : `Datacall ${datacallid}`
   }
+
+  const sortedDatacalls = sortDatacallsByDeadline(datacalls)
+  const currentDcIndex = latestScore
+    ? sortedDatacalls.findIndex(
+        (dc) => dc.datacallid === latestScore.datacallid
+      )
+    : -1
+  const previousScoreEntry =
+    currentDcIndex >= 0
+      ? scores.find(
+          (s) =>
+            s.datacallid === sortedDatacalls[currentDcIndex + 1]?.datacallid
+        ) ?? null
+      : null
+
+  const currentDatacallName = latestScore
+    ? getQuarterName(latestScore.datacallid)
+    : 'Current'
+  const previousDatacallName = previousScoreEntry
+    ? getQuarterName(previousScoreEntry.datacallid)
+    : 'Previous'
 
   // Helper function to get trend information
   const getTrendInfo = (currentScore: number, previousScore: number | null) => {
@@ -368,7 +396,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             mb: 0.3,
                           }}
                         >
-                          Previous: {previousSystemScore.toFixed(2)}
+                          {`${previousDatacallName}: ${previousSystemScore.toFixed(2)}`}
                         </Typography>
                         <Typography
                           variant="caption"
@@ -521,7 +549,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             fontSize: '0.75rem',
                           }}
                         >
-                          Previous: {previousPillarScore.toFixed(2)}
+                          {`${previousDatacallName}: ${previousPillarScore.toFixed(2)}`}
                         </Typography>
                       )}
 
@@ -570,7 +598,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
               </Typography>
               <Box
                 role="img"
-                aria-label={`Radar chart showing pillar scores. Current scores: ${radarData.map((d) => `${d.pillar}: ${d.current.toFixed(2)}`).join(', ')}`}
+                aria-label={`Radar chart showing pillar scores. ${currentDatacallName} scores: ${radarData.map((d) => `${d.pillar}: ${d.current.toFixed(2)}`).join(', ')}`}
               >
                 <ResponsiveContainer width="100%" height={400}>
                   <RadarChart
@@ -588,7 +616,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       tickCount={6}
                     />
                     <Radar
-                      name="Current"
+                      name={currentDatacallName}
                       dataKey="current"
                       stroke="#8884d8"
                       fill="#8884d8"
@@ -597,7 +625,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                     />
                     {scores.length > 1 && (
                       <Radar
-                        name="Previous"
+                        name={previousDatacallName}
                         dataKey="previous"
                         stroke="#82ca9d"
                         fill="#82ca9d"
@@ -629,11 +657,13 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                                     height: 12,
                                     backgroundColor: entry.color,
                                     border:
-                                      entry.value === 'Previous'
+                                      entry.value === previousDatacallName
                                         ? '1px dashed'
                                         : 'none',
                                     opacity:
-                                      entry.value === 'Previous' ? 0.7 : 0.8,
+                                      entry.value === previousDatacallName
+                                        ? 0.7
+                                        : 0.8,
                                   }}
                                 />
                                 <Typography
@@ -651,7 +681,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                     <Tooltip
                       formatter={(value: number, name: string) => [
                         value.toFixed(2),
-                        name === 'current' ? 'Current Score' : 'Previous Score',
+                        name,
                       ]}
                     />
                   </RadarChart>
@@ -703,11 +733,11 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             <strong>Pillar Name</strong>
                           </TableCell>
                           <TableCell align="right">
-                            <strong>Current Score</strong>
+                            <strong>{currentDatacallName}</strong>
                           </TableCell>
                           {scores.length > 1 && (
                             <TableCell align="right">
-                              <strong>Previous Score</strong>
+                              <strong>{previousDatacallName}</strong>
                             </TableCell>
                           )}
                           <TableCell align="right">

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -16,6 +16,9 @@ import {
   Paper,
   Collapse,
   Button,
+  FormControl,
+  Select,
+  MenuItem,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import CloseIcon from '@mui/icons-material/Close'
@@ -34,6 +37,7 @@ import axiosInstance from '@/axiosConfig'
 import type { ScoreAggregate } from '@/types'
 import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
+import { parseDatacallName } from '@/utils/datacallGrouping'
 
 // Static cache for datacalls that persists across component instances
 const datacallsCache: { data: DataCall[] | null; timestamp: number | null } = {
@@ -72,6 +76,12 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
 }) => {
   const [datacalls, setDatacalls] = useState<DataCall[]>([])
   const [showDataTable, setShowDataTable] = useState(false)
+  // undefined = not set by user (use deadline-based default)
+  // null      = user explicitly selected "None" (no comparison)
+  // number    = user selected a specific datacall
+  const [selectedComparisonId, setSelectedComparisonId] = useState<
+    number | null | undefined
+  >(undefined)
   const dialogRef = useRef<HTMLDivElement>(null)
   const initialFocusRef = useRef<HTMLButtonElement>(null)
 
@@ -91,32 +101,52 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     latestScore.pillarscores &&
     latestScore.pillarscores.length > 0
 
+  const sortedDatacalls = useMemo(
+    () => sortDatacallsByDeadline(datacalls),
+    [datacalls]
+  )
+
+  // Deadline-ordered when datacalls have loaded; falls back to datacallid
+  // ordering during the async fetch so the comparison series doesn't disappear.
+  const previousScoreEntry = (() => {
+    if (!latestScore) return null
+    if (sortedDatacalls.length > 0) {
+      const idx = sortedDatacalls.findIndex(
+        (dc) => dc.datacallid === latestScore.datacallid
+      )
+      if (idx < 0) return null
+      const prevDcId = sortedDatacalls[idx + 1]?.datacallid
+      return prevDcId !== undefined
+        ? scores.find((s) => s.datacallid === prevDcId) ?? null
+        : null
+    }
+    const sorted = [...scores].sort((a, b) => b.datacallid - a.datacallid)
+    const idx = sorted.findIndex((s) => s.datacallid === latestScore.datacallid)
+    return idx >= 0 ? sorted[idx + 1] ?? null : null
+  })()
+
+  // Effective comparison entry based on selection state.
+  const comparisonScoreEntry =
+    selectedComparisonId === undefined
+      ? previousScoreEntry
+      : selectedComparisonId === null
+        ? null
+        : scores.find((s) => s.datacallid === selectedComparisonId) ?? null
+
   // Prepare radar chart data
   const radarData = useMemo(() => {
     if (!hasValidData || !latestScore?.pillarscores) return []
-
-    const sortedDcs = sortDatacallsByDeadline(datacalls)
-    const currentIdx = sortedDcs.findIndex(
-      (dc) => dc.datacallid === latestScore.datacallid
-    )
-    const prevDcId = sortedDcs[currentIdx + 1]?.datacallid
-    const previousEntry =
-      prevDcId !== undefined
-        ? scores.find((s) => s.datacallid === prevDcId) ?? null
-        : null
-
     return latestScore.pillarscores.map((pillar) => {
-      const previousPillarScore = previousEntry?.pillarscores?.find(
+      const comparisonPillarScore = comparisonScoreEntry?.pillarscores?.find(
         (p) => p.pillarid === pillar.pillarid
       )?.score
-
       return {
         pillar: pillar.pillar,
         current: pillar.score ?? 0,
-        previous: previousPillarScore ?? 0,
+        previous: comparisonPillarScore ?? 0,
       }
     })
-  }, [scores, latestScore, hasValidData, datacalls])
+  }, [hasValidData, latestScore, comparisonScoreEntry])
 
   // Fetch datacalls when modal opens (with caching)
   useEffect(() => {
@@ -168,32 +198,29 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     }
   }, [open])
 
-  // Helper function to get quarter name by datacallid
+  // Reset to default (undefined) when the viewed call changes
+  useEffect(() => {
+    setSelectedComparisonId(undefined)
+  }, [latestScore?.datacallid])
+
+  // Returns "{name} · {tenant}" to match the year-grouped selector styling.
   const getQuarterName = (datacallid: number) => {
     const datacall = datacalls.find((dc) => dc.datacallid === datacallid)
-    return datacall ? datacall.datacall : `Datacall ${datacallid}`
+    if (!datacall) return `Datacall ${datacallid}`
+    const { tenant } = parseDatacallName(datacall.datacall)
+    return `${datacall.datacall} · ${tenant}`
   }
 
-  const sortedDatacalls = sortDatacallsByDeadline(datacalls)
-  const currentDcIndex = latestScore
-    ? sortedDatacalls.findIndex(
-        (dc) => dc.datacallid === latestScore.datacallid
-      )
-    : -1
-  const previousScoreEntry =
-    currentDcIndex >= 0
-      ? scores.find(
-          (s) =>
-            s.datacallid === sortedDatacalls[currentDcIndex + 1]?.datacallid
-        ) ?? null
-      : null
-
-  const currentDatacallName = latestScore
-    ? getQuarterName(latestScore.datacallid)
-    : 'Current'
-  const previousDatacallName = previousScoreEntry
-    ? getQuarterName(previousScoreEntry.datacallid)
-    : 'Previous'
+  // Show 'Current'/'Previous' until the datacalls fetch resolves so labels
+  // don't flash 'Datacall {id}' during the initial load.
+  const currentDatacallName =
+    latestScore && datacalls.length > 0
+      ? getQuarterName(latestScore.datacallid)
+      : 'Current'
+  const comparisonDatacallName =
+    comparisonScoreEntry && datacalls.length > 0
+      ? getQuarterName(comparisonScoreEntry.datacallid)
+      : 'Previous'
 
   // Helper function to get trend information
   const getTrendInfo = (currentScore: number, previousScore: number | null) => {
@@ -279,6 +306,53 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
         </Box>
         {hasValidData ? (
           <Box>
+            {/* Comparison selector — shown whenever other scores exist (synchronous
+                check so the picker appears on the first render, not after the
+                async datacalls fetch resolves). Dropdown options use sortedDatacalls
+                which may briefly be empty while the fetch is in flight. */}
+            {scores.length > 1 && (
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                mb={2}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  Viewing: <strong>{currentDatacallName}</strong>
+                </Typography>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Typography variant="body2" color="text.secondary">
+                    Compare with:
+                  </Typography>
+                  <FormControl size="small">
+                    <Select
+                      value={
+                        selectedComparisonId === undefined
+                          ? previousScoreEntry?.datacallid ?? ''
+                          : selectedComparisonId ?? ''
+                      }
+                      onChange={(e) => {
+                        const val = e.target.value
+                        setSelectedComparisonId(val === '' ? null : Number(val))
+                      }}
+                      displayEmpty
+                      sx={{ minWidth: 160 }}
+                    >
+                      <MenuItem value="">None</MenuItem>
+                      {sortedDatacalls
+                        .filter(
+                          (dc) => dc.datacallid !== latestScore?.datacallid
+                        )
+                        .map((dc) => (
+                          <MenuItem key={dc.datacallid} value={dc.datacallid}>
+                            {`${dc.datacall} · ${parseDatacallName(dc.datacall).tenant}`}
+                          </MenuItem>
+                        ))}
+                    </Select>
+                  </FormControl>
+                </Box>
+              </Box>
+            )}
             {/* Overall System Score */}
             <Box mb={2} textAlign="center">
               <Typography variant="h3" sx={{ fontSize: '1.5rem' }} gutterBottom>
@@ -345,12 +419,8 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                   gap={1.5}
                 >
                   {(() => {
-                    // Find previous system score for trend calculation
-                    const previousSystemScore = scores
-                      .filter((s) => s.datacallid < latestScore.datacallid)
-                      .sort(
-                        (a, b) => b.datacallid - a.datacallid
-                      )[0]?.systemscore
+                    const previousSystemScore =
+                      comparisonScoreEntry?.systemscore
 
                     if (latestScore.systemscore && previousSystemScore) {
                       const trendInfo = getTrendInfo(
@@ -376,10 +446,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                 </Box>
 
                 {(() => {
-                  // Show previous score and change information
-                  const previousSystemScore = scores
-                    .filter((s) => s.datacallid < latestScore.datacallid)
-                    .sort((a, b) => b.datacallid - a.datacallid)[0]?.systemscore
+                  const previousSystemScore = comparisonScoreEntry?.systemscore
 
                   if (latestScore.systemscore && previousSystemScore) {
                     const trendInfo = getTrendInfo(
@@ -396,7 +463,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             mb: 0.3,
                           }}
                         >
-                          {`${previousDatacallName}: ${previousSystemScore.toFixed(2)}`}
+                          {`${comparisonDatacallName}: ${previousSystemScore.toFixed(2)}`}
                         </Typography>
                         <Typography
                           variant="caption"
@@ -440,13 +507,8 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
             </Typography>
             <Grid container spacing={2}>
               {(latestScore.pillarscores ?? []).map((pillar) => {
-                // Find previous score for this pillar
-                const previousDatacall = scores
-                  .filter((s) => s.datacallid < latestScore.datacallid)
-                  .sort((a, b) => b.datacallid - a.datacallid)[0]
-
                 const previousPillarScore =
-                  previousDatacall?.pillarscores?.find(
+                  comparisonScoreEntry?.pillarscores?.find(
                     (p) => p.pillarid === pillar.pillarid
                   )?.score
 
@@ -549,7 +611,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                             fontSize: '0.75rem',
                           }}
                         >
-                          {`${previousDatacallName}: ${previousPillarScore.toFixed(2)}`}
+                          {`${comparisonDatacallName}: ${previousPillarScore.toFixed(2)}`}
                         </Typography>
                       )}
 
@@ -623,9 +685,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       fillOpacity={0.3}
                       strokeWidth={2}
                     />
-                    {scores.length > 1 && (
+                    {comparisonScoreEntry !== null && (
                       <Radar
-                        name={previousDatacallName}
+                        name={comparisonDatacallName}
                         dataKey="previous"
                         stroke="#82ca9d"
                         fill="#82ca9d"
@@ -657,11 +719,11 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                                     height: 12,
                                     backgroundColor: entry.color,
                                     border:
-                                      entry.value === previousDatacallName
+                                      entry.value === comparisonDatacallName
                                         ? '1px dashed'
                                         : 'none',
                                     opacity:
-                                      entry.value === previousDatacallName
+                                      entry.value === comparisonDatacallName
                                         ? 0.7
                                         : 0.8,
                                   }}
@@ -735,9 +797,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                           <TableCell align="right">
                             <strong>{currentDatacallName}</strong>
                           </TableCell>
-                          {scores.length > 1 && (
+                          {comparisonScoreEntry !== null && (
                             <TableCell align="right">
-                              <strong>{previousDatacallName}</strong>
+                              <strong>{comparisonDatacallName}</strong>
                             </TableCell>
                           )}
                           <TableCell align="right">
@@ -750,14 +812,8 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       </TableHead>
                       <TableBody>
                         {latestScore?.pillarscores?.map((pillar) => {
-                          const previousDatacall = scores
-                            .filter(
-                              (s) => s.datacallid < latestScore.datacallid
-                            )
-                            .sort((a, b) => b.datacallid - a.datacallid)[0]
-
                           const previousPillarScore =
-                            previousDatacall?.pillarscores?.find(
+                            comparisonScoreEntry?.pillarscores?.find(
                               (p) => p.pillarid === pillar.pillarid
                             )?.score
 
@@ -786,7 +842,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                                   ? currentScore.toFixed(2)
                                   : 'N/A'}
                               </TableCell>
-                              {scores.length > 1 && (
+                              {comparisonScoreEntry !== null && (
                                 <TableCell align="right">
                                   {prevScore > 0 ? prevScore.toFixed(2) : 'N/A'}
                                 </TableCell>

--- a/src/types.ts
+++ b/src/types.ts
@@ -307,6 +307,9 @@ export type FismaTableProps = {
   // Which active data call(s) each system has scores in, keyed by
   // fismasystemid, so per-row actions target the system's own call.
   systemCallMap?: Record<number, number[]>
+  // The single call chosen for each system's dashboard row (most-recently-updated),
+  // used so Pillar Scores opens on the same call the table is displaying.
+  chosenCallMap?: Record<number, number>
 }
 
 export type ThemeColor =

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -52,6 +52,7 @@ import { progressSortValue } from './progressHelpers'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
+import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import type { OpDiv } from '@/types'
 import {
   applyDashboardFilters,
@@ -539,12 +540,14 @@ export default function FismaTable({
     systemAcronym: string
     fismasystemid: number
     scores: ScoreAggregate[]
+    selectedDataCallId: number
   }>({
     open: false,
     systemName: '',
     systemAcronym: '',
     fismasystemid: 0,
     scores: [],
+    selectedDataCallId: 0,
   })
   const handleCloseModal = () => {
     setOpen(false)
@@ -552,6 +555,16 @@ export default function FismaTable({
   }
 
   const handleOpenPillarScores = async (row: FismaSystemType) => {
+    // Use the row's own call among the active ones (newest by deadline) so
+    // the modal shows the right "current" call when a full year is selected
+    // and activeDataCallId is just a global fallback.
+    const rowCallObjs = sortDatacallsByDeadline(
+      (systemCallMap[row.fismasystemid] ?? [])
+        .map((id) => datacalls.find((d) => d.datacallid === id))
+        .filter((d): d is datacall => Boolean(d))
+    )
+    const rowDataCallId = rowCallObjs[0]?.datacallid ?? activeDataCallId
+
     try {
       // Check cache first
       const cached = pillarScoresCache.get(row.fismasystemid)
@@ -582,6 +595,7 @@ export default function FismaTable({
         systemAcronym: row.fismaacronym,
         fismasystemid: row.fismasystemid,
         scores: scoresData,
+        selectedDataCallId: rowDataCallId,
       })
     } catch (error) {
       console.error('Error fetching pillar scores:', error)
@@ -720,13 +734,11 @@ export default function FismaTable({
         // The system's own call(s) among the active ones, newest first. One
         // call opens directly; more than one opens a picker so the user
         // chooses which to open (#467).
-        const rowCallObjs = (systemCallMap[params.row.fismasystemid] ?? [])
-          .map((id) => datacalls.find((d) => d.datacallid === id))
-          .filter((d): d is datacall => Boolean(d))
-          .sort(
-            (a, b) =>
-              new Date(b.deadline).getTime() - new Date(a.deadline).getTime()
-          )
+        const rowCallObjs = sortDatacallsByDeadline(
+          (systemCallMap[params.row.fismasystemid] ?? [])
+            .map((id) => datacalls.find((d) => d.datacallid === id))
+            .filter((d): d is datacall => Boolean(d))
+        )
         return (
           <>
             <Tooltip title="Questionnaire">
@@ -884,7 +896,7 @@ export default function FismaTable({
         systemName={pillarScoresModal.systemName}
         systemAcronym={pillarScoresModal.systemAcronym}
         scores={pillarScoresModal.scores}
-        selectedDataCallId={activeDataCallId}
+        selectedDataCallId={pillarScoresModal.selectedDataCallId}
       />
       <Menu
         anchorEl={callPicker?.anchor ?? null}

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -403,6 +403,7 @@ export default function FismaTable({
   scores,
   progress,
   systemCallMap = {},
+  chosenCallMap = {},
 }: FismaTableProps) {
   const apiRef = useGridApiRef()
   const {
@@ -555,15 +556,19 @@ export default function FismaTable({
   }
 
   const handleOpenPillarScores = async (row: FismaSystemType) => {
-    // Use the row's own call among the active ones (newest by deadline) so
-    // the modal shows the right "current" call when a full year is selected
-    // and activeDataCallId is just a global fallback.
-    const rowCallObjs = sortDatacallsByDeadline(
-      (systemCallMap[row.fismasystemid] ?? [])
-        .map((id) => datacalls.find((d) => d.datacallid === id))
-        .filter((d): d is datacall => Boolean(d))
-    )
-    const rowDataCallId = rowCallObjs[0]?.datacallid ?? activeDataCallId
+    // Use the same call the dashboard row is displaying (chosen by most-recently-updated
+    // in buildDashboardMaps) so the modal's "current" always matches the table cell.
+    // Falls back to newest-by-deadline if chosenCallMap has no entry (e.g. single-call
+    // system or map not yet populated), then to activeDataCallId as a last resort.
+    const chosenId = chosenCallMap[row.fismasystemid]
+    const rowDataCallId =
+      chosenId ??
+      sortDatacallsByDeadline(
+        (systemCallMap[row.fismasystemid] ?? [])
+          .map((id) => datacalls.find((d) => d.datacallid === id))
+          .filter((d): d is datacall => Boolean(d))
+      )[0]?.datacallid ??
+      activeDataCallId
 
     try {
       // Check cache first

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -23,6 +23,8 @@ export default function HomePageContainer() {
   const [systemCallMap, setSystemCallMap] = useState<Record<number, number[]>>(
     {}
   )
+  const [chosenCallMap, setChosenCallMap] = useState<Record<number, number>>({})
+
   const { activeDatacallIds } = useContextProp()
   useEffect(() => {
     const controller = new AbortController()
@@ -69,6 +71,7 @@ export default function HomePageContainer() {
       setScoreMap(maps.scoreMap)
       setProgressMap(maps.progressMap)
       setSystemCallMap(maps.systemCallMap)
+      setChosenCallMap(maps.chosenCallMap)
       setLoading(false)
     }
 
@@ -106,6 +109,7 @@ export default function HomePageContainer() {
         scores={scoreMap}
         progress={progressMap}
         systemCallMap={systemCallMap}
+        chosenCallMap={chosenCallMap}
       />
     </Box>
   )

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -75,6 +75,7 @@ describe('buildDashboardMaps', () => {
       scoreMap: {},
       progressMap: {},
       systemCallMap: {},
+      chosenCallMap: {},
     })
   })
 

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -39,17 +39,19 @@ describe('buildDashboardMaps', () => {
   it('shows the call a multi-call system most recently updated, not the newest', () => {
     // System 1 is in both calls; it completed the OLDER call (3) recently and
     // never touched the newer call (38). Expect the older call's score/progress.
-    const { scoreMap, progressMap, systemCallMap } = buildDashboardMaps(
-      CALL_IDS,
-      [[agg(1, 0)], [agg(1, 89)]], // newer call score 0, older call score 89
-      [
-        [prog(1, 0, null)], // newer call: never updated
-        [prog(1, 40, '2025-05-07')], // older call: completed
-      ]
-    )
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[agg(1, 0)], [agg(1, 89)]], // newer call score 0, older call score 89
+        [
+          [prog(1, 0, null)], // newer call: never updated
+          [prog(1, 40, '2025-05-07')], // older call: completed
+        ]
+      )
     expect(scoreMap[1].score).toBe(89) // older call wins
     expect(progressMap[1].questionsupdated).toBe(40)
     expect(systemCallMap[1]).toEqual([38, 3]) // both calls recorded
+    expect(chosenCallMap[1]).toBe(3) // chosen = the call most recently updated
   })
 
   it('falls back to the newest call when a system never updated any call', () => {

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -5,6 +5,8 @@ export type DashboardMaps = {
   progressMap: Record<number, ScoreProgress>
   /** Which active data call(s) each system has scores in, for per-row actions. */
   systemCallMap: Record<number, number[]>
+  /** The single call chosen for each system's dashboard row (most-recently-updated). */
+  chosenCallMap: Record<number, number>
 }
 
 const lastUpdatedMs = (entry: ScoreProgress | undefined): number => {
@@ -62,6 +64,7 @@ export function buildDashboardMaps(
   const scoreMap: Record<number, SystemScoreEntry> = {}
   const progressMap: Record<number, ScoreProgress> = {}
   const systemCallMap: Record<number, number[]> = {}
+  const chosenCallMap: Record<number, number> = {}
 
   for (const [sys, idxs] of systemIdxs) {
     // Choose the call this system most recently updated; ties and
@@ -83,7 +86,8 @@ export function buildDashboardMaps(
     const progress = progressByCall[chosen]?.get(sys)
     if (progress) progressMap[sys] = progress
     systemCallMap[sys] = idxs.map((idx) => callIds[idx])
+    chosenCallMap[sys] = callIds[chosen]
   }
 
-  return { scoreMap, progressMap, systemCallMap }
+  return { scoreMap, progressMap, systemCallMap, chosenCallMap }
 }


### PR DESCRIPTION
## Summary

Closes #468.

Replaces the generic \"Current\" / \"Previous\" labels throughout the Pillar Scores modal with the real data-call names, adds a user-selectable comparison picker, and fixes how FismaTable resolves each row's data call so the modal always opens anchored to the call the row is displaying.

### Acceptance criteria

| Requirement | Status |
|---|---|
| Radar series, tooltip, summary lines, and table headers show actual data-call names | ✅ |
| Graceful fallback when no previous call exists (single series, no "Previous" label/column) | ✅ |
| Long names handled without breaking legend/tooltip layout | ✅ |
| "Previous" resolved by deadline, not datacallid (per #393 / #467 issue comment) | ✅ |
| Label format matches year-grouped selector styling (e.g. "FY2025 Q3 · CMS") | ✅ |
| Works correctly alongside the multi-call selector (#467) | ✅ |
| Pillar Scores modal opens anchored to the same call the dashboard row is displaying | ✅ |

---

## Changes

### `PillarScoresModal.tsx`

**Label replacement**
- `name="Current"` / `name="Previous"` on the `<Radar>` series replaced with real data-call names from `getQuarterName`, which appends `· {tenant}` (e.g. `· CMS`, `· HHS`) to match the year-grouped selector format
- System score card, pillar cards, data table column headers, and `aria-label` all use real names
- Tooltip replaced with a custom `content` renderer that wraps long names without overflow

**Deadline-based previous resolution**
- Previous call resolved via `sortDatacallsByDeadline` rather than by datacallid (unreliable after historical re-imports, see #393)
- `previousDatacall` (the deadline-adjacent predecessor call object) and `previousScoreEntry` (its score, which can be `null`) are tracked separately — so the picker shows the predecessor's name even when the system has no submission for it, displaying "No data for {name}" rather than silently falling back to a different call

**Comparison picker**
- "Viewing: **{name}** / Compare with: [dropdown]" bar added at the top of the modal when the system has more than one score
- Dropdown lists all data calls sorted newest-first by deadline, regardless of whether the system has submitted for each
- Three-way state (`undefined` = deadline default, `null` = user picked None, `number` = explicit selection) ensures "None" reliably clears the comparison without silently reverting
- Resets on every modal open or target change — effect depends on `[open, selectedDataCallId]` so switching between two systems that share the same active call correctly resets the picker

**Conditional rendering**
- `comparisonActive` flag distinguishes "comparison selected but no score → show 'No data for {name}'" from "None selected / no predecessor → hide comparison UI"
- `hasComparisonPillarData` guards the radar second series and comparison table column — requires the comparison entry to have pillar detail, preventing a phantom all-zero series when only an aggregate-level score exists

### `FismaTable.tsx` + `aggregateScores.ts` + `Home.tsx`

**Per-row data-call resolution**
- `buildDashboardMaps` now returns `chosenCallMap` — the single call chosen per system for its dashboard row (the one most recently updated by that system)
- `chosenCallMap` is lifted through `Home` → `FismaTable` → `handleOpenPillarScores`, so `selectedDataCallId` passed to the modal always matches the call the table row is showing
- Falls back to newest-by-deadline if no entry exists, then to `activeDataCallId` as a last resort

**Deadline sort tiebreak**
- Questionnaire button `renderCell` was sorting data calls with an inline deadline comparison that omitted the datacallid tiebreak; now uses `sortDatacallsByDeadline` consistently

### Tests

- `aggregateScores.test.ts` — multi-call test extended to assert `chosenCallMap` resolves to the most-recently-updated call; empty-maps test covers the new field
- `aggregateScores.ts` return type (`DashboardMaps`) updated with `chosenCallMap`

---
## UX
Datacall names on Pillar Scores modal
<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/8029a2ab-71a6-4159-8ca3-3c19e6c48804" />


Comparison dropdown, sorted by deadline
<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/9a7e86ac-e67c-4207-9560-a32b232e2db5" />


Comparison with datacall that contains no scores for the selected system states "No Data for {datacallname}"
<img width="1728" height="960" alt="image" src="https://github.com/user-attachments/assets/75bac45f-d8d6-4676-874c-2470cb16b3ee" />


None selected on the comparison
<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/acb1b46c-7323-456f-9625-3e97c193bec3" />


## Test plan

- [ ] Open Pillar Scores for a system with multiple scores — confirm radar legend, tooltip, summary lines, and table headers all show real names with tenant suffix (e.g. "FY2025 Q3 · CMS")
- [ ] Hover a radar data point — confirm tooltip shows the data-call name, not "Current Score" / "Previous Score"
- [ ] Open for a system with only one score — confirm no Previous series, no comparison column, no "Previous" label, and no "Compare with" picker
- [ ] Use the "Compare with:" dropdown — confirm scores, trend arrows, radar overlay, and table column all update to the selected call
- [ ] Select a call the system has no score for — confirm "No data for {comparison call name}" appears in the score box and each pillar card, radar shows a single series, comparison column is hidden
- [ ] Select "None" — confirm comparison is fully hidden and does not silently revert to the default
- [ ] With a full year selected on the dashboard, open Pillar Scores for a multi-call system — confirm "Viewing:" shows the call the table row is displaying, not the global fallback
- [ ] Open the modal, change the comparison, close, reopen for a different system sharing the same active call — confirm the picker resets to the new system's default
- [ ] Open Pillar Scores for a system where the predecessor call exists but was never submitted — confirm the picker defaults to that predecessor's name (not "None") and pillar cards show "No data for {predecessor call name}"

## Questions for Reviewers

1. Should there be two dropdown selectors in the pillar scores modal (similar to the Questionnaire Page Compare Datacalls Modal)? Currently we only have one which is the comparison datacall and defaults to the "previous" datacall sorted by deadline.

2. Is the dropdown component in line with the design / good as is, or should it be changed to Autocomplete (used in other areas of the app)?