### PR TITLE
ZTMF Insights panel on the questionnaire

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -58,6 +58,8 @@ jobs:
         # Default off; flip per environment as IdP rollout progresses.
         env:
           VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
+          # Insights "How to fix" remediation — trialed in impl only; off in dev/prod.
+          VITE_INSIGHTS_SUGGEST_FIX_ENABLED: ${{ inputs.environment == 'impl' && 'true' || 'false' }}
           # Dev-only banner overrides. Sourced from secrets so the feedback form
           # URL and contact address stay out of the repo. Clear these secrets
           # when the testing window ends and the banner reverts to default copy.

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export type AppConfig = AppFeatureFlags & AppEnvironment
 
 export type AppFeatureFlags = {
   IDP_ENABLED: boolean
+  // Gates the ZTMF Insights "How to fix" remediation text on the questionnaire.
+  // On in impl only (we're trialing whether to offer fixes); off in dev/prod.
+  INSIGHTS_SUGGEST_FIX_ENABLED: boolean
 }
 
 // Environment-derived settings. IS_NONPROD gates the development banner; the
@@ -173,6 +176,7 @@ export type QuestionScores = {
 }
 
 export type Question = {
+  questionid: number
   question: string
   notesprompt: string
   description: string
@@ -269,6 +273,9 @@ export type ScoreProgress = {
 export type QuestionChoice = {
   label: string
   value: number
+  // Maturity score (1-4) of this answer option. Carried so the radio group can
+  // match an option against a ZTMF Insight's suggested/prior score for badging.
+  score?: number
   defaultChecked?: boolean
 }
 export type users = {
@@ -362,4 +369,100 @@ export type ScoreDiffEntry = {
     email: string
     role: string
   }
+}
+
+// ── ZTMF Insights (GET /api/v1/insights) ───────────────────────────────
+// Evidence-backed maturity suggestion per system x question, synced daily
+// from Snowflake. The endpoint returns [] for every "should not show" case
+// (OpDiv not enabled, caller not entitled, not yet synced), so the UI is
+// driven purely off row presence — see InsightsPanel.
+//
+// `payload` is an opaque, additive document owned by the pipeline. Treat
+// every key as optional and render defensively; the string index signature
+// keeps forward-added keys type-safe without an API change here.
+
+// One affected host for a Hardenize finding. `domain` is always present;
+// `detail` (specific error text) is present ~half the time and may be plain
+// text or a stringified JSON object.
+export type InsightHardenizeInstance = {
+  domain?: string
+  detail?: string
+}
+
+// One structured finding, shared across all sources (Kion / SecurityHub /
+// Hardenize). title/description/remediation are seeded from the findings
+// dictionary and may be null; instances is Hardenize-only (affected domains).
+export type InsightFinding = {
+  id?: string
+  title?: string
+  description?: string
+  remediation?: string
+  severity?: string
+  nist_controls?: string
+  instances?: InsightHardenizeInstance[]
+}
+
+export type InsightFindings = {
+  kion?: InsightFinding[]
+  sechub?: InsightFinding[]
+  hardenize?: InsightFinding[]
+}
+
+export type InsightPayload = {
+  // The suggestion
+  suggested_score?: number | null
+  suggested_label?: string | null
+  evidence_sources?: string | null
+  score_floor_source?: string | null
+  score_direction?: string | null
+
+  // Prior self-reported score (for comparison)
+  last_score?: number | null
+  last_score_label?: string | null
+  last_score_date?: string | null
+  last_score_notes?: string | null
+  last_datacall?: string | null
+
+  // Per-source suggested scores + availability flags
+  has_kion_data?: boolean
+  kion_suggested_score?: number | null
+  kion_suggested_label?: string | null
+  kion_remediation?: string | null
+
+  has_sechub_data?: boolean
+  sechub_suggested_score?: number | null
+  sechub_suggested_label?: string | null
+  sechub_remediation?: string | null
+
+  has_hardenize_data?: boolean
+  hardenize_suggested_score?: number | null
+  hardenize_suggested_label?: string | null
+  hardenize_remediation?: string | null
+
+  cfacts_suggested_score?: number | null
+  cfacts_suggested_label?: string | null
+  cfacts_auth_methods?: string | null
+  cfacts_reasoning?: string | null
+
+  ars_maturity?: number | string | null
+  ars_control_score?: number | null
+  ars_controls_total?: number | null
+  ars_controls_satisfied?: number | null
+  // The actual ARS control IDs behind the counts. Additive passthrough from the
+  // pipeline; may be undefined (before it ships / on non-ARS questions), null,
+  // or []. `ars_satisfied_controls` length == `ars_controls_satisfied`.
+  ars_satisfied_controls?: string[] | null
+  ars_failing_controls?: string[] | null
+
+  findings?: InsightFindings
+
+  // Additive: the pipeline may add keys at any time.
+  [key: string]: unknown
+}
+
+export type Insight = {
+  fismasystemid: number
+  questionid: number
+  payload: InsightPayload
+  synced_at: string
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,6 +8,10 @@ import type { AppConfig } from '@/types'
 const CONFIG = {
   //* Feature flags
   IDP_ENABLED: String(import.meta.env.VITE_IDP_ENABLED) === 'true',
+  // ZTMF Insights "How to fix" remediation. Set true only on the impl build
+  // (VITE_INSIGHTS_SUGGEST_FIX_ENABLED in ui.yml); unset elsewhere → false.
+  INSIGHTS_SUGGEST_FIX_ENABLED:
+    String(import.meta.env.VITE_INSIGHTS_SUGGEST_FIX_ENABLED) === 'true',
 
   //* Environment
   // Vite's build mode is 'production' only for `yarn build:prod`; local dev,

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1,0 +1,482 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import InsightsPanel, {
+  OptionInsightBadges,
+  severityStyle,
+} from './InsightsPanel'
+import type { InsightPayload } from '@/types'
+import CONFIG from '@/utils/config'
+
+// The "How to fix" remediation is gated by CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED,
+// which is false in the test env (no VITE_INSIGHTS_SUGGEST_FIX_ENABLED). Mock the
+// config so the default is ON here (matching impl); tests flip the flag on the
+// imported (mocked) CONFIG object, which the component reads by the same
+// reference. Only the flag field is used by this subtree, so a partial mock is
+// safe. jest.mock is hoisted above imports, so the flag object is created inside
+// the factory (referencing an outer const would hit the TDZ).
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: true },
+}))
+
+const fullPayload: InsightPayload = {
+  suggested_score: 1,
+  suggested_label: 'Traditional',
+  evidence_sources: 'Kion, SecurityHub, Hardenize',
+  score_floor_source: 'Kion (failing password policy)',
+  score_direction: 'lower',
+  last_score: 2,
+  last_score_label: 'Initial',
+  has_kion_data: true,
+  kion_suggested_score: 1,
+  has_sechub_data: true,
+  sechub_suggested_score: 1,
+  has_hardenize_data: false,
+  cfacts_suggested_score: 2,
+  cfacts_reasoning: 'IDM-Okta detected. MFA required, PR-MFA not available.',
+  ars_maturity: 'Initial',
+  ars_control_score: 2,
+  ars_controls_total: 4,
+  ars_controls_satisfied: 4,
+  findings: {
+    kion: [
+      {
+        id: 'iam-user-without-mfa-device-enabled',
+        nist_controls: 'IA-02',
+        remediation: 'Enable an MFA device for the user.',
+      },
+    ],
+    sechub: [
+      { id: 'IAM.10', title: 'MFA should be enabled', severity: 'MEDIUM' },
+    ],
+  },
+}
+
+describe('InsightsPanel', () => {
+  it('renders the ZTMF Insights label and all five source chips', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    for (const source of [
+      'Kion',
+      'SecurityHub',
+      'Hardenize',
+      'CFACTS',
+      'ARS',
+    ]) {
+      expect(screen.getByText(source)).toBeInTheDocument()
+    }
+  })
+
+  it('renders the suggested maturity pill when the suggestion differs from the prior score', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    expect(screen.getByText(/Suggested: Traditional \(1\)/)).toBeInTheDocument()
+  })
+
+  it('labels the pill "Confirmed" when the suggestion matches the prior score', () => {
+    render(<InsightsPanel payload={{ ...fullPayload, last_score: 1 }} />)
+    expect(screen.getByText(/Confirmed: Traditional \(1\)/)).toBeInTheDocument()
+  })
+
+  it('marks a source with no data using a dash instead of a score', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    // Hardenize has has_hardenize_data:false, so its dot renders an en-dash.
+    expect(screen.getByText('–')).toBeInTheDocument()
+  })
+
+  it('shows "No suggestion" when suggested_score is null', () => {
+    render(<InsightsPanel payload={{ suggested_score: null }} />)
+    expect(screen.getByText('No suggestion')).toBeInTheDocument()
+  })
+
+  it('shows a hardenize finding heading + affected domains', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            hardenize: [
+              {
+                id: 'WWW_TLS_CONN_FAILED',
+                title: 'TLS connection failed',
+                description: 'Hardenize could not connect to the domain.',
+                severity: 'error',
+                instances: [
+                  {
+                    domain: 'portaldev.cms.gov',
+                    detail: '{"Error":"timeout"}',
+                  },
+                  { domain: 'api.cms.gov', detail: '' },
+                ],
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('TLS connection failed')).toBeInTheDocument()
+    // Description lives in the severity badge hover, not the card body.
+    expect(
+      screen.getByLabelText(
+        /error: Hardenize could not connect to the domain\./
+      )
+    ).toBeInTheDocument()
+    // Domains affordance + reachable via aria-label (hover reveals the list).
+    expect(screen.getByText('2 domains')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('portaldev.cms.gov, api.cms.gov')
+    ).toBeInTheDocument()
+  })
+
+  it('renders a hardenize finding with no domains and no crash', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            hardenize: [
+              {
+                id: 'WWW_HSTS_POWERUP',
+                title: 'Deploy HSTS',
+                severity: 'warn',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('Deploy HSTS')).toBeInTheDocument()
+    expect(screen.queryByText(/domain/)).not.toBeInTheDocument()
+  })
+
+  it('renders a finding uniformly: code, title, description, severity, How to fix', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            sechub: [
+              {
+                id: 'IAM.10',
+                title: 'MFA should be enabled',
+                description: 'Enable MFA for all IAM users.',
+                remediation: 'Turn on MFA in the IAM console.',
+                severity: 'MEDIUM',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('IAM.10')).toBeInTheDocument()
+    expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+    // Description surfaces in the severity badge hover, not the card body.
+    expect(
+      screen.getByLabelText(/MEDIUM: Enable MFA for all IAM users\./)
+    ).toBeInTheDocument()
+    expect(screen.getByText('MEDIUM')).toBeInTheDocument()
+    expect(screen.getByText(/How to fix/)).toBeInTheDocument()
+  })
+
+  it('hides "How to fix" when INSIGHTS_SUGGEST_FIX_ENABLED is off, keeping the finding and CFACTS reasoning', () => {
+    CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED = false
+    try {
+      render(
+        <InsightsPanel
+          payload={{
+            suggested_score: 1,
+            cfacts_reasoning: 'IDM-Okta detected. MFA required.',
+            findings: {
+              sechub: [
+                {
+                  id: 'IAM.10',
+                  title: 'MFA should be enabled',
+                  remediation: 'Turn on MFA in the IAM console.',
+                  severity: 'MEDIUM',
+                },
+              ],
+            },
+          }}
+        />
+      )
+      fireEvent.click(screen.getByRole('button', { name: /details/i }))
+      // Remediation gated off...
+      expect(screen.queryByText(/How to fix/)).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(/Turn on MFA in the IAM console/)
+      ).not.toBeInTheDocument()
+      // ...but the finding itself and the CFACTS reasoning still render.
+      expect(screen.getByText('IAM.10')).toBeInTheDocument()
+      expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+      expect(screen.getByText(/IDM-Okta detected/)).toBeInTheDocument()
+    } finally {
+      CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED = true
+    }
+  })
+
+  it('hides findings until details is toggled, then reveals them', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    expect(
+      screen.queryByText(/iam-user-without-mfa-device-enabled/)
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+
+    expect(
+      screen.getByText(/iam-user-without-mfa-device-enabled/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+  })
+
+  it('lists satisfied and failing ARS control IDs when the pipeline provides them', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: ['IA-01', 'IA-02(01)'],
+          ars_failing_controls: ['AC-17'],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // Satisfied controls render with a ✓; the failing one with a ✗.
+    expect(screen.getByText('IA-01').textContent).toContain('✓')
+    expect(screen.getByText('IA-02(01)').textContent).toContain('✓')
+    expect(screen.getByText('AC-17').textContent).toContain('✗')
+  })
+
+  it('drops non-string control IDs instead of throwing', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: [
+            'IA-01',
+            { bad: true },
+            42,
+          ] as unknown as string[],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // The valid string still renders; the panel is not blanked.
+    expect(screen.getByText('IA-01')).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+
+  it('shows the ARS Controls count with no chips when the control arrays are absent', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/4 of 4 satisfied/)).toBeInTheDocument()
+    expect(screen.queryByText('IA-01')).not.toBeInTheDocument()
+  })
+
+  it('renders a minimal payload without a details toggle', () => {
+    render(
+      <InsightsPanel
+        payload={{ suggested_score: 3, suggested_label: 'Advanced' }}
+      />
+    )
+    expect(screen.getByText(/Suggested: Advanced \(3\)/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /details/i })
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('OptionInsightBadges', () => {
+  const insight: InsightPayload = {
+    suggested_score: 1,
+    last_score: 2,
+    last_datacall: 'FY2024 Q1',
+  }
+
+  it('renders the recommendation badge on the suggested option', () => {
+    render(<OptionInsightBadges score={1} insight={insight} />)
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.queryByText(/FY2024 Q1 answer/)).not.toBeInTheDocument()
+  })
+
+  it("renders the prior-answer badge on last year's option", () => {
+    render(<OptionInsightBadges score={2} insight={insight} />)
+    expect(screen.getByText('FY2024 Q1 answer')).toBeInTheDocument()
+    expect(screen.queryByText('ZTMF Insights')).not.toBeInTheDocument()
+  })
+
+  it('renders both badges when the suggestion and prior score coincide', () => {
+    render(
+      <OptionInsightBadges
+        score={3}
+        insight={{ suggested_score: 3, last_score: 3, last_datacall: 'FY2024' }}
+      />
+    )
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.getByText('FY2024 answer')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic prior label when last_datacall is absent', () => {
+    render(<OptionInsightBadges score={2} insight={{ last_score: 2 }} />)
+    expect(screen.getByText("Last year's answer")).toBeInTheDocument()
+  })
+
+  it('renders nothing for an option matching neither score', () => {
+    const { container } = render(
+      <OptionInsightBadges score={4} insight={insight} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there is no insight', () => {
+    const { container } = render(<OptionInsightBadges score={1} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('suppresses the prior-answer badge when viewing the call it names (slug form)', () => {
+    render(
+      <OptionInsightBadges
+        score={2}
+        insight={insight}
+        viewedDatacall="FY2024_Q1"
+      />
+    )
+    expect(screen.queryByText('FY2024 Q1 answer')).not.toBeInTheDocument()
+  })
+
+  it('still shows the prior-answer badge when viewing a different call', () => {
+    render(
+      <OptionInsightBadges
+        score={2}
+        insight={insight}
+        viewedDatacall="FY25_ZTM"
+      />
+    )
+    expect(screen.getByText('FY2024 Q1 answer')).toBeInTheDocument()
+  })
+
+  it('keeps the recommendation badge even when the prior badge is suppressed', () => {
+    // suggested (1) and prior (1) coincide on the same option; viewing the prior
+    // call should drop only the prior badge, not the recommendation.
+    render(
+      <OptionInsightBadges
+        score={1}
+        insight={{
+          suggested_score: 1,
+          last_score: 1,
+          last_datacall: 'FY2024 Q1',
+        }}
+        viewedDatacall="FY2024_Q1"
+      />
+    )
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.queryByText('FY2024 Q1 answer')).not.toBeInTheDocument()
+  })
+})
+
+describe('InsightsPanel resilience (opaque payload)', () => {
+  it('degrades gracefully when a findings field is not an array', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          evidence_sources: 'ARS, CFACTS',
+          findings: { kion: 'not-an-array' as unknown as [] },
+        }}
+      />
+    )
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    // The malformed findings block is skipped, not thrown on.
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/ARS, CFACTS/)).toBeInTheDocument()
+  })
+
+  it('degrades a malformed non-string text field instead of blanking the panel', () => {
+    // evidence_sources arriving as an object would throw "Objects are not valid
+    // as a React child"; asText coerces it so the panel stays intact.
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          evidence_sources: { bad: true } as unknown as string,
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(screen.getByText(/Based on:/)).toBeInTheDocument()
+  })
+
+  it('coerces a non-string finding field instead of throwing', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          findings: {
+            sechub: [{ id: 'IAM.10', title: { x: 1 } as unknown as string }],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+})
+
+describe('severityStyle', () => {
+  it('maps severities to red / amber / neutral', () => {
+    for (const s of ['error', 'ERROR', 'high', 'critical']) {
+      expect(severityStyle(s).fg).toBe('#b02a37') // red
+    }
+    for (const s of ['warning', 'medium', 'WARN']) {
+      expect(severityStyle(s).fg).toBe('#b26a00') // amber
+    }
+    for (const s of ['low', 'powerup', 'anything', undefined]) {
+      expect(severityStyle(s).fg).toBe('#666') // neutral
+    }
+  })
+})
+
+describe('severity help (findings)', () => {
+  const withSeverity = (severity: string) => ({
+    suggested_score: 1,
+    findings: {
+      hardenize: [{ id: 'X', title: 'A finding', severity }],
+    },
+  })
+
+  it('adds an explanation tooltip on the powerup severity badge', () => {
+    render(<InsightsPanel payload={withSeverity('powerup')} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(
+      screen.getByLabelText(/powerup:.*recommended enhancement/i)
+    ).toBeInTheDocument()
+  })
+
+  it('adds an explanation tooltip on the error severity badge', () => {
+    render(<InsightsPanel payload={withSeverity('error')} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByLabelText(/error:.*failing check/i)).toBeInTheDocument()
+  })
+})
+
+describe('FindingRow resilience', () => {
+  it('drops a null finding element instead of blanking the panel', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            sechub: [
+              null as unknown as { id: string },
+              { id: 'IAM.10', title: 'MFA should be enabled' },
+            ],
+          },
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('IAM.10')).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+})

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -1,0 +1,740 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Tooltip from '@mui/material/Tooltip'
+import Collapse from '@mui/material/Collapse'
+import Link from '@mui/material/Link'
+import type { InsightPayload, InsightFinding } from '@/types'
+import CONFIG from '@/utils/config'
+
+type Props = {
+  payload: InsightPayload
+}
+
+// ZTMF maturity levels. The pipeline sends numeric scores; labels come with
+// the payload where available, but we fall back to this map for the pill and
+// per-source chips so a missing label never renders a bare number.
+const MATURITY_LABEL: Record<number, string> = {
+  1: 'Traditional',
+  2: 'Initial',
+  3: 'Advanced',
+  4: 'Optimal',
+}
+
+function maturityLabel(score?: number | null): string | null {
+  if (score == null) return null
+  return MATURITY_LABEL[score] ?? null
+}
+
+// Suggested-pill tint keyed by score. Mirrors the prototype's trad/init/adv/opt
+// palette. Unknown/blank score renders neutral.
+const SUGGESTED_TINT: Record<number, { bg: string; fg: string }> = {
+  1: { bg: '#fff3e0', fg: '#a86500' },
+  2: { bg: '#fff8e1', fg: '#7d6608' },
+  3: { bg: '#e8eef5', fg: '#2c5282' },
+  4: { bg: '#e3f2fd', fg: '#0d47a1' },
+}
+
+type SourceConfig = {
+  key: string
+  label: string
+  color: string
+  score?: number | null
+  active: boolean
+}
+
+// Order and brand colors match the enrichment prototype. `active` decides the
+// solid vs greyed chip; it is derived from the source's own availability flag /
+// key presence rather than assuming every source contributed.
+function buildSources(p: InsightPayload): SourceConfig[] {
+  return [
+    {
+      key: 'kion',
+      label: 'Kion',
+      color: '#e86c25',
+      score: p.kion_suggested_score,
+      active: p.has_kion_data === true || p.kion_suggested_score != null,
+    },
+    {
+      key: 'sechub',
+      label: 'SecurityHub',
+      color: '#3a7ca5',
+      score: p.sechub_suggested_score,
+      active: p.has_sechub_data === true || p.sechub_suggested_score != null,
+    },
+    {
+      key: 'hardenize',
+      label: 'Hardenize',
+      color: '#b0651e',
+      score: p.hardenize_suggested_score,
+      active:
+        p.has_hardenize_data === true || p.hardenize_suggested_score != null,
+    },
+    {
+      key: 'cfacts',
+      label: 'CFACTS',
+      color: '#0071bc',
+      score: p.cfacts_suggested_score,
+      active: p.cfacts_suggested_score != null || p.cfacts_auth_methods != null,
+    },
+    {
+      // ARS dot shows the numeric maturity score (ars_control_score, 1-4) —
+      // NOT ars_maturity (the string label like "Initial", which won't fit the
+      // dot) and NOT the controls-satisfied count (which is coverage, not
+      // maturity: 4/4 controls can still be Initial=2). The label is surfaced in
+      // the chip tooltip via maturityLabel(score).
+      key: 'ars',
+      label: 'ARS',
+      color: '#7c5cbf',
+      score: p.ars_control_score,
+      active: p.ars_control_score != null || p.ars_controls_total != null,
+    },
+  ]
+}
+
+// A source is the "floor" (drove the suggestion) when score_floor_source names
+// it. The backend sends free text like "Hardenize (failing TLS remarks)", so we
+// match on the label appearing in that string.
+function isFloor(floorSource: string | null | undefined, label: string) {
+  if (!floorSource) return false
+  return floorSource.toLowerCase().includes(label.toLowerCase())
+}
+
+function ScoreDot({
+  score,
+  color,
+  active,
+}: {
+  score?: number | null
+  color: string
+  active: boolean
+}) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        width: 16,
+        height: 16,
+        borderRadius: '50%',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 9,
+        fontWeight: 700,
+        color: '#fff',
+        lineHeight: 1,
+        flexShrink: 0,
+        bgcolor: active ? color : '#ccc',
+      }}
+    >
+      {score != null ? score : '–'}
+    </Box>
+  )
+}
+
+function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
+  const title = src.active
+    ? `${src.label}${src.score != null ? `: ${maturityLabel(src.score) ?? `Score ${src.score}`}` : ''}${
+        floor ? ' — drives the suggested score' : ''
+      }`
+    : `${src.label}: no data for this system`
+
+  return (
+    <Tooltip title={title} placement="top" arrow>
+      <Box
+        component="span"
+        aria-label={title}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          pl: 0.5,
+          pr: 1,
+          py: 0.25,
+          borderRadius: '12px',
+          fontSize: 11,
+          fontWeight: 600,
+          bgcolor: floor ? '#fffdf5' : '#fff',
+          border: floor ? '1.5px solid #b08d00' : '1px solid #ddd',
+          color: floor ? '#7d6608' : src.active ? '#333' : '#888',
+          opacity: src.active ? 1 : 0.4,
+        }}
+      >
+        <ScoreDot score={src.score} color={src.color} active={src.active} />
+        <Box component="span">{src.label}</Box>
+      </Box>
+    </Tooltip>
+  )
+}
+
+// Normalize a data-call name for comparison: fold underscores/whitespace and
+// case so "FY2025_Q3" (the viewed call slug) matches "FY2025 Q3" (the payload's
+// label form).
+function sameDatacall(a?: string | null, b?: string | null): boolean {
+  if (!a || !b) return false
+  const norm = (s: string) =>
+    s
+      .replace(/[_\s]+/g, ' ')
+      .trim()
+      .toLowerCase()
+  return norm(a) === norm(b)
+}
+
+// Inline badges for a single answer option, matched by maturity score against
+// the question's insight. Rendered next to the option label in the radio group
+// so a scorer sees, at the point of choosing, which answer the evidence points
+// to and which answer they gave last cycle.
+export function OptionInsightBadges({
+  score,
+  insight,
+  viewedDatacall,
+}: {
+  score?: number
+  insight?: InsightPayload
+  // The data call currently being viewed. The prior-answer badge is only
+  // meaningful when the insight's last answer is from an EARLIER call; if the
+  // insight's last_datacall is the call on screen, the badge would label the
+  // current call as "prior", so it is suppressed.
+  viewedDatacall?: string
+}) {
+  if (!insight || score == null) return null
+  const isSuggested =
+    insight.suggested_score != null && score === insight.suggested_score
+  const isPrior =
+    insight.last_score != null &&
+    score === insight.last_score &&
+    !sameDatacall(insight.last_datacall, viewedDatacall)
+  if (!isSuggested && !isPrior) return null
+
+  const priorLabel = insight.last_datacall
+    ? `${String(insight.last_datacall).replaceAll('_', ' ')} answer`
+    : "Last year's answer"
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        gap: 0.5,
+        ml: 0.75,
+        verticalAlign: 'middle',
+      }}
+    >
+      {isSuggested && (
+        <Box
+          component="span"
+          sx={{
+            px: 0.75,
+            py: 0.125,
+            borderRadius: '4px',
+            fontSize: 10,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.3px',
+            color: '#2c5282',
+            bgcolor: '#eaf1fb',
+            border: '1px dashed #5666b8',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          ZTMF Insights
+        </Box>
+      )}
+      {isPrior && (
+        <Box
+          component="span"
+          sx={{
+            px: 0.75,
+            py: 0.125,
+            borderRadius: '4px',
+            fontSize: 10,
+            fontWeight: 600,
+            color: '#555',
+            bgcolor: '#f0f0f0',
+            border: '1px solid #ddd',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {priorLabel}
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+function InsightsPanelInner({ payload }: Props) {
+  const [open, setOpen] = React.useState(false)
+
+  // Parent already gates on payload presence, but guard so the component is
+  // safe to render defensively anywhere.
+  if (!payload) return null
+
+  const sources = buildSources(payload)
+  const suggestedScore = payload.suggested_score
+  const suggestedLabel =
+    payload.suggested_label ?? maturityLabel(suggestedScore)
+  const tint =
+    suggestedScore != null ? SUGGESTED_TINT[suggestedScore] : undefined
+  // "Confirmed" when the suggestion matches the prior self-reported score.
+  const confirmed =
+    suggestedScore != null &&
+    payload.last_score != null &&
+    suggestedScore === payload.last_score
+  const suggestedText =
+    suggestedScore != null
+      ? `${confirmed ? 'Confirmed' : 'Suggested'}: ${suggestedLabel ?? `Score ${suggestedScore}`}${
+          suggestedScore != null ? ` (${suggestedScore})` : ''
+        }`
+      : 'No suggestion'
+
+  // The payload is opaque/additive, so a sub-field the type declares as an
+  // array could arrive as something else. Coerce to real arrays before mapping
+  // so a malformed findings block degrades to "no findings" instead of throwing
+  // during render (which the route errorElement would turn into a full-page
+  // error for the whole questionnaire).
+  const findings = payload.findings
+  const asFindingArray = (v: unknown): InsightFinding[] =>
+    Array.isArray(v) ? (v as InsightFinding[]) : []
+  const kionFindings = asFindingArray(findings?.kion)
+  const sechubFindings = asFindingArray(findings?.sechub)
+  const hardenizeFindings = asFindingArray(findings?.hardenize)
+  const hasFindings =
+    kionFindings.length > 0 ||
+    sechubFindings.length > 0 ||
+    hardenizeFindings.length > 0
+  // ARS control IDs behind the counts. Optional/additive — undefined, null, or
+  // [] until the pipeline emits them; render only when non-empty. The payload is
+  // opaque, so filter to strings: a non-string element would otherwise render as
+  // a React child and throw, blanking the whole panel via the boundary.
+  const toStringArray = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((c): c is string => typeof c === 'string') : []
+  const arsSatisfied = toStringArray(payload.ars_satisfied_controls)
+  const arsFailing = toStringArray(payload.ars_failing_controls)
+  const hasDetail =
+    hasFindings ||
+    !!payload.cfacts_reasoning ||
+    !!payload.ars_controls_total ||
+    !!payload.evidence_sources
+
+  return (
+    <Box
+      sx={{
+        bgcolor: '#f8f9fe',
+        border: '1px solid #d8dce8',
+        borderLeft: '4px solid',
+        borderLeftColor: '#5666b8',
+        borderRadius: '6px',
+        p: '14px 18px',
+        my: 2,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.25,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography
+          component="span"
+          sx={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: '#5666b8',
+            flexShrink: 0,
+          }}
+        >
+          ZTMF Insights
+        </Typography>
+
+        <Box sx={{ display: 'flex', gap: 0.625, flexWrap: 'wrap' }}>
+          {sources.map((src) => (
+            <SourceChip
+              key={src.key}
+              src={src}
+              floor={isFloor(payload.score_floor_source, src.label)}
+            />
+          ))}
+        </Box>
+
+        <Box
+          component="span"
+          sx={{
+            ml: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            px: 1.5,
+            py: 0.375,
+            borderRadius: '4px',
+            fontSize: 12,
+            fontWeight: 700,
+            whiteSpace: 'nowrap',
+            bgcolor: tint?.bg ?? '#eeeeee',
+            color: tint?.fg ?? '#555',
+          }}
+        >
+          {suggestedText}
+        </Box>
+
+        {hasDetail && (
+          <Link
+            component="button"
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            sx={{ fontSize: 11, color: '#5666b8', flexShrink: 0 }}
+          >
+            {open ? 'hide' : 'details'}
+          </Link>
+        )}
+      </Box>
+
+      <Collapse in={open} unmountOnExit>
+        <Box sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid #e0e4f0' }}>
+          {payload.evidence_sources && (
+            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                Based on:
+              </Box>{' '}
+              {asText(payload.evidence_sources)}
+            </Typography>
+          )}
+
+          {payload.cfacts_reasoning && (
+            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                CFACTS:
+              </Box>{' '}
+              {asText(payload.cfacts_reasoning)}
+            </Typography>
+          )}
+
+          {payload.ars_controls_total != null && (
+            <Box sx={{ mb: 0.75 }}>
+              <Typography sx={{ fontSize: 12, color: '#555' }}>
+                <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                  ARS Controls:
+                </Box>{' '}
+                {asText(payload.ars_controls_satisfied) ?? 0} of{' '}
+                {asText(payload.ars_controls_total)} satisfied
+              </Typography>
+              {(arsSatisfied.length > 0 || arsFailing.length > 0) && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 0.5,
+                    mt: 0.5,
+                  }}
+                >
+                  {arsSatisfied.map((id, i) => (
+                    <ControlChip key={`sat-${id}-${i}`} id={id} passed />
+                  ))}
+                  {arsFailing.map((id, i) => (
+                    <ControlChip
+                      key={`fail-${id}-${i}`}
+                      id={id}
+                      passed={false}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
+          )}
+
+          {kionFindings.map((f, i) => (
+            <FindingRow key={`kion-${f?.id ?? i}`} source="Kion" finding={f} />
+          ))}
+          {sechubFindings.map((f, i) => (
+            <FindingRow
+              key={`sechub-${f?.id ?? i}`}
+              source="SecurityHub"
+              finding={f}
+            />
+          ))}
+          {hardenizeFindings.map((f, i) => (
+            <FindingRow
+              key={`hardenize-${f?.id ?? i}`}
+              source="Hardenize"
+              finding={f}
+            />
+          ))}
+        </Box>
+      </Collapse>
+    </Box>
+  )
+}
+
+// Error boundary around the panel: a render throw (e.g. an opaque payload field
+// arriving in an unexpected shape) degrades to rendering nothing instead of
+// bubbling to the route's errorElement and replacing the entire questionnaire
+// with an error page. The panel is purely additive — failing to render it must
+// never take down the page.
+class InsightPanelBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false }
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+  render() {
+    return this.state.failed ? null : <>{this.props.children}</>
+  }
+}
+
+export default function InsightsPanel(props: Props) {
+  return (
+    <InsightPanelBoundary>
+      <InsightsPanelInner {...props} />
+    </InsightPanelBoundary>
+  )
+}
+
+// A single ARS control ID pill — green when satisfied, red when failing.
+function ControlChip({ id, passed }: { id: string; passed: boolean }) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.375,
+        px: 0.75,
+        py: 0.125,
+        borderRadius: '4px',
+        fontSize: 10,
+        fontWeight: 600,
+        fontFamily: 'monospace',
+        whiteSpace: 'nowrap',
+        bgcolor: passed ? '#e6f4ea' : '#fdecec',
+        color: passed ? '#1e7e34' : '#b02a37',
+        border: passed ? '1px solid #b7dfc2' : '1px solid #f1b0b0',
+      }}
+    >
+      <Box component="span">{passed ? '✓' : '✗'}</Box>
+      {id}
+    </Box>
+  )
+}
+
+// Coerce an opaque payload value to renderable text. The payload is untrusted
+// JSON, so a field the type declares as a string could arrive as an object or
+// array; rendering that directly throws "Objects are not valid as a React
+// child" and (via the error boundary) blanks the whole panel. Coercing to a
+// string degrades gracefully instead. Returns undefined for nullish/empty so
+// existing truthiness guards still hide the element.
+function asText(v: unknown): string | undefined {
+  if (v == null || v === '') return undefined
+  return typeof v === 'string' ? v : String(v)
+}
+
+// Hardenize instance `detail` is inconsistent — a stringified JSON object
+// ({"Error message":"..."}), plain text ("Dangling DNS record: ..."), or empty
+// ({}). Surface something readable: JSON objects → their values joined; plain
+// text as-is; empty → nothing.
+function formatHardenizeDetail(detail?: string): string | undefined {
+  const t = asText(detail)
+  if (!t || t === '{}') return undefined
+  try {
+    const parsed = JSON.parse(t)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const vals = Object.values(parsed).map(String).filter(Boolean)
+      return vals.length ? vals.join('; ') : undefined
+    }
+  } catch {
+    /* not JSON — fall through to raw text */
+  }
+  return t
+}
+
+// Severity → chip color. error/high/critical = red, warning/medium = amber,
+// everything else (low, powerup, unknown) = neutral.
+export function severityStyle(sev?: string): { bg: string; fg: string } {
+  const s = (sev ?? '').toLowerCase()
+  if (s === 'error' || s === 'high' || s === 'critical')
+    return { bg: '#fdecec', fg: '#b02a37' }
+  if (s === 'warning' || s === 'warn' || s === 'medium')
+    return { bg: '#fff4e5', fg: '#b26a00' }
+  return { bg: '#f0f0f0', fg: '#666' }
+}
+
+// TEMPORARY stopgap severity glossary shown on hover when a finding has no
+// dictionary description yet. The long-term home for this copy is the findings
+// dictionary / Snowflake view (ztmf-insights#32) — remove this map once the
+// dictionary covers findings and the scoring-treatment classification lands.
+const SEVERITY_HELP: Record<string, string> = {
+  error:
+    'A failing check — the scanner found a condition that does not meet the control. Review the finding and affected hosts; some (e.g. connection failures) may reflect reachability rather than a security weakness.',
+  critical: 'A critical failing check — remediate urgently.',
+  high: 'A high-severity failing check — prioritize remediation.',
+  warning: 'A moderate issue worth addressing, lower priority than an error.',
+  medium: 'A moderate issue worth addressing, lower priority than high/error.',
+  low: 'A low-severity or informational finding.',
+  notice:
+    'An informational notice — a best-practice observation, not a failing check.',
+  powerup:
+    'A recommended enhancement, not a failure — an opportunity to further harden this host beyond the baseline.',
+  inconclusive:
+    'Inconclusive — the scanner could not reach the host to test it, often because the domain is private/internal or retired. This is not a pass or a fail and does not count against the score.',
+  unknown:
+    'Inconclusive — the scanner could not reach the host to test it, often because the domain is private/internal or retired. This is not a pass or a fail and does not count against the score.',
+}
+function severityHelp(sev?: string): string | undefined {
+  return SEVERITY_HELP[(sev ?? '').toLowerCase()]
+}
+
+// One structured finding, uniform across sources. Card = id (code) + title +
+// severity + description; "How to fix" when remediation is present; a hover
+// "N domains" affordance for Hardenize instances. Every field is optional and
+// coerced to text, so a null/malformed field degrades instead of throwing.
+function FindingRow({
+  source,
+  finding,
+}: {
+  source: string
+  finding: InsightFinding
+}) {
+  // The payload is opaque — a findings array could contain a null/non-object
+  // element. Guard so it degrades to nothing instead of throwing on field
+  // access (which the boundary would turn into a blanked panel).
+  if (!finding || typeof finding !== 'object') return null
+  const code = asText(finding.id)
+  const heading = asText(finding.title)
+  const severity = asText(finding.severity)
+  const sevStyle = severityStyle(severity)
+  const description = asText(finding.description)
+  // The severity badge's hover carries the "what it means" text: prefer the
+  // finding's dictionary-seeded description; fall back to the temporary generic
+  // per-severity glossary until the dictionary covers everything (see
+  // ztmf-insights#32). This lets an alarming badge (e.g. a red "error" that is
+  // really a reachability finding) be honestly contextualized on hover.
+  const sevTooltip = description ?? severityHelp(severity)
+  const remediation = asText(finding.remediation)
+  const nistControls = asText(finding.nist_controls)
+  // Affected hosts (Hardenize). domain is required; detail is optional.
+  const domains = (Array.isArray(finding.instances) ? finding.instances : [])
+    .map((inst) => ({
+      domain: asText(inst?.domain),
+      detail: formatHardenizeDetail(inst?.detail),
+    }))
+    .filter((d) => d.domain)
+  const domainsTooltip =
+    domains.length > 0 ? (
+      <Box sx={{ py: 0.25 }}>
+        {domains.map((d, i) => (
+          <Box key={`${d.domain}-${i}`} sx={{ fontSize: 11, lineHeight: 1.5 }}>
+            {d.domain}
+            {d.detail ? ` — ${d.detail}` : ''}
+          </Box>
+        ))}
+      </Box>
+    ) : null
+  return (
+    <Box sx={{ fontSize: 12, color: '#555', mb: 0.75, lineHeight: 1.6 }}>
+      <Box component="span" sx={{ fontWeight: 700, color: '#333' }}>
+        {source}
+      </Box>
+      {code && (
+        <Box
+          component="span"
+          sx={{
+            ml: 0.75,
+            fontFamily: 'monospace',
+            fontSize: 11,
+            color: '#9a6700',
+          }}
+        >
+          {code}
+        </Box>
+      )}
+      {heading && (
+        <Box component="span" sx={{ ml: 0.75, color: '#333' }}>
+          {heading}
+        </Box>
+      )}
+      {severity && (
+        <Tooltip
+          title={sevTooltip ?? ''}
+          placement="top"
+          arrow
+          disableHoverListener={!sevTooltip}
+          disableFocusListener={!sevTooltip}
+          disableTouchListener={!sevTooltip}
+        >
+          <Box
+            component="span"
+            aria-label={sevTooltip ? `${severity}: ${sevTooltip}` : undefined}
+            sx={{
+              ml: 0.75,
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '3px',
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              bgcolor: sevStyle.bg,
+              color: sevStyle.fg,
+              cursor: sevTooltip ? 'help' : undefined,
+              borderBottom: sevTooltip ? '1px dotted currentColor' : undefined,
+            }}
+          >
+            {severity}
+          </Box>
+        </Tooltip>
+      )}
+      {nistControls && (
+        <Box
+          component="span"
+          sx={{
+            ml: 0.75,
+            px: 0.75,
+            py: 0.125,
+            borderRadius: '3px',
+            fontSize: 10,
+            fontWeight: 600,
+            bgcolor: '#e8eef5',
+            color: '#2c5282',
+          }}
+        >
+          {nistControls}
+        </Box>
+      )}
+      {domainsTooltip && (
+        <Tooltip title={domainsTooltip} placement="top" arrow>
+          <Box
+            component="span"
+            aria-label={domains.map((d) => d.domain).join(', ')}
+            sx={{
+              ml: 0.75,
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '3px',
+              fontSize: 10,
+              fontWeight: 600,
+              bgcolor: '#eef2f8',
+              color: '#3a5a80',
+              cursor: 'default',
+              borderBottom: '1px dotted #7a94b8',
+            }}
+          >
+            {domains.length} domain{domains.length === 1 ? '' : 's'}
+          </Box>
+        </Tooltip>
+      )}
+      {/* Description lives in the severity badge hover. When a finding has no
+          severity badge to carry it, show it in the body so it isn't lost. */}
+      {!severity && description && (
+        <Box sx={{ mt: 0.25, color: '#666' }}>{description}</Box>
+      )}
+      {CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED && remediation && (
+        <Box sx={{ mt: 0.25, color: '#5a6a8a' }}>
+          <Box component="span" sx={{ fontWeight: 600 }}>
+            How to fix:
+          </Box>{' '}
+          {remediation}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -17,6 +17,8 @@ import {
   Question,
   QuestionChoice,
   QuestionScores,
+  Insight,
+  InsightPayload,
 } from '@/types'
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
@@ -43,6 +45,9 @@ import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
+import InsightsPanel, {
+  OptionInsightBadges,
+} from './InsightsPanel/InsightsPanel'
 import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
@@ -123,6 +128,12 @@ export default function QuestionnarePage() {
   const [openAlert, setOpenAlert] = React.useState<boolean>(false)
   const [options, setOptions] = React.useState<QuestionChoice[]>([])
   const [questions, setQuestions] = React.useState<Record<number, Question>>([])
+  // ZTMF Insights keyed by DB questionid. Empty for every "off" case (OpDiv not
+  // enabled, not entitled, not yet synced) — the endpoint returns [] and the
+  // panel simply never renders, leaving the page unchanged.
+  const [insightsByQuestion, setInsightsByQuestion] = React.useState<
+    Map<number, InsightPayload>
+  >(new Map())
   const [question, setQuestion] = React.useState<string>('')
   const [datacallID, setDatacallID] = React.useState<number>(0)
   const [datacall, setDatacall] = React.useState<string>('')
@@ -204,6 +215,30 @@ export default function QuestionnarePage() {
     if (draftStatus === 'restored') setDraftStatus('idle')
   }
   const renderRadioGroup = (options: QuestionChoice[]) => {
+    // Enrich each option label with insight badges (recommended answer / last
+    // year's answer). When there is no insight for this question, the badge
+    // component renders nothing and labels are just the option text.
+    const choices = options.map((o) => ({
+      label: (
+        <Box
+          component="span"
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box component="span">{o.label}</Box>
+          <OptionInsightBadges
+            score={o.score}
+            insight={currentInsight}
+            viewedDatacall={datacall}
+          />
+        </Box>
+      ),
+      value: o.value,
+      defaultChecked: o.defaultChecked,
+    }))
     return (
       <Box
         sx={{
@@ -213,7 +248,7 @@ export default function QuestionnarePage() {
         }}
       >
         <ChoiceList
-          choices={options}
+          choices={choices}
           name={'radio-choices'}
           type={'radio'}
           label={undefined}
@@ -253,6 +288,40 @@ export default function QuestionnarePage() {
   }>({})
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
+
+  // Fetch ZTMF Insights for this system once (not per question — one call
+  // returns every question's row). Failures and empty responses both leave the
+  // map empty so the questionnaire is never blocked or altered by insights.
+  React.useEffect(() => {
+    if (!system) return
+    const controller = new AbortController()
+    // Clear the previous system's insights up front so a system change can't
+    // briefly render stale badges/panel while the new fetch is in flight.
+    setInsightsByQuestion(new Map())
+    const load = async () => {
+      try {
+        const res = await axiosInstance.get<{ data: Insight[] }>('insights', {
+          params: { fismasystemid: system },
+          signal: controller.signal,
+        })
+        const map = new Map<number, InsightPayload>()
+        for (const row of res.data?.data ?? []) {
+          if (row?.questionid != null && row.payload) {
+            map.set(row.questionid, row.payload)
+          }
+        }
+        setInsightsByQuestion(map)
+      } catch {
+        if (!controller.signal.aborted) {
+          // Insights are additive and optional; swallow errors and render the
+          // page exactly as it is without them.
+          setInsightsByQuestion(new Map())
+        }
+      }
+    }
+    void load()
+    return () => controller.abort()
+  }, [system])
   // Resolve the system's raw datacenter environment to its scoring category
   // for pillar filtering. Falls back to the raw value until the vocabulary
   // loads or for any value not in the map.
@@ -424,6 +493,7 @@ export default function QuestionnarePage() {
                   organizedData[question.pillar.pillar] = []
                 }
                 questionData[question.function.functionid] = {
+                  questionid: question.questionid,
                   question: question.question,
                   notesprompt: question.notesprompt,
                   description: question.function.description,
@@ -569,6 +639,7 @@ export default function QuestionnarePage() {
             const choiceOpt: QuestionChoice = {
               label: item.description,
               value: item.functionoptionid,
+              score: item.score,
             }
             if (item.functionoptionid in questionScoresRef.current) {
               funcOptId = item.functionoptionid
@@ -818,6 +889,14 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
+  // Insight for the question currently on screen. questionId holds the current
+  // functionid; the Question record carries the DB questionid the insight rows
+  // are keyed by. Undefined for any question without a synced insight row, in
+  // which case the panel is not rendered and the page is unchanged.
+  const currentInsight =
+    questionId != null
+      ? insightsByQuestion.get(questions[questionId]?.questionid ?? -1)
+      : undefined
   return (
     <>
       <Box
@@ -941,6 +1020,7 @@ export default function QuestionnarePage() {
               <Typography variant="h6" sx={{ mt: 1, mb: 0 }}>
                 {question}
               </Typography>
+              {currentInsight && <InsightsPanel payload={currentInsight} />}
               {loadingQuestion ? (
                 <Box
                   sx={{

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_AWS_REGION: string
   readonly VITE_IDP_ENABLED: string
+  readonly VITE_INSIGHTS_SUGGEST_FIX_ENABLED: string
   readonly VITE_COGNITO_DOMAIN: string
   readonly VITE_COGNITO_REDIRECT_SIGN_IN: string
   // more env variables...


### PR DESCRIPTION
Promotes the ZTMF Insights panel from impl to dev (and, on merge, prod).

## What it does

Alongside each questionnaire question, the panel surfaces the evidence ZTMF maps to that question from the security tooling it ingests — Kion, SecurityHub, Hardenize, CFACTS, ARS — plus prior-year context, and badges the answer options that match a suggested or prior score.

It is **purely informational**: it never changes, gates, or auto-sets the score. The responder still chooses; the panel just puts the evidence next to the answer.

## Invisible when off

The panel renders only for systems whose OpDiv is entitled and only when the insights endpoint returns data. Systems without insights (most OpDivs at first, since rollout is CMS-first) see no change to the questionnaire — no empty panel, no "no data" banner.

## The remediation flag

Includes a build-time flag, `INSIGHTS_SUGGEST_FIX_ENABLED`, that gates the "How to fix" remediation text on a finding. `ui.yml` sets it true **only on the impl build**; dev and prod ship Insights **without** the remediation while that piece is being trialed. This is intentional.

## Safety

The panel is wrapped in an error boundary and renders nothing on any malformed payload, so a bad insight can never blank the questionnaire. The payload is treated as opaque and additive (every field optional, arrays guarded).

## Testing

Full suite green (376 passing, InsightsPanel adds ~30), typecheck and lint clean. This PR deploys to dev for validation before any merge to prod.
