### PR TITLE
Enrich the insights findings panel (unified findings, severity hover, Hardenize domains)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -378,31 +378,31 @@ export type ScoreDiffEntry = {
 // every key as optional and render defensively; the string index signature
 // keeps forward-added keys type-safe without an API change here.
 
-export type InsightKionFinding = {
+// One affected host for a Hardenize finding. `domain` is always present;
+// `detail` (specific error text) is present ~half the time and may be plain
+// text or a stringified JSON object.
+export type InsightHardenizeInstance = {
+  domain?: string
+  detail?: string
+}
+
+// One structured finding, shared across all sources (Kion / SecurityHub /
+// Hardenize). title/description/remediation are seeded from the findings
+// dictionary and may be null; instances is Hardenize-only (affected domains).
+export type InsightFinding = {
   id?: string
+  title?: string
+  description?: string
+  remediation?: string
+  severity?: string
   nist_controls?: string
-  description?: string
-  remediation?: string
-}
-
-export type InsightSecHubFinding = {
-  id?: string
-  title?: string
-  severity?: string
-  description?: string
-  remediation?: string
-}
-
-export type InsightHardenizeFinding = {
-  id?: string
-  title?: string
-  severity?: string
+  instances?: InsightHardenizeInstance[]
 }
 
 export type InsightFindings = {
-  kion?: InsightKionFinding[]
-  sechub?: InsightSecHubFinding[]
-  hardenize?: InsightHardenizeFinding[]
+  kion?: InsightFinding[]
+  sechub?: InsightFinding[]
+  hardenize?: InsightFinding[]
 }
 
 export type InsightPayload = {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -71,6 +71,94 @@ describe('InsightsPanel', () => {
     expect(screen.getByText('No suggestion')).toBeInTheDocument()
   })
 
+  it('shows a hardenize finding heading + affected domains', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            hardenize: [
+              {
+                id: 'WWW_TLS_CONN_FAILED',
+                title: 'TLS connection failed',
+                description: 'Hardenize could not connect to the domain.',
+                severity: 'error',
+                instances: [
+                  {
+                    domain: 'portaldev.cms.gov',
+                    detail: '{"Error":"timeout"}',
+                  },
+                  { domain: 'api.cms.gov', detail: '' },
+                ],
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('TLS connection failed')).toBeInTheDocument()
+    expect(
+      screen.getByText('Hardenize could not connect to the domain.')
+    ).toBeInTheDocument()
+    // Domains affordance + reachable via aria-label (hover reveals the list).
+    expect(screen.getByText('2 domains')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('portaldev.cms.gov, api.cms.gov')
+    ).toBeInTheDocument()
+  })
+
+  it('renders a hardenize finding with no domains and no crash', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            hardenize: [
+              {
+                id: 'WWW_HSTS_POWERUP',
+                title: 'Deploy HSTS',
+                severity: 'warn',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('Deploy HSTS')).toBeInTheDocument()
+    expect(screen.queryByText(/domain/)).not.toBeInTheDocument()
+  })
+
+  it('renders a finding uniformly: code, title, description, severity, How to fix', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            sechub: [
+              {
+                id: 'IAM.10',
+                title: 'MFA should be enabled',
+                description: 'Enable MFA for all IAM users.',
+                remediation: 'Turn on MFA in the IAM console.',
+                severity: 'MEDIUM',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('IAM.10')).toBeInTheDocument()
+    expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+    expect(
+      screen.getByText('Enable MFA for all IAM users.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('MEDIUM')).toBeInTheDocument()
+    expect(screen.getByText(/How to fix/)).toBeInTheDocument()
+  })
+
   it('hides findings until details is toggled, then reveals them', () => {
     render(<InsightsPanel payload={fullPayload} />)
     expect(

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import InsightsPanel, { OptionInsightBadges } from './InsightsPanel'
+import InsightsPanel, {
+  OptionInsightBadges,
+  severityStyle,
+} from './InsightsPanel'
 import type { InsightPayload } from '@/types'
 
 const fullPayload: InsightPayload = {
@@ -98,8 +101,11 @@ describe('InsightsPanel', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText('TLS connection failed')).toBeInTheDocument()
+    // Description lives in the severity badge hover, not the card body.
     expect(
-      screen.getByText('Hardenize could not connect to the domain.')
+      screen.getByLabelText(
+        /error: Hardenize could not connect to the domain\./
+      )
     ).toBeInTheDocument()
     // Domains affordance + reachable via aria-label (hover reveals the list).
     expect(screen.getByText('2 domains')).toBeInTheDocument()
@@ -152,8 +158,9 @@ describe('InsightsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText('IAM.10')).toBeInTheDocument()
     expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+    // Description surfaces in the severity badge hover, not the card body.
     expect(
-      screen.getByText('Enable MFA for all IAM users.')
+      screen.getByLabelText(/MEDIUM: Enable MFA for all IAM users\./)
     ).toBeInTheDocument()
     expect(screen.getByText('MEDIUM')).toBeInTheDocument()
     expect(screen.getByText(/How to fix/)).toBeInTheDocument()
@@ -363,6 +370,64 @@ describe('InsightsPanel resilience (opaque payload)', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+})
+
+describe('severityStyle', () => {
+  it('maps severities to red / amber / neutral', () => {
+    for (const s of ['error', 'ERROR', 'high', 'critical']) {
+      expect(severityStyle(s).fg).toBe('#b02a37') // red
+    }
+    for (const s of ['warning', 'medium', 'WARN']) {
+      expect(severityStyle(s).fg).toBe('#b26a00') // amber
+    }
+    for (const s of ['low', 'powerup', 'anything', undefined]) {
+      expect(severityStyle(s).fg).toBe('#666') // neutral
+    }
+  })
+})
+
+describe('severity help (findings)', () => {
+  const withSeverity = (severity: string) => ({
+    suggested_score: 1,
+    findings: {
+      hardenize: [{ id: 'X', title: 'A finding', severity }],
+    },
+  })
+
+  it('adds an explanation tooltip on the powerup severity badge', () => {
+    render(<InsightsPanel payload={withSeverity('powerup')} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(
+      screen.getByLabelText(/powerup:.*recommended enhancement/i)
+    ).toBeInTheDocument()
+  })
+
+  it('adds an explanation tooltip on the error severity badge', () => {
+    render(<InsightsPanel payload={withSeverity('error')} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByLabelText(/error:.*failing check/i)).toBeInTheDocument()
+  })
+})
+
+describe('FindingRow resilience', () => {
+  it('drops a null finding element instead of blanking the panel', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            sechub: [
+              null as unknown as { id: string },
+              { id: 'IAM.10', title: 'MFA should be enabled' },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('IAM.10')).toBeInTheDocument()
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
   })
 })

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -4,12 +4,7 @@ import Typography from '@mui/material/Typography'
 import Tooltip from '@mui/material/Tooltip'
 import Collapse from '@mui/material/Collapse'
 import Link from '@mui/material/Link'
-import type {
-  InsightPayload,
-  InsightKionFinding,
-  InsightSecHubFinding,
-  InsightHardenizeFinding,
-} from '@/types'
+import type { InsightPayload, InsightFinding } from '@/types'
 
 type Props = {
   payload: InsightPayload
@@ -297,15 +292,11 @@ function InsightsPanelInner({ payload }: Props) {
   // during render (which the route errorElement would turn into a full-page
   // error for the whole questionnaire).
   const findings = payload.findings
-  const kionFindings = Array.isArray(findings?.kion)
-    ? (findings?.kion as InsightKionFinding[])
-    : []
-  const sechubFindings = Array.isArray(findings?.sechub)
-    ? (findings?.sechub as InsightSecHubFinding[])
-    : []
-  const hardenizeFindings = Array.isArray(findings?.hardenize)
-    ? (findings?.hardenize as InsightHardenizeFinding[])
-    : []
+  const asFindingArray = (v: unknown): InsightFinding[] =>
+    Array.isArray(v) ? (v as InsightFinding[]) : []
+  const kionFindings = asFindingArray(findings?.kion)
+  const sechubFindings = asFindingArray(findings?.sechub)
+  const hardenizeFindings = asFindingArray(findings?.hardenize)
   const hasFindings =
     kionFindings.length > 0 ||
     sechubFindings.length > 0 ||
@@ -451,32 +442,20 @@ function InsightsPanelInner({ payload }: Props) {
           )}
 
           {kionFindings.map((f, i) => (
-            <FindingRow
-              key={`kion-${f.id ?? i}`}
-              source="Kion"
-              title={f.id}
-              description={f.description}
-              remediation={f.remediation}
-              nistControls={f.nist_controls}
-            />
+            <FindingRow key={`kion-${f.id ?? i}`} source="Kion" finding={f} />
           ))}
           {sechubFindings.map((f, i) => (
             <FindingRow
               key={`sechub-${f.id ?? i}`}
               source="SecurityHub"
-              title={f.id}
-              severity={f.severity}
-              description={f.title ?? f.description}
-              remediation={f.remediation}
+              finding={f}
             />
           ))}
           {hardenizeFindings.map((f, i) => (
             <FindingRow
               key={`hardenize-${f.id ?? i}`}
               source="Hardenize"
-              title={f.id}
-              severity={f.severity}
-              description={f.title}
+              finding={f}
             />
           ))}
         </Box>
@@ -549,26 +528,78 @@ function asText(v: unknown): string | undefined {
   return typeof v === 'string' ? v : String(v)
 }
 
-function FindingRow(props: {
+// Hardenize instance `detail` is inconsistent — a stringified JSON object
+// ({"Error message":"..."}), plain text ("Dangling DNS record: ..."), or empty
+// ({}). Surface something readable: JSON objects → their values joined; plain
+// text as-is; empty → nothing.
+function formatHardenizeDetail(detail?: string): string | undefined {
+  const t = asText(detail)
+  if (!t || t === '{}') return undefined
+  try {
+    const parsed = JSON.parse(t)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const vals = Object.values(parsed).map(String).filter(Boolean)
+      return vals.length ? vals.join('; ') : undefined
+    }
+  } catch {
+    /* not JSON — fall through to raw text */
+  }
+  return t
+}
+
+// Severity → chip color. error/high/critical = red, warning/medium = amber,
+// everything else (low, powerup, unknown) = neutral.
+function severityStyle(sev?: string): { bg: string; fg: string } {
+  const s = (sev ?? '').toLowerCase()
+  if (s === 'error' || s === 'high' || s === 'critical')
+    return { bg: '#fdecec', fg: '#b02a37' }
+  if (s === 'warning' || s === 'warn' || s === 'medium')
+    return { bg: '#fff4e5', fg: '#b26a00' }
+  return { bg: '#f0f0f0', fg: '#666' }
+}
+
+// One structured finding, uniform across sources. Card = id (code) + title +
+// severity + description; "How to fix" when remediation is present; a hover
+// "N domains" affordance for Hardenize instances. Every field is optional and
+// coerced to text, so a null/malformed field degrades instead of throwing.
+function FindingRow({
+  source,
+  finding,
+}: {
   source: string
-  title?: unknown
-  severity?: unknown
-  description?: unknown
-  remediation?: unknown
-  nistControls?: unknown
+  finding: InsightFinding
 }) {
-  const source = props.source
-  const title = asText(props.title)
-  const severity = asText(props.severity)
-  const description = asText(props.description)
-  const remediation = asText(props.remediation)
-  const nistControls = asText(props.nistControls)
+  const code = asText(finding.id)
+  const heading = asText(finding.title)
+  const severity = asText(finding.severity)
+  const sevStyle = severityStyle(severity)
+  const description = asText(finding.description)
+  const remediation = asText(finding.remediation)
+  const nistControls = asText(finding.nist_controls)
+  // Affected hosts (Hardenize). domain is required; detail is optional.
+  const domains = (Array.isArray(finding.instances) ? finding.instances : [])
+    .map((inst) => ({
+      domain: asText(inst?.domain),
+      detail: formatHardenizeDetail(inst?.detail),
+    }))
+    .filter((d) => d.domain)
+  const domainsTooltip =
+    domains.length > 0 ? (
+      <Box sx={{ py: 0.25 }}>
+        {domains.map((d, i) => (
+          <Box key={`${d.domain}-${i}`} sx={{ fontSize: 11, lineHeight: 1.5 }}>
+            {d.domain}
+            {d.detail ? ` — ${d.detail}` : ''}
+          </Box>
+        ))}
+      </Box>
+    ) : null
   return (
     <Box sx={{ fontSize: 12, color: '#555', mb: 0.75, lineHeight: 1.6 }}>
       <Box component="span" sx={{ fontWeight: 700, color: '#333' }}>
         {source}
       </Box>
-      {title && (
+      {code && (
         <Box
           component="span"
           sx={{
@@ -578,7 +609,12 @@ function FindingRow(props: {
             color: '#9a6700',
           }}
         >
-          {title}
+          {code}
+        </Box>
+      )}
+      {heading && (
+        <Box component="span" sx={{ ml: 0.75, color: '#333' }}>
+          {heading}
         </Box>
       )}
       {severity && (
@@ -592,8 +628,8 @@ function FindingRow(props: {
             fontSize: 10,
             fontWeight: 700,
             textTransform: 'uppercase',
-            bgcolor: '#f0f0f0',
-            color: '#666',
+            bgcolor: sevStyle.bg,
+            color: sevStyle.fg,
           }}
         >
           {severity}
@@ -616,11 +652,33 @@ function FindingRow(props: {
           {nistControls}
         </Box>
       )}
+      {domainsTooltip && (
+        <Tooltip title={domainsTooltip} placement="top" arrow>
+          <Box
+            component="span"
+            aria-label={domains.map((d) => d.domain).join(', ')}
+            sx={{
+              ml: 0.75,
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '3px',
+              fontSize: 10,
+              fontWeight: 600,
+              bgcolor: '#eef2f8',
+              color: '#3a5a80',
+              cursor: 'default',
+              borderBottom: '1px dotted #7a94b8',
+            }}
+          >
+            {domains.length} domain{domains.length === 1 ? '' : 's'}
+          </Box>
+        </Tooltip>
+      )}
       {description && <Box sx={{ mt: 0.25, color: '#666' }}>{description}</Box>}
       {remediation && (
         <Box sx={{ mt: 0.25, color: '#5a6a8a' }}>
           <Box component="span" sx={{ fontWeight: 600 }}>
-            Fix:
+            How to fix:
           </Box>{' '}
           {remediation}
         </Box>

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -442,18 +442,18 @@ function InsightsPanelInner({ payload }: Props) {
           )}
 
           {kionFindings.map((f, i) => (
-            <FindingRow key={`kion-${f.id ?? i}`} source="Kion" finding={f} />
+            <FindingRow key={`kion-${f?.id ?? i}`} source="Kion" finding={f} />
           ))}
           {sechubFindings.map((f, i) => (
             <FindingRow
-              key={`sechub-${f.id ?? i}`}
+              key={`sechub-${f?.id ?? i}`}
               source="SecurityHub"
               finding={f}
             />
           ))}
           {hardenizeFindings.map((f, i) => (
             <FindingRow
-              key={`hardenize-${f.id ?? i}`}
+              key={`hardenize-${f?.id ?? i}`}
               source="Hardenize"
               finding={f}
             />
@@ -549,13 +549,38 @@ function formatHardenizeDetail(detail?: string): string | undefined {
 
 // Severity → chip color. error/high/critical = red, warning/medium = amber,
 // everything else (low, powerup, unknown) = neutral.
-function severityStyle(sev?: string): { bg: string; fg: string } {
+export function severityStyle(sev?: string): { bg: string; fg: string } {
   const s = (sev ?? '').toLowerCase()
   if (s === 'error' || s === 'high' || s === 'critical')
     return { bg: '#fdecec', fg: '#b02a37' }
   if (s === 'warning' || s === 'warn' || s === 'medium')
     return { bg: '#fff4e5', fg: '#b26a00' }
   return { bg: '#f0f0f0', fg: '#666' }
+}
+
+// TEMPORARY stopgap severity glossary shown on hover when a finding has no
+// dictionary description yet. The long-term home for this copy is the findings
+// dictionary / Snowflake view (ztmf-insights#32) — remove this map once the
+// dictionary covers findings and the scoring-treatment classification lands.
+const SEVERITY_HELP: Record<string, string> = {
+  error:
+    'A failing check — the scanner found a condition that does not meet the control. Review the finding and affected hosts; some (e.g. connection failures) may reflect reachability rather than a security weakness.',
+  critical: 'A critical failing check — remediate urgently.',
+  high: 'A high-severity failing check — prioritize remediation.',
+  warning: 'A moderate issue worth addressing, lower priority than an error.',
+  medium: 'A moderate issue worth addressing, lower priority than high/error.',
+  low: 'A low-severity or informational finding.',
+  notice:
+    'An informational notice — a best-practice observation, not a failing check.',
+  powerup:
+    'A recommended enhancement, not a failure — an opportunity to further harden this host beyond the baseline.',
+  inconclusive:
+    'Inconclusive — the scanner could not reach the host to test it, often because the domain is private/internal or retired. This is not a pass or a fail and does not count against the score.',
+  unknown:
+    'Inconclusive — the scanner could not reach the host to test it, often because the domain is private/internal or retired. This is not a pass or a fail and does not count against the score.',
+}
+function severityHelp(sev?: string): string | undefined {
+  return SEVERITY_HELP[(sev ?? '').toLowerCase()]
 }
 
 // One structured finding, uniform across sources. Card = id (code) + title +
@@ -569,11 +594,21 @@ function FindingRow({
   source: string
   finding: InsightFinding
 }) {
+  // The payload is opaque — a findings array could contain a null/non-object
+  // element. Guard so it degrades to nothing instead of throwing on field
+  // access (which the boundary would turn into a blanked panel).
+  if (!finding || typeof finding !== 'object') return null
   const code = asText(finding.id)
   const heading = asText(finding.title)
   const severity = asText(finding.severity)
   const sevStyle = severityStyle(severity)
   const description = asText(finding.description)
+  // The severity badge's hover carries the "what it means" text: prefer the
+  // finding's dictionary-seeded description; fall back to the temporary generic
+  // per-severity glossary until the dictionary covers everything (see
+  // ztmf-insights#32). This lets an alarming badge (e.g. a red "error" that is
+  // really a reachability finding) be honestly contextualized on hover.
+  const sevTooltip = description ?? severityHelp(severity)
   const remediation = asText(finding.remediation)
   const nistControls = asText(finding.nist_controls)
   // Affected hosts (Hardenize). domain is required; detail is optional.
@@ -618,22 +653,34 @@ function FindingRow({
         </Box>
       )}
       {severity && (
-        <Box
-          component="span"
-          sx={{
-            ml: 0.75,
-            px: 0.75,
-            py: 0.125,
-            borderRadius: '3px',
-            fontSize: 10,
-            fontWeight: 700,
-            textTransform: 'uppercase',
-            bgcolor: sevStyle.bg,
-            color: sevStyle.fg,
-          }}
+        <Tooltip
+          title={sevTooltip ?? ''}
+          placement="top"
+          arrow
+          disableHoverListener={!sevTooltip}
+          disableFocusListener={!sevTooltip}
+          disableTouchListener={!sevTooltip}
         >
-          {severity}
-        </Box>
+          <Box
+            component="span"
+            aria-label={sevTooltip ? `${severity}: ${sevTooltip}` : undefined}
+            sx={{
+              ml: 0.75,
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '3px',
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              bgcolor: sevStyle.bg,
+              color: sevStyle.fg,
+              cursor: sevTooltip ? 'help' : undefined,
+              borderBottom: sevTooltip ? '1px dotted currentColor' : undefined,
+            }}
+          >
+            {severity}
+          </Box>
+        </Tooltip>
       )}
       {nistControls && (
         <Box
@@ -674,7 +721,11 @@ function FindingRow({
           </Box>
         </Tooltip>
       )}
-      {description && <Box sx={{ mt: 0.25, color: '#666' }}>{description}</Box>}
+      {/* Description lives in the severity badge hover. When a finding has no
+          severity badge to carry it, show it in the body so it isn't lost. */}
+      {!severity && description && (
+        <Box sx={{ mt: 0.25, color: '#666' }}>{description}</Box>
+      )}
       {remediation && (
         <Box sx={{ mt: 0.25, color: '#5a6a8a' }}>
           <Box component="span" sx={{ fontWeight: 600 }}>


### PR DESCRIPTION
## What this does

Enriches the ZTMF Insights findings evidence panel to the full dictionary contract.

- **Unified `InsightFinding`** across Kion/SecurityHub/Hardenize (id, title, description, remediation, severity, nist_controls, plus Hardenize-only `instances`). All sources render uniformly.
- **Card**: source · `id` code · title · colored severity badge (error/high/critical red, warning/medium amber, else neutral) · "How to fix" when remediation present.
- **Severity hover** carries the "what it means" text — the finding's dictionary-seeded `description` when present, falling back to a temporary generic per-severity glossary until the dictionary + scoring-treatment work lands (ztmf-insights#32). Lets a red "error" that is really a reachability finding be honestly contextualized instead of alarming.
- **Hardenize domains** behind a hover "N domains" affordance (`instances[].domain` + detail, formatted defensively).

Additive and defensive throughout: null/absent fields degrade to nothing, opaque values coerced, a null/non-object findings element is guarded, so a malformed payload never throws.

## Testing
- tsc / lint / tests clean (29 in the panel suite; full suite green). Covers the uniform render, severity color mapping, description-in-hover, domains, ARS controls, and the resilience/guard paths.
- Verified live against seeded dictionary data (SecurityHub + Hardenize findings, descriptions, domains).
