### PR TITLE
Group the data-call selector by year and aggregate the dashboard

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,9 @@ export type FismaTableProps = {
   // fismasystemid. Optional so the table degrades to an em-dash column if
   // the progress fetch fails - score display must not depend on it.
   progress?: Record<number, ScoreProgress>
+  // Which active data call(s) each system has scores in, keyed by
+  // fismasystemid, so per-row actions target the system's own call.
+  systemCallMap?: Record<number, number[]>
 }
 
 export type ThemeColor =

--- a/src/utils/datacallGrouping.test.ts
+++ b/src/utils/datacallGrouping.test.ts
@@ -1,0 +1,76 @@
+import { parseDatacallName, groupDatacallsByYear } from './datacallGrouping'
+
+type Row = { datacallid: number; datacall: string; deadline: string }
+
+describe('parseDatacallName', () => {
+  it('parses a 4-digit CMS quarterly call', () => {
+    expect(parseDatacallName('FY2025 Q3')).toEqual({
+      fiscalYear: 2025,
+      tenant: 'CMS',
+    })
+  })
+
+  it('parses a 2-digit HHS ZTM call', () => {
+    expect(parseDatacallName('FY25 ZTM')).toEqual({
+      fiscalYear: 2025,
+      tenant: 'HHS',
+    })
+  })
+
+  it('expands a 2-digit fiscal year to 20##', () => {
+    expect(parseDatacallName('FY23 Q1').fiscalYear).toBe(2023)
+  })
+
+  it('returns Other/null for an unrecognized name', () => {
+    expect(parseDatacallName('Special one-off')).toEqual({
+      fiscalYear: null,
+      tenant: 'Other',
+    })
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseDatacallName('  FY24 ZTM  ').fiscalYear).toBe(2024)
+  })
+})
+
+describe('groupDatacallsByYear', () => {
+  const calls: Row[] = [
+    { datacallid: 1, datacall: 'FY23 ZTM', deadline: '2023-09-30' },
+    { datacallid: 2, datacall: 'FY2025 Q3', deadline: '2025-05-07' },
+    { datacallid: 3, datacall: 'FY25 ZTM', deadline: '2025-09-30' },
+    { datacallid: 4, datacall: 'FY24 ZTM', deadline: '2024-09-30' },
+    { datacallid: 5, datacall: 'FY2023 Q4', deadline: '2024-08-31' },
+  ]
+
+  it('groups by fiscal year, newest first', () => {
+    const groups = groupDatacallsByYear(calls)
+    expect(groups.map((g) => g.year)).toEqual([2025, 2024, 2023])
+  })
+
+  it('pairs the CMS and HHS calls under the same year', () => {
+    const y2025 = groupDatacallsByYear(calls).find((g) => g.year === 2025)
+    expect(y2025?.calls.map((c) => c.datacall)).toEqual([
+      'FY25 ZTM', // deadline 2025-09-30, furthest out first
+      'FY2025 Q3', // deadline 2025-05-07
+    ])
+    const y2023 = groupDatacallsByYear(calls).find((g) => g.year === 2023)
+    expect(y2023?.calls.map((c) => c.datacall).sort()).toEqual([
+      'FY2023 Q4',
+      'FY23 ZTM',
+    ])
+  })
+
+  it('sinks an unparseable call to the bottom in its own null-year bucket', () => {
+    const withOther: Row[] = [
+      ...calls,
+      { datacallid: 9, datacall: 'Legacy import', deadline: '2022-01-01' },
+    ]
+    const groups = groupDatacallsByYear(withOther)
+    expect(groups[groups.length - 1].year).toBeNull()
+    expect(groups[groups.length - 1].calls[0].datacall).toBe('Legacy import')
+  })
+
+  it('returns an empty array for no calls', () => {
+    expect(groupDatacallsByYear([])).toEqual([])
+  })
+})

