### PR TITLE
fix(questionnaire): make questionnaire deep links self-addressable (#500)

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Deep-link integration test for #500: a questionnaire URL reached by paste /
+// refresh / bookmark (no router location.state) must resolve the system from
+// :fismaacronym, the cycle from the datacall segment, and open the named
+// :pillar/:function — not fail to load or snap to the first function.
+
+// config.ts reads import.meta.env, which jest can't parse; only the insight
+// feature flag is reachable from this page, so a minimal default is enough.
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+// Seed shape mirrors GET /fismasystems/:id/questions (empire data, SSD-EX).
+const PILLARS: [string, number, string][] = [
+  ['Identity', 7006, 'Imperial Identity Verification'],
+  ['Devices', 7001, 'Imperial Device Management'],
+  ['Networks', 7003, 'Imperial Network Security'],
+  ['Applications', 7002, 'Fleet Application Security'],
+  ['Data', 7004, 'Fleet Data Protection'],
+  ['CrossCutting', 7005, 'Imperial Cross-Cutting Controls'],
+]
+
+const QUESTIONS = PILLARS.map(([pillar, functionid, fn], i) => ({
+  questionid: 900 + i,
+  question: `Question for ${fn}`,
+  notesprompt: 'Notes',
+  pillar: { pillar },
+  function: {
+    functionid,
+    function: fn,
+    description: `${fn} description`,
+    datacenterenvironment: 'Imperial-Fleet',
+  },
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role: 'OWNER',
+    } as userData,
+    // Latest is call 5; the deep link below names call 4 — so a scores query
+    // for datacallid=4 proves the cycle was resolved from the URL, not defaulted.
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+      {
+        datacallid: 4,
+        datacall: 'FY2025 Death Star Assessment',
+        datecreated: '',
+        deadline: '2025-03-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={AppRoutes.QUESTIONNAIRE} element={<QuestionnairePage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+const optionsCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => u.includes('/options'))
+
+it('resolves the system from :fismaacronym on a cold load (no location.state)', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  // The old failure mode was this warning; it must not appear now.
+  await waitFor(() =>
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('/fismasystems/1002/questions'),
+      expect.anything()
+    )
+  )
+  expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})
+
+it('resolves the cycle from the URL datacall segment (not the latest/selected call)', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  await waitFor(() =>
+    expect(
+      mockGet.mock.calls.some(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].startsWith('scores') &&
+          c[0].includes('datacallid=4')
+      )
+    ).toBe(true)
+  )
+  // The latest call (5) must NOT be the one queried for scores.
+  expect(
+    mockGet.mock.calls.some(
+      (c) =>
+        typeof c[0] === 'string' &&
+        c[0].startsWith('scores') &&
+        c[0].includes('datacallid=5')
+    )
+  ).toBe(false)
+})
+
+it('opens the deep-linked :pillar/:function instead of the first', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  // Networks/Imperial Network Security is functionid 7003; the first pillar
+  // (Identity) is 7006. Honoring the URL means we fetch options for 7003.
+  await waitFor(() =>
+    expect(
+      optionsCalls().some((u) => u.includes('functions/7003/options'))
+    ).toBe(true)
+  )
+  expect(optionsCalls().some((u) => u.includes('functions/7006/options'))).toBe(
+    false
+  )
+})
+
+it('falls back to the first function when the URL omits :pillar/:function', async () => {
+  renderAt('/questionnaire/ssd-ex')
+
+  // No pillar/function in the URL -> first pillar (Identity, 7006).
+  await waitFor(() =>
+    expect(
+      optionsCalls().some((u) => u.includes('functions/7006/options'))
+    ).toBe(true)
+  )
+})
+
+it('shows a not-found warning once systems are loaded and the acronym is unknown', async () => {
+  renderAt(
+    '/questionnaire/does-not-exist/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  await waitFor(() =>
+    expect(screen.getByText(/Could not find a system/i)).toBeInTheDocument()
+  )
+})
+
+it('shows a spinner (not the not-found warning) while the systems list is still loading', () => {
+  mockCtx.fismaSystems = []
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
 import QuestionnairePage from './QuestionnairePage'
 import type { userData } from '@/types'
@@ -118,20 +118,28 @@ beforeEach(() => {
   })
 })
 
