### PR TITLE
fix(questionnaire): make questionnaire deep links self-addressable (#500)

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Deep-link integration test for #500: a questionnaire URL reached by paste /
+// refresh / bookmark (no router location.state) must resolve the system from
+// :fismaacronym, the cycle from the datacall segment, and open the named
+// :pillar/:function — not fail to load or snap to the first function.
+
+// config.ts reads import.meta.env, which jest can't parse; only the insight
+// feature flag is reachable from this page, so a minimal default is enough.
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+// Seed shape mirrors GET /fismasystems/:id/questions (empire data, SSD-EX).
+const PILLARS: [string, number, string][] = [
+  ['Identity', 7006, 'Imperial Identity Verification'],
+  ['Devices', 7001, 'Imperial Device Management'],
+  ['Networks', 7003, 'Imperial Network Security'],
+  ['Applications', 7002, 'Fleet Application Security'],
+  ['Data', 7004, 'Fleet Data Protection'],
+  ['CrossCutting', 7005, 'Imperial Cross-Cutting Controls'],
+]
+
+const QUESTIONS = PILLARS.map(([pillar, functionid, fn], i) => ({
+  questionid: 900 + i,
+  question: `Question for ${fn}`,
+  notesprompt: 'Notes',
+  pillar: { pillar },
+  function: {
+    functionid,
+    function: fn,
+    description: `${fn} description`,
+    datacenterenvironment: 'Imperial-Fleet',
+  },
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role: 'OWNER',
+    } as userData,
+    // Latest is call 5; the deep link below names call 4 — so a scores query
+    // for datacallid=4 proves the cycle was resolved from the URL, not defaulted.
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+      {
+        datacallid: 4,
+        datacall: 'FY2025 Death Star Assessment',
+        datecreated: '',
+        deadline: '2025-03-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={AppRoutes.QUESTIONNAIRE} element={<QuestionnairePage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+const optionsCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => u.includes('/options'))
+
+it('resolves the system from :fismaacronym on a cold load (no location.state)', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  // The old failure mode was this warning; it must not appear now.
+  await waitFor(() =>
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('/fismasystems/1002/questions'),
+      expect.anything()
+    )
+  )
+  expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})
+
+it('resolves the cycle from the URL datacall segment (not the latest/selected call)', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  await waitFor(() =>
+    expect(
+      mockGet.mock.calls.some(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].startsWith('scores') &&
+          c[0].includes('datacallid=4')
+      )
+    ).toBe(true)
+  )
+  // The latest call (5) must NOT be the one queried for scores.
+  expect(
+    mockGet.mock.calls.some(
+      (c) =>
+        typeof c[0] === 'string' &&
+        c[0].startsWith('scores') &&
+        c[0].includes('datacallid=5')
+    )
+  ).toBe(false)
+})
+
+it('opens the deep-linked :pillar/:function instead of the first', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  // Networks/Imperial Network Security is functionid 7003; the first pillar
+  // (Identity) is 7006. Honoring the URL means we fetch options for 7003.
+  await waitFor(() =>
+    expect(
+      optionsCalls().some((u) => u.includes('functions/7003/options'))
+    ).toBe(true)
+  )
+  expect(optionsCalls().some((u) => u.includes('functions/7006/options'))).toBe(
+    false
+  )
+})
+
+it('falls back to the first function when the URL omits :pillar/:function', async () => {
+  renderAt('/questionnaire/ssd-ex')
+
+  // No pillar/function in the URL -> first pillar (Identity, 7006).
+  await waitFor(() =>
+    expect(
+      optionsCalls().some((u) => u.includes('functions/7006/options'))
+    ).toBe(true)
+  )
+})
+
+it('shows a not-found warning once systems are loaded and the acronym is unknown', async () => {
+  renderAt(
+    '/questionnaire/does-not-exist/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  await waitFor(() =>
+    expect(screen.getByText(/Could not find a system/i)).toBeInTheDocument()
+  )
+})
+
+it('shows a spinner (not the not-found warning) while the systems list is still loading', () => {
+  mockCtx.fismaSystems = []
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -54,6 +54,12 @@ import {
 } from './saveGuard'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
+import {
+  toSlug,
+  resolveSystemIdByAcronym,
+  resolveDatacallBySlug,
+  resolveFunctionTarget,
+} from './deepLink'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -87,12 +93,6 @@ const CssTextField = styled(TextField)({
     },
   },
 })