--- a/src/utils/datacallGrouping.ts
+++ b/src/utils/datacallGrouping.ts
@@ -1,0 +1,80 @@
+import { sortDatacallsByDeadline } from './sortDatacallsByDeadline'
+
+/**
+ * Tenant that a data call belongs to. CMS runs quarterly calls (`FY## Q#`);
+ * HHS OpDivs run an annual ZTM call (`FY## ZTM`). Names that do not match the
+ * known grammar resolve to 'Other' so the selector can still display them
+ * without guessing.
+ */
+export type DatacallTenant = 'CMS' | 'HHS' | 'Other'
+
+/**
+ * Grammar for a data-call name, mirroring the validator in DataCallModal.
+ * `FY` + a 2- or 4-digit fiscal year + either a CMS quarter or the HHS `ZTM`
+ * marker, e.g. `FY25 ZTM`, `FY2025 Q3`.
+ */
+const DATACALL_NAME_PATTERN = /^FY(\d{2}|\d{4}) (Q[1-4]|ZTM)$/
+
+/**
+ * Parse the fiscal year and tenant out of a data-call name. Year and tenant
+ * are not stored fields, so they are derived from the name. A 2-digit year is
+ * expanded to 20##; an unrecognized name yields `{ fiscalYear: null, tenant:
+ * 'Other' }` rather than throwing.
+ * @param {string} name - The data-call name (the `datacall` field).
+ * @returns {{ fiscalYear: number | null; tenant: DatacallTenant }} Parsed parts.
+ */
+export function parseDatacallName(name: string): {
+  fiscalYear: number | null
+  tenant: DatacallTenant
+} {
+  const match = DATACALL_NAME_PATTERN.exec(name.trim())
+  if (!match) {
+    return { fiscalYear: null, tenant: 'Other' }
+  }
+  const [, yearToken, cadence] = match
+  const fiscalYear =
+    yearToken.length === 2 ? 2000 + Number(yearToken) : Number(yearToken)
+  const tenant: DatacallTenant = cadence === 'ZTM' ? 'HHS' : 'CMS'
+  return { fiscalYear, tenant }
+}
+
+/** A fiscal year and the data calls that belong to it. */
+export type DatacallYearGroup<T> = {
+  /** Fiscal year, or null for names that do not match the known grammar. */
+  year: number | null
+  calls: T[]
+}
+
+/**
+ * Group data calls by fiscal year for the year-grouped selector. Years are
+ * ordered most-recent first; calls within a year follow the deadline-based
+ * order; the unparseable ('Other', year null) bucket sinks to the bottom.
+ * @param {T[]} calls - The data calls to group.
+ * @returns {DatacallYearGroup<T>[]} Groups, newest year first.
+ */
+export function groupDatacallsByYear<
+  T extends { datacall: string; deadline: string; datacallid: number },
+>(calls: T[]): DatacallYearGroup<T>[] {
+  const byYear = new Map<number | null, T[]>()
+  for (const call of calls) {
+    const { fiscalYear } = parseDatacallName(call.datacall)
+    const bucket = byYear.get(fiscalYear)
+    if (bucket) {
+      bucket.push(call)
+    } else {
+      byYear.set(fiscalYear, [call])
+    }
+  }
+
+  return Array.from(byYear.entries())
+    .map(([year, groupCalls]) => ({
+      year,
+      calls: sortDatacallsByDeadline(groupCalls),
+    }))
+    .sort((a, b) => {
+      // Unparseable years (null) sink below every real year.
+      if (a.year === null) return 1
+      if (b.year === null) return -1
+      return b.year - a.year
+    })
+}

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -21,6 +21,8 @@ import {
   Select,
   MenuItem,
   ListItemText,
+  ListSubheader,
+  Menu,
   Button,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
@@ -42,13 +44,14 @@ import BarChartIcon from '@mui/icons-material/BarChart'
 import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresModal'
 // import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import { FismaTableProps } from '@/types'
-import type { ScoreAggregate, SystemScoreEntry } from '@/types'
+import type { ScoreAggregate, SystemScoreEntry, datacall } from '@/types'
 import { hasSystemAccess } from '@/utils/userRoles'
 import { cellStyleForTier } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
+import { parseDatacallName } from '@/utils/datacallGrouping'
 import type { OpDiv } from '@/types'
 import {
   applyDashboardFilters,
@@ -418,6 +421,28 @@ export default function FismaTable({
   const [opdivs, setOpDivs] = useState<OpDiv[]>([])
   const navigate = useNavigate()
 
+  // When a system has scores in more than one active call, the questionnaire
+  // button opens a small picker (#467) instead of guessing which call to open.
+  const [callPicker, setCallPicker] = useState<{
+    anchor: HTMLElement
+    fismasystemid: number
+    fismaacronym: string
+    calls: datacall[]
+  } | null>(null)
+  const openQuestionnaire = (
+    fismasystemid: number,
+    fismaacronym: string,
+    call: datacall | undefined
+  ) => {
+    navigate(`/${RouteNames.QUESTIONNAIRE}/${fismaacronym.toLowerCase()}`, {
+      state: {
+        fismasystemid,
+        datacallid: call?.datacallid ?? activeDataCallId,
+        datacall: call?.datacall,
+      },
+    })
+  }
+
   // OpDiv list is only needed to label the OpDiv filter. Include inactive
   // OpDivs so a system tied to a since-deactivated OpDiv still shows a name,
   // not a bare id. Fetched once; failure is non-fatal.
@@ -688,22 +713,19 @@ export default function FismaTable({
       sortable: false,
       disableColumnMenu: true,
       renderCell: (params: GridRenderCellParams) => {
-        // Each system belongs to one call, so the questionnaire opens that
-        // system's own call. A system with data in more than one active call
-        // is genuinely ambiguous and is gated until the selector is narrowed.
-        const rowCalls = systemCallMap[params.row.fismasystemid] ?? []
-        const questionnaireAmbiguous = rowCalls.length > 1
-        const rowCallId = rowCalls[0] ?? activeDataCallId
-        const rowCall = datacalls.find((d) => d.datacallid === rowCallId)
+        // The system's own call(s) among the active ones, newest first. One
+        // call opens directly; more than one opens a picker so the user
+        // chooses which to open (#467).
+        const rowCallObjs = (systemCallMap[params.row.fismasystemid] ?? [])
+          .map((id) => datacalls.find((d) => d.datacallid === id))
+          .filter((d): d is datacall => Boolean(d))
+          .sort(
+            (a, b) =>
+              new Date(b.deadline).getTime() - new Date(a.deadline).getTime()
+          )
         return (
           <>
-            <Tooltip
-              title={
-                questionnaireAmbiguous
-                  ? 'This system has more than one data call this year — pick a single call in the selector to open its questionnaire'
-                  : 'Questionnaire'
-              }
-            >
+            <Tooltip title="Questionnaire">
               <span>
                 <GridActionsCellItem
                   icon={<QuestionAnswerOutlinedIcon />}
@@ -711,18 +733,22 @@ export default function FismaTable({
                   label={`View Questionnaire for ${params.row.fismaname}`}
                   className="textPrimary"
                   role="button"
-                  disabled={questionnaireAmbiguous}
                   onClick={(event) => {
                     event.stopPropagation()
-                    navigate(
-                      `/${RouteNames.QUESTIONNAIRE}/${params.row.fismaacronym.toLowerCase()}`,
-                      {
-                        state: {
-                          fismasystemid: params.row.fismasystemid,
-                          datacallid: rowCallId,
-                          datacall: rowCall?.datacall,
-                        },
-                      }
+                    if (rowCallObjs.length > 1) {
+                      setCallPicker({
+                        anchor: event.currentTarget,
+                        fismasystemid: params.row.fismasystemid,
+                        fismaacronym: params.row.fismaacronym,
+                        calls: rowCallObjs,
+                      })
+                      return
+                    }
+                    openQuestionnaire(
+                      params.row.fismasystemid,
+                      params.row.fismaacronym,
+                      rowCallObjs[0] ??
+                        datacalls.find((d) => d.datacallid === activeDataCallId)
                     )
                   }}
                   color="inherit"
@@ -856,6 +882,38 @@ export default function FismaTable({
         scores={pillarScoresModal.scores}
         selectedDataCallId={activeDataCallId}
       />
+      <Menu
+        anchorEl={callPicker?.anchor ?? null}
+        open={Boolean(callPicker)}
+        onClose={() => setCallPicker(null)}
+      >
+        <ListSubheader>Open which data call?</ListSubheader>
+        {callPicker?.calls.map((call) => {
+          const isClosed = new Date() > new Date(call.deadline)
+          const deadlineLabel = new Date(call.deadline).toLocaleDateString(
+            'en-US',
+            { month: 'short', day: 'numeric', year: 'numeric' }
+          )
+          return (
+            <MenuItem
+              key={call.datacallid}
+              onClick={() => {
+                openQuestionnaire(
+                  callPicker.fismasystemid,
+                  callPicker.fismaacronym,
+                  call
+                )
+                setCallPicker(null)
+              }}
+            >
+              <ListItemText
+                primary={`${call.datacall} · ${parseDatacallName(call.datacall).tenant}`}
+                secondary={`${isClosed ? 'Closed' : 'Active'} · deadline ${deadlineLabel}`}
+              />
+            </MenuItem>
+          )
+        })}
+      </Menu>
     </Box>
   )
 }

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -64,6 +64,7 @@ declare module '@mui/x-data-grid' {
     fismaSystems: FismaSystemType[]
     activeDataCallId: number
     scores: Record<number, SystemScoreEntry>
+    systemCallMap?: Record<number, number[]>
   }
   interface ToolbarPropsOverrides {
     filters: DashboardFilterState
@@ -86,8 +87,27 @@ export function CustomFooterSaveComponent(
   const handleCloseSnackbar = () => {
     setOpenSnackbar(false)
   }
+  // The export endpoint targets one data call. Derive it from the selected
+  // rows' own call(s): if they all share one call, export that; an empty
+  // provenance falls back to the active call; a selection that spans more than
+  // one call has no single export target, so the button is disabled.
+  const selectedCallIds = new Set<number>()
+  const callMap = props.systemCallMap ?? {}
+  for (const id of props.selectedRows ?? []) {
+    for (const cid of callMap[id as number] ?? []) selectedCallIds.add(cid)
+  }
+  const exportCallId =
+    selectedCallIds.size === 1
+      ? [...selectedCallIds][0]
+      : selectedCallIds.size === 0
+        ? props.activeDataCallId
+        : null
+  const exportBlocked =
+    !props.selectedRows ||
+    props.selectedRows.length === 0 ||
+    exportCallId === null
   const saveSystemAnswers = async () => {
-    let exportUrl = `/datacalls/${props.activeDataCallId}/export`
+    let exportUrl = `/datacalls/${exportCallId}/export`
     if (props.selectedRows && props.selectedRows.length > 0) {
       exportUrl += '?'
       let idString: string = ''
@@ -136,14 +156,18 @@ export function CustomFooterSaveComponent(
             position: 'relative',
           }}
         >
-          <Tooltip title="Download selected system answers">
+          <Tooltip
+            title={
+              exportCallId === null
+                ? 'Selected systems span more than one data call — narrow the selection or the data-call selector'
+                : 'Download selected system answers'
+            }
+          >
             <span role="presentation">
               <IconButton
                 sx={{ color: '#004297' }}
                 onClick={saveSystemAnswers}
-                disabled={
-                  !props.selectedRows || props.selectedRows.length === 0
-                }
+                disabled={exportBlocked}
                 aria-label={`Download selected system answers${props.selectedRows && props.selectedRows.length > 0 ? ` (${props.selectedRows.length} selected)` : ' (no systems selected)'}`}
               >
                 <FileDownloadSharpIcon />
@@ -369,12 +393,17 @@ interface CachedScore {
 }
 const pillarScoresCache = new Map<number, CachedScore>()
 
-export default function FismaTable({ scores, progress }: FismaTableProps) {
+export default function FismaTable({
+  scores,
+  progress,
+  systemCallMap = {},
+}: FismaTableProps) {
   const apiRef = useGridApiRef()
   const {
     fismaSystems,
     latestDataCallId,
     selectedDatacall,
+    datacalls,
     userInfo,
     datacenterEnvironments,
   } = useContextProp()
@@ -658,65 +687,85 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
       hideable: false,
       sortable: false,
       disableColumnMenu: true,
-      renderCell: (params: GridRenderCellParams) => (
-        <>
-          <Tooltip title="Questionnaire">
-            <span>
-              <GridActionsCellItem
-                icon={<QuestionAnswerOutlinedIcon />}
-                key={`question-${params.row.fismasystemid}`}
-                label={`View Questionnaire for ${params.row.fismaname}`}
-                className="textPrimary"
-                role="button"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  navigate(
-                    `/${RouteNames.QUESTIONNAIRE}/${params.row.fismaacronym.toLowerCase()}`,
-                    {
-                      state: { fismasystemid: params.row.fismasystemid },
-                    }
-                  )
-                }}
-                color="inherit"
-              />
-            </span>
-          </Tooltip>
-          <Tooltip title="Pillar Scores">
-            <span>
-              <GridActionsCellItem
-                icon={<BarChartIcon />}
-                key={`chart-${params.row.fismasystemid}`}
-                label={`View Pillar Scores for ${params.row.fismaname}`}
-                className="textPrimary"
-                role="button"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  handleOpenPillarScores(params.row as FismaSystemType)
-                }}
-                color="inherit"
-              />
-            </span>
-          </Tooltip>
-          {hasSystemDetailAccess && (
-            <Tooltip title="System Details">
+      renderCell: (params: GridRenderCellParams) => {
+        // Each system belongs to one call, so the questionnaire opens that
+        // system's own call. A system with data in more than one active call
+        // is genuinely ambiguous and is gated until the selector is narrowed.
+        const rowCalls = systemCallMap[params.row.fismasystemid] ?? []
+        const questionnaireAmbiguous = rowCalls.length > 1
+        const rowCallId = rowCalls[0] ?? activeDataCallId
+        const rowCall = datacalls.find((d) => d.datacallid === rowCallId)
+        return (
+          <>
+            <Tooltip
+              title={
+                questionnaireAmbiguous
+                  ? 'This system has more than one data call this year — pick a single call in the selector to open its questionnaire'
+                  : 'Questionnaire'
+              }
+            >
               <span>
                 <GridActionsCellItem
-                  icon={<VisibilityIcon />}
-                  key={`view-${params.row.fismasystemid}`}
-                  label={`View system details for ${params.row.fismaname}`}
+                  icon={<QuestionAnswerOutlinedIcon />}
+                  key={`question-${params.row.fismasystemid}`}
+                  label={`View Questionnaire for ${params.row.fismaname}`}
                   className="textPrimary"
                   role="button"
+                  disabled={questionnaireAmbiguous}
                   onClick={(event) => {
                     event.stopPropagation()
-                    navigate(`/systems/${params.row.fismasystemid}`)
+                    navigate(
+                      `/${RouteNames.QUESTIONNAIRE}/${params.row.fismaacronym.toLowerCase()}`,
+                      {
+                        state: {
+                          fismasystemid: params.row.fismasystemid,
+                          datacallid: rowCallId,
+                          datacall: rowCall?.datacall,
+                        },
+                      }
+                    )
                   }}
                   color="inherit"
                 />
               </span>
             </Tooltip>
-          )}
-        </>
-      ),
+            <Tooltip title="Pillar Scores">
+              <span>
+                <GridActionsCellItem
+                  icon={<BarChartIcon />}
+                  key={`chart-${params.row.fismasystemid}`}
+                  label={`View Pillar Scores for ${params.row.fismaname}`}
+                  className="textPrimary"
+                  role="button"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    handleOpenPillarScores(params.row as FismaSystemType)
+                  }}
+                  color="inherit"
+                />
+              </span>
+            </Tooltip>
+            {hasSystemDetailAccess && (
+              <Tooltip title="System Details">
+                <span>
+                  <GridActionsCellItem
+                    icon={<VisibilityIcon />}
+                    key={`view-${params.row.fismasystemid}`}
+                    label={`View system details for ${params.row.fismaname}`}
+                    className="textPrimary"
+                    role="button"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      navigate(`/systems/${params.row.fismasystemid}`)
+                    }}
+                    color="inherit"
+                  />
+                </span>
+              </Tooltip>
+            )}
+          </>
+        )
+      },
     },
   ]
 
@@ -736,7 +785,13 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
           setSelectedRows(selectedIDs)
         }}
         slotProps={{
-          footer: { selectedRows, fismaSystems, activeDataCallId, scores },
+          footer: {
+            selectedRows,
+            fismaSystems,
+            activeDataCallId,
+            scores,
+            systemCallMap,
+          },
           toolbar: {
             filters,
             onFiltersChange: setFilters,

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -303,6 +303,7 @@ function QuickSearchToolbar(props: {
                 <MenuItem key={opt} value={opt}>
                   <Checkbox
                     checked={filters.environments.includes(opt)}
+                    readOnly
                     size="small"
                   />
                   <ListItemText primary={opt} />
@@ -341,6 +342,7 @@ function QuickSearchToolbar(props: {
                 <MenuItem key={o.id} value={o.id}>
                   <Checkbox
                     checked={filters.opdivIds.includes(o.id)}
+                    readOnly
                     size="small"
                   />
                   <ListItemText primary={o.label} />

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -439,6 +439,7 @@ export default function FismaTable({
         fismasystemid,
         datacallid: call?.datacallid ?? activeDataCallId,
         datacall: call?.datacall,
+        deadline: call?.deadline,
       },
     })
   }
@@ -886,6 +887,7 @@ export default function FismaTable({
         anchorEl={callPicker?.anchor ?? null}
         open={Boolean(callPicker)}
         onClose={() => setCallPicker(null)}
+        MenuListProps={{ 'aria-label': 'Open which data call' }}
       >
         <ListSubheader>Open which data call?</ListSubheader>
         {callPicker?.calls.map((call) => {

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -44,7 +44,13 @@ export default function HomePageContainer() {
               signal: controller.signal,
             })
             .then((res) => res.data.data as ScoreAggregate[])
-            .catch(() => [] as ScoreAggregate[])
+            .catch((error) => {
+              // Log so a single call's failure (which shows its systems as 0)
+              // is diagnosable rather than silent.
+              if (!controller.signal.aborted)
+                console.error(`scores/aggregate ${id} failed:`, error)
+              return [] as ScoreAggregate[]
+            })
         )
       )
       if (controller.signal.aborted) return
@@ -64,7 +70,11 @@ export default function HomePageContainer() {
               signal: controller.signal,
             })
             .then((res) => res.data.data as ScoreProgress[])
-            .catch(() => [] as ScoreProgress[])
+            .catch((error) => {
+              if (!controller.signal.aborted)
+                console.error(`scores/progress ${id} failed:`, error)
+              return [] as ScoreProgress[]
+            })
         )
       )
       if (controller.signal.aborted) return

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -6,11 +6,7 @@ import { useContextProp } from '../Title/Context'
 import { Box, CircularProgress } from '@mui/material'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
-import {
-  buildScoreMap,
-  buildProgressMap,
-  buildSystemCallMap,
-} from './aggregateScores'
+import { buildDashboardMaps } from './aggregateScores'
 /**
  * Component that renders the contents of the Home view.
  * @returns {JSX.Element} Component that renders the home contents.
@@ -32,53 +28,48 @@ export default function HomePageContainer() {
     const controller = new AbortController()
     const ids = activeDatacallIds
 
-    // Scores are aggregated across every active call in the year: each call is
-    // fetched independently (per-request .catch so one failure doesn't sink the
-    // batch) and the rows are merged by fismasystemid. A CMS system shows its
-    // FY.. Q# score and an HHS system its FY.. ZTM score, so no tenant reads 0.
-    async function fetchScores() {
-      const rowsPerCall = await Promise.all(
-        ids.map((id) =>
-          axiosInstance
-            .get(`/scores/aggregate?datacallid=${id}`, {
-              signal: controller.signal,
-            })
-            .then((res) => res.data.data as ScoreAggregate[])
-            .catch((error) => {
-              // Log so a single call's failure (which shows its systems as 0)
-              // is diagnosable rather than silent.
-              if (!controller.signal.aborted)
-                console.error(`scores/aggregate ${id} failed:`, error)
-              return [] as ScoreAggregate[]
-            })
-        )
-      )
+    // Aggregate every active call in the year. Each call is fetched
+    // independently (per-request .catch so one failure doesn't sink the batch
+    // or block the others), then buildDashboardMaps merges them per system,
+    // choosing the call each system most recently updated. Scores and progress
+    // are fetched together because the chosen call depends on both.
+    async function load() {
+      const [scoresPerCall, progressPerCall] = await Promise.all([
+        Promise.all(
+          ids.map((id) =>
+            axiosInstance
+              .get(`/scores/aggregate?datacallid=${id}`, {
+                signal: controller.signal,
+              })
+              .then((res) => res.data.data as ScoreAggregate[])
+              .catch((error) => {
+                if (!controller.signal.aborted)
+                  console.error(`scores/aggregate ${id} failed:`, error)
+                return [] as ScoreAggregate[]
+              })
+          )
+        ),
+        Promise.all(
+          ids.map((id) =>
+            axiosInstance
+              .get(`/scores/progress?datacallid=${id}`, {
+                signal: controller.signal,
+              })
+              .then((res) => res.data.data as ScoreProgress[])
+              .catch((error) => {
+                if (!controller.signal.aborted)
+                  console.error(`scores/progress ${id} failed:`, error)
+                return [] as ScoreProgress[]
+              })
+          )
+        ),
+      ])
       if (controller.signal.aborted) return
-      setScoreMap(buildScoreMap(rowsPerCall))
-      setSystemCallMap(buildSystemCallMap(rowsPerCall))
+      const maps = buildDashboardMaps(ids, scoresPerCall, progressPerCall)
+      setScoreMap(maps.scoreMap)
+      setProgressMap(maps.progressMap)
+      setSystemCallMap(maps.systemCallMap)
       setLoading(false)
-    }
-
-    // Progress (ztmf#299) aggregated the same way, but independent of scores: a
-    // failure here leaves the progress column as em-dashes without blocking the
-    // score display, so it doesn't gate `loading`.
-    async function fetchProgress() {
-      const rowsPerCall = await Promise.all(
-        ids.map((id) =>
-          axiosInstance
-            .get(`/scores/progress?datacallid=${id}`, {
-              signal: controller.signal,
-            })
-            .then((res) => res.data.data as ScoreProgress[])
-            .catch((error) => {
-              if (!controller.signal.aborted)
-                console.error(`scores/progress ${id} failed:`, error)
-              return [] as ScoreProgress[]
-            })
-        )
-      )
-      if (controller.signal.aborted) return
-      setProgressMap(buildProgressMap(rowsPerCall))
     }
 
     // Keep the spinner until the active calls resolve — activeDatacallIds is
@@ -86,8 +77,7 @@ export default function HomePageContainer() {
     // don't clear loading (which would flash an empty dashboard) until there
     // are calls to fetch.
     if (ids.length > 0) {
-      fetchScores()
-      fetchProgress()
+      load()
     }
     return () => {
       controller.abort()

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -6,6 +6,11 @@ import { useContextProp } from '../Title/Context'
 import { Box, CircularProgress } from '@mui/material'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
+import {
+  buildScoreMap,
+  buildProgressMap,
+  buildSystemCallMap,
+} from './aggregateScores'
 /**
  * Component that renders the contents of the Home view.
  * @returns {JSX.Element} Component that renders the home contents.
@@ -17,62 +22,65 @@ export default function HomePageContainer() {
   const [progressMap, setProgressMap] = useState<Record<number, ScoreProgress>>(
     {}
   )
-  const { latestDataCallId, selectedDatacall } = useContextProp()
-  const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
+  // Which active call(s) each system has scores in, so per-row actions open the
+  // system's own data call instead of a globally-selected one.
+  const [systemCallMap, setSystemCallMap] = useState<Record<number, number[]>>(
+    {}
+  )
+  const { activeDatacallIds } = useContextProp()
   useEffect(() => {
     const controller = new AbortController()
+    const ids = activeDatacallIds
+
+    // Scores are aggregated across every active call in the year: each call is
+    // fetched independently (per-request .catch so one failure doesn't sink the
+    // batch) and the rows are merged by fismasystemid. A CMS system shows its
+    // FY.. Q# score and an HHS system its FY.. ZTM score, so no tenant reads 0.
     async function fetchScores() {
-      if (activeDataCallId !== 0) {
-        try {
-          const res = await axiosInstance.get(
-            `/scores/aggregate?datacallid=${activeDataCallId}`,
-            { signal: controller.signal }
-          )
-          const scoresMap: Record<number, SystemScoreEntry> = {}
-          for (const obj of res.data.data as ScoreAggregate[]) {
-            scoresMap[obj.fismasystemid] = {
-              score: obj.systemscore ?? 0,
-              tier: obj.systemtier,
-            }
-          }
-          setScoreMap(scoresMap)
-        } catch (error) {
-          if (controller.signal.aborted) return
-          console.error('Error fetching scores:', error)
-        } finally {
-          if (!controller.signal.aborted) setLoading(false)
-        }
-      }
+      const rowsPerCall = await Promise.all(
+        ids.map((id) =>
+          axiosInstance
+            .get(`/scores/aggregate?datacallid=${id}`, {
+              signal: controller.signal,
+            })
+            .then((res) => res.data.data as ScoreAggregate[])
+            .catch(() => [] as ScoreAggregate[])
+        )
+      )
+      if (controller.signal.aborted) return
+      setScoreMap(buildScoreMap(rowsPerCall))
+      setSystemCallMap(buildSystemCallMap(rowsPerCall))
+      setLoading(false)
     }
-    // Questionnaire progress for the active data call (ztmf#299). Fetched
-    // alongside the aggregate but independent of it: a failure here leaves
-    // the progress column as em-dashes without blocking the score display,
-    // so it neither gates `loading` nor shares the aggregate's try/catch.
+
+    // Progress (ztmf#299) aggregated the same way, but independent of scores: a
+    // failure here leaves the progress column as em-dashes without blocking the
+    // score display, so it doesn't gate `loading`.
     async function fetchProgress() {
-      if (activeDataCallId !== 0) {
-        try {
-          const res = await axiosInstance.get(
-            `/scores/progress?datacallid=${activeDataCallId}`,
-            { signal: controller.signal }
-          )
-          const map: Record<number, ScoreProgress> = {}
-          for (const obj of res.data.data as ScoreProgress[]) {
-            map[obj.fismasystemid] = obj
-          }
-          setProgressMap(map)
-        } catch (error) {
-          if (controller.signal.aborted) return
-          console.error('Error fetching data call progress:', error)
-          setProgressMap({})
-        }
-      }
+      const rowsPerCall = await Promise.all(
+        ids.map((id) =>
+          axiosInstance
+            .get(`/scores/progress?datacallid=${id}`, {
+              signal: controller.signal,
+            })
+            .then((res) => res.data.data as ScoreProgress[])
+            .catch(() => [] as ScoreProgress[])
+        )
+      )
+      if (controller.signal.aborted) return
+      setProgressMap(buildProgressMap(rowsPerCall))
     }
-    fetchScores()
-    fetchProgress()
+
+    if (ids.length === 0) {
+      setLoading(false)
+    } else {
+      fetchScores()
+      fetchProgress()
+    }
     return () => {
       controller.abort()
     }
-  }, [activeDataCallId])
+  }, [activeDatacallIds])
 
   if (loading) {
     return (
@@ -92,7 +100,11 @@ export default function HomePageContainer() {
     <Box>
       <StatisticsBlocks scores={scoreMap} />
       <BreadCrumbs />
-      <FismaTable scores={scoreMap} progress={progressMap} />
+      <FismaTable
+        scores={scoreMap}
+        progress={progressMap}
+        systemCallMap={systemCallMap}
+      />
     </Box>
   )
 }

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -71,9 +71,11 @@ export default function HomePageContainer() {
       setProgressMap(buildProgressMap(rowsPerCall))
     }
 
-    if (ids.length === 0) {
-      setLoading(false)
-    } else {
+    // Keep the spinner until the active calls resolve — activeDatacallIds is
+    // empty on the first paint while Title is still fetching /datacalls, so
+    // don't clear loading (which would flash an empty dashboard) until there
+    // are calls to fetch.
+    if (ids.length > 0) {
       fetchScores()
       fetchProgress()
     }

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -38,6 +38,15 @@ describe('buildScoreMap', () => {
   it('returns an empty map for no calls', () => {
     expect(buildScoreMap([])).toEqual({})
   })
+
+  it('keeps the newest call for a system in more than one call', () => {
+    // rowsPerCall is passed newest-call-first, so the first write wins.
+    const map = buildScoreMap([
+      [agg(1, 90)], // newer call (e.g. FY25 ZTM)
+      [agg(1, 55)], // older call (e.g. FY2025 Q3)
+    ])
+    expect(map[1].score).toBe(90)
+  })
 })
 
 describe('buildProgressMap', () => {

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -1,9 +1,5 @@
 import type { ScoreAggregate, ScoreProgress } from '@/types'
-import {
-  buildScoreMap,
-  buildProgressMap,
-  buildSystemCallMap,
-} from './aggregateScores'
+import { buildDashboardMaps } from './aggregateScores'
 
 const agg = (fismasystemid: number, systemscore: number): ScoreAggregate => ({
   fismasystemid,
@@ -11,80 +7,84 @@ const agg = (fismasystemid: number, systemscore: number): ScoreAggregate => ({
   datacallid: 0,
 })
 
-const prog = (fismasystemid: number, questionsupdated: number): ScoreProgress =>
+const prog = (
+  fismasystemid: number,
+  questionsupdated: number,
+  lastupdatedat: string | null
+): ScoreProgress =>
   ({
     fismasystemid,
     questionsexpected: 40,
     questionsupdated,
+    lastupdatedat,
     updatedsincestart: questionsupdated > 0,
   }) as ScoreProgress
 
-describe('buildScoreMap', () => {
-  it('unions disjoint systems across calls (CMS call + HHS call)', () => {
-    const map = buildScoreMap([
-      [agg(1, 80), agg(2, 60)], // CMS call
-      [agg(3, 90)], // HHS call
-    ])
-    expect(Object.keys(map)).toEqual(['1', '2', '3'])
-    expect(map[1].score).toBe(80)
-    expect(map[3].score).toBe(90)
+// callIds newest-first: 38 = newer (FY25 ZTM), 3 = older (FY2025 Q3)
+const CALL_IDS = [38, 3]
+
+describe('buildDashboardMaps', () => {
+  it('unions disjoint single-call systems', () => {
+    const { scoreMap, systemCallMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 80)], [agg(2, 60)]],
+      [[prog(1, 40, '2025-09-01')], [prog(2, 40, '2025-05-01')]]
+    )
+    expect(scoreMap[1].score).toBe(80)
+    expect(scoreMap[2].score).toBe(60)
+    expect(systemCallMap[1]).toEqual([38])
+    expect(systemCallMap[2]).toEqual([3])
+  })
+
+  it('shows the call a multi-call system most recently updated, not the newest', () => {
+    // System 1 is in both calls; it completed the OLDER call (3) recently and
+    // never touched the newer call (38). Expect the older call's score/progress.
+    const { scoreMap, progressMap, systemCallMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 0)], [agg(1, 89)]], // newer call score 0, older call score 89
+      [
+        [prog(1, 0, null)], // newer call: never updated
+        [prog(1, 40, '2025-05-07')], // older call: completed
+      ]
+    )
+    expect(scoreMap[1].score).toBe(89) // older call wins
+    expect(progressMap[1].questionsupdated).toBe(40)
+    expect(systemCallMap[1]).toEqual([38, 3]) // both calls recorded
+  })
+
+  it('falls back to the newest call when a system never updated any call', () => {
+    const { scoreMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 12)], [agg(1, 99)]],
+      [[prog(1, 0, null)], [prog(1, 0, null)]]
+    )
+    expect(scoreMap[1].score).toBe(12) // newest (idx 0) fallback
   })
 
   it('defaults a missing score to 0', () => {
-    const map = buildScoreMap([[{ fismasystemid: 5 } as ScoreAggregate]])
-    expect(map[5].score).toBe(0)
+    const { scoreMap } = buildDashboardMaps(
+      [1],
+      [[{ fismasystemid: 5 } as ScoreAggregate]],
+      [[]]
+    )
+    expect(scoreMap[5].score).toBe(0)
   })
 
-  it('returns an empty map for no calls', () => {
-    expect(buildScoreMap([])).toEqual({})
+  it('returns empty maps for no calls', () => {
+    expect(buildDashboardMaps([], [], [])).toEqual({
+      scoreMap: {},
+      progressMap: {},
+      systemCallMap: {},
+    })
   })
 
-  it('keeps the newest call for a system in more than one call', () => {
-    // rowsPerCall is passed newest-call-first, so the first write wins.
-    const map = buildScoreMap([
-      [agg(1, 90)], // newer call (e.g. FY25 ZTM)
-      [agg(1, 55)], // older call (e.g. FY2025 Q3)
-    ])
-    expect(map[1].score).toBe(90)
-  })
-})
-
-describe('buildProgressMap', () => {
-  it('unions progress from several calls, keyed by system', () => {
-    const map = buildProgressMap([[prog(1, 0)], [prog(2, 40)]])
-    expect(map[1].questionsupdated).toBe(0)
-    expect(map[2].questionsupdated).toBe(40)
-  })
-
-  it('tolerates an empty call result (partial failure fallback)', () => {
-    const map = buildProgressMap([[prog(1, 10)], []])
-    expect(Object.keys(map)).toEqual(['1'])
-  })
-})
-
-describe('buildSystemCallMap', () => {
-  const row = (fismasystemid: number, datacallid: number): ScoreAggregate => ({
-    fismasystemid,
-    datacallid,
-    systemscore: 0,
-  })
-
-  it('records the single call each system belongs to', () => {
-    const map = buildSystemCallMap([
-      [row(1, 42), row(2, 42)], // CMS call 42
-      [row(3, 43)], // HHS call 43
-    ])
-    expect(map[1]).toEqual([42])
-    expect(map[3]).toEqual([43])
-  })
-
-  it('flags a system that appears in more than one active call', () => {
-    const map = buildSystemCallMap([[row(1, 42)], [row(1, 43)]])
-    expect(map[1]).toEqual([42, 43])
-  })
-
-  it('does not duplicate a call id for the same system', () => {
-    const map = buildSystemCallMap([[row(1, 42), row(1, 42)]])
-    expect(map[1]).toEqual([42])
+  it('tolerates a failed (empty) call result', () => {
+    const { scoreMap, progressMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 70)], []], // older call failed -> []
+      [[prog(1, 10, '2025-09-01')], []]
+    )
+    expect(scoreMap[1].score).toBe(70)
+    expect(progressMap[1].questionsupdated).toBe(10)
   })
 })

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -1,0 +1,81 @@
+import type { ScoreAggregate, ScoreProgress } from '@/types'
+import {
+  buildScoreMap,
+  buildProgressMap,
+  buildSystemCallMap,
+} from './aggregateScores'
+
+const agg = (fismasystemid: number, systemscore: number): ScoreAggregate => ({
+  fismasystemid,
+  systemscore,
+  datacallid: 0,
+})
+
+const prog = (fismasystemid: number, questionsupdated: number): ScoreProgress =>
+  ({
+    fismasystemid,
+    questionsexpected: 40,
+    questionsupdated,
+    updatedsincestart: questionsupdated > 0,
+  }) as ScoreProgress
+
+describe('buildScoreMap', () => {
+  it('unions disjoint systems across calls (CMS call + HHS call)', () => {
+    const map = buildScoreMap([
+      [agg(1, 80), agg(2, 60)], // CMS call
+      [agg(3, 90)], // HHS call
+    ])
+    expect(Object.keys(map)).toEqual(['1', '2', '3'])
+    expect(map[1].score).toBe(80)
+    expect(map[3].score).toBe(90)
+  })
+
+  it('defaults a missing score to 0', () => {
+    const map = buildScoreMap([[{ fismasystemid: 5 } as ScoreAggregate]])
+    expect(map[5].score).toBe(0)
+  })
+
+  it('returns an empty map for no calls', () => {
+    expect(buildScoreMap([])).toEqual({})
+  })
+})
+
+describe('buildProgressMap', () => {
+  it('unions progress from several calls, keyed by system', () => {
+    const map = buildProgressMap([[prog(1, 0)], [prog(2, 40)]])
+    expect(map[1].questionsupdated).toBe(0)
+    expect(map[2].questionsupdated).toBe(40)
+  })
+
+  it('tolerates an empty call result (partial failure fallback)', () => {
+    const map = buildProgressMap([[prog(1, 10)], []])
+    expect(Object.keys(map)).toEqual(['1'])
+  })
+})
+
+describe('buildSystemCallMap', () => {
+  const row = (fismasystemid: number, datacallid: number): ScoreAggregate => ({
+    fismasystemid,
+    datacallid,
+    systemscore: 0,
+  })
+
+  it('records the single call each system belongs to', () => {
+    const map = buildSystemCallMap([
+      [row(1, 42), row(2, 42)], // CMS call 42
+      [row(3, 43)], // HHS call 43
+    ])
+    expect(map[1]).toEqual([42])
+    expect(map[3]).toEqual([43])
+  })
+
+  it('flags a system that appears in more than one active call', () => {
+    const map = buildSystemCallMap([[row(1, 42)], [row(1, 43)]])
+    expect(map[1]).toEqual([42, 43])
+  })
+
+  it('does not duplicate a call id for the same system', () => {
+    const map = buildSystemCallMap([[row(1, 42), row(1, 42)]])
+    expect(map[1]).toEqual([42])
+  })
+})

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -1,0 +1,63 @@
+import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
+
+/**
+ * Merge the score rows from several data calls into one map keyed by
+ * fismasystemid. A system belongs to exactly one call per year, so the keys
+ * are disjoint across calls and there is no meaningful collision; if one ever
+ * occurred, the later call wins. Pure so the aggregation is unit-testable.
+ * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, one array per call.
+ * @returns {Record<number, SystemScoreEntry>} Score entry per system.
+ */
+export function buildScoreMap(
+  rowsPerCall: ScoreAggregate[][]
+): Record<number, SystemScoreEntry> {
+  const map: Record<number, SystemScoreEntry> = {}
+  for (const rows of rowsPerCall) {
+    for (const row of rows) {
+      map[row.fismasystemid] = {
+        score: row.systemscore ?? 0,
+        tier: row.systemtier,
+      }
+    }
+  }
+  return map
+}
+
+/**
+ * Merge the progress rows from several data calls into one map keyed by
+ * fismasystemid (disjoint keys, later call wins on any collision).
+ * @param {ScoreProgress[][]} rowsPerCall - Progress rows, one array per call.
+ * @returns {Record<number, ScoreProgress>} Progress per system.
+ */
+export function buildProgressMap(
+  rowsPerCall: ScoreProgress[][]
+): Record<number, ScoreProgress> {
+  const map: Record<number, ScoreProgress> = {}
+  for (const rows of rowsPerCall) {
+    for (const row of rows) {
+      map[row.fismasystemid] = row
+    }
+  }
+  return map
+}
+
+/**
+ * Record which data call(s) each system has scores in across the active calls.
+ * Normally a system is in exactly one call per year, so this lets a per-row
+ * action open that system's own call. A system in more than one active call is
+ * genuinely ambiguous and its single-call actions should be gated.
+ * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, one array per call.
+ * @returns {Record<number, number[]>} Distinct datacallids per system.
+ */
+export function buildSystemCallMap(
+  rowsPerCall: ScoreAggregate[][]
+): Record<number, number[]> {
+  const map: Record<number, number[]> = {}
+  for (const rows of rowsPerCall) {
+    for (const row of rows) {
+      const list = map[row.fismasystemid] ?? (map[row.fismasystemid] = [])
+      if (!list.includes(row.datacallid)) list.push(row.datacallid)
+    }
+  }
+  return map
+}

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -2,10 +2,12 @@ import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 
 /**
  * Merge the score rows from several data calls into one map keyed by
- * fismasystemid. A system belongs to exactly one call per year, so the keys
- * are disjoint across calls and there is no meaningful collision; if one ever
- * occurred, the later call wins. Pure so the aggregation is unit-testable.
- * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, one array per call.
+ * fismasystemid. A system may appear in more than one of a year's calls
+ * (e.g. an annual ZTM call and a Q# call); when it does, the newest call
+ * wins. Callers pass `rowsPerCall` newest-call-first, so the first write for a
+ * system is kept and later (older) calls do not overwrite it. Pure so the
+ * aggregation is unit-testable.
+ * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, newest call first.
  * @returns {Record<number, SystemScoreEntry>} Score entry per system.
  */
 export function buildScoreMap(
@@ -14,6 +16,7 @@ export function buildScoreMap(
   const map: Record<number, SystemScoreEntry> = {}
   for (const rows of rowsPerCall) {
     for (const row of rows) {
+      if (row.fismasystemid in map) continue // keep the newer call's score
       map[row.fismasystemid] = {
         score: row.systemscore ?? 0,
         tier: row.systemtier,
@@ -25,8 +28,9 @@ export function buildScoreMap(
 
 /**
  * Merge the progress rows from several data calls into one map keyed by
- * fismasystemid (disjoint keys, later call wins on any collision).
- * @param {ScoreProgress[][]} rowsPerCall - Progress rows, one array per call.
+ * fismasystemid. Newest call wins for a system in more than one call: callers
+ * pass `rowsPerCall` newest-call-first, so the first write is kept.
+ * @param {ScoreProgress[][]} rowsPerCall - Progress rows, newest call first.
  * @returns {Record<number, ScoreProgress>} Progress per system.
  */
 export function buildProgressMap(
@@ -35,6 +39,7 @@ export function buildProgressMap(
   const map: Record<number, ScoreProgress> = {}
   for (const rows of rowsPerCall) {
     for (const row of rows) {
+      if (row.fismasystemid in map) continue // keep the newer call's progress
       map[row.fismasystemid] = row
     }
   }

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -1,68 +1,89 @@
 import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 
+export type DashboardMaps = {
+  scoreMap: Record<number, SystemScoreEntry>
+  progressMap: Record<number, ScoreProgress>
+  /** Which active data call(s) each system has scores in, for per-row actions. */
+  systemCallMap: Record<number, number[]>
+}
+
+const lastUpdatedMs = (entry: ScoreProgress | undefined): number => {
+  if (!entry?.lastupdatedat) return -1
+  const t = new Date(entry.lastupdatedat).getTime()
+  return Number.isNaN(t) ? -1 : t
+}
+
 /**
- * Merge the score rows from several data calls into one map keyed by
- * fismasystemid. A system may appear in more than one of a year's calls
- * (e.g. an annual ZTM call and a Q# call); when it does, the newest call
- * wins. Callers pass `rowsPerCall` newest-call-first, so the first write for a
- * system is kept and later (older) calls do not overwrite it. Pure so the
- * aggregation is unit-testable.
- * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, newest call first.
- * @returns {Record<number, SystemScoreEntry>} Score entry per system.
+ * Build the dashboard's score, progress, and system→calls maps from the active
+ * data calls, aggregated per system.
+ *
+ * A system can appear in more than one of a year's calls (e.g. an annual ZTM
+ * call and a Q# call). We display the call the system **most recently updated**
+ * (max `lastupdatedat`), so a system that completed one call is shown as such
+ * rather than as 0 against a newer call it never touched. A system that never
+ * updated any call falls back to the newest call available. Score and progress
+ * are taken from that same chosen call so they stay consistent.
+ *
+ * Inputs are aligned by index and ordered newest-call-first, which is both the
+ * tiebreak for the fallback and the order `callIds` is passed in.
+ * @param {number[]} callIds - Active data-call ids, newest first.
+ * @param {ScoreAggregate[][]} scoresPerCall - Aggregate rows, aligned to callIds.
+ * @param {ScoreProgress[][]} progressPerCall - Progress rows, aligned to callIds.
+ * @returns {DashboardMaps} The per-system score, progress, and call maps.
  */
-export function buildScoreMap(
-  rowsPerCall: ScoreAggregate[][]
-): Record<number, SystemScoreEntry> {
-  const map: Record<number, SystemScoreEntry> = {}
-  for (const rows of rowsPerCall) {
-    for (const row of rows) {
-      if (row.fismasystemid in map) continue // keep the newer call's score
-      map[row.fismasystemid] = {
-        score: row.systemscore ?? 0,
-        tier: row.systemtier,
+export function buildDashboardMaps(
+  callIds: number[],
+  scoresPerCall: ScoreAggregate[][],
+  progressPerCall: ScoreProgress[][]
+): DashboardMaps {
+  // Per-call lookups keyed by system for O(1) access.
+  const scoreByCall = scoresPerCall.map((rows) => {
+    const m = new Map<number, ScoreAggregate>()
+    for (const row of rows) m.set(row.fismasystemid, row)
+    return m
+  })
+  const progressByCall = progressPerCall.map((rows) => {
+    const m = new Map<number, ScoreProgress>()
+    for (const row of rows) m.set(row.fismasystemid, row)
+    return m
+  })
+
+  // The call indices each system appears in (scores drive the table), newest
+  // first since callIds is newest first.
+  const systemIdxs = new Map<number, number[]>()
+  scoreByCall.forEach((m, idx) => {
+    for (const sys of m.keys()) {
+      const arr = systemIdxs.get(sys)
+      if (arr) arr.push(idx)
+      else systemIdxs.set(sys, [idx])
+    }
+  })
+
+  const scoreMap: Record<number, SystemScoreEntry> = {}
+  const progressMap: Record<number, ScoreProgress> = {}
+  const systemCallMap: Record<number, number[]> = {}
+
+  for (const [sys, idxs] of systemIdxs) {
+    // Choose the call this system most recently updated; ties and
+    // never-updated systems keep the newest call (idxs[0]).
+    let chosen = idxs[0]
+    let bestT = lastUpdatedMs(progressByCall[chosen]?.get(sys))
+    for (const idx of idxs) {
+      const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
+      if (t > bestT) {
+        bestT = t
+        chosen = idx
       }
     }
-  }
-  return map
-}
 
-/**
- * Merge the progress rows from several data calls into one map keyed by
- * fismasystemid. Newest call wins for a system in more than one call: callers
- * pass `rowsPerCall` newest-call-first, so the first write is kept.
- * @param {ScoreProgress[][]} rowsPerCall - Progress rows, newest call first.
- * @returns {Record<number, ScoreProgress>} Progress per system.
- */
-export function buildProgressMap(
-  rowsPerCall: ScoreProgress[][]
-): Record<number, ScoreProgress> {
-  const map: Record<number, ScoreProgress> = {}
-  for (const rows of rowsPerCall) {
-    for (const row of rows) {
-      if (row.fismasystemid in map) continue // keep the newer call's progress
-      map[row.fismasystemid] = row
+    const score = scoreByCall[chosen]?.get(sys)
+    if (score) {
+      scoreMap[sys] = { score: score.systemscore ?? 0, tier: score.systemtier }
     }
+    const progress = progressByCall[chosen]?.get(sys)
+    if (progress) progressMap[sys] = progress
+    systemCallMap[sys] = idxs.map((idx) => callIds[idx])
   }
-  return map
-}
 
-/**
- * Record which data call(s) each system has scores in across the active calls.
- * Normally a system is in exactly one call per year, so this lets a per-row
- * action open that system's own call. A system in more than one active call is
- * genuinely ambiguous and its single-call actions should be gated.
- * @param {ScoreAggregate[][]} rowsPerCall - Aggregate rows, one array per call.
- * @returns {Record<number, number[]>} Distinct datacallids per system.
- */
-export function buildSystemCallMap(
-  rowsPerCall: ScoreAggregate[][]
-): Record<number, number[]> {
-  const map: Record<number, number[]> = {}
-  for (const rows of rowsPerCall) {
-    for (const row of rows) {
-      const list = map[row.fismasystemid] ?? (map[row.fismasystemid] = [])
-      if (!list.includes(row.datacallid)) list.push(row.datacallid)
-    }
-  }
-  return map
+  return { scoreMap, progressMap, systemCallMap }
 }

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -234,6 +234,11 @@ export default function QuestionnarePage() {
   // location.state. Optional-chain instead of crashing on first render; the
   // missing-system path is handled by an early render guard below.
   const system = location.state?.fismasystemid as number | undefined
+  // The dashboard opens the questionnaire for the system's own data call
+  // (year-aggregated view, #467): the specific call id and name ride along in
+  // the route state. Absent (deep link), fall back to the selected/latest call.
+  const routeDatacallId = location.state?.datacallid as number | undefined
+  const routeDatacall = location.state?.datacall as string | undefined
   const systemRef = React.useRef(system)
   systemRef.current = system
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
@@ -339,22 +344,36 @@ export default function QuestionnarePage() {
         try {
           let questionsEmpty = false
           let datacall = ''
-          const isHistorical =
-            selectedDatacall !== null &&
-            selectedDatacall.datacallid !== latestDataCallId
           let activeDataCallId: number
-          if (isHistorical && selectedDatacall) {
-            datacall = selectedDatacall.datacall.replaceAll(' ', '_')
+          if (routeDatacallId && routeDatacall) {
+            // Opened for a specific system's own call from the dashboard.
+            datacall = routeDatacall.replaceAll(' ', '_')
             setDatacall(datacall)
-            setIsPastDeadline(true)
-            activeDataCallId = selectedDatacall.datacallid
-          } else {
-            datacall = latestDatacall.replaceAll(' ', '_')
-            setDatacall(datacall)
+            activeDataCallId = routeDatacallId
             setIsPastDeadline(
-              latestDeadline ? new Date() > new Date(latestDeadline) : true
+              routeDatacallId === latestDataCallId
+                ? latestDeadline
+                  ? new Date() > new Date(latestDeadline)
+                  : true
+                : true // a non-latest call is historical and read-only
             )
-            activeDataCallId = latestDataCallId
+          } else {
+            const isHistorical =
+              selectedDatacall !== null &&
+              selectedDatacall.datacallid !== latestDataCallId
+            if (isHistorical && selectedDatacall) {
+              datacall = selectedDatacall.datacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(true)
+              activeDataCallId = selectedDatacall.datacallid
+            } else {
+              datacall = latestDatacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(
+                latestDeadline ? new Date() > new Date(latestDeadline) : true
+              )
+              activeDataCallId = latestDataCallId
+            }
           }
           // Hoisted so both the questions block and the final batch can access them.
           const questionData: Record<number, Question> = {}
@@ -497,6 +516,8 @@ export default function QuestionnarePage() {
     system,
     navigate,
     fismaacronym,
+    routeDatacallId,
+    routeDatacall,
     selectedDatacall,
     latestDataCallId,
     latestDatacall,

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -239,6 +239,7 @@ export default function QuestionnarePage() {
   // the route state. Absent (deep link), fall back to the selected/latest call.
   const routeDatacallId = location.state?.datacallid as number | undefined
   const routeDatacall = location.state?.datacall as string | undefined
+  const routeDeadline = location.state?.deadline as string | undefined
   const systemRef = React.useRef(system)
   systemRef.current = system
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
@@ -346,16 +347,14 @@ export default function QuestionnarePage() {
           let datacall = ''
           let activeDataCallId: number
           if (routeDatacallId && routeDatacall) {
-            // Opened for a specific system's own call from the dashboard.
+            // Opened for a specific system's own call from the dashboard. Read
+            // only when that call's own deadline has passed - not by comparing
+            // to the global latest, since two calls can be open at once.
             datacall = routeDatacall.replaceAll(' ', '_')
             setDatacall(datacall)
             activeDataCallId = routeDatacallId
             setIsPastDeadline(
-              routeDatacallId === latestDataCallId
-                ? latestDeadline
-                  ? new Date() > new Date(latestDeadline)
-                  : true
-                : true // a non-latest call is historical and read-only
+              routeDeadline ? new Date() > new Date(routeDeadline) : true
             )
           } else {
             const isHistorical =
@@ -518,6 +517,7 @@ export default function QuestionnarePage() {
     fismaacronym,
     routeDatacallId,
     routeDatacall,
+    routeDeadline,
     selectedDatacall,
     latestDataCallId,
     latestDatacall,
@@ -1111,16 +1111,18 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
-      {/* selectedDataCallId seeds the "To" picker default in ScoreDiffModal.
-          #417 renamed selectedDataCallId → selectedDatacall (datacall object)
-          on context; use the id off the object now that #408 has landed. */}
+      {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
+          questionnaire was opened for (the row's own call), since the dashboard
+          may be aggregating a whole year and selectedDatacall is then null. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
-        selectedDataCallId={selectedDatacall?.datacallid}
+        selectedDataCallId={
+          routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
+        }
       />
     </>
   )

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -14,8 +14,13 @@ type ContextType = {
   latestDataCallId: number
   latestDatacall: string
   latestDeadline: string
+  // All data calls (deadline-sorted) for resolving a call id to its name.
+  datacalls: datacall[]
+  // The data calls whose scores/progress the dashboard aggregates — the active
+  // year's calls, toggleable. selectedDatacall is the single active call when
+  // exactly one is on (drives the single-id flows), else null while aggregating.
+  activeDatacallIds: number[]
   selectedDatacall: datacall | null
-  setSelectedDatacall: React.Dispatch<React.SetStateAction<datacall | null>>
   showDecommissioned: boolean
   setShowDecommissioned: (show: boolean) => void
   fetchFismaSystems: (decommissioned?: boolean) => Promise<void>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -540,6 +540,7 @@ export default function Title() {
                           >
                             <Checkbox
                               checked={checked}
+                              readOnly
                               size="small"
                               sx={{ mr: 1 }}
                             />

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -1,10 +1,12 @@
 import {
   Container,
   Typography,
-  Autocomplete,
-  TextField,
-  Chip,
+  Button,
+  Checkbox,
+  ListSubheader,
+  ListItemText,
 } from '@mui/material'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import { useLoaderData, useLocation } from 'react-router-dom'
 import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
@@ -21,7 +23,11 @@ import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import {
+  groupDatacallsByYear,
+  parseDatacallName,
+} from '@/utils/datacallGrouping'
 import { FismaSystemType } from '@/types'
 import { Routes } from '@/router/constants'
 import type { AuthLoaderData } from '@/router/authLoader'
@@ -65,9 +71,13 @@ export default function Title() {
   const [fismaSystems, setFismaSystems] = useState<FismaSystemType[]>([])
   const [datacalls, setDatacalls] = useState<datacall[]>([])
   const [latestDataCallId, setLatestDataCallId] = useState<number>(0)
-  const [selectedDatacall, setSelectedDatacall] = useState<datacall | null>(
-    null
-  )
+  // The dashboard aggregates the active year's data calls. activeYear is the
+  // selected fiscal year; activeDatacallIds are the toggled-on calls within it
+  // (all on by default). See groupDatacallsByYear / #467.
+  const [activeYear, setActiveYear] = useState<number | null>(null)
+  const [activeDatacallIds, setActiveDatacallIds] = useState<number[]>([])
+  const [datacallMenuAnchor, setDatacallMenuAnchor] =
+    useState<null | HTMLElement>(null)
   const [latestDeadline, setLatestDeadline] = useState<string>('')
   const [openModal, setOpenModal] = useState<boolean>(false)
   const [openEmailModal, setOpenEmailModal] = useState<boolean>(false)
@@ -132,7 +142,12 @@ export default function Title() {
           setLatestDataCallId(sorted[0].datacallid)
           setLatestDatacall(sorted[0].datacall)
           setLatestDeadline(sorted[0].deadline)
-          setSelectedDatacall(sorted[0])
+          // Default to the latest year with data, all of its calls toggled on.
+          const [firstGroup] = groupDatacallsByYear(sorted)
+          if (firstGroup) {
+            setActiveYear(firstGroup.year)
+            setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
+          }
         }
       } catch (error) {
         if (controller.signal.aborted) return
@@ -162,6 +177,40 @@ export default function Title() {
       controller.abort()
     }
   }, [loaderData.status])
+  const datacallsByYear = useMemo(
+    () => groupDatacallsByYear(datacalls),
+    [datacalls]
+  )
+  // Single active call when exactly one is toggled on, else null. Drives the
+  // single-id flows (questionnaire, export, diff); null signals aggregation.
+  const selectedDatacall = useMemo<datacall | null>(
+    () =>
+      activeDatacallIds.length === 1
+        ? datacalls.find((d) => d.datacallid === activeDatacallIds[0]) ?? null
+        : null,
+    [activeDatacallIds, datacalls]
+  )
+  // Selecting a call in a different year switches to that whole year (all on);
+  // within the active year, toggle a call but never leave the year empty.
+  const handleDatacallToggle = (
+    group: (typeof datacallsByYear)[number],
+    call: datacall
+  ) => {
+    if (group.year !== activeYear) {
+      setActiveYear(group.year)
+      setActiveDatacallIds(group.calls.map((c) => c.datacallid))
+      return
+    }
+    setActiveDatacallIds((prev) => {
+      if (prev.includes(call.datacallid)) {
+        return prev.length === 1
+          ? prev
+          : prev.filter((id) => id !== call.datacallid)
+      }
+      return [...prev, call.datacallid]
+    })
+  }
+
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget)
   }
@@ -433,73 +482,72 @@ export default function Title() {
               </Typography>
             ) : (
               datacalls.length > 0 && (
-                <Autocomplete
-                  size="small"
-                  options={datacalls}
-                  getOptionLabel={(dc) => dc.datacall}
-                  isOptionEqualToValue={(option, value) =>
-                    option.datacallid === value.datacallid
-                  }
-                  value={selectedDatacall ?? datacalls[0]}
-                  onChange={(_, dc) => {
-                    if (dc) setSelectedDatacall(dc)
-                  }}
-                  renderOption={(props, option) => {
-                    const isLatest = option.datacallid === latestDataCallId
-                    const isClosed = new Date() > new Date(option.deadline)
-                    const { key, ...rest } = props
-                    const deadlineLabel = new Date(
-                      option.deadline
-                    ).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })
-                    return (
-                      <li key={key} {...rest}>
-                        <Box sx={{ width: '100%' }}>
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'space-between',
-                              width: '100%',
-                              gap: 1,
-                            }}
+                <>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={(e) => setDatacallMenuAnchor(e.currentTarget)}
+                    endIcon={<ArrowDropDownIcon />}
+                    sx={{
+                      minWidth: 260,
+                      justifyContent: 'space-between',
+                      textTransform: 'none',
+                      color: 'text.primary',
+                      borderColor: 'rgba(0,0,0,0.23)',
+                    }}
+                  >
+                    {activeYear ?? 'Data call'}
+                    {selectedDatacall
+                      ? ` · ${selectedDatacall.datacall}`
+                      : activeDatacallIds.length > 1
+                        ? ` · ${activeDatacallIds.length} calls`
+                        : ''}
+                  </Button>
+                  <Menu
+                    anchorEl={datacallMenuAnchor}
+                    open={Boolean(datacallMenuAnchor)}
+                    onClose={() => setDatacallMenuAnchor(null)}
+                  >
+                    {datacallsByYear.flatMap((group) => [
+                      <ListSubheader key={`year-${group.year ?? 'other'}`}>
+                        {group.year ?? 'Other'}
+                      </ListSubheader>,
+                      ...group.calls.map((call) => {
+                        const checked =
+                          group.year === activeYear &&
+                          activeDatacallIds.includes(call.datacallid)
+                        const { tenant } = parseDatacallName(call.datacall)
+                        const isClosed = new Date() > new Date(call.deadline)
+                        const deadlineLabel = new Date(
+                          call.deadline
+                        ).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })
+                        return (
+                          <MenuItem
+                            key={call.datacallid}
+                            dense
+                            onClick={() => handleDatacallToggle(group, call)}
                           >
-                            <Typography variant="body2">
-                              {option.datacall}
-                            </Typography>
-                            {/* Only the latest-by-deadline call is badged:
-                                "Current" while still open, "Latest" once its
-                                deadline has passed (#393). */}
-                            {isLatest && (
-                              <Chip
-                                label={isClosed ? 'Latest' : 'Current'}
-                                size="small"
-                                variant="outlined"
-                                color={isClosed ? 'default' : 'primary'}
-                                sx={{ height: 18, fontSize: '0.65rem' }}
-                              />
-                            )}
-                          </Box>
-                          <Typography
-                            variant="caption"
-                            sx={{ color: 'text.secondary' }}
-                          >
-                            {isClosed ? 'Closed' : 'Active'} · deadline{' '}
-                            {deadlineLabel}
-                          </Typography>
-                        </Box>
-                      </li>
-                    )
-                  }}
-                  disableClearable
-                  sx={{ minWidth: 260 }}
-                  renderInput={(params) => (
-                    <TextField {...params} size="small" />
-                  )}
-                />
+                            <Checkbox
+                              checked={checked}
+                              size="small"
+                              sx={{ mr: 1 }}
+                            />
+                            <ListItemText
+                              primary={`${call.datacall} · ${tenant}`}
+                              secondary={`${
+                                isClosed ? 'Closed' : 'Active'
+                              } · deadline ${deadlineLabel}`}
+                            />
+                          </MenuItem>
+                        )
+                      }),
+                    ])}
+                  </Menu>
+                </>
               )
             )}
           </Box>
@@ -527,8 +575,9 @@ export default function Title() {
                   latestDataCallId,
                   latestDatacall,
                   latestDeadline,
+                  datacalls,
+                  activeDatacallIds,
                   selectedDatacall,
-                  setSelectedDatacall,
                   showDecommissioned,
                   setShowDecommissioned,
                   fetchFismaSystems,

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -202,12 +202,17 @@ export default function Title() {
       return
     }
     setActiveDatacallIds((prev) => {
-      if (prev.includes(call.datacallid)) {
-        return prev.length === 1
-          ? prev
-          : prev.filter((id) => id !== call.datacallid)
+      const removing = prev.includes(call.datacallid)
+      if (removing && prev.length === 1) return prev // never empty the year
+      const next = new Set(prev)
+      if (removing) {
+        next.delete(call.datacallid)
+      } else {
+        next.add(call.datacallid)
       }
-      return [...prev, call.datacallid]
+      // Keep the group's deadline order (newest first) so the dashboard merge
+      // deterministically resolves a multi-call system to its newest call.
+      return group.calls.map((c) => c.datacallid).filter((id) => next.has(id))
     })
   }
 
@@ -496,7 +501,8 @@ export default function Title() {
                       borderColor: 'rgba(0,0,0,0.23)',
                     }}
                   >
-                    {activeYear ?? 'Data call'}
+                    {activeYear ??
+                      (activeDatacallIds.length ? 'Other' : 'Data call')}
                     {selectedDatacall
                       ? ` · ${selectedDatacall.datacall}`
                       : activeDatacallIds.length > 1
@@ -507,6 +513,7 @@ export default function Title() {
                     anchorEl={datacallMenuAnchor}
                     open={Boolean(datacallMenuAnchor)}
                     onClose={() => setDatacallMenuAnchor(null)}
+                    MenuListProps={{ 'aria-label': 'Select data call by year' }}
                   >
                     {datacallsByYear.flatMap((group) => [
                       <ListSubheader key={`year-${group.year ?? 'other'}`}>


### PR DESCRIPTION
Closes #467.

## Problem

The HHS historical import added a second data call per year (e.g. 2025 has FY2025 Q3 and FY25 ZTM). The flat data-call selector defaulted to a single call, so every system that wasn't in that specific call showed as `0/40 Not updated` on the dashboard, making it look broken.

## What changed

**Year-grouped selector.** The data-call picker now groups calls by fiscal year (parsed from the name). Selecting a year toggles on all of that year's calls; the dashboard aggregates them so each system shows its real status. Per-call checkboxes let you narrow within a year. Defaults to the latest year with data. Each option is tagged with its call type (ZTM / Q#) and deadline as a visual aid — note that tag is derived from the name, not a stored field.

**Dashboard aggregation.** `Home` fetches `/scores/aggregate` and `/scores/progress` for each active call and merges them by system (frontend only, no backend change).

**Multi-call systems.** We found systems that appear in more than one of a year's calls (217 systems in 2025). Handled as:
- Dashboard shows the system's **newest call by deadline**.
- The **questionnaire** action opens the system's own call; if it has more than one, a small picker lets the user choose which to open.
- Read-only / deadline state is decided by the opened call's own deadline.

**Export** targets the call shared by the selected rows; a selection spanning multiple calls is disabled.

## Testing

- New unit tests: year/type parsing and grouping, the score/progress merge (including the multi-call newest-wins case), and the filter logic.
- Full suite green (352), typecheck and lint clean. Verified locally against dev data.

## Follow-ups (not in this PR)

- **Pillar Scores modal** has the same multi-call ambiguity; being handled on a separate branch.
- A single system that belongs to two calls can't be exported yet (the multi-call export gate catches it).
- The default score shown for a multi-call system (currently newest-by-deadline) is still being confirmed with the team.
