### PR TITLE
Fix ARS source chip to show a numeric maturity score

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -441,10 +441,14 @@ export type InsightPayload = {
   cfacts_auth_methods?: string | null
   cfacts_reasoning?: string | null
 
-  ars_maturity?: number | null
+  ars_maturity?: number | string | null
   ars_control_score?: number | null
   ars_controls_total?: number | null
   ars_controls_satisfied?: number | null
+  // Applicable ARS control IDs (e.g. ["IA-01","IA-02(01)"]). NOT yet emitted by
+  // the pipeline as of 2026-07 — the payload currently carries only the counts.
+  // Rendered defensively so it appears once the backend populates it.
+  ars_controls?: string[] | null
 
   findings?: InsightFindings
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -17,7 +17,8 @@ const fullPayload: InsightPayload = {
   has_hardenize_data: false,
   cfacts_suggested_score: 2,
   cfacts_reasoning: 'IDM-Okta detected. MFA required, PR-MFA not available.',
-  ars_maturity: 2,
+  ars_maturity: 'Initial',
+  ars_control_score: 2,
   ars_controls_total: 4,
   ars_controls_satisfied: 4,
   findings: {
@@ -82,6 +83,23 @@ describe('InsightsPanel', () => {
       screen.getByText(/iam-user-without-mfa-device-enabled/)
     ).toBeInTheDocument()
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+  })
+
+  it('lists ARS control IDs in the details when the pipeline provides them', () => {
+    render(
+      <InsightsPanel
+        payload={{ ...fullPayload, ars_controls: ['IA-01', 'IA-02(01)'] }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/IA-01, IA-02\(01\)/)).toBeInTheDocument()
+  })
+
+  it('shows the ARS Controls count with no list when ars_controls is absent', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/4 of 4 satisfied/)).toBeInTheDocument()
+    expect(screen.queryByText(/IA-01/)).not.toBeInTheDocument()
   })
 
   it('renders a minimal payload without a details toggle', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -82,11 +82,16 @@ function buildSources(p: InsightPayload): SourceConfig[] {
       active: p.cfacts_suggested_score != null || p.cfacts_auth_methods != null,
     },
     {
+      // ARS dot shows the numeric maturity score (ars_control_score, 1-4) —
+      // NOT ars_maturity (the string label like "Initial", which won't fit the
+      // dot) and NOT the controls-satisfied count (which is coverage, not
+      // maturity: 4/4 controls can still be Initial=2). The label is surfaced in
+      // the chip tooltip via maturityLabel(score).
       key: 'ars',
       label: 'ARS',
       color: '#7c5cbf',
-      score: p.ars_maturity ?? p.ars_control_score,
-      active: p.ars_maturity != null || p.ars_controls_total != null,
+      score: p.ars_control_score,
+      active: p.ars_control_score != null || p.ars_controls_total != null,
     },
   ]
 }
@@ -411,6 +416,13 @@ function InsightsPanelInner({ payload }: Props) {
               </Box>{' '}
               {payload.ars_controls_satisfied ?? 0} of{' '}
               {payload.ars_controls_total} satisfied
+              {Array.isArray(payload.ars_controls) &&
+                payload.ars_controls.length > 0 && (
+                  <Box
+                    component="span"
+                    sx={{ color: '#777' }}
+                  >{` (${payload.ars_controls.join(', ')})`}</Box>
+                )}
             </Typography>
           )}
 


### PR DESCRIPTION
## What this does

Fixes a visual bug in the ZTMF Insights source-chip row: the **ARS** chip fed its score dot `ars_maturity` — a string tier label like "Initial" — which overflowed the 16px circle. It now uses `ars_control_score` (the numeric 1–4 maturity), matching every other source chip. The tier label still appears in the chip tooltip.

Backed by the data (all insight rows): `ars_control_score` is always present when ARS data exists, and the maturity is **distinct from the controls-satisfied count** — 4/4 controls can still be Initial (2) — so the count must not be shown as the score.

Also wires the "ARS Controls" detail line to list applicable control IDs (`ars_controls`) comma-separated **when present**. The pipeline does not emit that field yet, so it renders defensively — invisible until the payload carries it.

## Testing
- tsc / lint / tests clean (373, 3 skipped). New cases cover the ARS controls list rendering and its absence.
- Verified live on local dev: the ARS dot now shows the numeric score (e.g. 2) instead of the clipped word.