-const toSlug = (str: string) =>
-  str
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .toLowerCase()
-    .replaceAll(' ', '-')
-
 const addSpace = (str: string) => {
   for (let i = 0; i < str.length; i++) {
     if (
@@ -115,6 +115,7 @@ export default function QuestionnarePage() {
     latestDatacall,
     latestDeadline,
     fismaSystems,
+    datacalls,
     datacenterEnvironments,
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
@@ -263,12 +264,34 @@ export default function QuestionnarePage() {
 
   const navigate = useNavigate()
   const location = useLocation()
-  const { fismaacronym } = useParams()
+  // `function` is a reserved word, so the :function route param is aliased.
+  const {
+    fismaacronym,
+    datacallid: datacallSlug,
+    pillar: pillarSlug,
+    function: functionSlug,
+  } = useParams()
 
   // Direct/bookmarked navigation to /questionnaire/<acronym> has a null
-  // location.state. Optional-chain instead of crashing on first render; the
-  // missing-system path is handled by an early render guard below.
-  const system = location.state?.fismasystemid as number | undefined
+  // location.state. On such a cold load (paste / refresh / bookmark) fall back
+  // to resolving :fismaacronym against the systems list the app already loads,
+  // so the questionnaire is self-addressable (#500). In-app navigation keeps
+  // carrying the id in location.state, which takes precedence.
+  const stateSystem = location.state?.fismasystemid as number | undefined
+  const resolvedSystem = React.useMemo(
+    () => resolveSystemIdByAcronym(fismaSystems, fismaacronym),
+    [fismaSystems, fismaacronym]
+  )
+  const system = stateSystem ?? resolvedSystem
+  // Deep-link URL params, read via refs inside the data-fetch effect so honoring
+  // them doesn't enroll them as effect deps (which would refetch on every
+  // in-survey question change, since those rewrite :pillar/:function).
+  const pillarSlugRef = React.useRef(pillarSlug)
+  pillarSlugRef.current = pillarSlug
+  const functionSlugRef = React.useRef(functionSlug)
+  functionSlugRef.current = functionSlug
+  const datacallSlugRef = React.useRef(datacallSlug)
+  datacallSlugRef.current = datacallSlug
   // The dashboard opens the questionnaire for the system's own data call
   // (year-aggregated view, #467): the specific call id and name ride along in
   // the route state. Absent (deep link), fall back to the selected/latest call.
@@ -411,7 +434,10 @@ export default function QuestionnarePage() {
   }
 
   React.useEffect(() => {
-    if (system) {
+    // Wait for the data calls to load before fetching: a cold deep link can
+    // resolve `system` (from the systems list) before the datacall context is
+    // ready, and firing early would query scores with datacallid=0. (#500)
+    if (system && latestDataCallId > 0) {
       const controller = new AbortController()
       // Reset the empty-questionnaire flag so a previous decommissioned-system
       // view does not bleed into the next render when system changes.
@@ -440,10 +466,31 @@ export default function QuestionnarePage() {
               deadline: routeDeadline,
             }
           } else {
+            // Cold deep link (no route state): resolve the cycle from the URL's
+            // data-call segment. Falls through to the selected/latest call when
+            // the segment is absent or unrecognized. (#500)
+            const deepLinkDatacall = resolveDatacallBySlug(
+              datacalls,
+              datacallSlugRef.current
+            )
             const isHistorical =
               selectedDatacall !== null &&
               selectedDatacall.datacallid !== latestDataCallId
-            if (isHistorical && selectedDatacall) {
+            if (deepLinkDatacall) {
+              datacall = deepLinkDatacall.datacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(
+                deepLinkDatacall.deadline
+                  ? new Date() > new Date(deepLinkDatacall.deadline)
+                  : true
+              )
+              activeDataCallId = deepLinkDatacall.datacallid
+              datacallStateRef.current = {
+                datacallid: deepLinkDatacall.datacallid,
+                datacall: deepLinkDatacall.datacall,
+                deadline: deepLinkDatacall.deadline,
+              }
+            } else if (isHistorical && selectedDatacall) {
               datacall = selectedDatacall.datacall.replaceAll(' ', '_')
               setDatacall(datacall)
               setIsPastDeadline(true)
@@ -470,6 +517,9 @@ export default function QuestionnarePage() {
           // Hoisted so both the questions block and the final batch can access them.
           const questionData: Record<number, Question> = {}
           let sortedFuncId: number[] = []
+          // The function to open. Defaults to the first; overridden below when the
+          // URL's :pillar/:function names a valid function (deep link, #500).
+          let targetFuncId: number | undefined
           try {
             const response = await axiosInstance.get(
               `/fismasystems/${system}/questions`,
@@ -528,6 +578,19 @@ export default function QuestionnarePage() {
                 },
                 {}
               )
+              // Honor the URL's :pillar/:function when they name a valid
+              // function; otherwise open the first (#500).
+              const target = resolveFunctionTarget(
+                categoriesData,
+                pillarSlugRef.current,
+                functionSlugRef.current
+              )
+              targetFuncId = target?.functionid ?? sortedFuncId[0]
+              const targetPillarName =
+                target?.pillarName ?? categoriesData[0].name
+              const targetFunctionName =
+                target?.functionName ??
+                categoriesData[0].steps[0].function.function
               // Update sidebar/nav state immediately so the question list
               // renders while scores are still loading. setQuestions,
               // setDatacallID, and setQuestionId are deferred to the batch
@@ -537,13 +600,13 @@ export default function QuestionnarePage() {
               setStepFunctionId(sortedFuncId)
               setCategories(categoriesData)
               navigate(
-                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
+                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(targetPillarName)}/${toSlug(targetFunctionName)}`,
                 {
                   state: { fismasystemid: system, ...datacallStateRef.current },
                   replace: true,
                 }
               )
-              setSelectedIndex(sortedFuncId[0])
+              setSelectedIndex(targetFuncId)
             }
           } catch (error) {
             if (controller.signal.aborted) return
@@ -591,7 +654,7 @@ export default function QuestionnarePage() {
           setQuestions(questionData)
           setQuestionScores(hashTable)
           setDatacallID(activeDataCallId)
-          setQuestionId(sortedFuncId[0])
+          setQuestionId(targetFuncId ?? sortedFuncId[0])
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) {
@@ -617,6 +680,7 @@ export default function QuestionnarePage() {
     latestDatacall,
     latestDeadline,
     systemCategory,
+    datacalls,
   ])
   React.useEffect(() => {
     if (questionId) {
@@ -854,13 +918,29 @@ export default function QuestionnarePage() {
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
     : undefined
   if (!system) {
+    // Cold load (paste / refresh / bookmark): the systems list may still be in
+    // flight, so :fismaacronym can't be resolved yet. Show a spinner until it
+    // arrives; only once systems are loaded and the acronym still isn't among
+    // them is the link genuinely unresolvable. (#500)
+    if (fismaSystems.length === 0) {
+      return (
+        <>
+          <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+          <Container maxWidth={false} disableGutters>
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+              <Spinner size="big" />
+            </Box>
+          </Container>
+        </>
+      )
+    }
     return (
       <>
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
         <Container maxWidth={false} disableGutters>
           <Alert severity="warning" sx={{ mt: 2 }}>
-            Cannot load questionnaire from a direct link. Please open it from
-            the system list.
+            Could not find a system matching “{fismaacronym}”. It may not exist,
+            or you may not have access to it.
           </Alert>
         </Container>
       </>

--- a/src/views/QuestionnairePage/deepLink.test.ts
+++ b/src/views/QuestionnairePage/deepLink.test.ts
@@ -1,0 +1,109 @@
+import {
+  toSlug,
+  resolveSystemIdByAcronym,
+  resolveDatacallBySlug,
+  resolveFunctionTarget,
+} from './deepLink'
+import { FismaSystemType, datacall } from '@/types'
+
+const sys = (fismasystemid: number, fismaacronym: string) =>
+  ({ fismasystemid, fismaacronym }) as FismaSystemType
+
+const dc = (datacallid: number, name: string): datacall =>
+  ({
+    datacallid,
+    datacall: name,
+    datecreated: '',
+    deadline: '',
+  }) as datacall
+
+const cat = (name: string, steps: [number, string][]) => ({
+  name,
+  steps: steps.map(([functionid, fn]) => ({
+    function: { functionid, function: fn },
+  })),
+})
+
+describe('toSlug', () => {
+  it('lowercases and hyphenates camelCase and spaces', () => {
+    expect(toSlug('CrossCutting')).toBe('cross-cutting')
+    expect(toSlug('Data Center')).toBe('data-center')
+  })
+})
+
+describe('resolveSystemIdByAcronym', () => {
+  const systems = [sys(1, 'ACO-MS'), sys(2, 'ACUMEN-GSS')]
+
+  it('resolves case-insensitively', () => {
+    expect(resolveSystemIdByAcronym(systems, 'aco-ms')).toBe(1)
+    expect(resolveSystemIdByAcronym(systems, 'ACUMEN-GSS')).toBe(2)
+  })
+
+  it('returns undefined for an unknown acronym', () => {
+    expect(resolveSystemIdByAcronym(systems, 'nope')).toBeUndefined()
+  })
+
+  it('returns undefined when the acronym is missing', () => {
+    expect(resolveSystemIdByAcronym(systems, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when systems have not loaded yet', () => {
+    expect(resolveSystemIdByAcronym([], 'aco-ms')).toBeUndefined()
+  })
+})
+
+describe('resolveDatacallBySlug', () => {
+  const datacalls = [dc(10, 'FY2026 Q1'), dc(11, 'FY2025 Q4')]
+
+  it('matches the URL segment (spaces as underscores) to the datacall', () => {
+    expect(resolveDatacallBySlug(datacalls, 'FY2026_Q1')?.datacallid).toBe(10)
+    expect(resolveDatacallBySlug(datacalls, 'FY2025_Q4')?.datacallid).toBe(11)
+  })
+
+  it('returns undefined for an unrecognized or missing segment', () => {
+    expect(resolveDatacallBySlug(datacalls, 'FY1999_Q9')).toBeUndefined()
+    expect(resolveDatacallBySlug(datacalls, undefined)).toBeUndefined()
+    expect(resolveDatacallBySlug([], 'FY2026_Q1')).toBeUndefined()
+  })
+})
+
+describe('resolveFunctionTarget', () => {
+  const categories = [
+    cat('Identity', [
+      [100, 'Authentication'],
+      [101, 'Identity Stores'],
+    ]),
+    cat('CrossCutting', [[200, 'Visibility Analytics']]),
+  ]
+
+  it('resolves a pillar/function slug pair to the concrete function', () => {
+    expect(
+      resolveFunctionTarget(categories, 'identity', 'identity-stores')
+    ).toEqual({
+      functionid: 101,
+      pillarName: 'Identity',
+      functionName: 'Identity Stores',
+    })
+  })
+
+  it('resolves camelCase pillar names via their slug', () => {
+    expect(
+      resolveFunctionTarget(categories, 'cross-cutting', 'visibility-analytics')
+    ).toMatchObject({ functionid: 200 })
+  })
+
+  it('returns undefined when the function is not in the named pillar', () => {
+    expect(
+      resolveFunctionTarget(categories, 'identity', 'visibility-analytics')
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when either param is missing (fall back to first)', () => {
+    expect(
+      resolveFunctionTarget(categories, undefined, 'authentication')
+    ).toBeUndefined()
+    expect(
+      resolveFunctionTarget(categories, 'identity', undefined)
+    ).toBeUndefined()
+  })
+})

--- a/src/views/QuestionnairePage/deepLink.ts
+++ b/src/views/QuestionnairePage/deepLink.ts
@@ -1,0 +1,73 @@
+import { FismaSystemType, datacall } from '@/types'
+
+// Slugify a pillar/function name for the questionnaire URL. Kept here (rather
+// than inline in QuestionnairePage) so the deep-link resolvers below and the
+// page's navigate() calls share one canonical definition.
+export const toSlug = (str: string) =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replaceAll(' ', '-')
+
+// Resolve the :fismaacronym URL param to a fismasystemid using the systems list
+// the app already loads. Enables cold loads (paste / refresh / bookmark) where
+// router location.state is empty. Case-insensitive; undefined when unresolved.
+export function resolveSystemIdByAcronym(
+  systems: FismaSystemType[],
+  acronym: string | undefined
+): number | undefined {
+  if (!acronym) return undefined
+  const target = acronym.toLowerCase()
+  return systems.find((s) => s.fismaacronym?.toLowerCase() === target)
+    ?.fismasystemid
+}
+
+// Resolve the URL's data-call segment back to its datacall. The segment is the
+// call's name with spaces encoded as underscores (see how the page builds the
+// URL), so undo that before matching. undefined when absent or unrecognized —
+// callers fall back to the selected/latest call.
+export function resolveDatacallBySlug(
+  datacalls: datacall[],
+  slug: string | undefined
+): datacall | undefined {
+  if (!slug) return undefined
+  return datacalls.find((dc) => dc.datacall.replaceAll(' ', '_') === slug)
+}
+
+export type FunctionTarget = {
+  functionid: number
+  pillarName: string
+  functionName: string
+}
+
+// Structural shape of the page's Category so this module doesn't depend on the
+// component. Matches { name, steps: FismaQuestion[] }.
+type CategoryLike = {
+  name: string
+  steps: { function: { functionid: number; function: string } }[]
+}
+
+// Resolve the :pillar/:function URL params to a concrete function within the
+// loaded categories, so a deep link opens the named question instead of always
+// snapping to the first one. undefined when either param is missing or does not
+// match any loaded pillar/function — callers fall back to categories[0].
+export function resolveFunctionTarget(
+  categories: CategoryLike[],
+  pillarSlug: string | undefined,
+  functionSlug: string | undefined
+): FunctionTarget | undefined {
+  if (!pillarSlug || !functionSlug) return undefined
+  for (const cat of categories) {
+    if (toSlug(cat.name) !== pillarSlug) continue
+    for (const step of cat.steps) {
+      if (toSlug(step.function.function) === functionSlug) {
+        return {
+          functionid: step.function.functionid,
+          pillarName: cat.name,
+          functionName: step.function.function,
+        }
+      }
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

Fixes #500. A questionnaire URL (`/#/questionnaire/:fismaacronym/:datacallid/:pillar/:function`) only worked when reached by clicking through from the dashboard. Pasting, refreshing, or bookmarking one failed — the page could not resolve the system, and any pillar/function in the URL was discarded. This is entirely client-side routing (the API already serves questionnaire/score/insight data by `fismasystemid` on a direct request), so there is no backend change.

`QuestionnairePage` sourced `fismasystemid` only from React Router `location.state` (empty on a cold load) and, after categories loaded, unconditionally redirected to the first pillar/function.

## Changes

All in `src/views/QuestionnairePage/`:

- **Resolve the system** from `:fismaacronym` against the already-loaded systems list when `location.state` is absent. While that list is still loading the page shows a spinner; the "cannot load" warning now appears only once systems are loaded and the acronym is still unmatched (reworded to a not-found message).
- **Resolve the cycle** from the URL's data-call segment via the `datacalls` list (already on context), falling back to the selected/latest call when the segment is absent or unrecognized.
- **Honor `:pillar/:function`** on mount, falling back to `categoriesData[0]` only when they are missing or invalid.
- **Gate the fetch** on the datacall context being ready (`latestDataCallId > 0`) so a cold link cannot query scores with `datacallid=0` before datacalls load.

The deep-link branch only runs when router state is absent, so the dashboard → questionnaire path is unchanged.

## Tests

- `deepLink.ts` — resolution logic extracted as pure functions (`resolveSystemIdByAcronym`, `resolveDatacallBySlug`, `resolveFunctionTarget`, shared `toSlug`), unit-tested in `deepLink.test.ts`.
- `QuestionnairePage.deeplink.test.tsx` — mounts the real page at a cold deep link (no `location.state`) and asserts the system resolves, the cycle is read from the URL (scores queried for the URL's call, not the latest), the deep-linked pillar/function opens (not the first), plus the fallback / not-found / loading paths.

Full frontend suite green locally: `tsc --noEmit`, `eslint` (0 errors), `jest` (394 passed).

Closes #500.