### PR TITLE
Show non-satisfied ARS controls greyed in insights panel

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -452,6 +452,10 @@ export type InsightPayload = {
   // pipeline; may be undefined (before it ships / on non-ARS questions), null,
   // or []. `ars_satisfied_controls` length == `ars_controls_satisfied`.
   ars_satisfied_controls?: string[] | null
+  // Applicable-but-not-satisfied controls (applicable − satisfied). Informational,
+  // rendered greyed — distinct from `ars_failing_controls` (Archer-explicit fails).
+  // satisfied + not_satisfied == ars_controls_total when the pipeline emits them.
+  ars_not_satisfied_controls?: string[] | null
   ars_failing_controls?: string[] | null
 
   findings?: InsightFindings

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -229,12 +229,13 @@ describe('InsightsPanel', () => {
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
   })
 
-  it('lists satisfied and failing ARS control IDs when the pipeline provides them', () => {
+  it('lists satisfied, non-satisfied, and failing ARS control IDs when the pipeline provides them', () => {
     render(
       <InsightsPanel
         payload={{
           ...fullPayload,
           ars_satisfied_controls: ['IA-01', 'IA-02(01)'],
+          ars_not_satisfied_controls: ['IA-02(02)', 'IA-02(08)'],
           ars_failing_controls: ['AC-17'],
         }}
       />
@@ -244,6 +245,23 @@ describe('InsightsPanel', () => {
     expect(screen.getByText('IA-01').textContent).toContain('✓')
     expect(screen.getByText('IA-02(01)').textContent).toContain('✓')
     expect(screen.getByText('AC-17').textContent).toContain('✗')
+    // Non-satisfied controls render greyed with a neutral marker — NOT the red ✗.
+    expect(screen.getByText('IA-02(02)').textContent).toContain('○')
+    expect(screen.getByText('IA-02(02)').textContent).not.toContain('✗')
+    expect(screen.getByText('IA-02(08)').textContent).toContain('○')
+  })
+
+  it('renders non-satisfied ARS controls even when the satisfied array is absent', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_not_satisfied_controls: ['IA-02(02)'],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('IA-02(02)').textContent).toContain('○')
   })
 
   it('drops non-string control IDs instead of throwing', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -309,6 +309,7 @@ function InsightsPanelInner({ payload }: Props) {
   const toStringArray = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((c): c is string => typeof c === 'string') : []
   const arsSatisfied = toStringArray(payload.ars_satisfied_controls)
+  const arsNotSatisfied = toStringArray(payload.ars_not_satisfied_controls)
   const arsFailing = toStringArray(payload.ars_failing_controls)
   const hasDetail =
     hasFindings ||
@@ -418,7 +419,9 @@ function InsightsPanelInner({ payload }: Props) {
                 {asText(payload.ars_controls_satisfied) ?? 0} of{' '}
                 {asText(payload.ars_controls_total)} satisfied
               </Typography>
-              {(arsSatisfied.length > 0 || arsFailing.length > 0) && (
+              {(arsSatisfied.length > 0 ||
+                arsNotSatisfied.length > 0 ||
+                arsFailing.length > 0) && (
                 <Box
                   sx={{
                     display: 'flex',
@@ -428,13 +431,24 @@ function InsightsPanelInner({ payload }: Props) {
                   }}
                 >
                   {arsSatisfied.map((id, i) => (
-                    <ControlChip key={`sat-${id}-${i}`} id={id} passed />
+                    <ControlChip
+                      key={`sat-${id}-${i}`}
+                      id={id}
+                      variant="satisfied"
+                    />
+                  ))}
+                  {arsNotSatisfied.map((id, i) => (
+                    <ControlChip
+                      key={`unsat-${id}-${i}`}
+                      id={id}
+                      variant="unsatisfied"
+                    />
                   ))}
                   {arsFailing.map((id, i) => (
                     <ControlChip
                       key={`fail-${id}-${i}`}
                       id={id}
-                      passed={false}
+                      variant="failing"
                     />
                   ))}
                 </Box>
@@ -491,8 +505,42 @@ export default function InsightsPanel(props: Props) {
   )
 }
 
-// A single ARS control ID pill — green when satisfied, red when failing.
-function ControlChip({ id, passed }: { id: string; passed: boolean }) {
+// A single ARS control ID pill. Three states: satisfied (green ✓), unsatisfied
+// (grey ○ — informational, applicable-but-not-satisfied, no alarm), failing
+// (red ✗ — Archer-explicit fails).
+type ControlChipVariant = 'satisfied' | 'unsatisfied' | 'failing'
+const CONTROL_CHIP_STYLE: Record<
+  ControlChipVariant,
+  { marker: string; bgcolor: string; color: string; border: string }
+> = {
+  satisfied: {
+    marker: '✓',
+    bgcolor: '#e6f4ea',
+    color: '#1e7e34',
+    border: '1px solid #b7dfc2',
+  },
+  unsatisfied: {
+    marker: '○',
+    bgcolor: '#eceef2',
+    color: '#5c636a',
+    border: '1px solid #d8dce8',
+  },
+  failing: {
+    marker: '✗',
+    bgcolor: '#fdecec',
+    color: '#b02a37',
+    border: '1px solid #f1b0b0',
+  },
+}
+
+function ControlChip({
+  id,
+  variant,
+}: {
+  id: string
+  variant: ControlChipVariant
+}) {
+  const style = CONTROL_CHIP_STYLE[variant]
   return (
     <Box
       component="span"
@@ -507,12 +555,12 @@ function ControlChip({ id, passed }: { id: string; passed: boolean }) {
         fontWeight: 600,
         fontFamily: 'monospace',
         whiteSpace: 'nowrap',
-        bgcolor: passed ? '#e6f4ea' : '#fdecec',
-        color: passed ? '#1e7e34' : '#b02a37',
-        border: passed ? '1px solid #b7dfc2' : '1px solid #f1b0b0',
+        bgcolor: style.bgcolor,
+        color: style.color,
+        border: style.border,
       }}
     >
-      <Box component="span">{passed ? '✓' : '✗'}</Box>
+      <Box component="span">{style.marker}</Box>
       {id}
     </Box>
   )


### PR DESCRIPTION
## What

Shows the non-satisfied ARS controls behind the "X of Y satisfied" count in the questionnaire insights panel, greyed out. Before, only the satisfied controls rendered as pills, so a reader seeing "1 of 4 satisfied" (e.g. EPPEC) couldn't tell which three controls were missing.

Now all controls behind the count are visible:
- satisfied → green with a ✓ (unchanged)
- non-satisfied → grey with a ○ (new — informational, not an alarm)
- failing → red with a ✗ (unchanged; rare, Archer-explicit fails)

## Why grey, not red

"Not satisfied" is informational, consistent with the panel's informational-only framing. Most non-satisfied controls are applicable-but-unassessed, not failures — so they get a muted neutral treatment, distinct from the red "failing" state.

## Backend dependency (already landed)

Rides a new payload field `ars_not_satisfied_controls`, emitted by the insights view so that `satisfied + not_satisfied = total`. The field is null on non-ARS questions, so the panel keeps its existing count-only fallback with no empty state.

## Changes

- `types.ts` — add `ars_not_satisfied_controls?: string[] | null` to the insight payload.
- `InsightsPanel.tsx` — render the grey pills between green and red; `ControlChip` goes from a binary satisfied/failing prop to a three-state variant. Reuses the existing `toStringArray` guard, so a malformed payload can't throw.
- tests — cover the three-state render and the grey (non-red) marker; the count-only fallback test stays green.

## Test

System **EPPEC**, Identity pillar, question 1 ("How does the system authenticate user identity?"). Expand the insight details → ARS Controls: "1 of 4 satisfied", IA-01 green, IA-02(01)/IA-02(02)/IA-02(08) grey.

Closes #518