-function renderAt(path: string) {
-  return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path={AppRoutes.QUESTIONNAIRE} element={<QuestionnairePage />} />
-      </Routes>
-    </MemoryRouter>
+// Data-router harness (createMemoryRouter + RouterProvider) to match the real
+// app (createHashRouter): data routers hand components the stable useNavigate,
+// while plain <MemoryRouter> gets the pathname-keyed unstable one, whose
+// identity change on the canonical redirect re-runs the fetch effect and makes
+// exact-count assertions lie about production behavior.
+function renderAt(entry: string | { pathname: string; state: unknown }) {
+  const router = createMemoryRouter(
+    [{ path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> }],
+    { initialEntries: [entry] }
   )
+  return render(<RouterProvider router={router} />)
 }
 
 const optionsCalls = () =>
   mockGet.mock.calls
     .map((c) => c[0] as string)
     .filter((u) => u.includes('/options'))
+
+const callsTo = (fragment: string) =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => u.includes(fragment))
 
 it('resolves the system from :fismaacronym on a cold load (no location.state)', async () => {
   renderAt(
@@ -219,4 +227,91 @@ it('shows a spinner (not the not-found warning) while the systems list is still 
   )
 
   expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})
+
+it('runs the fetch exactly once per cold deep-link mount (no self-triggered rerun)', async () => {
+  renderAt(
+    '/questionnaire/ssd-ex/FY2025_Death_Star_Assessment/networks/imperial-network-security'
+  )
+
+  // Settle: the deep-linked question's options request marks the end of the
+  // load chain; give any (buggy) second effect pass time to fire after it.
+  await waitFor(() =>
+    expect(
+      optionsCalls().some((u) => u.includes('functions/7003/options'))
+    ).toBe(true)
+  )
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50))
+  })
+
+  expect(callsTo('/fismasystems/1002/questions')).toHaveLength(1)
+  expect(callsTo('scores?')).toHaveLength(1)
+  expect(optionsCalls()).toHaveLength(1)
+})
+
+it('runs the fetch exactly once for the dashboard flow too (route state present)', async () => {
+  renderAt({
+    pathname: '/questionnaire/ssd-ex',
+    state: {
+      fismasystemid: 1002,
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+  })
+
+  await waitFor(() => expect(optionsCalls().length).toBeGreaterThan(0))
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50))
+  })
+
+  // Route state wins (#467/#501): scores queried for the opened call, once.
+  expect(callsTo('scores?')).toHaveLength(1)
+  expect(callsTo('scores?')[0]).toContain('datacallid=5')
+  expect(callsTo('/fismasystems/1002/questions')).toHaveLength(1)
+})
+
+it('resolves a decommissioned system and shows its no-questionnaire state, not the not-found warning', async () => {
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('fismasystems?decommissioned=true'))
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              fismasystemid: 1099,
+              fismaacronym: 'OLD-SYS',
+              fismaname: 'Retired Imperial System',
+              datacenterenvironment: 'Imperial-Fleet',
+              decommissioned: true,
+            },
+          ],
+        },
+      })
+    // Decommissioned systems join to zero functions; backend serializes null.
+    if (url.includes('/fismasystems/1099/questions'))
+      return Promise.resolve({ data: { data: null } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  renderAt('/questionnaire/old-sys/FY2025_Death_Star_Assessment')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/No questionnaire is available for this system/i)
+    ).toBeInTheDocument()
+  )
+  expect(screen.queryByText(/Could not find a system/i)).not.toBeInTheDocument()
+})
+
+it('still warns not-found when the acronym is in neither the active nor the decommissioned list', async () => {
+  renderAt('/questionnaire/nope/FY2025_Death_Star_Assessment')
+
+  await waitFor(() =>
+    expect(screen.getByText(/Could not find a system/i)).toBeInTheDocument()
+  )
+  // The decommissioned list was actually consulted before concluding.
+  expect(callsTo('fismasystems?decommissioned=true')).toHaveLength(1)
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -54,6 +54,12 @@ import {
 } from './saveGuard'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
+import {
+  toSlug,
+  resolveSystemIdByAcronym,
+  resolveDatacallBySlug,
+  resolveFunctionTarget,
+} from './deepLink'
 type Category = {
   name: string
   steps: FismaQuestion[]
@@ -87,12 +93,6 @@ const CssTextField = styled(TextField)({
     },
   },
 })
-const toSlug = (str: string) =>
-  str
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .toLowerCase()
-    .replaceAll(' ', '-')
-
 const addSpace = (str: string) => {
   for (let i = 0; i < str.length; i++) {
     if (
@@ -115,6 +115,7 @@ export default function QuestionnarePage() {
     latestDatacall,
     latestDeadline,
     fismaSystems,
+    datacalls,
     datacenterEnvironments,
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
@@ -263,12 +264,34 @@ export default function QuestionnarePage() {
 
   const navigate = useNavigate()
   const location = useLocation()
-  const { fismaacronym } = useParams()
+  // `function` is a reserved word, so the :function route param is aliased.
+  const {
+    fismaacronym,
+    datacallid: datacallSlug,
+    pillar: pillarSlug,
+    function: functionSlug,
+  } = useParams()
 
   // Direct/bookmarked navigation to /questionnaire/<acronym> has a null
-  // location.state. Optional-chain instead of crashing on first render; the
-  // missing-system path is handled by an early render guard below.
-  const system = location.state?.fismasystemid as number | undefined
+  // location.state. On such a cold load (paste / refresh / bookmark) fall back
+  // to resolving :fismaacronym against the systems list the app already loads,
+  // so the questionnaire is self-addressable (#500). In-app navigation keeps
+  // carrying the id in location.state, which takes precedence.
+  const stateSystem = location.state?.fismasystemid as number | undefined
+  const resolvedSystem = React.useMemo(
+    () => resolveSystemIdByAcronym(fismaSystems, fismaacronym),
+    [fismaSystems, fismaacronym]
+  )
+  const system = stateSystem ?? resolvedSystem
+  // Deep-link URL params, read via refs inside the data-fetch effect so honoring
+  // them doesn't enroll them as effect deps (which would refetch on every
+  // in-survey question change, since those rewrite :pillar/:function).
+  const pillarSlugRef = React.useRef(pillarSlug)
+  pillarSlugRef.current = pillarSlug
+  const functionSlugRef = React.useRef(functionSlug)
+  functionSlugRef.current = functionSlug
+  const datacallSlugRef = React.useRef(datacallSlug)
+  datacallSlugRef.current = datacallSlug
   // The dashboard opens the questionnaire for the system's own data call
   // (year-aggregated view, #467): the specific call id and name ride along in
   // the route state. Absent (deep link), fall back to the selected/latest call.
@@ -411,7 +434,10 @@ export default function QuestionnarePage() {
   }
 
   React.useEffect(() => {
-    if (system) {
+    // Wait for the data calls to load before fetching: a cold deep link can
+    // resolve `system` (from the systems list) before the datacall context is
+    // ready, and firing early would query scores with datacallid=0. (#500)
+    if (system && latestDataCallId > 0) {
       const controller = new AbortController()
       // Reset the empty-questionnaire flag so a previous decommissioned-system
       // view does not bleed into the next render when system changes.
@@ -440,10 +466,31 @@ export default function QuestionnarePage() {
               deadline: routeDeadline,
             }
           } else {
+            // Cold deep link (no route state): resolve the cycle from the URL's
+            // data-call segment. Falls through to the selected/latest call when
+            // the segment is absent or unrecognized. (#500)
+            const deepLinkDatacall = resolveDatacallBySlug(
+              datacalls,
+              datacallSlugRef.current
+            )
             const isHistorical =
               selectedDatacall !== null &&
               selectedDatacall.datacallid !== latestDataCallId
-            if (isHistorical && selectedDatacall) {
+            if (deepLinkDatacall) {
+              datacall = deepLinkDatacall.datacall.replaceAll(' ', '_')
+              setDatacall(datacall)
+              setIsPastDeadline(
+                deepLinkDatacall.deadline
+                  ? new Date() > new Date(deepLinkDatacall.deadline)
+                  : true
+              )
+              activeDataCallId = deepLinkDatacall.datacallid
+              datacallStateRef.current = {
+                datacallid: deepLinkDatacall.datacallid,
+                datacall: deepLinkDatacall.datacall,
+                deadline: deepLinkDatacall.deadline,
+              }
+            } else if (isHistorical && selectedDatacall) {
               datacall = selectedDatacall.datacall.replaceAll(' ', '_')
               setDatacall(datacall)
               setIsPastDeadline(true)
@@ -470,6 +517,9 @@ export default function QuestionnarePage() {
           // Hoisted so both the questions block and the final batch can access them.
           const questionData: Record<number, Question> = {}
           let sortedFuncId: number[] = []
+          // The function to open. Defaults to the first; overridden below when the
+          // URL's :pillar/:function names a valid function (deep link, #500).
+          let targetFuncId: number | undefined
           try {
             const response = await axiosInstance.get(
               `/fismasystems/${system}/questions`,
@@ -528,6 +578,19 @@ export default function QuestionnarePage() {
                 },
                 {}
               )
+              // Honor the URL's :pillar/:function when they name a valid
+              // function; otherwise open the first (#500).
+              const target = resolveFunctionTarget(
+                categoriesData,
+                pillarSlugRef.current,
+                functionSlugRef.current
+              )
+              targetFuncId = target?.functionid ?? sortedFuncId[0]
+              const targetPillarName =
+                target?.pillarName ?? categoriesData[0].name
+              const targetFunctionName =
+                target?.functionName ??
+                categoriesData[0].steps[0].function.function
               // Update sidebar/nav state immediately so the question list
               // renders while scores are still loading. setQuestions,
               // setDatacallID, and setQuestionId are deferred to the batch
@@ -537,13 +600,13 @@ export default function QuestionnarePage() {
               setStepFunctionId(sortedFuncId)
               setCategories(categoriesData)
               navigate(
-                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(categoriesData[0].name)}/${toSlug(categoriesData[0].steps[0].function.function)}`,
+                `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(targetPillarName)}/${toSlug(targetFunctionName)}`,
                 {
                   state: { fismasystemid: system, ...datacallStateRef.current },
                   replace: true,
                 }
               )
-              setSelectedIndex(sortedFuncId[0])
+              setSelectedIndex(targetFuncId)
             }
           } catch (error) {
             if (controller.signal.aborted) return
@@ -591,7 +654,7 @@ export default function QuestionnarePage() {
           setQuestions(questionData)
           setQuestionScores(hashTable)
           setDatacallID(activeDataCallId)
-          setQuestionId(sortedFuncId[0])
+          setQuestionId(targetFuncId ?? sortedFuncId[0])
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) {
@@ -617,6 +680,7 @@ export default function QuestionnarePage() {
     latestDatacall,
     latestDeadline,
     systemCategory,
+    datacalls,
   ])
   React.useEffect(() => {
     if (questionId) {
@@ -854,13 +918,29 @@ export default function QuestionnarePage() {
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
     : undefined
   if (!system) {
+    // Cold load (paste / refresh / bookmark): the systems list may still be in
+    // flight, so :fismaacronym can't be resolved yet. Show a spinner until it
+    // arrives; only once systems are loaded and the acronym still isn't among
+    // them is the link genuinely unresolvable. (#500)
+    if (fismaSystems.length === 0) {
+      return (
+        <>
+          <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+          <Container maxWidth={false} disableGutters>
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+              <Spinner size="big" />
+            </Box>
+          </Container>
+        </>
+      )
+    }
     return (
       <>
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
         <Container maxWidth={false} disableGutters>
           <Alert severity="warning" sx={{ mt: 2 }}>
-            Cannot load questionnaire from a direct link. Please open it from
-            the system list.
+            Could not find a system matching “{fismaacronym}”. It may not exist,
+            or you may not have access to it.
           </Alert>
         </Container>
       </>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -13,6 +13,7 @@ import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import TextField from '@mui/material/TextField'
 import {
   FismaQuestion,
+  FismaSystemType,
   QuestionOption,
   Question,
   QuestionChoice,
@@ -56,6 +57,7 @@ import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
 import {
   toSlug,
+  encodeDatacallSlug,
   resolveSystemIdByAcronym,
   resolveDatacallBySlug,
   resolveFunctionTarget,
@@ -282,7 +284,48 @@ export default function QuestionnarePage() {
     () => resolveSystemIdByAcronym(fismaSystems, fismaacronym),
     [fismaSystems, fismaacronym]
   )
-  const system = stateSystem ?? resolvedSystem
+  // The context list holds active systems only, so a deep link to a
+  // decommissioned system would read as "not found" and mislead (its real
+  // state is "no questionnaire available"). When the acronym misses the active
+  // list, lazily fetch the decommissioned list once and retry against it.
+  // null = not fetched; [] = fetched (empty or failed).
+  const [decommissionedSystems, setDecommissionedSystems] = React.useState<
+    FismaSystemType[] | null
+  >(null)
+  const resolvedDecommissioned = React.useMemo(
+    () => resolveSystemIdByAcronym(decommissionedSystems ?? [], fismaacronym),
+    [decommissionedSystems, fismaacronym]
+  )
+  const system = stateSystem ?? resolvedSystem ?? resolvedDecommissioned
+  React.useEffect(() => {
+    if (
+      system !== undefined ||
+      fismaSystems.length === 0 ||
+      !fismaacronym ||
+      decommissionedSystems !== null
+    )
+      return
+    const controller = new AbortController()
+    const load = async () => {
+      try {
+        const res = await axiosInstance.get(
+          'fismasystems?decommissioned=true',
+          {
+            signal: controller.signal,
+          }
+        )
+        setDecommissionedSystems(res.data?.data ?? [])
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        // Resolution proceeds without the list; the not-found warning is the
+        // fallback rather than an indefinite spinner.
+        setDecommissionedSystems([])
+      }
+    }
+    void load()
+    return () => controller.abort()
+  }, [system, fismaSystems.length, fismaacronym, decommissionedSystems])
   // Deep-link URL params, read via refs inside the data-fetch effect so honoring
   // them doesn't enroll them as effect deps (which would refetch on every
   // in-survey question change, since those rewrite :pillar/:function).
@@ -301,15 +344,25 @@ export default function QuestionnarePage() {
   const systemRef = React.useRef(system)
   systemRef.current = system
   // The in-survey navigate() calls (Next, Back, sidebar, canonical redirect)
-  // reset router state and would drop the chosen data call, reverting the
-  // survey to the latest call (#501). Persist the resolved call here and
-  // re-supply it in every internal navigation so the choice survives.
+  // reset router state and would drop a picker-chosen data call, reverting the
+  // survey to the latest call (#501). Persist the dashboard-opened call here
+  // and re-supply it in every internal navigation so the choice survives.
+  //
+  // Populated ONLY on the dashboard path (route state present). For URL-driven
+  // flows (deep link / selected / latest) it stays empty on purpose: the URL's
+  // datacall segment already carries the cycle across navigations, and writing
+  // these values into location.state from the fetch effect's own navigate()
+  // would flip the routeDatacall* deps from undefined to defined and re-run
+  // the whole fetch — every cold deep-link used to hit /questions and /scores
+  // twice (#524 review).
   const datacallStateRef = React.useRef<{
     datacallid?: number
     datacall?: string
     deadline?: string
   }>({})
-  const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
+  const systemInfo =
+    fismaSystems.find((s) => s.fismasystemid === system) ??
+    decommissionedSystems?.find((s) => s.fismasystemid === system)
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
 
   // Fetch ZTMF Insights for this system once (not per question — one call
@@ -454,7 +507,7 @@ export default function QuestionnarePage() {
             // Opened for a specific system's own call from the dashboard. Read
             // only when that call's own deadline has passed - not by comparing
             // to the global latest, since two calls can be open at once.
-            datacall = routeDatacall.replaceAll(' ', '_')
+            datacall = encodeDatacallSlug(routeDatacall)
             setDatacall(datacall)
             activeDataCallId = routeDatacallId
             setIsPastDeadline(
@@ -469,6 +522,14 @@ export default function QuestionnarePage() {
             // Cold deep link (no route state): resolve the cycle from the URL's
             // data-call segment. Falls through to the selected/latest call when
             // the segment is absent or unrecognized. (#500)
+            //
+            // These branches leave datacallStateRef empty — see its declaration.
+            // The cycle rides in the URL segment written by the canonical
+            // navigate below, so it survives re-runs and in-survey navigation
+            // without route state; a stale ref from a previous dashboard-opened
+            // call is also cleared here so it can't hijack a later system
+            // switch.
+            datacallStateRef.current = {}
             const deepLinkDatacall = resolveDatacallBySlug(
               datacalls,
               datacallSlugRef.current
@@ -477,7 +538,7 @@ export default function QuestionnarePage() {
               selectedDatacall !== null &&
               selectedDatacall.datacallid !== latestDataCallId
             if (deepLinkDatacall) {
-              datacall = deepLinkDatacall.datacall.replaceAll(' ', '_')
+              datacall = encodeDatacallSlug(deepLinkDatacall.datacall)
               setDatacall(datacall)
               setIsPastDeadline(
                 deepLinkDatacall.deadline
@@ -485,33 +546,18 @@ export default function QuestionnarePage() {
                   : true
               )
               activeDataCallId = deepLinkDatacall.datacallid
-              datacallStateRef.current = {
-                datacallid: deepLinkDatacall.datacallid,
-                datacall: deepLinkDatacall.datacall,
-                deadline: deepLinkDatacall.deadline,
-              }
             } else if (isHistorical && selectedDatacall) {
-              datacall = selectedDatacall.datacall.replaceAll(' ', '_')
+              datacall = encodeDatacallSlug(selectedDatacall.datacall)
               setDatacall(datacall)
               setIsPastDeadline(true)
               activeDataCallId = selectedDatacall.datacallid
-              datacallStateRef.current = {
-                datacallid: selectedDatacall.datacallid,
-                datacall: selectedDatacall.datacall,
-                deadline: selectedDatacall.deadline,
-              }
             } else {
-              datacall = latestDatacall.replaceAll(' ', '_')
+              datacall = encodeDatacallSlug(latestDatacall)
               setDatacall(datacall)
               setIsPastDeadline(
                 latestDeadline ? new Date() > new Date(latestDeadline) : true
               )
               activeDataCallId = latestDataCallId
-              datacallStateRef.current = {
-                datacallid: latestDataCallId,
-                datacall: latestDatacall,
-                deadline: latestDeadline,
-              }
             }
           }
           // Hoisted so both the questions block and the final batch can access them.
@@ -919,10 +965,11 @@ export default function QuestionnarePage() {
     : undefined
   if (!system) {
     // Cold load (paste / refresh / bookmark): the systems list may still be in
-    // flight, so :fismaacronym can't be resolved yet. Show a spinner until it
-    // arrives; only once systems are loaded and the acronym still isn't among
-    // them is the link genuinely unresolvable. (#500)
-    if (fismaSystems.length === 0) {
+    // flight, so :fismaacronym can't be resolved yet — and if it missed the
+    // active list, the decommissioned list is being checked before concluding
+    // not-found. Show a spinner until both have answered; only then is the
+    // link genuinely unresolvable. (#500 / #524 review)
+    if (fismaSystems.length === 0 || decommissionedSystems === null) {
       return (
         <>
           <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
@@ -1305,8 +1352,9 @@ export default function QuestionnarePage() {
         </Grid>
       </Container>
       {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
-          questionnaire was opened for (the row's own call), since the dashboard
-          may be aggregating a whole year and selectedDatacall is then null. */}
+          questionnaire actually resolved (datacallID covers every entry path,
+          including URL deep links where no route state exists); fall back to
+          the route/selected/latest chain during the pre-fetch window. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
@@ -1314,7 +1362,11 @@ export default function QuestionnarePage() {
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
         selectedDataCallId={
-          routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
+          datacallID > 0
+            ? datacallID
+            : routeDatacallId ??
+              selectedDatacall?.datacallid ??
+              latestDataCallId
         }
       />
     </>

--- a/src/views/QuestionnairePage/deepLink.test.ts
+++ b/src/views/QuestionnairePage/deepLink.test.ts
@@ -1,0 +1,109 @@
+import {
+  toSlug,
+  resolveSystemIdByAcronym,
+  resolveDatacallBySlug,
+  resolveFunctionTarget,
+} from './deepLink'
+import { FismaSystemType, datacall } from '@/types'
+
+const sys = (fismasystemid: number, fismaacronym: string) =>
+  ({ fismasystemid, fismaacronym }) as FismaSystemType
+
+const dc = (datacallid: number, name: string): datacall =>
+  ({
+    datacallid,
+    datacall: name,
+    datecreated: '',
+    deadline: '',
+  }) as datacall
+
+const cat = (name: string, steps: [number, string][]) => ({
+  name,
+  steps: steps.map(([functionid, fn]) => ({
+    function: { functionid, function: fn },
+  })),
+})
+
+describe('toSlug', () => {
+  it('lowercases and hyphenates camelCase and spaces', () => {
+    expect(toSlug('CrossCutting')).toBe('cross-cutting')
+    expect(toSlug('Data Center')).toBe('data-center')
+  })
+})
+
+describe('resolveSystemIdByAcronym', () => {
+  const systems = [sys(1, 'ACO-MS'), sys(2, 'ACUMEN-GSS')]
+
+  it('resolves case-insensitively', () => {
+    expect(resolveSystemIdByAcronym(systems, 'aco-ms')).toBe(1)
+    expect(resolveSystemIdByAcronym(systems, 'ACUMEN-GSS')).toBe(2)
+  })
+
+  it('returns undefined for an unknown acronym', () => {
+    expect(resolveSystemIdByAcronym(systems, 'nope')).toBeUndefined()
+  })
+
+  it('returns undefined when the acronym is missing', () => {
+    expect(resolveSystemIdByAcronym(systems, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when systems have not loaded yet', () => {
+    expect(resolveSystemIdByAcronym([], 'aco-ms')).toBeUndefined()
+  })
+})
+
+describe('resolveDatacallBySlug', () => {
+  const datacalls = [dc(10, 'FY2026 Q1'), dc(11, 'FY2025 Q4')]
+
+  it('matches the URL segment (spaces as underscores) to the datacall', () => {
+    expect(resolveDatacallBySlug(datacalls, 'FY2026_Q1')?.datacallid).toBe(10)
+    expect(resolveDatacallBySlug(datacalls, 'FY2025_Q4')?.datacallid).toBe(11)
+  })
+
+  it('returns undefined for an unrecognized or missing segment', () => {
+    expect(resolveDatacallBySlug(datacalls, 'FY1999_Q9')).toBeUndefined()
+    expect(resolveDatacallBySlug(datacalls, undefined)).toBeUndefined()
+    expect(resolveDatacallBySlug([], 'FY2026_Q1')).toBeUndefined()
+  })
+})
+
+describe('resolveFunctionTarget', () => {
+  const categories = [
+    cat('Identity', [
+      [100, 'Authentication'],
+      [101, 'Identity Stores'],
+    ]),
+    cat('CrossCutting', [[200, 'Visibility Analytics']]),
+  ]
+
+  it('resolves a pillar/function slug pair to the concrete function', () => {
+    expect(
+      resolveFunctionTarget(categories, 'identity', 'identity-stores')
+    ).toEqual({
+      functionid: 101,
+      pillarName: 'Identity',
+      functionName: 'Identity Stores',
+    })
+  })
+
+  it('resolves camelCase pillar names via their slug', () => {
+    expect(
+      resolveFunctionTarget(categories, 'cross-cutting', 'visibility-analytics')
+    ).toMatchObject({ functionid: 200 })
+  })
+
+  it('returns undefined when the function is not in the named pillar', () => {
+    expect(
+      resolveFunctionTarget(categories, 'identity', 'visibility-analytics')
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when either param is missing (fall back to first)', () => {
+    expect(
+      resolveFunctionTarget(categories, undefined, 'authentication')
+    ).toBeUndefined()
+    expect(
+      resolveFunctionTarget(categories, 'identity', undefined)
+    ).toBeUndefined()
+  })
+})

--- a/src/views/QuestionnairePage/deepLink.test.ts
+++ b/src/views/QuestionnairePage/deepLink.test.ts
@@ -1,5 +1,6 @@
 import {
   toSlug,
+  encodeDatacallSlug,
   resolveSystemIdByAcronym,
   resolveDatacallBySlug,
   resolveFunctionTarget,
@@ -52,12 +53,37 @@ describe('resolveSystemIdByAcronym', () => {
   })
 })
 
+describe('encodeDatacallSlug', () => {
+  it('encodes spaces as underscores (existing URL convention)', () => {
+    expect(encodeDatacallSlug('FY2026 Q1')).toBe('FY2026_Q1')
+  })
+
+  it('doubles literal underscores so space/underscore mixes stay distinct', () => {
+    expect(encodeDatacallSlug('FY_2025 Q4')).toBe('FY__2025_Q4')
+    expect(encodeDatacallSlug('FY 2025_Q4')).toBe('FY_2025__Q4')
+    expect(encodeDatacallSlug('FY_2025 Q4')).not.toBe(
+      encodeDatacallSlug('FY 2025_Q4')
+    )
+  })
+})
+
 describe('resolveDatacallBySlug', () => {
   const datacalls = [dc(10, 'FY2026 Q1'), dc(11, 'FY2025 Q4')]
 
   it('matches the URL segment (spaces as underscores) to the datacall', () => {
     expect(resolveDatacallBySlug(datacalls, 'FY2026_Q1')?.datacallid).toBe(10)
     expect(resolveDatacallBySlug(datacalls, 'FY2025_Q4')?.datacallid).toBe(11)
+  })
+
+  it('matches case-insensitively, like the other resolvers', () => {
+    expect(resolveDatacallBySlug(datacalls, 'fy2026_q1')?.datacallid).toBe(10)
+    expect(resolveDatacallBySlug(datacalls, 'Fy2025_q4')?.datacallid).toBe(11)
+  })
+
+  it('distinguishes names that differ only by space vs literal underscore', () => {
+    const tricky = [dc(20, 'FY_2025 Q4'), dc(21, 'FY 2025_Q4')]
+    expect(resolveDatacallBySlug(tricky, 'FY__2025_Q4')?.datacallid).toBe(20)
+    expect(resolveDatacallBySlug(tricky, 'FY_2025__Q4')?.datacallid).toBe(21)
   })
 
   it('returns undefined for an unrecognized or missing segment', () => {

--- a/src/views/QuestionnairePage/deepLink.ts
+++ b/src/views/QuestionnairePage/deepLink.ts
@@ -22,16 +22,30 @@ export function resolveSystemIdByAcronym(
     ?.fismasystemid
 }
 
-// Resolve the URL's data-call segment back to its datacall. The segment is the
-// call's name with spaces encoded as underscores (see how the page builds the
-// URL), so undo that before matching. undefined when absent or unrecognized —
-// callers fall back to the selected/latest call.
+// Encode a datacall name for its URL segment. Spaces become underscores (the
+// long-standing URL convention), and a literal underscore is doubled first so
+// names like "FY_2025 Q4" and "FY 2025_Q4" encode distinctly instead of
+// colliding on FY_2025_Q4. Current names contain no underscores, so existing
+// URLs are unchanged. Matching re-encodes each candidate name rather than
+// decoding the slug, so the scheme only needs to be collision-free, not
+// reversible.
+export const encodeDatacallSlug = (name: string) =>
+  name.replaceAll('_', '__').replaceAll(' ', '_')
+
+// Resolve the URL's data-call segment back to its datacall by re-encoding each
+// candidate name and comparing case-insensitively (consistent with the other
+// resolvers — a case-mangled shared URL should still land on the right cycle,
+// not silently fall back to the latest one). undefined when absent or
+// unrecognized — callers fall back to the selected/latest call.
 export function resolveDatacallBySlug(
   datacalls: datacall[],
   slug: string | undefined
 ): datacall | undefined {
   if (!slug) return undefined
-  return datacalls.find((dc) => dc.datacall.replaceAll(' ', '_') === slug)
+  const target = slug.toLowerCase()
+  return datacalls.find(
+    (dc) => encodeDatacallSlug(dc.datacall).toLowerCase() === target
+  )
 }
 
 export type FunctionTarget = {

--- a/src/views/QuestionnairePage/deepLink.ts
+++ b/src/views/QuestionnairePage/deepLink.ts
@@ -1,0 +1,73 @@
+import { FismaSystemType, datacall } from '@/types'
+
+// Slugify a pillar/function name for the questionnaire URL. Kept here (rather
+// than inline in QuestionnairePage) so the deep-link resolvers below and the
+// page's navigate() calls share one canonical definition.
+export const toSlug = (str: string) =>
+  str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replaceAll(' ', '-')
+
+// Resolve the :fismaacronym URL param to a fismasystemid using the systems list
+// the app already loads. Enables cold loads (paste / refresh / bookmark) where
+// router location.state is empty. Case-insensitive; undefined when unresolved.
+export function resolveSystemIdByAcronym(
+  systems: FismaSystemType[],
+  acronym: string | undefined
+): number | undefined {
+  if (!acronym) return undefined
+  const target = acronym.toLowerCase()
+  return systems.find((s) => s.fismaacronym?.toLowerCase() === target)
+    ?.fismasystemid
+}
+
+// Resolve the URL's data-call segment back to its datacall. The segment is the
+// call's name with spaces encoded as underscores (see how the page builds the
+// URL), so undo that before matching. undefined when absent or unrecognized —
+// callers fall back to the selected/latest call.
+export function resolveDatacallBySlug(
+  datacalls: datacall[],
+  slug: string | undefined
+): datacall | undefined {
+  if (!slug) return undefined
+  return datacalls.find((dc) => dc.datacall.replaceAll(' ', '_') === slug)
+}
+
+export type FunctionTarget = {
+  functionid: number
+  pillarName: string
+  functionName: string
+}
+
+// Structural shape of the page's Category so this module doesn't depend on the
+// component. Matches { name, steps: FismaQuestion[] }.
+type CategoryLike = {
+  name: string
+  steps: { function: { functionid: number; function: string } }[]
+}
+
+// Resolve the :pillar/:function URL params to a concrete function within the
+// loaded categories, so a deep link opens the named question instead of always
+// snapping to the first one. undefined when either param is missing or does not
+// match any loaded pillar/function — callers fall back to categories[0].
+export function resolveFunctionTarget(
+  categories: CategoryLike[],
+  pillarSlug: string | undefined,
+  functionSlug: string | undefined
+): FunctionTarget | undefined {
+  if (!pillarSlug || !functionSlug) return undefined
+  for (const cat of categories) {
+    if (toSlug(cat.name) !== pillarSlug) continue
+    for (const step of cat.steps) {
+      if (toSlug(step.function.function) === functionSlug) {
+        return {
+          functionid: step.function.functionid,
+          pillarName: cat.name,
+          functionName: step.function.function,
+        }
+      }
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
> **Note:** In-repo copy of #523 by @voidspooks. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #523

---

## Summary

Fixes #500. A questionnaire URL (`/#/questionnaire/:fismaacronym/:datacallid/:pillar/:function`) only worked when reached by clicking through from the dashboard. Pasting, refreshing, or bookmarking one failed — the page could not resolve the system, and any pillar/function in the URL was discarded. This is entirely client-side routing (the API already serves questionnaire/score/insight data by `fismasystemid` on a direct request), so there is no backend change.

`QuestionnairePage` sourced `fismasystemid` only from React Router `location.state` (empty on a cold load) and, after categories loaded, unconditionally redirected to the first pillar/function.

## Changes

All in `src/views/QuestionnairePage/`:

- **Resolve the system** from `:fismaacronym` against the already-loaded systems list when `location.state` is absent. While that list is still loading the page shows a spinner; the "cannot load" warning now appears only once systems are loaded and the acronym is still unmatched (reworded to a not-found message).
- **Resolve the cycle** from the URL's data-call segment via the `datacalls` list (already on context), falling back to the selected/latest call when the segment is absent or unrecognized.
- **Honor `:pillar/:function`** on mount, falling back to `categoriesData[0]` only when they are missing or invalid.
- **Gate the fetch** on the datacall context being ready (`latestDataCallId > 0`) so a cold link cannot query scores with `datacallid=0` before datacalls load.

The deep-link branch only runs when router state is absent, so the dashboard → questionnaire path is unchanged.

## Tests

- `deepLink.ts` — resolution logic extracted as pure functions (`resolveSystemIdByAcronym`, `resolveDatacallBySlug`, `resolveFunctionTarget`, shared `toSlug`), unit-tested in `deepLink.test.ts`.
- `QuestionnairePage.deeplink.test.tsx` — mounts the real page at a cold deep link (no `location.state`) and asserts the system resolves, the cycle is read from the URL (scores queried for the URL's call, not the latest), the deep-linked pillar/function opens (not the first), plus the fallback / not-found / loading paths.

Full frontend suite green locally: `tsc --noEmit`, `eslint` (0 errors), `jest` (394 passed).

Closes #500.

