### PR TITLE
Rename CfactsRecordCard to SystemEnrichmentCard

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -329,7 +329,7 @@ export type ThemeColor =
 
 export type ThemeSkin = 'filled' | 'light' | 'light-static'
 
-export type CfactsSystemType = {
+export type SystemEnrichmentType = {
   fisma_uuid: string
   fisma_acronym: string
   authorization_package_name: string | null

--- a/src/utils/authHandling.invariants.test.ts
+++ b/src/utils/authHandling.invariants.test.ts
@@ -4,7 +4,7 @@
 // the per-view redirect/permission ladders that the centralization
 // replaced. This is a long-lived consistency check, not a behavioral
 // test. Behavioral coverage lives next to each view (e.g.
-// EmailModal.test.tsx, CfactsRecordCard.test.tsx).
+// EmailModal.test.tsx, SystemEnrichmentCard.test.tsx).
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -60,7 +60,7 @@ const expectations: FileExpectation[] = [
     excludes: ['Routes.SIGNIN'],
   },
   {
-    filePath: 'src/views/SystemDetailPage/CfactsRecordCard.tsx',
+    filePath: 'src/views/SystemDetailPage/SystemEnrichmentCard.tsx',
     includes: ['skipAuthHandling: true'],
   },
   {

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -28,7 +28,7 @@ import {
   TARGET_JUSTIFICATION_MAX,
 } from './targetMaturityConfig'
 import { EXTENDED_METADATA_KEYS } from './fieldConfig'
-import CfactsRecordCard from './CfactsRecordCard'
+import SystemEnrichmentCard from './SystemEnrichmentCard'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
@@ -669,7 +669,7 @@ export default function SystemDetailPage() {
           <Typography variant="h6" sx={{ mb: 2 }}>
             ZTMF Insights
           </Typography>
-          <CfactsRecordCard fismaUid={system.fismauid} />
+          <SystemEnrichmentCard fismaUid={system.fismauid} />
         </>
       )}
 

--- a/src/views/SystemDetailPage/SystemEnrichmentCard.test.tsx
+++ b/src/views/SystemDetailPage/SystemEnrichmentCard.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@/axiosConfig', () => {
 
 import axiosInstance from '@/axiosConfig'
 import router from '@/router/router'
-import CfactsRecordCard from './CfactsRecordCard'
+import SystemEnrichmentCard from './SystemEnrichmentCard'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 
 const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
@@ -52,7 +52,7 @@ test('200 response renders the enrichment cards with payload fields', async () =
     },
   })
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(await screen.findByText('Test Package')).toBeInTheDocument()
   expect(screen.getByText('Test ISSO')).toBeInTheDocument()
