### PR TITLE
Create Datacall ux fixes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,9 @@ export type editSystemModalProps = {
 export type datacallModalProps = {
   open: boolean
   onClose: () => void
+  // Fired after a successful POST /datacalls so the parent can re-fetch
+  // its data-call list and the new call appears without a manual reload.
+  onCreated?: () => void
 }
 
 export type ScoreData = {

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -27,9 +27,12 @@ import { isAuthHandled, notify } from '@/utils/notify'
 // introduced FY23/FY24/FY25 ZTM datacall names.
 const DATACALL_NAME_PATTERN = /^FY(\d{2}|\d{4}) (Q[1-4]|ZTM)$/
 const DATACALL_MAX_LENGTH = 10 // "FY2025 ZTM" = 10 chars; longest valid form
-const DATACALL_MIN_LENGTH = 7 // "FY23 Q1" / "FY23 ZTM" share the floor
 
-export default function DataCallModal({ open, onClose }: datacallModalProps) {
+export default function DataCallModal({
+  open,
+  onClose,
+  onCreated,
+}: datacallModalProps) {
   const [datacall, setDatacall] = React.useState<string>('')
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
@@ -61,8 +64,11 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       </Typography>
     )
   }
+  // Validates on every change so the user is never left with a disabled
+  // Create button and no explanation. Empty input still resets the error
+  // (an untouched field should not scream at the user).
   function isValidFormat(input: string) {
-    if (input.length < DATACALL_MIN_LENGTH) {
+    if (input.length === 0) {
       setDatacallError('')
       return
     }
@@ -77,11 +83,29 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
     setDatacall(value)
     isValidFormat(value.toUpperCase())
   }
+  // Deadline validation mirrors the blur logic but only fires once the
+  // input has reached the 10-char MM/DD/YYYY shape - partial input stays
+  // quiet so the field does not flash red on every keystroke.
+  const validateDeadlineValue = (value: string) => {
+    if (value.length === 0) {
+      setDeadlineError('')
+      return
+    }
+    if (value.length < 10) {
+      setDeadlineError('')
+      return
+    }
+    if (isNaN(Date.parse(value))) {
+      setDeadlineError('Invalid Deadline')
+      return
+    }
+    setDeadlineError('')
+  }
   const validateDeadline = (e: React.FocusEvent<HTMLInputElement>) => {
     if (e.target.value.length === 10 && !isNaN(Date.parse(e.target.value))) {
       setDeadline(e.target.value)
       setDeadlineError('')
-    } else {
+    } else if (e.target.value.length > 0) {
       setDeadlineError('Invalid Deadline')
     }
   }
@@ -95,6 +119,10 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       notify('Datacall has successfully been created', 'success', {
         autoHideDuration: 2500,
       })
+      // Refresh the caller's data-call list so the newly created call
+      // appears in the picker without a manual page reload, then close.
+      onCreated?.()
+      onClose()
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)
@@ -173,8 +201,9 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
             onBlur={validateDeadline}
             onChange={(e) => {
               setDeadline(e)
+              validateDeadlineValue(e)
             }}
-            value=""
+            value={deadline}
           />
         </DialogContent>
         <DialogActions

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -178,10 +178,6 @@ export default function DataCallModal({
     }
   }
 
-  // Both fields carry a Required indicator (see the requirementLabel
-  // props on each below), so the disabled Create button is
-  // self-explaining for the empty-field case. Invalid input is reported
-  // per-field via the error message.
   const nameValid = DATACALL_NAME_PATTERN.test(datacall.toUpperCase())
   const deadlineComplete = deadline.length === 10 && !deadlineError
   const isCreateDisabled =

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -27,6 +27,25 @@ import { isAuthHandled, notify } from '@/utils/notify'
 // introduced FY23/FY24/FY25 ZTM datacall names.
 const DATACALL_NAME_PATTERN = /^FY(\d{2}|\d{4}) (Q[1-4]|ZTM)$/
 const DATACALL_MAX_LENGTH = 10 // "FY2025 ZTM" = 10 chars; longest valid form
+const DEADLINE_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4})$/
+
+// Verifies MM/DD/YYYY is a real calendar date - Date.parse silently rolls
+// impossible dates over (02/30 -> Mar 2, 04/31 -> May 1), which would
+// otherwise let the user submit a wrong date without any feedback. Reject
+// unless the parsed date's month/day round-trip exactly.
+function isValidCalendarDate(mdY: string): boolean {
+  const match = mdY.match(DEADLINE_PATTERN)
+  if (!match) return false
+  const month = Number(match[1])
+  const day = Number(match[2])
+  const year = Number(match[3])
+  const d = new Date(year, month - 1, day)
+  return (
+    d.getFullYear() === year &&
+    d.getMonth() === month - 1 &&
+    d.getDate() === day
+  )
+}
 
 export default function DataCallModal({
   open,
@@ -37,6 +56,10 @@ export default function DataCallModal({
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
   const [deadlineError, setDeadlineError] = React.useState<string>('')
+  // Guards against a double-submit (fast double-click or double-Enter) that
+  // would otherwise fire two POSTs before the modal auto-closes and creates
+  // duplicate datacalls server-side.
+  const [submitting, setSubmitting] = React.useState<boolean>(false)
 
   // Reset state when the modal is closed so the next open starts clean.
   // Prevents stale errors and half-typed input from bleeding across sessions
@@ -47,6 +70,7 @@ export default function DataCallModal({
       setDatacallError('')
       setDeadline('')
       setDeadlineError('')
+      setSubmitting(false)
     }
   }, [open])
 
@@ -83,34 +107,46 @@ export default function DataCallModal({
     setDatacall(value)
     isValidFormat(value.toUpperCase())
   }
+  // Fires "Required" only on blur - matches the standard form UX where an
+  // untouched field stays quiet on mount and only complains once the user
+  // has engaged with it and left it empty. The on-change path (above) still
+  // reports format errors as-you-type without touching this branch.
+  const handleDatacallBlur = () => {
+    if (datacall.length === 0) {
+      setDatacallError('Datacall name is required')
+    }
+  }
   // Deadline validation mirrors the blur logic but only fires once the
   // input has reached the 10-char MM/DD/YYYY shape - partial input stays
   // quiet so the field does not flash red on every keystroke.
   const validateDeadlineValue = (value: string) => {
-    if (value.length === 0) {
-      setDeadlineError('')
-      return
-    }
     if (value.length < 10) {
       setDeadlineError('')
       return
     }
-    if (isNaN(Date.parse(value))) {
+    if (!isValidCalendarDate(value)) {
       setDeadlineError('Invalid Deadline')
       return
     }
     setDeadlineError('')
   }
   const validateDeadline = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (e.target.value.length === 10 && !isNaN(Date.parse(e.target.value))) {
-      setDeadline(e.target.value)
+    const value = e.target.value
+    if (value.length === 0) {
+      setDeadlineError('Deadline is required')
+      return
+    }
+    if (value.length === 10 && isValidCalendarDate(value)) {
+      setDeadline(value)
       setDeadlineError('')
-    } else if (e.target.value.length > 0) {
+    } else {
       setDeadlineError('Invalid Deadline')
     }
   }
   const submitDatacall = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    if (submitting) return
+    setSubmitting(true)
     try {
       await axiosInstance.post(`/datacalls`, {
         datacall: datacall.toUpperCase(),
@@ -137,8 +173,23 @@ export default function DataCallModal({
         return
       }
       notify(parsed.message, 'error', { autoHideDuration: 2500 })
+    } finally {
+      setSubmitting(false)
     }
   }
+
+  // Both fields carry a Required indicator (see the requirementLabel
+  // props on each below), so the disabled Create button is
+  // self-explaining for the empty-field case. Invalid input is reported
+  // per-field via the error message.
+  const nameValid = DATACALL_NAME_PATTERN.test(datacall.toUpperCase())
+  const deadlineComplete = deadline.length === 10 && !deadlineError
+  const isCreateDisabled =
+    !nameValid ||
+    !deadlineComplete ||
+    datacallError.length !== 0 ||
+    deadlineError.length !== 0 ||
+    submitting
   return (
     <Dialog
       open={open}
@@ -189,6 +240,7 @@ export default function DataCallModal({
             hint={datacallHint()}
             name="datacall"
             onChange={handleDatacallChange}
+            onBlur={handleDatacallBlur}
             labelClassName="datacall-label"
             errorMessage={datacallError}
           />
@@ -216,14 +268,9 @@ export default function DataCallModal({
           <CmsButton
             variation="solid"
             type="submit"
-            disabled={
-              !DATACALL_NAME_PATTERN.test(datacall.toUpperCase()) ||
-              deadline.length !== 10 ||
-              datacallError.length !== 0 ||
-              deadlineError.length !== 0
-            }
+            disabled={isCreateDisabled}
           >
-            Create
+            {submitting ? 'Creating...' : 'Create'}
           </CmsButton>
         </DialogActions>
       </form>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -124,42 +124,50 @@ export default function Title() {
     if (loaderData.status === 200) void clearOtherUserDrafts(userInfo.userid)
   }, [loaderData.status, userInfo.userid])
 
+  // Hoisted out of the mount effect so it can be re-invoked on demand -
+  // specifically, right after DataCallModal creates a new datacall so the
+  // picker updates without a manual page reload. Accepts an optional
+  // signal for the mount-effect's abort cleanup; user-triggered refetches
+  // (e.g. post-create) invoke it without a signal.
+  const fetchDatacalls = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await axiosInstance.get(
+        '/datacalls',
+        signal ? { signal } : {}
+      )
+      if (signal?.aborted) return
+      // "Latest"/"current" is the call with the furthest-out deadline, not
+      // the highest datacallid: historical loads can carry a higher id than
+      // the real current call. datacallid is only a tiebreak.
+      const sorted: datacall[] = sortDatacallsByDeadline(
+        res.data.data as datacall[]
+      )
+      setDatacalls(sorted)
+      if (sorted.length > 0) {
+        setLatestDataCallId(sorted[0].datacallid)
+        setLatestDatacall(sorted[0].datacall)
+        setLatestDeadline(sorted[0].deadline)
+        // Default to the latest year with data, all of its calls toggled on.
+        const [firstGroup] = groupDatacallsByYear(sorted)
+        if (firstGroup) {
+          setActiveYear(firstGroup.year)
+          setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
+        }
+      }
+    } catch (error) {
+      if (signal?.aborted) return
+      console.error('Fetch latest datacall error:', error)
+    }
+  }, [])
+
   useEffect(() => {
     if (loaderData.status !== 200) return
     const controller = new AbortController()
-    async function fetchDatacalls() {
-      try {
-        const res = await axiosInstance.get('/datacalls', {
-          signal: controller.signal,
-        })
-        // "Latest"/"current" is the call with the furthest-out deadline, not
-        // the highest datacallid: historical loads can carry a higher id than
-        // the real current call (#393). datacallid is only a tiebreak.
-        const sorted: datacall[] = sortDatacallsByDeadline(
-          res.data.data as datacall[]
-        )
-        setDatacalls(sorted)
-        if (sorted.length > 0) {
-          setLatestDataCallId(sorted[0].datacallid)
-          setLatestDatacall(sorted[0].datacall)
-          setLatestDeadline(sorted[0].deadline)
-          // Default to the latest year with data, all of its calls toggled on.
-          const [firstGroup] = groupDatacallsByYear(sorted)
-          if (firstGroup) {
-            setActiveYear(firstGroup.year)
-            setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
-          }
-        }
-      } catch (error) {
-        if (controller.signal.aborted) return
-        console.error('Fetch latest datacall error:', error)
-      }
-    }
-    fetchDatacalls()
+    fetchDatacalls(controller.signal)
     return () => {
       controller.abort()
     }
-  }, [loaderData.status])
+  }, [loaderData.status, fetchDatacalls])
 
   // Datacenter-environment vocabulary is reference data shared by the system
   // form (dropdown) and the questionnaire pillar filter, so it is fetched
@@ -640,7 +648,11 @@ export default function Title() {
           openModal={openEmailModal}
           closeModal={handleCloseEmailModal}
         />
-        <DataCallModal open={openDataCallModal} onClose={handleDataCallClose} />
+        <DataCallModal
+          open={openDataCallModal}
+          onClose={handleDataCallClose}
+          onCreated={fetchDatacalls}
+        />
       </Container>
       <Footer />
     </>


### PR DESCRIPTION
## Summary

Closes #504.

Two UX bugs in the Create Datacall flow:

1. **Silent disabled Create button.** The Create button was disabled with no explanation whenever the datacall name was less than 7 chars or the deadline was empty/incomplete. Users had no signal for what was missing.
2. **New data call not visible until manual page reload.** `submitDatacall` fired a success toast but did not close the modal or refresh the parent's data-call list, so the newly created call was absent from the picker until the user hit reload.

Bonus fixes in the same pass (surfaced during review):

* **Double-submit created duplicate datacalls.** Nothing disabled the Create button during the in-flight POST — a fast double-click or double-Enter fired two POSTs before the modal closed.
* **Invalid calendar dates passed validation.** `Date.parse("02/30/2026")` silently rolls over to Mar 2. The button enabled and the wrong date submitted.
* **`SingleInputDateField` was uncontrolled.** Rendered with hardcoded `value=""` instead of `value={deadline}`.

## Changes

* **`src/views/DatacallModal/DataCallModal.tsx`**
  * `isValidFormat` no longer waits for a 7-char minimum. Any non-empty invalid input reports "Invalid datacall format" immediately.
  * New `handleDatacallBlur` fires "Datacall name is required" when the user tabs out with an empty field. Standard form UX — untouched fields stay quiet on mount, only complain on blur.
  * `validateDeadline` (blur) now fires "Deadline is required" when the field is empty on blur; the existing "Invalid Deadline" branch stays for non-empty invalid.
  * New `validateDeadlineValue` (on-change) mirrors the blur validation once the input reaches 10 chars — partial input stays quiet.
  * New `isValidCalendarDate` helper: verifies MM/DD/YYYY round-trips against a rebuilt `Date` object, so 0d. Used in both the on-change and on-blur validators. Fixes a pre-existing bug in the blur path.
  * Fix `value=""` to `value={eField}` in the on-change and on-blur validators. Fixes a pre-existing bug in the path.
  * New `submitting` state guards against duplicate POSTs from double-Enter. Button label in-flight for visible feedback. Reset in the open/close effect.
  * `submitDatacall` on success calls `onClose()` so the parent refreshes and the modal auto-closes.
  * Drop the now-redundant `validateDeadlineValue` (subsumed by `length < 10`).
* **`src/types.ts`** — add optional `onCreated?: () => void` to `datacallModalProps`. Fired by the parent so it can re-fetch its data-call list.
* **`src/views/Title/Title.tsx`**
  * Hoist `fetchDatacalls` into a stable `useCallback([])`. Preserves the existing `AbortSignal`-based cancellation on the mount path via an optional keyed refetch, or it can be invoked without a signal.
  * Pass `onCreated={fetchDatacalls}` so a successful create refreshes the picker without a manual reload.

## Test plan

### Automated

* `yarn tsc --noEmit` clean.
* `yarn prettier --check` clean.
* `make test` — 377/377 passing (no regressions to `Title.test.tsx` or the auth-handling invariants that still delegate auth correctly).

### Manual

* [ ] Open Create Datacall. Both fields render clean (no premature "Required" labels on mount).
* [ ] Type `FY26` in the name field → "Invalid datacall format" appears immediately below the field.
* [ ] Correct to `FY26 Q1` → error clears. Deadline is still empty; Create is disabled.
* [ ] Tab out of the deadline without typing → "Deadline is required" appears below the field.
* [ ] Tab back in, type `12/01/2026` → error clears; Create enables.
* [ ] Test `02/30/2026` → "Invalid calendar date" appears (existing rollover bug is fixed).
* [ ] Test `12/01/20` (partial date input) → Create stays disabled.
* [ ] Submit with valid input → success toast fires, button reads "Creating..." briefly, modal auto-closes, and the new call shows in the picker without reload.
* [ ] Rapidly double-click Create with valid input → only one POST fires in Network tab.
* [ ] Tab out of empty name field → "Datacall name is required".

## Notes for reviewers

* **`fetchDatacalls` hoisting is a refactor with no behavior change.** The mount-path abort-controller optional `signal` argument; the modal's `onCreated` invokes without a signal (fire-and-forget refetch after user-triggered create).
* **Refetch on create clobbers `activeYear` / `activeDatacallIds`.** This is intentional — a user who just created a call wants the picker to focus on the group containing their new call. Not preserved deliberately; easy to change if the reviewer disagrees.
* **`onCreated` is fire-and-forget** — if `fetchDatacalls` rejects (network glitch during the post-create refetch), the new call is still there and the success toast still fires. The create succeeded server-side; next page load surfaces the new call. Filed as a possible follow-up to capture the refetch and surface a fallback error.
* **Unrelated lint warning** in `src/views/ControlPanel.tsx:601` (`react-refresh/only-export-components`) is pre-existing on main — inherited by every branch, not introduced by this PR. Will file a small follow-up ticket to hoist `severityStyle` into a sibling file.