### PR TITLE
Enhancement/add logout button

### DIFF
--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -5,7 +5,6 @@ export enum RouteIds {
   QUESTIONNAIRE = 'questionnaire',
   AUTH = 'auth',
   LOGIN = 'login',
-  LOGOUT = 'logout',
   HOME = 'home',
   DATA = 'data',
   USERS = 'users',
@@ -18,7 +17,6 @@ export enum RouteNames {
   DASHBOARD = 'Dashboard',
   QUESTIONNAIRE = 'questionnaire',
   LOGIN = 'Login',
-  LOGOUT = 'Logout',
   SIGNIN = 'Sign In',
 }
 
@@ -30,7 +28,6 @@ export enum Routes {
   QUESTIONNAIRE = `/${RouteIds.QUESTIONNAIRE}/:fismaacronym/:datacallid?/:pillar?/:function?`,
   AUTH = `/${RouteIds.AUTH}/*`,
   AUTH_LOGIN = `/${RouteIds.AUTH}/${RouteIds.LOGIN}`,
-  AUTH_LOGOUT = `/${RouteIds.AUTH}/${RouteIds.LOGOUT}`,
   SIGNIN = `/${RouteIds.SIGNIN}`,
   SYSTEM_DETAIL = '/systems/:fismasystemid',
   ADMIN_OPDIVS = '/admin/opdivs',

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -35,6 +35,14 @@ jest.mock('@/views/QuestionnairePage/draftStore', () => ({
   clearOtherUserDrafts: jest.fn(),
 }))
 
+// notify is fired to bridge the gap between click and page reload; mock so
+// the tests can assert the toast without pulling in notistack.
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  isAuthHandled: jest.fn(),
+}))
+
 // Heavy children the logout affordance does not depend on. Stubbing them keeps
 // the test focused on the header menu and avoids their own asset/network deps.
 jest.mock('@/components/EmailModal/EmailModal', () => ({
@@ -77,6 +85,7 @@ import { useLoaderData, useLocation } from 'react-router-dom'
 import axiosInstance from '@/axiosConfig'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
+import { notify } from '@/utils/notify'
 import Title from './Title'
 
 const mockedUseLoaderData = useLoaderData as jest.Mock
@@ -85,6 +94,7 @@ const mockedGet = axiosInstance.get as jest.Mock
 const mockedPost = axiosInstance.post as jest.Mock
 const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
 const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
+const mockedNotify = notify as jest.Mock
 
 function makeUser(role: UserRole): userData {
   return {
@@ -170,11 +180,26 @@ describe('Title logout affordance', () => {
       await screen.findByRole('menuitem', { name: /log out/i })
     )
 
-    await waitFor(() => expect(mockedPost).toHaveBeenCalledWith('/auth/logout'))
+    await waitFor(() =>
+      expect(mockedPost).toHaveBeenCalledWith(
+        '/auth/logout',
+        null,
+        expect.objectContaining({
+          // skipAuthHandling avoids the 401-interceptor cascade when the
+          // session has already expired.
+          skipAuthHandling: true,
+          // timeout caps a hung logout so a slow BE cannot strand the user.
+          timeout: 5000,
+        })
+      )
+    )
     await waitFor(() =>
       expect(window.location.reload as jest.Mock).toHaveBeenCalled()
     )
     expect(window.location.hash).toBe(Routes.SIGNIN)
+    // Toast fires immediately (before the await), covering the click-to-
+    // reload gap with visible feedback.
+    expect(mockedNotify).toHaveBeenCalledWith('Signing out...', 'info')
   })
 
   it('still redirects to sign-in when the logout request fails', async () => {

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { userData, UserRole } from '@/types'
+import { Routes } from '@/router/constants'
+
+// Title reads its session off the data-router loader via useLoaderData, which
+// a plain MemoryRouter (renderWithProviders) does not provide - see the
+// renderWithProviders caveat about the production hash router. So, like
+// LoginPage.test, react-router-dom is mocked module-wide and the loader /
+// location are driven per-test. Link and Outlet are stubbed to bare wrappers
+// because the account menu and page body only need to render, not navigate.
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useLoaderData: jest.fn(),
+  useLocation: jest.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Outlet: () => <div>OUTLET</div>,
+}))
+
+// The header does a burst of reference-data fetches on mount (systems,
+// datacalls) and posts to the logout endpoint on sign-out. Mock the axios
+// instance so nothing hits the network and the logout POST is observable.
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}))
+
+jest.mock('@/utils/dataCenterEnvironments', () => ({
+  __esModule: true,
+  fetchDataCenterEnvironments: jest.fn(),
+}))
+
+jest.mock('@/views/QuestionnairePage/draftStore', () => ({
+  __esModule: true,
+  clearOtherUserDrafts: jest.fn(),
+}))
+
+// Heavy children the logout affordance does not depend on. Stubbing them keeps
+// the test focused on the header menu and avoids their own asset/network deps.
+jest.mock('@/components/EmailModal/EmailModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/EditSystemModal/EditSystemModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/DatacallModal/DataCallModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/Footer/Footer', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/DevEnvironmentBanner/DevEnvironmentBanner', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/LoginPage/LoginPage', () => ({
+  __esModule: true,
+  default: () => <div>LOGINPAGE</div>,
+}))
+jest.mock('@/views/ServerErrorPage/ServerErrorPage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+// fileTransform.cjs returns the pre-Jest-28 raw-string contract, so a real PNG
+// import errors during transform; stub the header logo the same way
+// LoginPage.test stubs its own.
+jest.mock('@/assets/ztmf-logo-color.png', () => 'ztmf-logo-color.png', {
+  virtual: true,
+})
+
+import { useLoaderData, useLocation } from 'react-router-dom'
+import axiosInstance from '@/axiosConfig'
+import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
+import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
+import Title from './Title'
+
+const mockedUseLoaderData = useLoaderData as jest.Mock
+const mockedUseLocation = useLocation as jest.Mock
+const mockedGet = axiosInstance.get as jest.Mock
+const mockedPost = axiosInstance.post as jest.Mock
+const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
+const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
+
+function makeUser(role: UserRole): userData {
+  return {
+    userid: '11111111-1111-1111-1111-111111111111',
+    email: 'user@example.com',
+    fullname: 'Test User',
+    role,
+    assignedfismasystems: [],
+  }
+}
+
+function renderTitleFor(role: UserRole) {
+  mockedUseLoaderData.mockReturnValue({ status: 200, response: makeUser(role) })
+  mockedUseLocation.mockReturnValue({ pathname: '/' })
+  render(<Title />)
+}
+
+const originalLocation = window.location
+
+beforeEach(() => {
+  // resetMocks: true wipes every mock's implementation before each test, so
+  // (re)install the return values the mount effects and logout flow depend on
+  // here rather than in the module factories.
+  mockedUseLoaderData.mockReset()
+  mockedUseLocation.mockReset()
+  // Mount effects fetch reference data; resolve everything to empty payloads.
+  mockedGet.mockResolvedValue({ data: { data: [] } })
+  mockedPost.mockResolvedValue({ status: 204 })
+  mockedFetchEnvs.mockResolvedValue([])
+  mockedClearDrafts.mockResolvedValue(undefined)
+  // jsdom forbids assigning window.location.hash / calling reload on the real
+  // object; swap in a writable stub so the logout redirect is observable.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { hash: '', reload: jest.fn() },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+})
+
+describe('Title logout affordance', () => {
+  it('renders the account menu with Log out for an admin user', async () => {
+    renderTitleFor('OWNER')
+
+    await userEvent.click(screen.getByRole('button', { name: /account menu/i }))
+
+    expect(
+      await screen.findByRole('menuitem', { name: /log out/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the account menu with Log out for a non-admin user', async () => {
+    // Logout must reach users who previously got no menu at all because it
+    // was gated on hasAdminRead - non-admins had no signout affordance.
+    renderTitleFor('ISSO')
+
+    await userEvent.click(screen.getByRole('button', { name: /account menu/i }))
+
+    expect(
+      await screen.findByRole('menuitem', { name: /log out/i })
+    ).toBeInTheDocument()
+    // Admin-only items stay gated - a non-admin sees Dashboard + Log out only.
+    expect(
+      screen.queryByRole('menuitem', { name: /^users$/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('menuitem', { name: /add fisma system/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls the logout endpoint and lands the user on the sign-in page', async () => {
+    renderTitleFor('ISSO')
+
+    await userEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: /log out/i })
+    )
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalledWith('/auth/logout'))
+    await waitFor(() =>
+      expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+    )
+    expect(window.location.hash).toBe(Routes.SIGNIN)
+  })
+
+  it('still redirects to sign-in when the logout request fails', async () => {
+    // Logout is best-effort: a failed call must not strand the user in a
+    // signed-in-looking shell. It logs and drops them to sign-in anyway.
+    mockedPost.mockRejectedValueOnce(new Error('network'))
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    renderTitleFor('ISSO')
+
+    await userEvent.click(screen.getByRole('button', { name: /account menu/i }))
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: /log out/i })
+    )
+
+    await waitFor(() =>
+      expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+    )
+    expect(window.location.hash).toBe(Routes.SIGNIN)
+    errSpy.mockRestore()
+  })
+})

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -172,6 +172,24 @@ export default function Title() {
   const handleClose = () => {
     setAnchorEl(null)
   }
+  // Ends the session: calls the backend logout endpoint that clears the
+  // ztmf_session and ALB OIDC cookies, then forces a full reload
+  // onto the sign-in route. The reload is deliberate - it re-runs the root
+  // authLoader against the now-cleared cookie so Title re-renders LoginPage.
+  // A client-side hash change alone would not re-run the loader, and a full
+  // reload also guarantees no in-memory session state lingers. Logout is
+  // best-effort: even if the request fails we still drop the user to sign-in;
+  // a still-valid session simply lands them back on the dashboard.
+  const handleLogout = async () => {
+    setAnchorEl(null)
+    try {
+      await axiosInstance.post('/auth/logout')
+    } catch (error) {
+      console.error('Error logging out:', error)
+    }
+    window.location.hash = Routes.SIGNIN
+    window.location.reload()
+  }
   // Display name for the IdP that minted the user's session. Surfaced
   // as a small badge next to the name so support can debug "I logged
   // in but the dashboard looks wrong" without DevTools.
@@ -323,84 +341,85 @@ export default function Title() {
                   )}
                 </span>
               )}
-              {hasAdminRead && (
-                <>
-                  <IconButton
-                    aria-label="more"
-                    aria-controls="long-menu"
-                    aria-haspopup="true"
-                    onClick={handleClick}
+              {/* Account menu is rendered for every logged-in user so the
+                  logout affordance is always available. The admin-only items
+                  inside remain individually gated; a non-admin sees just
+                  Dashboard and Log out. */}
+              <>
+                <IconButton
+                  aria-label="Account menu"
+                  aria-controls="long-menu"
+                  aria-haspopup="true"
+                  onClick={handleClick}
+                >
+                  <MoreVertIcon />
+                </IconButton>
+                <Menu
+                  id="long-menu"
+                  anchorEl={anchorEl}
+                  keepMounted
+                  open={Boolean(anchorEl)}
+                  onClose={handleClose}
+                >
+                  <Link
+                    to={Routes.ROOT}
+                    style={{ textDecoration: 'none', color: 'black' }}
                   >
-                    <MoreVertIcon />
-                  </IconButton>
-                  <Menu
-                    id="long-menu"
-                    anchorEl={anchorEl}
-                    keepMounted
-                    open={Boolean(anchorEl)}
-                    onClose={handleClose}
-                  >
+                    <MenuItem onClick={() => handleOption()}>
+                      Dashboard
+                    </MenuItem>
+                  </Link>
+                  {hasAdminRead && (
                     <Link
-                      to={Routes.ROOT}
+                      to={Routes.USERS}
+                      style={{ textDecoration: 'none', color: 'black' }}
+                    >
+                      <MenuItem onClick={() => handleOption()}>Users</MenuItem>
+                    </Link>
+                  )}
+                  {userInfo.role === 'OWNER' && (
+                    <Link
+                      to={Routes.ADMIN_OPDIVS}
                       style={{ textDecoration: 'none', color: 'black' }}
                     >
                       <MenuItem onClick={() => handleOption()}>
-                        Dashboard
+                        Manage OpDivs
                       </MenuItem>
                     </Link>
-                    {hasAdminRead && (
-                      <Link
-                        to={Routes.USERS}
-                        style={{ textDecoration: 'none', color: 'black' }}
-                      >
-                        <MenuItem onClick={() => handleOption()}>
-                          Users
-                        </MenuItem>
-                      </Link>
-                    )}
-                    {userInfo.role === 'OWNER' && (
-                      <Link
-                        to={Routes.ADMIN_OPDIVS}
-                        style={{ textDecoration: 'none', color: 'black' }}
-                      >
-                        <MenuItem onClick={() => handleOption()}>
-                          Manage OpDivs
-                        </MenuItem>
-                      </Link>
-                    )}
-                    {isAdmin && (
-                      <MenuItem
-                        onClick={() => {
-                          setAnchorEl(null)
-                          setOpenModal(true)
-                        }}
-                      >
-                        Add Fisma System
-                      </MenuItem>
-                    )}
-                    {isUnscopedWriteAdmin(userInfo) && (
-                      <MenuItem
-                        onClick={() => {
-                          setAnchorEl(null)
-                          setOpenEmailModal(true)
-                        }}
-                      >
-                        {'Email Users'}
-                      </MenuItem>
-                    )}
-                    {isAdmin && (
-                      <MenuItem
-                        onClick={() => {
-                          handleClose()
-                          setOpenDataCallModal(true)
-                        }}
-                      >
-                        Create Datacall
-                      </MenuItem>
-                    )}
-                  </Menu>
-                </>
-              )}
+                  )}
+                  {isAdmin && (
+                    <MenuItem
+                      onClick={() => {
+                        setAnchorEl(null)
+                        setOpenModal(true)
+                      }}
+                    >
+                      Add Fisma System
+                    </MenuItem>
+                  )}
+                  {isUnscopedWriteAdmin(userInfo) && (
+                    <MenuItem
+                      onClick={() => {
+                        setAnchorEl(null)
+                        setOpenEmailModal(true)
+                      }}
+                    >
+                      {'Email Users'}
+                    </MenuItem>
+                  )}
+                  {isAdmin && (
+                    <MenuItem
+                      onClick={() => {
+                        handleClose()
+                        setOpenDataCallModal(true)
+                      }}
+                    >
+                      Create Datacall
+                    </MenuItem>
+                  )}
+                  <MenuItem onClick={handleLogout}>Log out</MenuItem>
+                </Menu>
+              </>
             </Box>
           )}
         </Box>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -27,6 +27,7 @@ import { Routes } from '@/router/constants'
 import type { AuthLoaderData } from '@/router/authLoader'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
