### PR TITLE
Show ARS satisfied/failing control IDs in the insights details

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -445,10 +445,11 @@ export type InsightPayload = {
   ars_control_score?: number | null
   ars_controls_total?: number | null
   ars_controls_satisfied?: number | null
-  // Applicable ARS control IDs (e.g. ["IA-01","IA-02(01)"]). NOT yet emitted by
-  // the pipeline as of 2026-07 — the payload currently carries only the counts.
-  // Rendered defensively so it appears once the backend populates it.
-  ars_controls?: string[] | null
+  // The actual ARS control IDs behind the counts. Additive passthrough from the
+  // pipeline; may be undefined (before it ships / on non-ARS questions), null,
+  // or []. `ars_satisfied_controls` length == `ars_controls_satisfied`.
+  ars_satisfied_controls?: string[] | null
+  ars_failing_controls?: string[] | null
 
   findings?: InsightFindings
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -85,21 +85,47 @@ describe('InsightsPanel', () => {
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
   })
 
-  it('lists ARS control IDs in the details when the pipeline provides them', () => {
+  it('lists satisfied and failing ARS control IDs when the pipeline provides them', () => {
     render(
       <InsightsPanel
-        payload={{ ...fullPayload, ars_controls: ['IA-01', 'IA-02(01)'] }}
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: ['IA-01', 'IA-02(01)'],
+          ars_failing_controls: ['AC-17'],
+        }}
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    expect(screen.getByText(/IA-01, IA-02\(01\)/)).toBeInTheDocument()
+    // Satisfied controls render with a ✓; the failing one with a ✗.
+    expect(screen.getByText('IA-01').textContent).toContain('✓')
+    expect(screen.getByText('IA-02(01)').textContent).toContain('✓')
+    expect(screen.getByText('AC-17').textContent).toContain('✗')
   })
 
-  it('shows the ARS Controls count with no list when ars_controls is absent', () => {
+  it('drops non-string control IDs instead of throwing', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: [
+            'IA-01',
+            { bad: true },
+            42,
+          ] as unknown as string[],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // The valid string still renders; the panel is not blanked.
+    expect(screen.getByText('IA-01')).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+
+  it('shows the ARS Controls count with no chips when the control arrays are absent', () => {
     render(<InsightsPanel payload={fullPayload} />)
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText(/4 of 4 satisfied/)).toBeInTheDocument()
-    expect(screen.queryByText(/IA-01/)).not.toBeInTheDocument()
+    expect(screen.queryByText('IA-01')).not.toBeInTheDocument()
   })
 
   it('renders a minimal payload without a details toggle', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -310,6 +310,14 @@ function InsightsPanelInner({ payload }: Props) {
     kionFindings.length > 0 ||
     sechubFindings.length > 0 ||
     hardenizeFindings.length > 0
+  // ARS control IDs behind the counts. Optional/additive — undefined, null, or
+  // [] until the pipeline emits them; render only when non-empty. The payload is
+  // opaque, so filter to strings: a non-string element would otherwise render as
+  // a React child and throw, blanking the whole panel via the boundary.
+  const toStringArray = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((c): c is string => typeof c === 'string') : []
+  const arsSatisfied = toStringArray(payload.ars_satisfied_controls)
+  const arsFailing = toStringArray(payload.ars_failing_controls)
   const hasDetail =
     hasFindings ||
     !!payload.cfacts_reasoning ||
@@ -410,20 +418,36 @@ function InsightsPanelInner({ payload }: Props) {
           )}
 
           {payload.ars_controls_total != null && (
-            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
-              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
-                ARS Controls:
-              </Box>{' '}
-              {payload.ars_controls_satisfied ?? 0} of{' '}
-              {payload.ars_controls_total} satisfied
-              {Array.isArray(payload.ars_controls) &&
-                payload.ars_controls.length > 0 && (
-                  <Box
-                    component="span"
-                    sx={{ color: '#777' }}
-                  >{` (${payload.ars_controls.join(', ')})`}</Box>
-                )}
-            </Typography>
+            <Box sx={{ mb: 0.75 }}>
+              <Typography sx={{ fontSize: 12, color: '#555' }}>
+                <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                  ARS Controls:
+                </Box>{' '}
+                {payload.ars_controls_satisfied ?? 0} of{' '}
+                {payload.ars_controls_total} satisfied
+              </Typography>
+              {(arsSatisfied.length > 0 || arsFailing.length > 0) && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 0.5,
+                    mt: 0.5,
+                  }}
+                >
+                  {arsSatisfied.map((id, i) => (
+                    <ControlChip key={`sat-${id}-${i}`} id={id} passed />
+                  ))}
+                  {arsFailing.map((id, i) => (
+                    <ControlChip
+                      key={`fail-${id}-${i}`}
+                      id={id}
+                      passed={false}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
           )}
 
           {kionFindings.map((f, i) => (
@@ -484,6 +508,33 @@ export default function InsightsPanel(props: Props) {
     <InsightPanelBoundary>
       <InsightsPanelInner {...props} />
     </InsightPanelBoundary>
+  )
+}
+
+// A single ARS control ID pill — green when satisfied, red when failing.
+function ControlChip({ id, passed }: { id: string; passed: boolean }) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.375,
+        px: 0.75,
+        py: 0.125,
+        borderRadius: '4px',
+        fontSize: 10,
+        fontWeight: 600,
+        fontFamily: 'monospace',
+        whiteSpace: 'nowrap',
+        bgcolor: passed ? '#e6f4ea' : '#fdecec',
+        color: passed ? '#1e7e34' : '#b02a37',
+        border: passed ? '1px solid #b7dfc2' : '1px solid #f1b0b0',
+      }}
+    >
+      <Box component="span">{passed ? '✓' : '✗'}</Box>
+      {id}
+    </Box>
   )
 }
 


### PR DESCRIPTION
## What this does

The insights pipeline is adding two additive payload arrays behind the existing ARS control counts: `ars_satisfied_controls` and `ars_failing_controls` — the actual control IDs behind "X of Y satisfied". This renders them in the ZTMF Insights details as pills: satisfied green with a ✓, failing red with a ✗.

- Read dynamically from the opaque payload (no API/type contract change beyond two optional fields).
- `Array.isArray`-guarded and **filtered to strings**, so a malformed opaque element is dropped rather than thrown on.
- Renders nothing when the arrays are undefined/null/empty — same additive, invisible-when-off contract as the rest of Insights. Ships the moment the pipeline emits the arrays.

## Testing
- tsc / lint / tests clean (21 in the panel suite; full suite green). Tests assert the ✓/✗ pass-vs-fail split and that non-string elements are dropped without blanking the panel.
- Verified the render live by temporarily injecting the arrays into a local DB row (reverted after).
- Reviewed by codex (two passes) — clean.