@@ -64,7 +64,7 @@ test('200 response renders the enrichment cards with payload fields', async () =
 test('403 renders the quiet empty state and the interceptor stays out of the way', async () => {
   mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(403)
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(
     await screen.findByText(/no ztmf insights data found/i)
@@ -78,7 +78,7 @@ test('403 renders the quiet empty state and the interceptor stays out of the way
 test('404 renders the same quiet empty state', async () => {
   mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(404)
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(
     await screen.findByText(/no ztmf insights data found/i)
@@ -88,7 +88,7 @@ test('404 renders the same quiet empty state', async () => {
 test('500 renders the failed-to-load message', async () => {
   mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(500)
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(
     await screen.findByText(/failed to load ztmf insights data/i)
@@ -107,7 +107,7 @@ test('formats a timestamp-format ATO expiration date instead of "Invalid Date"',
     },
   })
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(await screen.findByText('Test Package')).toBeInTheDocument()
   expect(screen.getByText('12/13/2026')).toBeInTheDocument()
@@ -126,7 +126,7 @@ test('renders the placeholder when no ATO expiration date is present', async () 
     },
   })
 
-  renderWithProviders(<CfactsRecordCard fismaUid={FISMA_UID} />)
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
 
   expect(await screen.findByText('Test Package')).toBeInTheDocument()
   expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument()

--- a/src/views/SystemDetailPage/SystemEnrichmentCard.tsx
+++ b/src/views/SystemDetailPage/SystemEnrichmentCard.tsx
@@ -9,10 +9,10 @@ import {
   Grid,
   Typography,
 } from '@mui/material'
-import { CfactsSystemType } from '@/types'
+import { SystemEnrichmentType } from '@/types'
 import axiosInstance from '@/axiosConfig'
 
-interface CfactsRecordCardProps {
+interface SystemEnrichmentCardProps {
   fismaUid: string
 }
 
@@ -84,8 +84,12 @@ function formatDate(dateStr: string | null): string | null {
   return date.toLocaleDateString()
 }
 
-export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
-  const [cfacts, setCfacts] = useState<CfactsSystemType | null>(null)
+export default function SystemEnrichmentCard({
+  fismaUid,
+}: SystemEnrichmentCardProps) {
+  const [enrichment, setEnrichment] = useState<SystemEnrichmentType | null>(
+    null
+  )
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [hasError, setHasError] = useState(false)
@@ -111,7 +115,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
         // top-level siblings. Flatten into the existing shape so the rendering
         // below is unchanged.
         const record = res.data?.data
-        setCfacts(
+        setEnrichment(
           record
             ? {
                 ...record.payload,
@@ -159,7 +163,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
     )
   }
 
-  if (notFound || !cfacts) {
+  if (notFound || !enrichment) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
         No ZTMF Insights data found.
@@ -167,7 +171,7 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
     )
   }
 
-  const atoColor = getAtoColor(cfacts.ato_expiration_date)
+  const atoColor = getAtoColor(enrichment.ato_expiration_date)
 
   return (
     <Grid container spacing={3}>
@@ -182,14 +186,17 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
           <CardContent>
             <FieldDisplay
               label="Package Name"
-              value={cfacts.authorization_package_name}
+              value={enrichment.authorization_package_name}
             />
-            <FieldDisplay label="Acronym" value={cfacts.fisma_acronym} />
-            <FieldDisplay label="FISMA UUID" value={cfacts.fisma_uuid} />
-            <FieldDisplay label="Component" value={cfacts.component_acronym} />
+            <FieldDisplay label="Acronym" value={enrichment.fisma_acronym} />
+            <FieldDisplay label="FISMA UUID" value={enrichment.fisma_uuid} />
+            <FieldDisplay
+              label="Component"
+              value={enrichment.component_acronym}
+            />
             <FieldDisplay
               label="Lifecycle Phase"
-              value={cfacts.lifecycle_phase}
+              value={enrichment.lifecycle_phase}
             />
           </CardContent>
         </Card>
@@ -204,11 +211,11 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
           />
           <CardContent>
             <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
-              <BooleanChip label="Active" value={cfacts.is_active} />
-              <BooleanChip label="Retired" value={cfacts.is_retired} />
+              <BooleanChip label="Active" value={enrichment.is_active} />
+              <BooleanChip label="Retired" value={enrichment.is_retired} />
               <BooleanChip
                 label="Decommissioned"
-                value={cfacts.is_decommissioned}
+                value={enrichment.is_decommissioned}
               />
             </Box>
             <Box sx={{ mb: 2 }}>
@@ -219,13 +226,13 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
                 variant="body1"
                 sx={atoColor ? { color: atoColor } : undefined}
               >
-                {formatDate(cfacts.ato_expiration_date) || '—'}
+                {formatDate(enrichment.ato_expiration_date) || '—'}
               </Typography>
             </Box>
-            {cfacts.decommission_date && (
+            {enrichment.decommission_date && (
               <FieldDisplay
                 label="Decommission Date"
-                value={formatDate(cfacts.decommission_date)}
+                value={formatDate(enrichment.decommission_date)}
               />
             )}
           </CardContent>
@@ -240,9 +247,15 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
             sx={{ pb: 0 }}
           />
           <CardContent>
-            <FieldDisplay label="Group Acronym" value={cfacts.group_acronym} />
-            <FieldDisplay label="Group Name" value={cfacts.group_name} />
-            <FieldDisplay label="Division Name" value={cfacts.division_name} />
+            <FieldDisplay
+              label="Group Acronym"
+              value={enrichment.group_acronym}
+            />
+            <FieldDisplay label="Group Name" value={enrichment.group_name} />
+            <FieldDisplay
+              label="Division Name"
+              value={enrichment.division_name}
+            />
           </CardContent>
         </Card>
       </Grid>
@@ -260,13 +273,13 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
               <Grid item xs={12} sm={6}>
                 <FieldDisplay
                   label="Primary ISSO Name"
-                  value={cfacts.primary_isso_name}
+                  value={enrichment.primary_isso_name}
                 />
               </Grid>
               <Grid item xs={12} sm={6}>
                 <FieldDisplay
                   label="Primary ISSO Email"
-                  value={cfacts.primary_isso_email}
+                  value={enrichment.primary_isso_email}
                 />
               </Grid>
             </Grid>
@@ -277,9 +290,9 @@ export default function CfactsRecordCard({ fismaUid }: CfactsRecordCardProps) {
       {/* Footer: sync info */}
       <Grid item xs={12}>
         <Typography variant="caption" color="text.secondary">
-          Data as of: {new Date(cfacts.synced_at).toLocaleString()}
-          {cfacts.last_modified_date &&
-            ` · Last modified in CFACTS: ${formatDate(cfacts.last_modified_date)}`}
+          Data as of: {new Date(enrichment.synced_at).toLocaleString()}
+          {enrichment.last_modified_date &&
+            ` · Last modified in CFACTS: ${formatDate(enrichment.last_modified_date)}`}
         </Typography>
       </Grid>
     </Grid>


### PR DESCRIPTION
> **Note:** In-repo copy of #499 by @tarratsco. Moved from the fork so Snyk and the deploy CI gates can run — those jobs require org secrets unavailable to fork PRs. Commits and authorship are unchanged.
>
> Refs #499

---

## Summary

Rename `CfactsRecordCard` → `SystemEnrichmentCard` for naming consistency with the endpoint it already reads from (`/systemenrichment`). No behavior change, no data-source change, and no user-visible impact beyond internal code identifiers.

The card migrated to the new endpoint in `#367` but kept its old file, component, and type names during the migration window while both surfaces coexisted. With the BE having retired the old `/cfactssystems` read surface, the naming can finally follow.

## Changes

| Concern | Before | After |
| --- | --- | --- |
| File | `CfactsRecordCard.tsx` | `SystemEnrichmentCard.tsx` |
| Test file | `CfactsRecordCard.test.tsx` | `SystemEnrichmentCard.test.tsx` |
| Component | `CfactsRecordCard` | `SystemEnrichmentCard` |
| Props interface | `CfactsRecordCardProps` | `SystemEnrichmentCardProps` |
| Type in `src/types.ts` | `CfactsSystemType` | `SystemEnrichmentType` |
| State var in card | `[cfacts, setCfacts]` | `[enrichment, setEnrichment]` |
| Field accesses | `cfacts.<field>` (~20 sites) | `enrichment.<field>` |
| Importer in `SystemDetailPage.tsx` | `CfactsRecordCard` | `SystemEnrichmentCard` |
| Invariants file-path assertion (`authHandling.invariants.test.ts`) | old path | new path |

Files renamed via `git mv` so history is preserved; the file rename shows as `R` in `git status`, not delete + create.

## Intentionally NOT changed

* **`Last modified in CFACTS: ...`** user-visible label at line 286. This refers to the actual upstream CMS source system ("CFACTS" is a real CMS system name), not our internal naming convention. Correct as-is.
* **`cfacts_systems` DB table** — different scope, different repo. The ticket's gate is the read surface (controller/endpoint), not the underlying sync-target table.

## Test plan

### Automated

* `yarn jest SystemEnrichment --no-coverage` — 6/6 passing. The behavioral tests (200/403/404/500 responses, ATO date formatting) are unchanged; they exercise the endpoint and the shape, both of which were untouched.
* `make check` clean.
* `make test` — 331 passing (same count as before the rename; the invariants test guardrail continues to enforce `skipAuthHandling: true` remains in the renamed file).

### Manual

* [ ] Open a system detail page for a system with `sdl_sync_enabled = true`.
* [ ] Confirm the ZTMF Insights section renders as it did before (same identity / status / organization / contacts sub-cards, same field labels, same loading/empty/error states).
* [ ] Confirm the footer still reads "Data as of: ..." and "Last modified in CFACTS: ..." (this label is intentional).
* [ ] Open a system with `sdl_sync_enabled = false` and confirm the ZTMF Insights section is still hidden (`#367` gating is untouched by this rename).

## Notes for reviewers

* **Ticket-scope decision**: the ticket text specifies "file + component + import." This PR goes slightly further and also renames the `CfactsSystemType` type and the internal `cfacts` state variable. Rationale: the rename is a consistency pass; leaving `Cfacts*` internals after a consistency-motivated file rename would be a half-fix. Two-minute audit; no behavior change. Happy to split back to the minimal interpretation if reviewer prefers.
* **History preserved**: files renamed with `git mv`; `git log --follow` on the new filename continues into the old history.
* **The one lingering `CFACTS` string** (line 286, "Last modified in CFACTS") is deliberate — CFACTS is the upstream data-source system's real name, and the label describes when the record was last touched in that upstream system. Renaming it would misrepresent the data lineage.

closes #526 