### PR TITLE
Gate Insights "How to fix" behind a flag (impl only)

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -58,6 +58,8 @@ jobs:
         # Default off; flip per environment as IdP rollout progresses.
         env:
           VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
+          # Insights "How to fix" remediation — trialed in impl only; off in dev/prod.
+          VITE_INSIGHTS_SUGGEST_FIX_ENABLED: ${{ inputs.environment == 'impl' && 'true' || 'false' }}
           # Dev-only banner overrides. Sourced from secrets so the feedback form
           # URL and contact address stay out of the repo. Clear these secrets
           # when the testing window ends and the banner reverts to default copy.

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export type AppConfig = AppFeatureFlags & AppEnvironment
 
 export type AppFeatureFlags = {
   IDP_ENABLED: boolean
+  // Gates the ZTMF Insights "How to fix" remediation text on the questionnaire.
+  // On in impl only (we're trialing whether to offer fixes); off in dev/prod.
+  INSIGHTS_SUGGEST_FIX_ENABLED: boolean
 }
 
 // Environment-derived settings. IS_NONPROD gates the development banner; the

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,6 +8,10 @@ import type { AppConfig } from '@/types'
 const CONFIG = {
   //* Feature flags
   IDP_ENABLED: String(import.meta.env.VITE_IDP_ENABLED) === 'true',
+  // ZTMF Insights "How to fix" remediation. Set true only on the impl build
+  // (VITE_INSIGHTS_SUGGEST_FIX_ENABLED in ui.yml); unset elsewhere → false.
+  INSIGHTS_SUGGEST_FIX_ENABLED:
+    String(import.meta.env.VITE_INSIGHTS_SUGGEST_FIX_ENABLED) === 'true',
 
   //* Environment
   // Vite's build mode is 'production' only for `yarn build:prod`; local dev,

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -4,6 +4,19 @@ import InsightsPanel, {
   severityStyle,
 } from './InsightsPanel'
 import type { InsightPayload } from '@/types'
+import CONFIG from '@/utils/config'
+
+// The "How to fix" remediation is gated by CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED,
+// which is false in the test env (no VITE_INSIGHTS_SUGGEST_FIX_ENABLED). Mock the
+// config so the default is ON here (matching impl); tests flip the flag on the
+// imported (mocked) CONFIG object, which the component reads by the same
+// reference. Only the flag field is used by this subtree, so a partial mock is
+// safe. jest.mock is hoisted above imports, so the flag object is created inside
+// the factory (referencing an outer const would hit the TDZ).
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: true },
+}))
 
 const fullPayload: InsightPayload = {
   suggested_score: 1,
@@ -164,6 +177,42 @@ describe('InsightsPanel', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('MEDIUM')).toBeInTheDocument()
     expect(screen.getByText(/How to fix/)).toBeInTheDocument()
+  })
+
+  it('hides "How to fix" when INSIGHTS_SUGGEST_FIX_ENABLED is off, keeping the finding and CFACTS reasoning', () => {
+    CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED = false
+    try {
+      render(
+        <InsightsPanel
+          payload={{
+            suggested_score: 1,
+            cfacts_reasoning: 'IDM-Okta detected. MFA required.',
+            findings: {
+              sechub: [
+                {
+                  id: 'IAM.10',
+                  title: 'MFA should be enabled',
+                  remediation: 'Turn on MFA in the IAM console.',
+                  severity: 'MEDIUM',
+                },
+              ],
+            },
+          }}
+        />
+      )
+      fireEvent.click(screen.getByRole('button', { name: /details/i }))
+      // Remediation gated off...
+      expect(screen.queryByText(/How to fix/)).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(/Turn on MFA in the IAM console/)
+      ).not.toBeInTheDocument()
+      // ...but the finding itself and the CFACTS reasoning still render.
+      expect(screen.getByText('IAM.10')).toBeInTheDocument()
+      expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+      expect(screen.getByText(/IDM-Okta detected/)).toBeInTheDocument()
+    } finally {
+      CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED = true
+    }
   })
 
   it('hides findings until details is toggled, then reveals them', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -5,6 +5,7 @@ import Tooltip from '@mui/material/Tooltip'
 import Collapse from '@mui/material/Collapse'
 import Link from '@mui/material/Link'
 import type { InsightPayload, InsightFinding } from '@/types'
+import CONFIG from '@/utils/config'
 
 type Props = {
   payload: InsightPayload
@@ -726,7 +727,7 @@ function FindingRow({
       {!severity && description && (
         <Box sx={{ mt: 0.25, color: '#666' }}>{description}</Box>
       )}
-      {remediation && (
+      {CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED && remediation && (
         <Box sx={{ mt: 0.25, color: '#5a6a8a' }}>
           <Box component="span" sx={{ fontWeight: 600 }}>
             How to fix:

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_AWS_REGION: string
   readonly VITE_IDP_ENABLED: string
+  readonly VITE_INSIGHTS_SUGGEST_FIX_ENABLED: string
   readonly VITE_COGNITO_DOMAIN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_IN: string
   // more env variables...


### PR DESCRIPTION
Adds a feature flag, `INSIGHTS_SUGGEST_FIX_ENABLED`, that controls whether the ZTMF Insights "How to fix" remediation text shows on the questionnaire.

There is open contention about whether we should offer remediation to responders at release. Rather than comment the code out and lose the work, this puts it behind a flag: on in impl so we can keep trialing it, off in dev and prod until the team decides.

**Behavior**
- Default off in every environment. On only for the impl build, set via `VITE_INSIGHTS_SUGGEST_FIX_ENABLED` in `ui.yml` (`inputs.environment == 'impl'`), mirroring how `VITE_IDP_ENABLED` is delivered.
- Only the per-finding "How to fix" block is gated. The suggestion pill, answer badges, findings, severities, and CFACTS reasoning are unchanged.

**Naming** follows the existing convention: config flag `INSIGHTS_SUGGEST_FIX_ENABLED` / env `VITE_INSIGHTS_SUGGEST_FIX_ENABLED`, parsed the same way as `IDP_ENABLED`. The name is deliberately explicit that it governs *suggesting a fix*.

**Files**
- `types.ts`, `utils/config.ts`, `vite-env.d.ts` — declare/read/type the flag.
- `.github/workflows/ui.yml` — set it true only for impl.
- `InsightsPanel.tsx` — gate the remediation block.
- `InsightsPanel.test.tsx` — mock the flag; tests cover both on and off states.

**Verification:** tsc clean, full jest suite passes (incl. a new off-state test proving the finding and CFACTS reasoning still render while "How to fix" is hidden), prettier clean, no eslint errors. Carries cleanly to main later — the flag stays off outside impl, so a promote to dev/prod ships Insights without the remediation text.