+import { notify } from '@/utils/notify'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import LoginPage from '../LoginPage/LoginPage'
@@ -173,17 +174,29 @@ export default function Title() {
     setAnchorEl(null)
   }
   // Ends the session: calls the backend logout endpoint that clears the
-  // ztmf_session and ALB OIDC cookies, then forces a full reload
-  // onto the sign-in route. The reload is deliberate - it re-runs the root
-  // authLoader against the now-cleared cookie so Title re-renders LoginPage.
-  // A client-side hash change alone would not re-run the loader, and a full
-  // reload also guarantees no in-memory session state lingers. Logout is
-  // best-effort: even if the request fails we still drop the user to sign-in;
-  // a still-valid session simply lands them back on the dashboard.
+  // ztmf_session and ALB OIDC cookies, then forces a full reload onto the
+  // sign-in route. The reload is deliberate - it re-runs the root authLoader
+  // against the now-cleared cookie so Title re-renders LoginPage. A client-
+  // side hash change alone would not re-run the loader, and a full reload
+  // also guarantees no in-memory session state lingers. Logout is best-
+  // effort: even if the request fails we still drop the user to sign-in.
+  //
+  // skipAuthHandling short-circuits the centralized 401 interceptor - if the
+  // session has already expired, the interceptor's own /signin redirect is
+  // redundant with the reload we do below and only causes a flash of the
+  // "Session expired" message before the reload lands.
+  //
+  // The timeout caps a hung logout so a dead or slow backend cannot leave
+  // the user stuck with no visible feedback. The notify toast covers the
+  // gap between click and reload on any connection speed.
   const handleLogout = async () => {
     setAnchorEl(null)
+    notify('Signing out...', 'info')
     try {
-      await axiosInstance.post('/auth/logout')
+      await axiosInstance.post('/auth/logout', null, {
+        skipAuthHandling: true,
+        timeout: 5000,
+      })
     } catch (error) {
       console.error('Error logging out:', error)
     }
@@ -348,14 +361,14 @@ export default function Title() {
               <>
                 <IconButton
                   aria-label="Account menu"
-                  aria-controls="long-menu"
+                  aria-controls="account-menu"
                   aria-haspopup="true"
                   onClick={handleClick}
                 >
                   <MoreVertIcon />
                 </IconButton>
                 <Menu
-                  id="long-menu"
+                  id="account-menu"
                   anchorEl={anchorEl}
                   keepMounted
                   open={Boolean(anchorEl)}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,7 +9,6 @@ interface ImportMetaEnv {
   readonly VITE_IDP_ENABLED: string
   readonly VITE_COGNITO_DOMAIN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_IN: string
-  readonly VITE_COGNITO_REDIRECT_SIGN_OUT: string
   // more env variables...
 }
 


### PR DESCRIPTION
In-repo version of #495 by @tarratsco, moved so the org-secret CI gates (Snyk,
Infrastructure/Deploy) can run — they can't on a fork PR. Commits pushed unchanged;
authorship preserved.

Closes #477.

## Summary
Adds a logout affordance to the header for every signed-in user (previously the account menu
was gated behind `hasAdminRead`, so non-admins had no way to end their session). Clicking
**Log out** posts to the backend logout endpoint, then forces a full page reload onto
`/signin` so the root `authLoader` re-runs against the now-cleared cookie and `Title` renders
`LoginPage`.

## Backend dependency
Pairs with the backend logout endpoint from CMS-Enterprise/ztmf#408.

## Changes
**`src/views/Title/Title.tsx`**
- Removed the `hasAdminRead` gate around the account menu `<IconButton>` + `<Menu>`. Menu now
  renders for every user whose session is active (`loaderData.status === 200`). Admin-only
  items (Users, Manage OpDivs, Add Fisma System, Email Users, Create Datacall) stay
  individually gated.
- New `handleLogout` async handler: fires a `notify('Signing out...', 'info')` toast
  immediately; `POST /auth/logout` with `{ skipAuthHandling: true, timeout: 5000 }`
  (`skipAuthHandling` short-circuits the centralized 401 interceptor if the session already
  expired; `timeout` caps a hung backend). Best-effort — any error is logged and the reload
  runs anyway. Sets `window.location.hash = Routes.SIGNIN` and calls
  `window.location.reload()` (deliberate: a hash change alone wouldn't re-run the root loader).
- `IconButton` `aria-label` renamed `"more"` → `"Account menu"`; `aria-controls` + `<Menu id>`
  renamed from `"long-menu"` for consistency.

**`src/router/constants.ts`** — removed dead constants `Routes.LOGOUT`, `Routes.AUTH_LOGOUT`
(never used; superseded by the direct axios call).

**`src/vite-env.d.ts`** — removed unused `VITE_COGNITO_REDIRECT_SIGN_OUT` (vestige of a
pre-ALB auth model).

**`src/views/Title/Title.test.tsx`** (new) — 4 tests: admin sees Log out; non-admin sees Log
out and admin-only items are gated out (regression guard); click flow posts with the expected
axios config and redirects on success; failed logout still redirects (best-effort).

## Test plan
Automated: `yarn jest Title.test --no-coverage` — 4/4 passing; `make check` + `make test`
clean. Manual against deployed dev (once the backend logout endpoint is available): admin and
non-admin both see Log out; non-admins do not see admin-only items; click shows the
"Signing out..." toast, reloads, lands on `/signin`; `POST /api/v1/auth/logout` completes
`withCredentials`; session + ALB OIDC cookies cleared afterward.

## Notes for reviewers
Full-page reload after logout is deliberate (a hash change alone wouldn't re-run the root
loader against the cleared cookie, and a reload guarantees no in-memory session state
lingers). IdP-side SSO logout is out of scope per the parent backend ticket — test the
"sign in again → new IdP prompt" check from a fresh/incognito session rather than assuming
logout alone forces re-auth.

Refs #495