### PR TITLE
Suppress the insights prior-answer badge when viewing the call it names

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -143,6 +143,46 @@ describe('OptionInsightBadges', () => {
     const { container } = render(<OptionInsightBadges score={1} />)
     expect(container).toBeEmptyDOMElement()
   })
+
+  it('suppresses the prior-answer badge when viewing the call it names (slug form)', () => {
+    render(
+      <OptionInsightBadges
+        score={2}
+        insight={insight}
+        viewedDatacall="FY2024_Q1"
+      />
+    )
+    expect(screen.queryByText('FY2024 Q1 answer')).not.toBeInTheDocument()
+  })
+
+  it('still shows the prior-answer badge when viewing a different call', () => {
+    render(
+      <OptionInsightBadges
+        score={2}
+        insight={insight}
+        viewedDatacall="FY25_ZTM"
+      />
+    )
+    expect(screen.getByText('FY2024 Q1 answer')).toBeInTheDocument()
+  })
+
+  it('keeps the recommendation badge even when the prior badge is suppressed', () => {
+    // suggested (1) and prior (1) coincide on the same option; viewing the prior
+    // call should drop only the prior badge, not the recommendation.
+    render(
+      <OptionInsightBadges
+        score={1}
+        insight={{
+          suggested_score: 1,
+          last_score: 1,
+          last_datacall: 'FY2024 Q1',
+        }}
+        viewedDatacall="FY2024_Q1"
+      />
+    )
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.queryByText('FY2024 Q1 answer')).not.toBeInTheDocument()
+  })
 })
 
 describe('InsightsPanel resilience (opaque payload)', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -166,6 +166,19 @@ function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
   )
 }
 
+// Normalize a data-call name for comparison: fold underscores/whitespace and
+// case so "FY2025_Q3" (the viewed call slug) matches "FY2025 Q3" (the payload's
+// label form).
+function sameDatacall(a?: string | null, b?: string | null): boolean {
+  if (!a || !b) return false
+  const norm = (s: string) =>
+    s
+      .replace(/[_\s]+/g, ' ')
+      .trim()
+      .toLowerCase()
+  return norm(a) === norm(b)
+}
+
 // Inline badges for a single answer option, matched by maturity score against
 // the question's insight. Rendered next to the option label in the radio group
 // so a scorer sees, at the point of choosing, which answer the evidence points
@@ -173,14 +186,23 @@ function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
 export function OptionInsightBadges({
   score,
   insight,
+  viewedDatacall,
 }: {
   score?: number
   insight?: InsightPayload
+  // The data call currently being viewed. The prior-answer badge is only
+  // meaningful when the insight's last answer is from an EARLIER call; if the
+  // insight's last_datacall is the call on screen, the badge would label the
+  // current call as "prior", so it is suppressed.
+  viewedDatacall?: string
 }) {
   if (!insight || score == null) return null
   const isSuggested =
     insight.suggested_score != null && score === insight.suggested_score
-  const isPrior = insight.last_score != null && score === insight.last_score
+  const isPrior =
+    insight.last_score != null &&
+    score === insight.last_score &&
+    !sameDatacall(insight.last_datacall, viewedDatacall)
   if (!isSuggested && !isPrior) return null
 
   const priorLabel = insight.last_datacall

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -240,7 +240,11 @@ export default function QuestionnarePage() {
           }}
         >
           <Box component="span">{o.label}</Box>
-          <OptionInsightBadges score={o.score} insight={currentInsight} />
+          <OptionInsightBadges
+            score={o.score}
+            insight={currentInsight}
+            viewedDatacall={datacall}
+          />
         </Box>
       ),
       value: o.value,


### PR DESCRIPTION
## What this does

The insights prior-answer badge ("<call> answer") is driven by the payload's `last_datacall`/`last_score`, which are fixed pipeline values not scoped to the data call being viewed. When the viewed call is the same one the insight names as its last answer (e.g. the newest call with data is also the most recently scored), the badge labeled the current call as "prior", which is confusing.

Now the prior-answer badge only shows when `last_datacall` is a **different** call than the one on screen (normalized comparison). The ZTMF Insights recommendation badge is unaffected.

## Testing
- `tsc`, `lint`, `test` clean (371 tests). New cases cover suppression on same-call, showing on a different call, and keeping the recommendation when the prior badge is suppressed.
- Verified live on local impl: viewing FY2025 Q3 (the call the insight names) suppresses the prior badge; viewing a newly created FY2026 call shows "FY2025 Q3 answer" as a genuinely prior answer.
