### PR TITLE
Preserve the picked data call across in-survey navigation

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -175,6 +175,17 @@ export default function QuestionnarePage() {
   optionsRef.current = options
   const loadingQuestionRef = React.useRef(loadingQuestion)
   loadingQuestionRef.current = loadingQuestion
+  // Persisted data-call context so in-questionnaire navigation (Next/Back/
+  // sidebar) can re-supply it via router state. Without this, the first
+  // click-through drops location.state.datacall* and the load effect reverts to
+  // the global data-call selector — opening a system for a specific picked call
+  // (e.g. FY2025 Q3) would silently fall back to the latest call (FY25) on the
+  // next click.
+  const datacallStateRef = React.useRef<{
+    datacallid: number
+    datacall: string
+    deadline?: string
+  }>({ datacallid: 0, datacall: '' })
   // Bumped when a re-seed changes the answer so the uncontrolled radio ChoiceList
   // (which only reflects defaultChecked on mount) remounts and shows the
   // corrected selection.
@@ -356,6 +367,11 @@ export default function QuestionnarePage() {
             setIsPastDeadline(
               routeDeadline ? new Date() > new Date(routeDeadline) : true
             )
+            datacallStateRef.current = {
+              datacallid: routeDatacallId,
+              datacall,
+              deadline: routeDeadline,
+            }
           } else {
             const isHistorical =
               selectedDatacall !== null &&
@@ -365,6 +381,11 @@ export default function QuestionnarePage() {
               setDatacall(datacall)
               setIsPastDeadline(true)
               activeDataCallId = selectedDatacall.datacallid
+              datacallStateRef.current = {
+                datacallid: selectedDatacall.datacallid,
+                datacall,
+                deadline: selectedDatacall.deadline,
+              }
             } else {
               datacall = latestDatacall.replaceAll(' ', '_')
               setDatacall(datacall)
@@ -372,6 +393,11 @@ export default function QuestionnarePage() {
                 latestDeadline ? new Date() > new Date(latestDeadline) : true
               )
               activeDataCallId = latestDataCallId
+              datacallStateRef.current = {
+                datacallid: latestDataCallId,
+                datacall,
+                deadline: latestDeadline ?? undefined,
+              }
             }
           }
           // Hoisted so both the questions block and the final batch can access them.
@@ -445,7 +471,12 @@ export default function QuestionnarePage() {
               navigate(
                 `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
                 {
-                  state: { fismasystemid: system },
+                  state: {
+                    fismasystemid: system,
+                    datacallid: datacallStateRef.current.datacallid,
+                    datacall: datacallStateRef.current.datacall,
+                    deadline: datacallStateRef.current.deadline,
+                  },
                   replace: true,
                 }
               )
@@ -879,7 +910,15 @@ export default function QuestionnarePage() {
                                 navigate(
                                   `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(pillar.name)}/${toSlug(func.function.function)}`,
                                   {
-                                    state: { fismasystemid: system },
+                                    state: {
+                                      fismasystemid: system,
+                                      datacallid:
+                                        datacallStateRef.current.datacallid,
+                                      datacall:
+                                        datacallStateRef.current.datacall,
+                                      deadline:
+                                        datacallStateRef.current.deadline,
+                                    },
                                     replace: true,
                                   }
                                 )
@@ -1009,7 +1048,13 @@ export default function QuestionnarePage() {
                             navigate(
                               `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
                               {
-                                state: { fismasystemid: system },
+                                state: {
+                                  fismasystemid: system,
+                                  datacallid:
+                                    datacallStateRef.current.datacallid,
+                                  datacall: datacallStateRef.current.datacall,
+                                  deadline: datacallStateRef.current.deadline,
+                                },
                                 replace: true,
                               }
                             )
@@ -1040,7 +1085,12 @@ export default function QuestionnarePage() {
                           navigate(
                             `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
                             {
-                              state: { fismasystemid: system },
+                              state: {
+                                fismasystemid: system,
+                                datacallid: datacallStateRef.current.datacallid,
+                                datacall: datacallStateRef.current.datacall,
+                                deadline: datacallStateRef.current.deadline,
+                              },
                               replace: true,
                             }
                           )


### PR DESCRIPTION
## What

Fixes #501. Opening a system's questionnaire for a specific data call from the dashboard picker works on first render, but the survey silently reverts to the latest data call after the first in-survey navigation (Next, Back, or a sidebar function click).

## Why

The picker passes the chosen call to `QuestionnairePage` via router `location.state` (`datacallid`, `datacall`, `deadline`), and the load effect honors it on first render. But the four in-questionnaire `navigate()` calls (Next, Back, the sidebar item, and the initial canonical-URL redirect) re-set state to only `{ fismasystemid }`, dropping the data-call fields. On the next render `location.state.datacallid`/`datacall` are `undefined`, so the load effect falls through to the global data-call selector and reverts the survey to the latest call.

## Fix

Persist the resolved data-call context (`datacallid` / `datacall` / `deadline`) in a ref when the load effect resolves it, and re-supply it in the state of every internal `navigate()` call so the chosen call survives click-through. Isolated to `src/views/QuestionnairePage/QuestionnairePage.tsx`.

## Testing

- `yarn typecheck` passes.
- Manually verified on the impl environment: pick a non-latest call (FY2025 Q3 with FY25 ZTM latest), open the questionnaire, click through functions — the survey stays on FY2025 Q3 (breadcrumb, URL, and answers).