### PR TITLE
Harden the insights panel against non-string opaque payload fields

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -246,11 +246,9 @@ describe('InsightsPanel resilience (opaque payload)', () => {
     expect(screen.getByText(/ARS, CFACTS/)).toBeInTheDocument()
   })
 
-  it('renders nothing (no page crash) when a rendered field throws', () => {
+  it('degrades a malformed non-string text field instead of blanking the panel', () => {
     // evidence_sources arriving as an object would throw "Objects are not valid
-    // as a React child" when details opens; the error boundary must swallow it
-    // so the surrounding questionnaire is never taken down.
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    // as a React child"; asText coerces it so the panel stays intact.
     render(
       <InsightsPanel
         payload={{
@@ -259,10 +257,24 @@ describe('InsightsPanel resilience (opaque payload)', () => {
         }}
       />
     )
-    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    // Boundary caught the throw and rendered nothing in place of the panel.
-    expect(screen.queryByText('ZTMF Insights')).not.toBeInTheDocument()
-    spy.mockRestore()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.getByText(/Based on:/)).toBeInTheDocument()
+  })
+
+  it('coerces a non-string finding field instead of throwing', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          findings: {
+            sechub: [{ id: 'IAM.10', title: { x: 1 } as unknown as string }],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
   })
 })

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -404,7 +404,7 @@ function InsightsPanelInner({ payload }: Props) {
               <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
                 Based on:
               </Box>{' '}
-              {payload.evidence_sources}
+              {asText(payload.evidence_sources)}
             </Typography>
           )}
 
@@ -413,7 +413,7 @@ function InsightsPanelInner({ payload }: Props) {
               <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
                 CFACTS:
               </Box>{' '}
-              {payload.cfacts_reasoning}
+              {asText(payload.cfacts_reasoning)}
             </Typography>
           )}
 
@@ -423,8 +423,8 @@ function InsightsPanelInner({ payload }: Props) {
                 <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
                   ARS Controls:
                 </Box>{' '}
-                {payload.ars_controls_satisfied ?? 0} of{' '}
-                {payload.ars_controls_total} satisfied
+                {asText(payload.ars_controls_satisfied) ?? 0} of{' '}
+                {asText(payload.ars_controls_total)} satisfied
               </Typography>
               {(arsSatisfied.length > 0 || arsFailing.length > 0) && (
                 <Box
@@ -538,21 +538,31 @@ function ControlChip({ id, passed }: { id: string; passed: boolean }) {
   )
 }
 
-function FindingRow({
-  source,
-  title,
-  severity,
-  description,
-  remediation,
-  nistControls,
-}: {
+// Coerce an opaque payload value to renderable text. The payload is untrusted
+// JSON, so a field the type declares as a string could arrive as an object or
+// array; rendering that directly throws "Objects are not valid as a React
+// child" and (via the error boundary) blanks the whole panel. Coercing to a
+// string degrades gracefully instead. Returns undefined for nullish/empty so
+// existing truthiness guards still hide the element.
+function asText(v: unknown): string | undefined {
+  if (v == null || v === '') return undefined
+  return typeof v === 'string' ? v : String(v)
+}
+
+function FindingRow(props: {
   source: string
-  title?: string
-  severity?: string
-  description?: string
-  remediation?: string
-  nistControls?: string
+  title?: unknown
+  severity?: unknown
+  description?: unknown
+  remediation?: unknown
+  nistControls?: unknown
 }) {
+  const source = props.source
+  const title = asText(props.title)
+  const severity = asText(props.severity)
+  const description = asText(props.description)
+  const remediation = asText(props.remediation)
+  const nistControls = asText(props.nistControls)
   return (
     <Box sx={{ fontSize: 12, color: '#555', mb: 0.75, lineHeight: 1.6 }}>
       <Box component="span" sx={{ fontWeight: 700, color: '#333' }}>


### PR DESCRIPTION
## What this does

Defensive hardening of the ZTMF Insights panel. The payload is opaque/untrusted JSON, so fields typed as `string` can arrive as objects/arrays. The findings rows (`FindingRow`) and free-text detail lines (`evidence_sources`, `cfacts_reasoning`, ARS counts) previously rendered those fields directly — a non-string value throws "Objects are not valid as a React child" and, via the panel's error boundary, blanks the entire panel.

This routes every such sink through a small `asText(v: unknown): string | undefined` helper (nullish/empty → undefined, else `String(v)`), so a malformed field degrades to text and the rest of the panel survives. `FindingRow` prop types widened to `unknown` and coerced at the top. The error boundary is retained as a last-resort net. Same posture as the ARS control-ID string filtering (#508).

## Testing
- tsc / lint / tests clean (22 in the panel suite). The old "boundary blanks the panel" test is now "degrades to text instead of blanking"; a new test covers a non-string finding field coercing instead of throwing.
- Reviewed by codex — clean, coercion confirmed complete, semantics-preserving.
