### PR TITLE
refactor into single TIERS constant

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -32,7 +32,7 @@ import {
 } from 'recharts'
 import axiosInstance from '@/axiosConfig'
 import type { ScoreAggregate } from '@/types'
-import { styleForTier, TIER_STYLES } from '@/utils/tierStyles'
+import { tierStyle, TIERS } from '@/utils/tierStyles'
 
 // Static cache for datacalls that persists across component instances
 const datacallsCache: { data: DataCall[] | null; timestamp: number | null } = {
@@ -57,9 +57,9 @@ interface PillarScoresModalProps {
 }
 
 // Background color used when the API has not (yet) returned a tier
-// string for this score. Matches TIER_STYLES['Not Assessed'] so a
+// string for this score. Matches TIERS['Not Assessed'] so a
 // missing-tier cell visually reads as "no data" rather than a blank.
-const FALLBACK_BACKGROUND = TIER_STYLES['Not Assessed'].backgroundColor
+const FALLBACK_BACKGROUND = TIERS['Not Assessed'].chip.backgroundColor
 
 const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   open,
@@ -263,7 +263,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                   borderColor: 'darkgray',
                   borderRadius: 2,
                   backgroundColor: latestScore.systemscore
-                    ? styleForTier(latestScore.systemtier)?.backgroundColor ??
+                    ? tierStyle(latestScore.systemtier)?.chip.backgroundColor ??
                       FALLBACK_BACKGROUND
                     : FALLBACK_BACKGROUND,
                   maxWidth: '320px',
@@ -299,7 +299,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                     <Typography
                       variant="body1"
                       sx={{
-                        color: TIER_STYLES[latestScore.systemtier].color,
+                        color: TIERS[latestScore.systemtier]?.chip.color,
                         fontWeight: 'bold',
                         fontSize: '1rem',
                         mb: 1,
@@ -440,7 +440,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         height: '100%',
                         backgroundColor:
                           currentScore > 0
-                            ? styleForTier(pillar.tier)?.backgroundColor ??
+                            ? tierStyle(pillar.tier)?.chip.backgroundColor ??
                               FALLBACK_BACKGROUND
                             : FALLBACK_BACKGROUND,
                       }}
@@ -502,7 +502,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                         <Typography
                           variant="caption"
                           sx={{
-                            color: TIER_STYLES[pillar.tier].color,
+                            color: TIERS[pillar.tier]?.chip.color,
                             fontWeight: 'bold',
                             fontSize: '0.8rem',
                             display: 'block',

--- a/src/utils/tierStyles.test.ts
+++ b/src/utils/tierStyles.test.ts
@@ -1,24 +1,12 @@
 import type { ScoreTier } from '@/types'
-import {
-  TIER_STYLES,
-  TIER_CHIP_STYLES,
-  TIER_CELL_STYLES,
-  styleForTier,
-  cellStyleForTier,
-} from '@/utils/tierStyles'
+import { TIERS, tierStyle } from '@/utils/tierStyles'
 
-/**
- * Regression contract for the HHS tier style map.
- *
- * TIER_STYLES is the single source of truth for tier color tokens used by
- * both the PillarScoresModal and the FismaTable score column. The five
- * tier strings (Optimal, Advanced, Initial, Traditional, Not Assessed)
- * are emitted authoritatively by the backend on /scores/aggregate. If a
- * future PR renames or drops a tier in the ScoreTier union the missing
- * key here surfaces at compile time via `satisfies Record<ScoreTier,...>`;
- * the test below also verifies the runtime shape so a stray accidental
- * color edit (typo in hex, dropped backgroundColor) fails fast.
- */
+// Regression contract for the HHS tier style map.
+// Five tier strings are emitted authoritatively by the backend on
+// /scores/aggregate. If a future PR renames or drops a tier in the
+// ScoreTier union the missing key surfaces at compile time; the tests
+// below also verify the runtime shape so an accidental color edit
+// (typo in hex, dropped key) fails fast.
 
 const allTiers: ScoreTier[] = [
   'Optimal',
@@ -30,67 +18,48 @@ const allTiers: ScoreTier[] = [
 
 const hex = /^#[0-9A-Fa-f]{6}$/
 
-test('TIER_STYLES exposes an entry for every ScoreTier value', () => {
+test('TIERS exposes an entry for every ScoreTier value', () => {
   allTiers.forEach((tier) => {
-    expect(TIER_STYLES[tier]).toBeDefined()
+    expect(TIERS[tier]).toBeDefined()
   })
-  expect(Object.keys(TIER_STYLES).sort()).toEqual([...allTiers].sort())
+  expect(Object.keys(TIERS).sort()).toEqual([...allTiers].sort())
 })
 
-test.each(allTiers)('TIER_STYLES[%s] has valid hex color tokens', (tier) => {
-  const style = TIER_STYLES[tier]
-  expect(style.color).toMatch(hex)
-  expect(style.backgroundColor).toMatch(hex)
-})
-
-test('styleForTier returns the matching entry for known tiers', () => {
-  allTiers.forEach((tier) => {
-    expect(styleForTier(tier)).toBe(TIER_STYLES[tier])
-  })
-})
-
-test('styleForTier returns undefined for an absent tier', () => {
-  expect(styleForTier(undefined)).toBeUndefined()
-})
-
-test('TIER_STYLES is a legacy alias for TIER_CHIP_STYLES', () => {
-  expect(TIER_STYLES).toBe(TIER_CHIP_STYLES)
-})
-
-test('TIER_CELL_STYLES exposes an entry for every ScoreTier value', () => {
-  allTiers.forEach((tier) => {
-    expect(TIER_CELL_STYLES[tier]).toBeDefined()
-    expect(TIER_CELL_STYLES[tier].backgroundColor).toBeDefined()
-  })
-})
-
-test.each(allTiers.filter((t) => t !== 'Not Assessed'))(
-  'TIER_CELL_STYLES[%s] has a valid hex background',
+test.each(allTiers)(
+  'TIERS[%s].chip has valid hex color and backgroundColor',
   (tier) => {
-    expect(TIER_CELL_STYLES[tier].backgroundColor).toMatch(hex)
+    expect(TIERS[tier].chip.color).toMatch(hex)
+    expect(TIERS[tier].chip.backgroundColor).toMatch(hex)
   }
 )
 
-test('TIER_CELL_STYLES["Not Assessed"] is transparent so the table row reads as "unknown"', () => {
-  expect(TIER_CELL_STYLES['Not Assessed'].backgroundColor).toBe('transparent')
+test.each(allTiers.filter((t) => t !== 'Not Assessed'))(
+  'TIERS[%s].cell has a valid hex backgroundColor',
+  (tier) => {
+    expect(TIERS[tier].cell.backgroundColor).toMatch(hex)
+  }
+)
+
+test('TIERS["Not Assessed"].cell is transparent so the table row reads as "unknown"', () => {
+  expect(TIERS['Not Assessed'].cell.backgroundColor).toBe('transparent')
 })
 
-test('cellStyleForTier returns the matching cell entry for known tiers', () => {
+test('tierStyle returns the matching TIERS entry for known tiers', () => {
   allTiers.forEach((tier) => {
-    expect(cellStyleForTier(tier)).toBe(TIER_CELL_STYLES[tier])
+    expect(tierStyle(tier)).toBe(TIERS[tier])
   })
 })
 
-test('cellStyleForTier returns undefined for an absent tier', () => {
-  expect(cellStyleForTier(undefined)).toBeUndefined()
+test('tierStyle returns undefined for an absent tier', () => {
+  expect(tierStyle(undefined)).toBeUndefined()
 })
 
-test('chip and cell palettes are deliberately distinct so the table can keep 508-passing high-contrast cell colors while the modal keeps chip pastels', () => {
+test('chip and cell palettes are deliberately distinct so the table keeps 508-passing high-contrast cell colors while the modal keeps chip pastels', () => {
   allTiers
     .filter((t) => t !== 'Not Assessed')
     .forEach((tier) => {
-      expect(TIER_CELL_STYLES[tier].backgroundColor).not.toBe(
-        TIER_CHIP_STYLES[tier].backgroundColor
+      expect(TIERS[tier].cell.backgroundColor).not.toBe(
+        TIERS[tier].chip.backgroundColor
       )
     })
 })

--- a/src/utils/tierStyles.ts
+++ b/src/utils/tierStyles.ts
@@ -1,49 +1,39 @@
 import type { ScoreTier } from '@/types'
 
-// Two style maps for two different surfaces, both keyed on the
-// authoritative tier string from /scores/aggregate.
-//
-// TIER_STYLES is the legacy alias for TIER_CHIP_STYLES; existing
-// PillarScoresModal call sites read it for the chip render. Kept as an
-// alias rather than removed so an out-of-tree consumer that imported
-// TIER_STYLES does not break.
-
-// Chip palette: soft pastel backgrounds with darker matching text. Used
-// inside the Pillar Scores modal where the tier label is rendered as
-// text on a small chip; the dark text on light pastel gives AAA
-// contrast at chip text size.
-export const TIER_CHIP_STYLES: Record<
+// Two style sub-keys per tier: chip (soft pastels + dark text for modal
+// chips; AAA contrast at chip text size) and cell (high-contrast pastels
+// that pass 508/WCAG color-distinguishability on table score cells;
+// black-on-pastel is >10:1 for every entry).
+// Not Assessed cell is transparent so a score-0 table row reads as
+// "no signal" rather than a false tier color.
+export const TIERS: Record<
   ScoreTier,
-  { color: string; backgroundColor: string }
+  {
+    chip: { color: string; backgroundColor: string }
+    cell: { backgroundColor: string }
+  }
 > = {
-  Optimal: { color: '#0F5C4C', backgroundColor: '#E8F8F6' },
-  Advanced: { color: '#6B6200', backgroundColor: '#FEFEF0' },
-  Initial: { color: '#A34200', backgroundColor: '#FFF4E6' },
-  Traditional: { color: '#663399', backgroundColor: '#F3F0FF' },
-  'Not Assessed': { color: '#525252', backgroundColor: '#F8F8F8' },
+  Optimal: {
+    chip: { color: '#0F5C4C', backgroundColor: '#E8F8F6' },
+    cell: { backgroundColor: '#93F0ED' },
+  },
+  Advanced: {
+    chip: { color: '#6B6200', backgroundColor: '#FEFEF0' },
+    cell: { backgroundColor: '#F2FBC4' },
+  },
+  Initial: {
+    chip: { color: '#A34200', backgroundColor: '#FFF4E6' },
+    cell: { backgroundColor: '#FFD5A5' },
+  },
+  Traditional: {
+    chip: { color: '#663399', backgroundColor: '#F3F0FF' },
+    cell: { backgroundColor: '#DAA9EC' },
+  },
+  'Not Assessed': {
+    chip: { color: '#525252', backgroundColor: '#F8F8F8' },
+    cell: { backgroundColor: 'transparent' },
+  },
 }
 
-// Cell palette: high-contrast pastel backgrounds picked specifically so
-// the table score column passes 508 / WCAG color-distinguishability
-// review. These are the original FismaTable cell colors; do not soften
-// them without a fresh accessibility pass. The score number renders
-// black (default) on top of the bright background; black-on-pastel is
-// >10:1 contrast (AAA) for every entry below.
-export const TIER_CELL_STYLES: Record<ScoreTier, { backgroundColor: string }> =
-  {
-    Optimal: { backgroundColor: '#93F0ED' }, // bright teal
-    Advanced: { backgroundColor: '#F2FBC4' }, // bright lime
-    Initial: { backgroundColor: '#FFD5A5' }, // bright orange
-    Traditional: { backgroundColor: '#DAA9EC' }, // bright purple
-    'Not Assessed': { backgroundColor: 'transparent' },
-  }
-
-// Legacy alias for prior consumers of the single map. New code should
-// import TIER_CHIP_STYLES or TIER_CELL_STYLES directly.
-export const TIER_STYLES = TIER_CHIP_STYLES
-
-export const styleForTier = (tier: ScoreTier | undefined) =>
-  tier ? TIER_CHIP_STYLES[tier] : undefined
-
-export const cellStyleForTier = (tier: ScoreTier | undefined) =>
-  tier ? TIER_CELL_STYLES[tier] : undefined
+export const tierStyle = (tier: ScoreTier | undefined) =>
+  tier ? TIERS[tier] : undefined

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -44,7 +44,7 @@ import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresMo
 import { FismaTableProps } from '@/types'
 import type { ScoreAggregate, SystemScoreEntry } from '@/types'
 import { hasSystemAccess } from '@/utils/userRoles'
-import { cellStyleForTier } from '@/utils/tierStyles'
+import { TIERS } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
 import { fetchOpDivs } from '@/utils/opdivs'
@@ -602,8 +602,9 @@ export default function FismaTable({ scores, progress }: FismaTableProps) {
         // it from the numeric score. Cells without a tier render with no
         // background fill so a transient deploy mismatch reads as
         // "unknown" rather than a misleading color.
-        const backgroundColor =
-          cellStyleForTier(entry?.tier)?.backgroundColor ?? 'transparent'
+        const backgroundColor = entry?.tier
+          ? TIERS[entry.tier]?.cell.backgroundColor ?? 'transparent'
+          : 'transparent'
         return (
           <Box
             sx={{

--- a/src/views/ScoreTable/ScoreTable.tsx
+++ b/src/views/ScoreTable/ScoreTable.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Table, TableBody, TableCell, TableRow, TableHead } from '@mui/material'
 import type { ScoreTier } from '@/types'
-import { TIER_CELL_STYLES, TIER_CHIP_STYLES } from '@/utils/tierStyles'
+import { TIERS } from '@/utils/tierStyles'
 
 // Static legend of the HHS scoring tiers. Order mirrors the maturity
 // progression so a reader scans left (lowest) to right (highest). Ranges
@@ -31,10 +31,10 @@ const ScoreTable: React.FC = (): JSX.Element => {
             // legend swatch on a white page looks like a missing cell, so
             // fall back to the soft chip gray for the Not Assessed legend
             // entry only.
-            const cellBg = TIER_CELL_STYLES[tier].backgroundColor
+            const cellBg = TIERS[tier]?.cell.backgroundColor
             const legendBg =
-              cellBg === 'transparent'
-                ? TIER_CHIP_STYLES[tier].backgroundColor
+              !cellBg || cellBg === 'transparent'
+                ? TIERS[tier]?.chip.backgroundColor
                 : cellBg
             return (
               <TableCell

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -124,7 +124,7 @@ export default function StatisticsBlocks({
         <Typography
           variant="h2"
           sx={{
-            color: TIERS[maxSystemTier ?? 'Not Assessed'].chip.color,
+            color: maxSystemTier ? TIERS[maxSystemTier].chip.color : 'inherit',
             fontSize: '50px',
           }}
         >
@@ -144,7 +144,7 @@ export default function StatisticsBlocks({
         <Typography
           variant="h2"
           sx={{
-            color: TIERS[minSystemTier ?? 'Not Assessed'].chip.color,
+            color: minSystemTier ? TIERS[minSystemTier].chip.color : 'inherit',
             fontSize: '50px',
           }}
         >

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -4,7 +4,8 @@ import Paper from '@mui/material/Paper'
 import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { useContextProp } from '../Title/Context'
-import type { SystemScoreEntry } from '@/types'
+import type { ScoreTier, SystemScoreEntry } from '@/types'
+import { TIERS } from '@/utils/tierStyles'
 const StatisticsPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(2),
   ...theme.typography.body2,
@@ -28,7 +29,13 @@ export default function StatisticsBlocks({
   const [avgSystemScore, setAvgSystemScore] = useState<number>(0)
   const [maxSystemAcronym, setMaxSystemAcronym] = useState<string>('')
   const [maxSystemScore, setMaxSystemScore] = useState<number>(0)
+  const [maxSystemTier, setMaxSystemTier] = useState<ScoreTier | undefined>(
+    undefined
+  )
   const [minSystemScore, setMinSystemScore] = useState<number>(0)
+  const [minSystemTier, setMinSystemTier] = useState<ScoreTier | undefined>(
+    undefined
+  )
   const [minSystemAcronym, setMinSystemAcronym] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
 
@@ -36,8 +43,10 @@ export default function StatisticsBlocks({
     const totalCount = fismaSystems.length
     let maxScore: number = 0
     let maxScoreSystem: string = ''
+    let maxScoreTier: ScoreTier | undefined
     let minScore: number = Number.POSITIVE_INFINITY
     let minScoreSystem: string = ''
+    let minScoreTier: ScoreTier | undefined
     let totalScores: number = 0
     for (const system of fismaSystems) {
       const entry = scores[system.fismasystemid]
@@ -45,10 +54,12 @@ export default function StatisticsBlocks({
         if (entry.score > maxScore) {
           maxScore = entry.score
           maxScoreSystem = system.fismaacronym
+          maxScoreTier = entry.tier
         }
         if (entry.score < minScore) {
           minScore = entry.score
           minScoreSystem = system.fismaacronym
+          minScoreTier = entry.tier
         }
         totalScores += entry.score
       }
@@ -62,8 +73,10 @@ export default function StatisticsBlocks({
     }
     setTotalSystems(totalCount)
     setMaxSystemScore(maxScore)
+    setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
 
+    setMinSystemTier(minScoreTier)
     setMinSystemAcronym(minScoreSystem || '')
     setLoading(false)
   }, [fismaSystems, scores])
@@ -111,7 +124,7 @@ export default function StatisticsBlocks({
         <Typography
           variant="h2"
           sx={{
-            color: '#128172',
+            color: TIERS[maxSystemTier ?? 'Not Assessed'].chip.color,
             fontSize: '50px',
           }}
         >
@@ -131,7 +144,7 @@ export default function StatisticsBlocks({
         <Typography
           variant="h2"
           sx={{
-            color: '#960B91',
+            color: TIERS[minSystemTier ?? 'Not Assessed'].chip.color,
             fontSize: '50px',
           }}
         >


### PR DESCRIPTION
## Summary

Closes #362

Consolidates the three separate tier color exports in `src/utils/tierStyles.ts` (`TIER_CHIP_STYLES`, `TIER_CELL_STYLES`, `TIER_STYLES`) and two helper functions (`styleForTier`, `cellStyleForTier`) into a single `TIERS` constant with nested `chip` and `cell` sub-keys per tier. Updates all color consumers to use the new shape. No color values were changed.

## Changes

### `src/utils/tierStyles.ts`
- Replaced `TIER_CHIP_STYLES`, `TIER_CELL_STYLES`, `TIER_STYLES`, `styleForTier`, and `cellStyleForTier` with a single `TIERS: Record<ScoreTier, { chip: { color, backgroundColor }, cell: { backgroundColor } }>` constant
- Added `tierStyle(tier)` helper that returns the full `TIERS[tier]` entry or `undefined`

### `src/components/PillarScoresModal/PillarScoresModal.tsx`
- Updated import: `{ styleForTier, TIER_STYLES }` → `{ tierStyle, TIERS }`
- Updated all chip color/background accesses to use `.chip.color` and `.chip.backgroundColor`

### `src/views/FismaTable/FismaTable.tsx`
- Updated import: `{ cellStyleForTier }` → `{ TIERS }`
- Updated score cell background to use `TIERS[entry.tier]?.cell.backgroundColor`

### `src/views/ScoreTable/ScoreTable.tsx`
- Updated import: `{ TIER_CELL_STYLES, TIER_CHIP_STYLES }` → `{ TIERS }`
- Updated legend swatch logic to use `TIERS[tier]?.cell.backgroundColor` and `TIERS[tier]?.chip.backgroundColor`

### `src/views/StatisticBlocks/StatisticsBlocks.tsx`
- Added `maxSystemTier` and `minSystemTier` state, populated from the highest/lowest scoring `SystemScoreEntry` in the existing useEffect loop
- Replaced hardcoded `#128172` / `#960B91` on the Highest/Lowest KPI numerals with `TIERS[tier ?? 'Not Assessed'].chip.color`
- All other score semantics (avg, min, max values, loading state) are unchanged

### `src/utils/tierStyles.test.ts`
- Rewrote tests to assert the new nested `TIERS` shape
- Covers: chip palette (all 5 tiers), cell palette (all 4 non-transparent tiers), `Not Assessed` cell is `'transparent'`, `tierStyle` returns correct entry and `undefined` for absent tier, chip and cell palettes are distinct (508 compliance contract)

## Test plan

- [ ] `yarn typecheck` — no new errors
- [ ] `yarn lint` — clean
- [ ] `yarn test` — 327 passed, 0 failed
- [ ] FismaTable score column: bright tier cell colors unchanged
- [ ] PillarScoresModal: tier chip colors and backgrounds unchanged
- [ ] StatisticsBlocks: Highest/Lowest KPI numerals now color-match the tier of the ranked system; Total Systems and Average System Score remain neutral blue
- [ ] StatisticsBlocks: when no systems are scored, KPI numerals display in `#525252` (Not Assessed gray) rather than a misleading tier color
