### PR TITLE
feat(questionnaire): ZTMF-insights justification field (#527) [impl]

### DIFF
--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -25,12 +25,17 @@ const insight: InsightPayload = {
   },
 }
 
-function Harness() {
+function Harness({
+  contextId = 'system-1003:question-1',
+}: {
+  contextId?: string
+}) {
   const initial = insight.last_score_notes ?? ''
   const [value, setValue] = React.useState(initial)
   const [review, setReview] = React.useState<PriorReviewState>('pending')
   return (
     <JustificationField
+      contextId={contextId}
       label="Explain the available authentication options"
       value={value}
       onChange={setValue}
@@ -61,6 +66,19 @@ describe('justification context helpers', () => {
 
   it('does not label the viewed data call as a previous response', () => {
     expect(priorResponseFor(insight, 'FY2025_Q1')).toBeUndefined()
+  })
+
+  it("labels prior content as last year's response", () => {
+    expect(priorResponseFor(insight, 'FY2025 Q2')).toEqual({
+      label: "Last year's response — FY2025 Q1",
+      text: insight.last_score_notes,
+    })
+    expect(
+      priorResponseFor({ last_score_notes: insight.last_score_notes })
+    ).toEqual({
+      label: "Last year's ISSO response",
+      text: insight.last_score_notes,
+    })
   })
 })
 
@@ -154,7 +172,11 @@ describe('JustificationField', () => {
       screen.getByRole('button', { name: 'Dismiss suggested justification' })
     )
     expect(screen.getByText('Not used')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
     expect(screen.getByText(/CFACTS \(2\): IDM-Okta\./)).toBeInTheDocument()
     expect(
       screen.getByRole('button', {
@@ -172,8 +194,13 @@ describe('JustificationField', () => {
       })
     )
     fireEvent.change(textbox, { target: { value: '' } })
+    expect(screen.getByText('Not used')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
     fireEvent.click(
       screen.getByRole('button', {
         name: 'Insert suggested justification into current response',
@@ -185,6 +212,72 @@ describe('JustificationField', () => {
     )
   })
 
+  it('disables reinserting an Insights suggestion that is still present', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Already included in the current response.')
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Close suggested justification review',
+      })
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      (
+        screen.getByRole('textbox', {
+          name: 'Current response',
+        }) as HTMLTextAreaElement
+      ).value
+    ).toContain('CFACTS (2): IDM-Okta.')
+  })
+
+  it('keeps an edited Insights suggestion marked as added', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.change(textbox, {
+      target: {
+        value: (textbox as HTMLTextAreaElement).value.replace(
+          'IDM-Okta.',
+          'IDM-Okta with phishing-resistant MFA.'
+        ),
+      },
+    })
+
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'Close suggested justification review',
+      })
+    ).toBeInTheDocument()
+  })
+
   it('lets the ISSO reopen an accepted previous response', () => {
     render(<Harness />)
     const textbox = screen.getByRole('textbox', { name: 'Current response' })
@@ -194,16 +287,148 @@ describe('JustificationField', () => {
       })
     )
     fireEvent.change(textbox, { target: { value: '' } })
+    expect(screen.getByText('Not used')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
 
     expect(screen.getByText(insight.last_score_notes ?? '')).toBeInTheDocument()
+  })
+
+  it('disables reinserting a reviewed previous response that is still present', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Already included in the current response.')
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Close previous ISSO response review',
+      })
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toHaveValue(insight.last_score_notes)
+  })
+
+  it('keeps an edited previous response marked as added', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.change(textbox, {
+      target: {
+        value: (insight.last_score_notes ?? '').replace(
+          'Okta policies.',
+          'phishing-resistant Okta policies.'
+        ),
+      },
+    })
+
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'Close previous ISSO response review',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('marks only the removed source as not used when other text remains', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+
+    fireEvent.change(textbox, { target: { value: insight.last_score_notes } })
+
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+  })
+
+  it('resets card state when the question context changes', () => {
+    const { rerender } = render(<Harness contextId="question-1" />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+
+    rerender(<Harness contextId="question-2" />)
+
+    expect(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/CFACTS \(2\): IDM-Okta\./)).toBeInTheDocument()
+  })
+
+  it('blocks editing while previous-response review is initializing', () => {
+    render(
+      <JustificationField
+        contextId="question-1"
+        label="Justification"
+        value={insight.last_score_notes ?? ''}
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="initializing"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+      />
+    )
+
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Checking the previous response…')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    ).not.toBeInTheDocument()
   })
 
   it('only shows the expansion control when context text is clipped', () => {
     render(<Harness />)
     expect(
-      screen.queryByRole('button', { name: 'Show all' })
+      screen.queryByRole('button', {
+        name: 'Show all: Suggested justification',
+      })
     ).not.toBeInTheDocument()
 
     const suggestion = screen.getByText(/CFACTS \(2\): IDM-Okta\./)
@@ -217,7 +442,63 @@ describe('JustificationField', () => {
     })
     fireEvent(window, new Event('resize'))
 
-    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Show all: Suggested justification',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps repeated compact actions source-specific for assistive technology', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('explains when contextual text cannot fit in the current response', () => {
+    render(
+      <JustificationField
+        label="Justification"
+        value={'x'.repeat(1990)}
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="not-required"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Not enough space remaining to insert this suggestion.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Not enough space remaining to insert the previous response.'
+      )
+    ).toBeInTheDocument()
   })
 
   it('shows context without action buttons in read-only mode', () => {

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -1,0 +1,246 @@
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { InsightPayload } from '@/types'
+import JustificationField, { PriorReviewState } from './JustificationField'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './justificationContext'
+
+const insight: InsightPayload = {
+  suggested_score: 1,
+  suggested_label: 'Traditional',
+  cfacts_suggested_score: 2,
+  cfacts_auth_methods: 'IDM-Okta',
+  kion_suggested_score: 1,
+  sechub_suggested_score: 1,
+  ars_control_score: 2,
+  ars_controls_satisfied: 4,
+  ars_controls_total: 4,
+  last_score_notes: 'MFA is enforced through Okta policies.',
+  last_datacall: 'FY2025 Q1',
+  findings: {
+    kion: [{ id: 'one' }, { id: 'two' }],
+    sechub: [{ id: 'one' }],
+  },
+}
+
+function Harness() {
+  const initial = insight.last_score_notes ?? ''
+  const [value, setValue] = React.useState(initial)
+  const [review, setReview] = React.useState<PriorReviewState>('pending')
+  return (
+    <JustificationField
+      label="Explain the available authentication options"
+      value={value}
+      onChange={setValue}
+      insight={insight}
+      viewedDatacall="FY2025 Q2"
+      priorReviewState={review}
+      onPriorReview={setReview}
+      maxLength={2000}
+    />
+  )
+}
+
+describe('justification context helpers', () => {
+  it('builds a concise source-attributed Insights suggestion', () => {
+    expect(buildInsightJustification(insight)).toBe(
+      'CFACTS (2): IDM-Okta. Kion (1): 2 failing checks. SecurityHub (1): 1 failing control. ARS (2): 4/4 controls satisfied.'
+    )
+  })
+
+  it('prefers a pipeline-authored suggested justification', () => {
+    expect(
+      buildInsightJustification({
+        ...insight,
+        suggested_justification: 'Use the approved MFA language.',
+      })
+    ).toBe('Use the approved MFA language.')
+  })
+
+  it('does not label the viewed data call as a previous response', () => {
+    expect(priorResponseFor(insight, 'FY2025_Q1')).toBeUndefined()
+  })
+})
+
+describe('JustificationField', () => {
+  it('keeps carried-forward text out of the current response until accepted', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    expect(textbox).toHaveValue('')
+    expect(textbox).not.toHaveAttribute('readonly')
+    expect(textbox.closest('.MuiTextField-root')).toHaveStyle({
+      flex: '0 0 160px',
+      height: '160px',
+    })
+    expect(screen.getByText('Review required')).toBeInTheDocument()
+    expect(
+      screen.getByText('Only the text in this field will be submitted.')
+    ).toBeInTheDocument()
+  })
+
+  it('copies the previous response into the submitted field after acceptance', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toHaveValue(insight.last_score_notes)
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Review the previous response before continuing.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('preserves a typed response when the ISSO declines the previous response', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.change(textbox, {
+      target: { value: 'The current call uses phishing-resistant MFA.' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+    expect(textbox).toHaveValue('The current call uses phishing-resistant MFA.')
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+  })
+
+  it('appends the previous response without overwriting current input', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.change(textbox, {
+      target: { value: 'Current-call update.' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(textbox).toHaveValue(
+      `Current-call update.\n\n${insight.last_score_notes}`
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+  })
+
+  it('adds the Insights suggestion without silently submitting it', () => {
+    const { unmount } = render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    expect(textbox).toHaveValue('')
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    expect((textbox as HTMLTextAreaElement).value).toContain(
+      'CFACTS (2): IDM-Okta.'
+    )
+    unmount()
+  })
+
+  it('lets the ISSO reopen a dismissed Insights suggestion', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+    expect(screen.getByText(/CFACTS \(2\): IDM-Okta\./)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('lets the ISSO reopen and re-add an accepted Insights suggestion', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.change(textbox, { target: { value: '' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+
+    expect((textbox as HTMLTextAreaElement).value).toContain(
+      'CFACTS (2): IDM-Okta.'
+    )
+  })
+
+  it('lets the ISSO reopen an accepted previous response', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.change(textbox, { target: { value: '' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review again' }))
+
+    expect(screen.getByText(insight.last_score_notes ?? '')).toBeInTheDocument()
+  })
+
+  it('only shows the expansion control when context text is clipped', () => {
+    render(<Harness />)
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).not.toBeInTheDocument()
+
+    const suggestion = screen.getByText(/CFACTS \(2\): IDM-Okta\./)
+    Object.defineProperty(suggestion, 'clientHeight', {
+      configurable: true,
+      value: 32,
+    })
+    Object.defineProperty(suggestion, 'scrollHeight', {
+      configurable: true,
+      value: 64,
+    })
+    fireEvent(window, new Event('resize'))
+
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
+  })
+
+  it('shows context without action buttons in read-only mode', () => {
+    render(
+      <JustificationField
+        label="Justification"
+        value="Saved response"
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="not-required"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+        disabled
+      />
+    )
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toBeDisabled()
+  })
+})

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { styled } from '@mui/material/styles'
 import type { InsightPayload } from '@/types'
@@ -13,15 +14,19 @@ import {
 
 export type PriorReviewState =
   | 'not-required'
+  | 'initializing'
   | 'pending'
   | 'accepted'
   | 'dismissed'
 
 type Props = {
+  contextId?: string
   label: string
   value: string
   onChange: (value: string) => void
   insight?: InsightPayload
+  priorResponse?: { label: string; text: string }
+  showInsightSuggestion?: boolean
   viewedDatacall?: string
   priorReviewState: PriorReviewState
   onPriorReview: (state: PriorReviewState) => void
@@ -60,6 +65,58 @@ function appendText(current: string, addition: string): string {
   return `${current.trimEnd()}\n\n${addition}`
 }
 
+type TextRange = { start: number; end: number }
+
+function exactTextRange(value: string, text?: string): TextRange | null {
+  if (!text) return null
+  const start = value.lastIndexOf(text)
+  return start < 0 ? null : { start, end: start + text.length }
+}
+
+/** Keep an inserted source's range aligned with one textarea replacement. */
+function remapTextRange(
+  before: string,
+  after: string,
+  range: TextRange | null
+): TextRange | null {
+  if (!range || before === after) return range
+
+  let changeStart = 0
+  while (
+    changeStart < before.length &&
+    changeStart < after.length &&
+    before[changeStart] === after[changeStart]
+  ) {
+    changeStart++
+  }
+
+  let oldEnd = before.length
+  let newEnd = after.length
+  while (
+    oldEnd > changeStart &&
+    newEnd > changeStart &&
+    before[oldEnd - 1] === after[newEnd - 1]
+  ) {
+    oldEnd--
+    newEnd--
+  }
+
+  const delta = newEnd - oldEnd
+  if (oldEnd <= range.start) {
+    return { start: range.start + delta, end: range.end + delta }
+  }
+  if (changeStart >= range.end) return range
+
+  const start = changeStart <= range.start ? changeStart : range.start
+  const end = oldEnd >= range.end ? newEnd : range.end + delta
+  if (end <= start || !after.slice(start, end).trim()) return null
+  return { start, end }
+}
+
+function hasTrackedText(value: string, range: TextRange | null): boolean {
+  return Boolean(range && value.slice(range.start, range.end).trim())
+}
+
 type ContextCardProps = {
   title: string
   author: string
@@ -74,6 +131,8 @@ type ContextCardProps = {
   onSecondary: () => void
   onRestore?: () => void
   primaryDisabled?: boolean
+  primaryDisabledReason?: string
+  primaryDisabledReasonSeverity?: 'error' | 'info'
   disabled?: boolean
 }
 
@@ -91,11 +150,17 @@ function ContextCard({
   onSecondary,
   onRestore,
   primaryDisabled,
+  primaryDisabledReason,
+  primaryDisabledReasonSeverity = 'error',
   disabled,
 }: ContextCardProps) {
   const [expanded, setExpanded] = React.useState(false)
   const [canExpand, setCanExpand] = React.useState(false)
   const textRef = React.useRef<HTMLParagraphElement>(null)
+  const primaryDisabledReasonId = React.useId()
+  const restoreLabel = `Review again: ${title}`
+  const expandLabel = `${expanded ? 'Show less' : 'Show all'}: ${title}`
+  const statusLabel = state === 'accepted' ? 'Added to response' : 'Not used'
 
   const measureOverflow = React.useCallback(() => {
     if (state !== 'available' || expanded || !text) return
@@ -135,19 +200,22 @@ function ContextCard({
         <Typography sx={{ fontSize: 12, fontWeight: 700 }}>{title}</Typography>
         <Chip
           size="small"
-          label={state === 'accepted' ? 'Added to response' : 'Not used'}
+          label={statusLabel}
           color={state === 'accepted' ? 'success' : 'default'}
           sx={{ height: 22, fontSize: 11 }}
         />
         {onRestore && !disabled && (
-          <Button
-            size="small"
-            variant="text"
-            onClick={onRestore}
-            sx={{ ml: 'auto', fontSize: 11 }}
-          >
-            Review again
-          </Button>
+          <Tooltip title={restoreLabel}>
+            <Button
+              size="small"
+              variant="text"
+              aria-label={restoreLabel}
+              onClick={onRestore}
+              sx={{ ml: 'auto', fontSize: 11 }}
+            >
+              Review again
+            </Button>
+          </Tooltip>
         )}
       </Box>
     )
@@ -217,6 +285,11 @@ function ContextCard({
               size="small"
               variant="contained"
               aria-label={primaryAriaLabel}
+              aria-describedby={
+                primaryDisabled && primaryDisabledReason
+                  ? primaryDisabledReasonId
+                  : undefined
+              }
               onClick={onPrimary}
               disabled={primaryDisabled}
               sx={{
@@ -250,24 +323,46 @@ function ContextCard({
         {text}
       </Typography>
       {canExpand && (
-        <Button
-          size="small"
-          variant="text"
-          onClick={() => setExpanded((value) => !value)}
-          sx={{ mt: 0.5, minWidth: 0, px: 0.5, fontSize: 11 }}
+        <Tooltip title={expandLabel}>
+          <Button
+            size="small"
+            variant="text"
+            aria-label={expandLabel}
+            onClick={() => setExpanded((value) => !value)}
+            sx={{ mt: 0.5, minWidth: 0, px: 0.5, fontSize: 11 }}
+          >
+            {expanded ? 'Show less' : 'Show all'}
+          </Button>
+        </Tooltip>
+      )}
+      {primaryDisabled && primaryDisabledReason && (
+        <Typography
+          id={primaryDisabledReasonId}
+          role={primaryDisabledReasonSeverity === 'error' ? 'alert' : 'status'}
+          sx={{
+            mt: 0.5,
+            fontSize: 11,
+            color:
+              primaryDisabledReasonSeverity === 'error'
+                ? 'error.main'
+                : 'text.secondary',
+          }}
         >
-          {expanded ? 'Show less' : 'Show all'}
-        </Button>
+          {primaryDisabledReason}
+        </Typography>
       )}
     </Box>
   )
 }
 
 export default function JustificationField({
+  contextId,
   label,
   value,
   onChange,
   insight,
+  priorResponse,
+  showInsightSuggestion = true,
   viewedDatacall,
   priorReviewState,
   onPriorReview,
@@ -276,23 +371,69 @@ export default function JustificationField({
   helperText,
   maxLength,
 }: Props) {
-  const prior = priorResponseFor(insight, viewedDatacall)
-  const suggestion = buildInsightJustification(insight)
-  const contextKey = `${viewedDatacall ?? ''}:${prior?.text ?? ''}:${suggestion ?? ''}`
-  const [suggestionState, setSuggestionState] = React.useState<
-    'available' | 'accepted' | 'dismissed'
-  >('available')
+  const prior = priorResponse ?? priorResponseFor(insight, viewedDatacall)
+  const suggestion = showInsightSuggestion
+    ? buildInsightJustification(insight)
+    : undefined
+  const contextKey = JSON.stringify([
+    contextId ?? null,
+    viewedDatacall ?? null,
+    prior?.text ?? null,
+    suggestion ?? null,
+  ])
+  const [suggestionOpen, setSuggestionOpen] = React.useState(true)
+  const [priorOpen, setPriorOpen] = React.useState(true)
+  const [suggestionRange, setSuggestionRange] =
+    React.useState<TextRange | null>(null)
+  const [priorRange, setPriorRange] = React.useState<TextRange | null>(null)
 
-  React.useEffect(() => setSuggestionState('available'), [contextKey])
+  React.useEffect(() => {
+    setSuggestionOpen(true)
+    setPriorOpen(true)
+    setSuggestionRange(null)
+    setPriorRange(null)
+  }, [contextKey])
 
-  const priorPending = priorReviewState === 'pending'
+  const priorInitializing = priorReviewState === 'initializing'
+  const priorPending =
+    priorReviewState === 'pending' || priorReviewState === 'initializing'
+  const interactionDisabled = disabled || priorInitializing
   const displayedValue =
     priorPending && prior && value.trim() === prior.text.trim() ? '' : value
   const suggestionResult = suggestion
     ? appendText(displayedValue, suggestion)
     : displayedValue
+  const suggestionExactRange = exactTextRange(displayedValue, suggestion)
+  const effectiveSuggestionRange = suggestionExactRange ?? suggestionRange
+  const suggestionAlreadyIncluded = Boolean(suggestionExactRange)
   const suggestionFits = suggestionResult.length <= maxLength
+  const priorExactRange = exactTextRange(displayedValue, prior?.text)
+  const effectivePriorRange = priorExactRange ?? priorRange
+  const priorTextIncluded = Boolean(priorExactRange)
+  const priorAlreadyIncluded = priorTextIncluded && !priorPending
+  const priorResult = prior
+    ? appendText(displayedValue, prior.text)
+    : displayedValue
   const hasContext = Boolean(suggestion || prior)
+  const suggestionState =
+    suggestionAlreadyIncluded ||
+    hasTrackedText(displayedValue, effectiveSuggestionRange)
+      ? 'accepted'
+      : 'dismissed'
+  const priorState =
+    priorTextIncluded || hasTrackedText(displayedValue, effectivePriorRange)
+      ? 'accepted'
+      : 'dismissed'
+
+  const changeResponse = (nextValue: string) => {
+    setSuggestionRange(
+      remapTextRange(displayedValue, nextValue, effectiveSuggestionRange)
+    )
+    setPriorRange(
+      remapTextRange(displayedValue, nextValue, effectivePriorRange)
+    )
+    onChange(nextValue)
+  }
 
   return (
     <Box>
@@ -318,19 +459,36 @@ export default function JustificationField({
                 title="Suggested justification"
                 author="ZTMF Insights"
                 text={suggestion}
-                state={suggestionState}
+                state={suggestionOpen ? 'available' : suggestionState}
                 primaryLabel="Insert into response"
                 primaryAriaLabel="Insert suggested justification into current response"
-                secondaryLabel="Dismiss"
-                secondaryAriaLabel="Dismiss suggested justification"
-                primaryDisabled={!suggestionFits}
-                disabled={disabled}
+                secondaryLabel={
+                  suggestionState === 'dismissed' ? 'Dismiss' : 'Close'
+                }
+                secondaryAriaLabel={
+                  suggestionState === 'dismissed'
+                    ? 'Dismiss suggested justification'
+                    : 'Close suggested justification review'
+                }
+                primaryDisabled={suggestionAlreadyIncluded || !suggestionFits}
+                primaryDisabledReason={
+                  suggestionAlreadyIncluded
+                    ? 'Already included in the current response.'
+                    : 'Not enough space remaining to insert this suggestion.'
+                }
+                primaryDisabledReasonSeverity={
+                  suggestionAlreadyIncluded ? 'info' : 'error'
+                }
+                disabled={interactionDisabled}
                 onPrimary={() => {
+                  setSuggestionRange(
+                    exactTextRange(suggestionResult, suggestion)
+                  )
                   onChange(suggestionResult)
-                  setSuggestionState('accepted')
+                  setSuggestionOpen(false)
                 }}
-                onSecondary={() => setSuggestionState('dismissed')}
-                onRestore={() => setSuggestionState('available')}
+                onSecondary={() => setSuggestionOpen(false)}
+                onRestore={() => setSuggestionOpen(true)}
               />
             )}
             {prior && (
@@ -339,36 +497,51 @@ export default function JustificationField({
                 author="ISSO"
                 text={prior.text}
                 required={priorPending}
-                state={
-                  priorReviewState === 'accepted'
-                    ? 'accepted'
-                    : priorReviewState === 'dismissed'
-                      ? 'dismissed'
-                      : 'available'
-                }
+                state={priorOpen ? 'available' : priorState}
                 primaryLabel="Insert into response"
                 primaryAriaLabel="Insert previous ISSO response into current response"
-                secondaryLabel="Dismiss"
-                secondaryAriaLabel="Dismiss previous ISSO response"
-                primaryDisabled={
-                  appendText(displayedValue, prior.text).length > maxLength
+                secondaryLabel={
+                  priorState === 'dismissed' ? 'Dismiss' : 'Close'
                 }
-                disabled={disabled}
+                secondaryAriaLabel={
+                  priorState === 'dismissed'
+                    ? 'Dismiss previous ISSO response'
+                    : 'Close previous ISSO response review'
+                }
+                primaryDisabled={
+                  priorAlreadyIncluded || priorResult.length > maxLength
+                }
+                primaryDisabledReason={
+                  priorAlreadyIncluded
+                    ? 'Already included in the current response.'
+                    : 'Not enough space remaining to insert the previous response.'
+                }
+                primaryDisabledReasonSeverity={
+                  priorAlreadyIncluded ? 'info' : 'error'
+                }
+                disabled={interactionDisabled}
                 onPrimary={() => {
-                  onChange(
+                  const nextValue =
                     priorPending && !displayedValue.trim()
                       ? prior.text
                       : appendText(displayedValue, prior.text)
-                  )
+                  setPriorRange(exactTextRange(nextValue, prior.text))
+                  onChange(nextValue)
                   onPriorReview('accepted')
+                  setPriorOpen(false)
                 }}
                 onSecondary={() => {
+                  if (priorState !== 'dismissed') {
+                    setPriorOpen(false)
+                    return
+                  }
                   if (priorPending && value.trim() === prior.text.trim()) {
                     onChange('')
                   }
                   onPriorReview('dismissed')
+                  setPriorOpen(false)
                 }}
-                onRestore={() => onPriorReview('not-required')}
+                onRestore={() => setPriorOpen(true)}
               />
             )}
           </Box>
@@ -410,7 +583,7 @@ export default function JustificationField({
           multiline
           fullWidth
           value={displayedValue}
-          disabled={disabled}
+          disabled={interactionDisabled}
           error={error}
           helperText={helperText}
           placeholder="Add your current justification here…"
@@ -421,7 +594,7 @@ export default function JustificationField({
               ? 'previous-response-review-message'
               : undefined,
           }}
-          onChange={(event) => onChange(event.target.value)}
+          onChange={(event) => changeResponse(event.target.value)}
           sx={hasContext ? { flex: '0 0 160px', height: 160 } : undefined}
         />
       </Box>
@@ -431,7 +604,9 @@ export default function JustificationField({
           role="status"
           sx={{ mt: 0.5, fontSize: 12, color: '#8a4b00' }}
         >
-          Review the previous response before continuing.
+          {priorInitializing
+            ? 'Checking the previous response…'
+            : 'Review the previous response before continuing.'}
         </Typography>
       )}
     </Box>

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -1,0 +1,439 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
+import type { InsightPayload } from '@/types'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './justificationContext'
+
+export type PriorReviewState =
+  | 'not-required'
+  | 'pending'
+  | 'accepted'
+  | 'dismissed'
+
+type Props = {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  insight?: InsightPayload
+  viewedDatacall?: string
+  priorReviewState: PriorReviewState
+  onPriorReview: (state: PriorReviewState) => void
+  disabled?: boolean
+  error?: boolean
+  helperText?: string
+  maxLength: number
+}
+
+const ResponseTextField = styled(TextField)({
+  flex: 1,
+  minHeight: 0,
+  '& .MuiOutlinedInput-root': {
+    height: '100%',
+    alignItems: 'flex-start',
+    borderRadius: 0,
+    '& fieldset': {
+      border: 0,
+      borderTop: '1px solid #d6d7d9',
+    },
+    '&.Mui-focused fieldset': {
+      border: 0,
+      borderTop: '1px solid #d6d7d9',
+      boxShadow: 'inset 0 0 0 3px #ffffff, inset 0 0 0 6px #bd13b8',
+    },
+  },
+  '& .MuiInputBase-inputMultiline': {
+    height: '100% !important',
+    overflow: 'auto !important',
+  },
+})
+
+function appendText(current: string, addition: string): string {
+  if (!current.trim()) return addition
+  if (current.includes(addition)) return current
+  return `${current.trimEnd()}\n\n${addition}`
+}
+
+type ContextCardProps = {
+  title: string
+  author: string
+  text: string
+  required?: boolean
+  state: 'available' | 'accepted' | 'dismissed'
+  primaryLabel: string
+  primaryAriaLabel: string
+  secondaryLabel: string
+  secondaryAriaLabel: string
+  onPrimary: () => void
+  onSecondary: () => void
+  onRestore?: () => void
+  primaryDisabled?: boolean
+  disabled?: boolean
+}
+
+function ContextCard({
+  title,
+  author,
+  text,
+  required,
+  state,
+  primaryLabel,
+  primaryAriaLabel,
+  secondaryLabel,
+  secondaryAriaLabel,
+  onPrimary,
+  onSecondary,
+  onRestore,
+  primaryDisabled,
+  disabled,
+}: ContextCardProps) {
+  const [expanded, setExpanded] = React.useState(false)
+  const [canExpand, setCanExpand] = React.useState(false)
+  const textRef = React.useRef<HTMLParagraphElement>(null)
+
+  const measureOverflow = React.useCallback(() => {
+    if (state !== 'available' || expanded || !text) return
+    const element = textRef.current
+    if (!element) return
+    setCanExpand(element.scrollHeight > element.clientHeight + 1)
+  }, [expanded, state, text])
+
+  React.useLayoutEffect(() => {
+    measureOverflow()
+    window.addEventListener('resize', measureOverflow)
+    const element = textRef.current
+    const observer =
+      element && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(measureOverflow)
+        : undefined
+    if (element) observer?.observe(element)
+    return () => {
+      window.removeEventListener('resize', measureOverflow)
+      observer?.disconnect()
+    }
+  }, [measureOverflow])
+
+  if (state !== 'available') {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          py: 0.75,
+          borderBottom: '1px solid #d6d7d9',
+          bgcolor: '#f5f5f5',
+        }}
+      >
+        <Typography sx={{ fontSize: 12, fontWeight: 700 }}>{title}</Typography>
+        <Chip
+          size="small"
+          label={state === 'accepted' ? 'Added to response' : 'Not used'}
+          color={state === 'accepted' ? 'success' : 'default'}
+          sx={{ height: 22, fontSize: 11 }}
+        />
+        {onRestore && !disabled && (
+          <Button
+            size="small"
+            variant="text"
+            onClick={onRestore}
+            sx={{ ml: 'auto', fontSize: 11 }}
+          >
+            Review again
+          </Button>
+        )}
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 1,
+        borderBottom: '1px solid #d6d7d9',
+        bgcolor: '#f5f5f5',
+        color: '#454545',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: '1 1 260px',
+            minWidth: 0,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: 11, color: '#666' }}>
+            by {author}
+          </Typography>
+          {required && (
+            <Chip
+              size="small"
+              label="Review required"
+              color="warning"
+              sx={{ height: 22, fontSize: 11 }}
+            />
+          )}
+        </Box>
+        {!disabled && (
+          <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5, flexShrink: 0 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              aria-label={secondaryAriaLabel}
+              onClick={onSecondary}
+              sx={{
+                minHeight: 26,
+                px: 1,
+                py: 0.25,
+                fontSize: 10.5,
+                borderRadius: '6px',
+              }}
+            >
+              {secondaryLabel}
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              aria-label={primaryAriaLabel}
+              onClick={onPrimary}
+              disabled={primaryDisabled}
+              sx={{
+                minHeight: 26,
+                px: 1,
+                py: 0.25,
+                fontSize: 10.5,
+                borderRadius: '6px',
+              }}
+            >
+              {primaryLabel}
+            </Button>
+          </Box>
+        )}
+      </Box>
+      <Typography
+        ref={textRef}
+        sx={
+          expanded
+            ? { mt: 0.5, fontSize: 13, whiteSpace: 'pre-wrap' }
+            : {
+                mt: 0.5,
+                fontSize: 13,
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+              }
+        }
+      >
+        {text}
+      </Typography>
+      {canExpand && (
+        <Button
+          size="small"
+          variant="text"
+          onClick={() => setExpanded((value) => !value)}
+          sx={{ mt: 0.5, minWidth: 0, px: 0.5, fontSize: 11 }}
+        >
+          {expanded ? 'Show less' : 'Show all'}
+        </Button>
+      )}
+    </Box>
+  )
+}
+
+export default function JustificationField({
+  label,
+  value,
+  onChange,
+  insight,
+  viewedDatacall,
+  priorReviewState,
+  onPriorReview,
+  disabled = false,
+  error = false,
+  helperText,
+  maxLength,
+}: Props) {
+  const prior = priorResponseFor(insight, viewedDatacall)
+  const suggestion = buildInsightJustification(insight)
+  const contextKey = `${viewedDatacall ?? ''}:${prior?.text ?? ''}:${suggestion ?? ''}`
+  const [suggestionState, setSuggestionState] = React.useState<
+    'available' | 'accepted' | 'dismissed'
+  >('available')
+
+  React.useEffect(() => setSuggestionState('available'), [contextKey])
+
+  const priorPending = priorReviewState === 'pending'
+  const displayedValue =
+    priorPending && prior && value.trim() === prior.text.trim() ? '' : value
+  const suggestionResult = suggestion
+    ? appendText(displayedValue, suggestion)
+    : displayedValue
+  const suggestionFits = suggestionResult.length <= maxLength
+  const hasContext = Boolean(suggestion || prior)
+
+  return (
+    <Box>
+      <Typography component="h3" variant="h6" sx={{ mb: 1 }}>
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          height: hasContext ? 'auto' : 400,
+          maxHeight: 400,
+          display: 'flex',
+          flexDirection: 'column',
+          border: `2px solid ${error ? '#b50909' : '#323232'}`,
+          borderRadius: '6px',
+          overflow: 'hidden',
+          bgcolor: '#fff',
+        }}
+      >
+        {hasContext && (
+          <Box sx={{ maxHeight: 190, overflowY: 'auto', flexShrink: 0 }}>
+            {suggestion && (
+              <ContextCard
+                title="Suggested justification"
+                author="ZTMF Insights"
+                text={suggestion}
+                state={suggestionState}
+                primaryLabel="Insert into response"
+                primaryAriaLabel="Insert suggested justification into current response"
+                secondaryLabel="Dismiss"
+                secondaryAriaLabel="Dismiss suggested justification"
+                primaryDisabled={!suggestionFits}
+                disabled={disabled}
+                onPrimary={() => {
+                  onChange(suggestionResult)
+                  setSuggestionState('accepted')
+                }}
+                onSecondary={() => setSuggestionState('dismissed')}
+                onRestore={() => setSuggestionState('available')}
+              />
+            )}
+            {prior && (
+              <ContextCard
+                title={prior.label}
+                author="ISSO"
+                text={prior.text}
+                required={priorPending}
+                state={
+                  priorReviewState === 'accepted'
+                    ? 'accepted'
+                    : priorReviewState === 'dismissed'
+                      ? 'dismissed'
+                      : 'available'
+                }
+                primaryLabel="Insert into response"
+                primaryAriaLabel="Insert previous ISSO response into current response"
+                secondaryLabel="Dismiss"
+                secondaryAriaLabel="Dismiss previous ISSO response"
+                primaryDisabled={
+                  appendText(displayedValue, prior.text).length > maxLength
+                }
+                disabled={disabled}
+                onPrimary={() => {
+                  onChange(
+                    priorPending && !displayedValue.trim()
+                      ? prior.text
+                      : appendText(displayedValue, prior.text)
+                  )
+                  onPriorReview('accepted')
+                }}
+                onSecondary={() => {
+                  if (priorPending && value.trim() === prior.text.trim()) {
+                    onChange('')
+                  }
+                  onPriorReview('dismissed')
+                }}
+                onRestore={() => onPriorReview('not-required')}
+              />
+            )}
+          </Box>
+        )}
+        <Box
+          sx={{
+            px: 1.5,
+            pt: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Box>
+            <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
+              Current response
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: '#666' }}>
+              Only the text in this field will be submitted.
+            </Typography>
+          </Box>
+          {!disabled && (
+            <Typography
+              variant="caption"
+              sx={{
+                color:
+                  displayedValue.length >= maxLength
+                    ? 'error.main'
+                    : displayedValue.length >= maxLength * 0.9
+                      ? 'warning.main'
+                      : 'text.secondary',
+              }}
+            >
+              {displayedValue.length}/{maxLength}
+            </Typography>
+          )}
+        </Box>
+        <ResponseTextField
+          multiline
+          fullWidth
+          value={displayedValue}
+          disabled={disabled}
+          error={error}
+          helperText={helperText}
+          placeholder="Add your current justification here…"
+          inputProps={{
+            maxLength,
+            'aria-label': 'Current response',
+            'aria-describedby': priorPending
+              ? 'previous-response-review-message'
+              : undefined,
+          }}
+          onChange={(event) => onChange(event.target.value)}
+          sx={hasContext ? { flex: '0 0 160px', height: 160 } : undefined}
+        />
+      </Box>
+      {priorPending && (
+        <Typography
+          id="previous-response-review-message"
+          role="status"
+          sx={{ mt: 0.5, fontSize: 12, color: '#8a4b00' }}
+        >
+          Review the previous response before continuing.
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/src/views/QuestionnairePage/JustificationField/justificationContext.ts
+++ b/src/views/QuestionnairePage/JustificationField/justificationContext.ts
@@ -1,0 +1,115 @@
+import type { InsightFinding, InsightPayload } from '@/types'
+
+const cleanText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const text = value.trim()
+  return text.length ? text : undefined
+}
+
+const sentence = (value: string): string =>
+  /[.!?]$/.test(value) ? value : `${value}.`
+
+const findingCount = (value: unknown): number =>
+  Array.isArray(value)
+    ? value.filter(
+        (finding): finding is InsightFinding =>
+          !!finding && typeof finding === 'object'
+      ).length
+    : 0
+
+const withScore = (label: string, score: unknown): string =>
+  typeof score === 'number' ? `${label} (${score})` : label
+
+/** Build the short, editable justification offered by ZTMF Insights. */
+export function buildInsightJustification(
+  payload?: InsightPayload
+): string | undefined {
+  if (!payload) return undefined
+
+  for (const key of [
+    'suggested_justification',
+    'justification_summary',
+    'insights_summary',
+  ]) {
+    const authored = cleanText(payload[key])
+    if (authored) return authored
+  }
+
+  const parts: string[] = []
+  const cfacts =
+    cleanText(payload.cfacts_auth_methods) ??
+    cleanText(payload.cfacts_reasoning)
+  if (cfacts) {
+    parts.push(
+      sentence(
+        `${withScore('CFACTS', payload.cfacts_suggested_score)}: ${cfacts}`
+      )
+    )
+  }
+
+  const kionCount = findingCount(payload.findings?.kion)
+  if (kionCount > 0) {
+    parts.push(
+      `${withScore('Kion', payload.kion_suggested_score)}: ${kionCount} failing ${kionCount === 1 ? 'check' : 'checks'}.`
+    )
+  }
+  const securityHubCount = findingCount(payload.findings?.sechub)
+  if (securityHubCount > 0) {
+    parts.push(
+      `${withScore('SecurityHub', payload.sechub_suggested_score)}: ${securityHubCount} failing ${securityHubCount === 1 ? 'control' : 'controls'}.`
+    )
+  }
+  const hardenizeCount = findingCount(payload.findings?.hardenize)
+  if (hardenizeCount > 0) {
+    parts.push(
+      `${withScore('Hardenize', payload.hardenize_suggested_score)}: ${hardenizeCount} ${hardenizeCount === 1 ? 'finding' : 'findings'}.`
+    )
+  }
+  if (typeof payload.ars_controls_total === 'number') {
+    const satisfied =
+      typeof payload.ars_controls_satisfied === 'number'
+        ? payload.ars_controls_satisfied
+        : 0
+    parts.push(
+      `${withScore('ARS', payload.ars_control_score)}: ${satisfied}/${payload.ars_controls_total} controls satisfied.`
+    )
+  }
+  if (parts.length) return parts.join(' ')
+
+  const suggested = cleanText(payload.suggested_label)
+  const sources = cleanText(payload.evidence_sources)
+  if (!suggested) return undefined
+  return `ZTMF Insights suggests ${suggested}${
+    typeof payload.suggested_score === 'number'
+      ? ` (${payload.suggested_score})`
+      : ''
+  }${sources ? ` based on ${sources}` : ''}.`
+}
+
+const normalizeDatacall = (value?: string | null): string =>
+  (value ?? '')
+    .replace(/[_\s]+/g, ' ')
+    .trim()
+    .toLowerCase()
+
+export function priorResponseFor(
+  payload?: InsightPayload,
+  viewedDatacall?: string
+): { label: string; text: string } | undefined {
+  const text = cleanText(payload?.last_score_notes)
+  if (!text) return undefined
+  const lastDatacall = cleanText(payload?.last_datacall)
+  if (
+    lastDatacall &&
+    viewedDatacall &&
+    normalizeDatacall(lastDatacall) === normalizeDatacall(viewedDatacall)
+  ) {
+    return undefined
+  }
+  return {
+    label: lastDatacall
+      ? `${lastDatacall.replaceAll('_', ' ')} response`
+      : 'Previous data-call response',
+    text,
+  }
+}

--- a/src/views/QuestionnairePage/JustificationField/justificationContext.ts
+++ b/src/views/QuestionnairePage/JustificationField/justificationContext.ts
@@ -108,8 +108,8 @@ export function priorResponseFor(
   }
   return {
     label: lastDatacall
-      ? `${lastDatacall.replaceAll('_', ' ')} response`
-      : 'Previous data-call response',
+      ? `Last year's response — ${lastDatacall.replaceAll('_', ' ')}`
+      : "Last year's ISSO response",
     text,
   }
 }

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1,0 +1,415 @@
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+  useParams: jest.fn(),
+}))
+
+jest.mock('@cmsgov/design-system', () => ({
+  __esModule: true,
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  ChoiceList: ({
+    choices,
+    onChange,
+    disabled,
+  }: {
+    choices: Array<{
+      label: React.ReactNode
+      value: number
+      defaultChecked?: boolean
+    }>
+    onChange: React.ChangeEventHandler<HTMLInputElement>
+    disabled?: boolean
+  }) => (
+    <div>
+      {choices.map((choice) => (
+        <label key={choice.value}>
+          <input
+            type="radio"
+            name="radio-choices"
+            value={choice.value}
+            defaultChecked={choice.defaultChecked}
+            disabled={disabled}
+            onChange={onChange}
+          />
+          {choice.label}
+        </label>
+      ))}
+    </div>
+  ),
+  Spinner: () => <div>Loading</div>,
+  ArrowIcon: () => null,
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), put: jest.fn(), post: jest.fn() },
+}))
+
+jest.mock('../Title/Context', () => ({
+  __esModule: true,
+  useContextProp: jest.fn(),
+}))
+
+jest.mock('@/components/BreadCrumbs/BreadCrumbs', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/ConfirmDialog/ConfirmDialog', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/ScoreDiffModal/ScoreDiffModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/AISummaryBadge/AISummaryBadge', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('./LastEditedFooter', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('./InsightsPanel/InsightsPanel', () => ({
+  __esModule: true,
+  default: () => <div>ZTMF Insights panel</div>,
+  OptionInsightBadges: () => <span>ZTMF Insights option badge</span>,
+}))
+jest.mock('./draftStore', () => ({
+  __esModule: true,
+  loadDraft: jest.fn(),
+  saveDraft: jest.fn(),
+  clearDraft: jest.fn(),
+}))
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  isAuthHandled: jest.fn(() => false),
+}))
+
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import axiosInstance from '@/axiosConfig'
+import { useContextProp } from '../Title/Context'
+import { clearDraft, loadDraft, saveDraft } from './draftStore'
+import QuestionnarePage from './QuestionnairePage'
+
+const mockedGet = axiosInstance.get as jest.Mock
+const mockedPut = axiosInstance.put as jest.Mock
+const mockedUseContext = useContextProp as jest.Mock
+const mockedUseLocation = useLocation as jest.Mock
+const mockedUseNavigate = useNavigate as jest.Mock
+const mockedUseParams = useParams as jest.Mock
+const mockedLoadDraft = loadDraft as jest.Mock
+const mockedSaveDraft = saveDraft as jest.Mock
+const mockedClearDraft = clearDraft as jest.Mock
+
+const priorResponse = 'MFA is enforced through Okta policies.'
+let insightRows: unknown[]
+let insightsResponsePromise: Promise<{ data: { data: unknown[] } }> | undefined
+
+const question = {
+  questionid: 1,
+  question: 'How does the system authenticate users?',
+  notesprompt: 'Explain the authentication mechanisms.',
+  pillar: { pillar: 'Identity', pillarid: 1, order: 1 },
+  function: {
+    functionid: 1,
+    function: 'Moon Identity Verification',
+    description: 'Authenticate users.',
+    datacenterenvironment: 'Other',
+  },
+}
+
+const carriedForwardScore = {
+  scoreid: 501,
+  fismasystemid: 1003,
+  datecalculated: 0,
+  notes: priorResponse,
+  functionoptionid: 11,
+  datacallid: 103,
+  last_edited_at: null,
+  last_edited_by: null,
+}
+
+function installApiMocks() {
+  mockedGet.mockImplementation((url: string) => {
+    if (url === 'insights') {
+      return (
+        insightsResponsePromise ??
+        Promise.resolve({ data: { data: insightRows } })
+      )
+    }
+    if (/^\/fismasystems\/\d+\/questions$/.test(url)) {
+      return Promise.resolve({ data: { data: [question] } })
+    }
+    if (url.startsWith('scores?')) {
+      return Promise.resolve({ data: { data: [carriedForwardScore] } })
+    }
+    if (url === 'functions/1/options') {
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              description: 'MFA is enforced',
+              functionid: 1,
+              functionoptionid: 11,
+              optionname: 'Initial',
+              score: 2,
+            },
+          ],
+        },
+      })
+    }
+    throw new Error(`Unexpected GET ${url}`)
+  })
+}
+
+beforeEach(() => {
+  insightsResponsePromise = undefined
+  insightRows = [
+    {
+      fismasystemid: 1003,
+      questionid: 1,
+      synced_at: '2026-07-14T00:00:00Z',
+      payload: {
+        suggested_score: 2,
+        suggested_label: 'Initial',
+        cfacts_auth_methods: 'IDM-Okta',
+        last_score_notes: priorResponse,
+        last_datacall: 'FY24 ZTM',
+      },
+    },
+  ]
+  mockedUseNavigate.mockReturnValue(jest.fn())
+  mockedUseParams.mockReturnValue({ fismaacronym: 'sld-gen' })
+  mockedUseLocation.mockReturnValue({
+    state: {
+      fismasystemid: 1003,
+      datacallid: 103,
+      datacall: 'FY25 ZTM',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+  })
+  mockedUseContext.mockReturnValue({
+    userInfo: {
+      userid: 'isso-user',
+      email: 'isso@example.com',
+      fullname: 'Test ISSO',
+      role: 'ISSO',
+      assignedfismasystems: [],
+    },
+    selectedDatacall: null,
+    latestDataCallId: 103,
+    latestDatacall: 'FY25 ZTM',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    fismaSystems: [
+      {
+        fismasystemid: 1003,
+        fismaacronym: 'SLD-GEN',
+        fismaname: 'Shield Generator',
+        datacenterenvironment: 'Other',
+      },
+      {
+        fismasystemid: 1004,
+        fismaacronym: 'TIE-FTR',
+        fismaname: 'TIE Fighter',
+        datacenterenvironment: 'Other',
+      },
+    ],
+    datacenterEnvironments: [],
+  })
+  mockedLoadDraft.mockResolvedValue(null)
+  mockedSaveDraft.mockResolvedValue(true)
+  mockedClearDraft.mockResolvedValue(undefined)
+  mockedPut.mockResolvedValue({ data: {} })
+  installApiMocks()
+})
+
+describe('QuestionnairePage justification integration', () => {
+  it('requires review and persists an explicitly accepted identical prior response', async () => {
+    render(<QuestionnarePage />)
+
+    const response = await screen.findByRole('textbox', {
+      name: 'Current response',
+    })
+    expect(response).toHaveValue('')
+    expect(screen.getByText('Review required')).toBeInTheDocument()
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('ZTMF Insights option badge')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Suggested justification')
+    ).not.toBeInTheDocument()
+
+    const complete = screen.getByRole('button', { name: 'Complete' })
+    expect(complete).toBeDisabled()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(response).toHaveValue(priorResponse)
+    expect(complete).toBeEnabled()
+
+    fireEvent.change(response, {
+      target: { value: 'MFA is enforced through phishing-resistant policies.' },
+    })
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY24 ZTM",
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Close previous ISSO response review',
+      })
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    fireEvent.change(response, { target: { value: priorResponse } })
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(response).toHaveValue(priorResponse)
+
+    fireEvent.click(complete)
+
+    await waitFor(() =>
+      expect(mockedPut).toHaveBeenCalledWith('scores/501', {
+        fismasystemid: 1003,
+        notes: priorResponse,
+        functionoptionid: 11,
+        datacallid: 103,
+        notes_is_ai_summary: false,
+      })
+    )
+  })
+
+  it('persists a required review after dismissing and manually restoring the prior text', async () => {
+    render(<QuestionnarePage />)
+
+    const response = await screen.findByRole('textbox', {
+      name: 'Current response',
+    })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+    expect(response).toHaveValue('')
+
+    fireEvent.change(response, { target: { value: priorResponse } })
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }))
+
+    await waitFor(() =>
+      expect(mockedPut).toHaveBeenCalledWith('scores/501', {
+        fismasystemid: 1003,
+        notes: priorResponse,
+        functionoptionid: 11,
+        datacallid: 103,
+        notes_is_ai_summary: false,
+      })
+    )
+  })
+
+  it('blocks submission until the initial Insights lookup settles', async () => {
+    let resolveInsights:
+      | ((value: { data: { data: unknown[] } }) => void)
+      | null = null
+    insightsResponsePromise = new Promise((resolve) => {
+      resolveInsights = resolve
+    })
+
+    render(<QuestionnarePage />)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Checking for prior responses…'
+    )
+    expect(complete).toBeDisabled()
+
+    await React.act(async () => {
+      resolveInsights?.({ data: { data: insightRows } })
+    })
+
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Checking for prior responses…')
+    ).not.toBeInTheDocument()
+    expect(complete).toBeDisabled()
+  })
+
+  it('preserves the original four-row textarea when the question has no insight', async () => {
+    insightRows = []
+    render(<QuestionnarePage />)
+
+    expect(
+      await screen.findByText('Explain the authentication mechanisms.')
+    ).toBeInTheDocument()
+    const response = screen.getByRole('textbox')
+    expect(response).toHaveAttribute('rows', '4')
+    expect(
+      screen.queryByRole('textbox', { name: 'Current response' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('Current response')).not.toBeInTheDocument()
+  })
+
+  it('shows Insights content for a CMS data call', async () => {
+    mockedUseLocation.mockReturnValue({
+      state: {
+        fismasystemid: 1003,
+        datacallid: 103,
+        datacall: 'FY2025 Q1',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    })
+
+    render(<QuestionnarePage />)
+
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights option badge')).toBeInTheDocument()
+    expect(screen.getByText('Suggested justification')).toBeInTheDocument()
+    expect(
+      screen.getByText("Last year's response — FY24 ZTM")
+    ).toBeInTheDocument()
+  })
+
+  it('requires a fresh prior-response review after changing systems', async () => {
+    const view = render(<QuestionnarePage />)
+    await screen.findByText('Review required')
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+    expect(screen.getByRole('button', { name: 'Complete' })).toBeEnabled()
+
+    mockedUseLocation.mockReturnValue({
+      state: {
+        fismasystemid: 1004,
+        datacallid: 103,
+        datacall: 'FY25 ZTM',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    })
+    view.rerender(<QuestionnarePage />)
+
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toHaveValue('')
+    expect(screen.getByRole('button', { name: 'Complete' })).toBeDisabled()
+  })
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -10,7 +10,6 @@ import { Button as CmsButton, ChoiceList, Spinner } from '@cmsgov/design-system'
 import Grid from '@mui/material/Grid'
 import Alert from '@mui/material/Alert'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
-import TextField from '@mui/material/TextField'
 import {
   FismaQuestion,
   QuestionOption,
@@ -21,7 +20,6 @@ import {
   InsightPayload,
 } from '@/types'
 import { Container } from '@mui/system'
-import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
@@ -48,6 +46,10 @@ import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel, {
   OptionInsightBadges,
 } from './InsightsPanel/InsightsPanel'
+import JustificationField, {
+  type PriorReviewState,
+} from './JustificationField/JustificationField'
+import { priorResponseFor } from './JustificationField/justificationContext'
 import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
@@ -61,32 +63,6 @@ type Category = {
 type questionScoreMap = {
   [key: number]: QuestionScores
 }
-const CssTextField = styled(TextField)({
-  '& .MuiOutlinedInput-root': {
-    '& fieldset': {
-      borderColor: '#000000',
-      borderWidth: '2px',
-    },
-    '&.Mui-focused fieldset': {
-      borderColor: '#000000',
-      borderWidth: '2px',
-      boxShadow: '0px 0px 0px 3px #FFFFFF, 0px 0px 3px 6px #bd13b8',
-    },
-    '@supports (-moz-appearance:none)': {
-      paddingTop: '30px',
-      '& .MuiInputBase-inputMultiline': {
-        // paddingTop: '-15px',
-        height: '100%',
-        width: '100%',
-        scrollbarWidth: 'none',
-      },
-    },
-    '& .MuiInputBase-inputMultiline': {
-      msOverflowStyle: 'none', // Hide scrollbar in IE/Edge
-      '&::-webkit-scrollbar': { display: 'none' },
-    },
-  },
-})
 const toSlug = (str: string) =>
   str
     .replace(/([a-z])([A-Z])/g, '$1-$2')
@@ -149,6 +125,9 @@ export default function QuestionnarePage() {
   const [initNotes, setInitNotes] = React.useState<string>('')
   const [notes, setNotes] = React.useState<string>('')
   const [notePrompt, setNotePrompt] = React.useState<string>('')
+  const [priorReviewState, setPriorReviewState] =
+    React.useState<PriorReviewState>('not-required')
+  const priorReviewKeyRef = React.useRef('')
   const [description, setDescription] = React.useState<string>('')
   const [stepId, setStepId] = React.useState<number>(0)
   const [selectQuestionOption, setSelectQuestionOption] =
@@ -173,12 +152,14 @@ export default function QuestionnarePage() {
     initQuestionChoice,
     notes,
     initNotes,
+    priorReviewState,
   })
   unsavedRef.current = {
     selectQuestionOption,
     initQuestionChoice,
     notes,
     initNotes,
+    priorReviewState,
   }
   // Refs so the out-of-band re-seed effect can read current options and loading
   // state without enrolling them as effect dependencies.
@@ -356,7 +337,13 @@ export default function QuestionnarePage() {
   }
 
   const saveResponse = async () => {
+    // Explicitly accepting carried-forward text is itself a current-call edit,
+    // even when the accepted text is byte-for-byte identical to the seeded
+    // notes. Persist it so the audit trail records that affirmative review.
+    const acceptedPriorResponse =
+      priorReviewState === 'accepted' && selectQuestionOption >= 0
     if (
+      !acceptedPriorResponse &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -799,7 +786,8 @@ export default function QuestionnarePage() {
       const s = unsavedRef.current
       const hasPendingEdits =
         shouldPersistResponse(s) ||
-        (s.selectQuestionOption === -1 && s.notes !== s.initNotes)
+        (s.selectQuestionOption === -1 && s.notes !== s.initNotes) ||
+        s.priorReviewState === 'accepted'
       if (hasPendingEdits) {
         e.preventDefault()
         e.returnValue = ''
@@ -824,7 +812,8 @@ export default function QuestionnarePage() {
         loadingQuestion: loadingQuestionRef.current,
         hasUnsavedEdits:
           u.selectQuestionOption !== u.initQuestionChoice ||
-          u.notes !== u.initNotes,
+          u.notes !== u.initNotes ||
+          u.priorReviewState === 'accepted',
         draftRestored: draftStatusRef.current === 'restored',
       })
     ) {
@@ -849,6 +838,49 @@ export default function QuestionnarePage() {
     setScoreId(sel.scoreid)
     setRadioKey((k) => k + 1)
   }, [questionScores, questionId])
+
+  // Insight for the question currently on screen. questionId holds the current
+  // functionid; the Question record carries the DB questionid used by Insights.
+  const currentInsight =
+    questionId != null
+      ? insightsByQuestion.get(questions[questionId]?.questionid ?? -1)
+      : undefined
+
+  // A score copied from the prior data call has no edit event for the current
+  // call. When its notes exactly match last_score_notes, keep that text as
+  // context rather than silently treating it as the current submitted answer.
+  // The key makes this an initializer: accepting/dismissing cannot be reset by
+  // the resulting notes state change, but navigating to a new question can.
+  React.useEffect(() => {
+    if (loadingQuestion) return
+    const prior = priorResponseFor(currentInsight, datacall)
+    const currentScore =
+      selectQuestionOption >= 0
+        ? questionScores[selectQuestionOption]
+        : undefined
+    const reviewKey = `${questionId ?? ''}:${datacall}:${prior?.text ?? ''}`
+    if (priorReviewKeyRef.current === reviewKey) return
+    priorReviewKeyRef.current = reviewKey
+
+    const isUnreviewedCarryForward =
+      !isReadOnly &&
+      !!prior &&
+      !!currentScore &&
+      !currentScore.last_edited_at &&
+      draftStatus !== 'restored' &&
+      notes.trim() === prior.text.trim()
+    setPriorReviewState(isUnreviewedCarryForward ? 'pending' : 'not-required')
+  }, [
+    currentInsight,
+    datacall,
+    draftStatus,
+    isReadOnly,
+    loadingQuestion,
+    notes,
+    questionId,
+    questionScores,
+    selectQuestionOption,
+  ])
 
   const breadcrumbSegmentLabels = fismaacronym
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
@@ -889,14 +921,6 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
-  // Insight for the question currently on screen. questionId holds the current
-  // functionid; the Question record carries the DB questionid the insight rows
-  // are keyed by. Undefined for any question without a synced insight row, in
-  // which case the panel is not rendered and the page is unchanged.
-  const currentInsight =
-    questionId != null
-      ? insightsByQuestion.get(questions[questionId]?.questionid ?? -1)
-      : undefined
   return (
     <>
       <Box
@@ -975,7 +999,8 @@ export default function QuestionnarePage() {
                                 ((selectQuestionOption !== -1 &&
                                   initQuestionChoice !==
                                     selectQuestionOption) ||
-                                  initNotes !== notes)
+                                  initNotes !== notes ||
+                                  priorReviewState === 'accepted')
                               ) {
                                 setOpenAlert(true)
                               } else {
@@ -1037,32 +1062,25 @@ export default function QuestionnarePage() {
                   <Box key={radioKey} sx={{ mb: 2 }}>
                     {renderRadioGroup(options)}
                   </Box>
-                  <Typography variant="h6" sx={{ mb: 1 }}>
-                    {notePrompt || ''}
-                  </Typography>
-                  <CssTextField
-                    multiline
-                    rows={4}
-                    fullWidth
+                  <JustificationField
+                    label={notePrompt || 'Justification'}
                     value={notes}
+                    onChange={(value) => {
+                      setNotes(value)
+                      if (draftStatus === 'restored') setDraftStatus('idle')
+                    }}
+                    insight={currentInsight}
+                    viewedDatacall={datacall}
+                    priorReviewState={priorReviewState}
+                    onPriorReview={setPriorReviewState}
                     disabled={isReadOnly}
                     error={needsNotesUpdate}
                     helperText={
                       needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
                     }
-                    inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
-                    onChange={(e) => {
-                      setNotes(e.target.value)
-                      if (draftStatus === 'restored') setDraftStatus('idle')
-                    }}
+                    maxLength={MAX_QUESTIONNAIRE_NOTES_LENGTH}
                   />
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      mt: 0.5,
-                    }}
-                  >
+                  <Box sx={{ mt: 0.5 }}>
                     <AISummaryBadge
                       show={
                         selectQuestionOption >= 0 &&
@@ -1070,23 +1088,6 @@ export default function QuestionnarePage() {
                           ?.notes_is_ai_summary === true
                       }
                     />
-                    {!isReadOnly && (
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          ml: 'auto',
-                          color:
-                            notes.length >= MAX_QUESTIONNAIRE_NOTES_LENGTH
-                              ? 'error.main'
-                              : notes.length >=
-                                  MAX_QUESTIONNAIRE_NOTES_LENGTH * 0.9
-                                ? 'warning.main'
-                                : 'text.secondary',
-                        }}
-                      >
-                        {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
-                      </Typography>
-                    )}
                   </Box>
                   <Box
                     position="relative"
@@ -1101,7 +1102,8 @@ export default function QuestionnarePage() {
                           !isReadOnly &&
                           ((selectQuestionOption !== -1 &&
                             initQuestionChoice !== selectQuestionOption) ||
-                            initNotes !== notes)
+                            initNotes !== notes ||
+                            priorReviewState === 'accepted')
                         ) {
                           setStepId(
                             stepFunctionId[functionIdIdx[selectedIndex] - 1]
@@ -1165,7 +1167,9 @@ export default function QuestionnarePage() {
                           saveResponse()
                         }
                       }}
-                      disabled={needsNotesUpdate}
+                      disabled={
+                        needsNotesUpdate || priorReviewState === 'pending'
+                      }
                       style={{ marginBottom: '8px', marginTop: '8px' }}
                     >
                       {selectedIndex ===

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -10,6 +10,7 @@ import { Button as CmsButton, ChoiceList, Spinner } from '@cmsgov/design-system'
 import Grid from '@mui/material/Grid'
 import Alert from '@mui/material/Alert'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
+import TextField from '@mui/material/TextField'
 import {
   FismaQuestion,
   QuestionOption,
@@ -20,6 +21,7 @@ import {
   InsightPayload,
 } from '@/types'
 import { Container } from '@mui/system'
+import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
@@ -35,6 +37,7 @@ import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
+import { parseDatacallName } from '@/utils/datacallGrouping'
 import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
@@ -49,7 +52,10 @@ import InsightsPanel, {
 import JustificationField, {
   type PriorReviewState,
 } from './JustificationField/JustificationField'
-import { priorResponseFor } from './JustificationField/justificationContext'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './JustificationField/justificationContext'
 import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
@@ -63,6 +69,31 @@ type Category = {
 type questionScoreMap = {
   [key: number]: QuestionScores
 }
+const CssTextField = styled(TextField)({
+  '& .MuiOutlinedInput-root': {
+    '& fieldset': {
+      borderColor: '#000000',
+      borderWidth: '2px',
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: '#000000',
+      borderWidth: '2px',
+      boxShadow: '0px 0px 0px 3px #FFFFFF, 0px 0px 3px 6px #bd13b8',
+    },
+    '@supports (-moz-appearance:none)': {
+      paddingTop: '30px',
+      '& .MuiInputBase-inputMultiline': {
+        height: '100%',
+        width: '100%',
+        scrollbarWidth: 'none',
+      },
+    },
+    '& .MuiInputBase-inputMultiline': {
+      msOverflowStyle: 'none',
+      '&::-webkit-scrollbar': { display: 'none' },
+    },
+  },
+})
 const toSlug = (str: string) =>
   str
     .replace(/([a-z])([A-Z])/g, '$1-$2')
@@ -110,10 +141,16 @@ export default function QuestionnarePage() {
   const [insightsByQuestion, setInsightsByQuestion] = React.useState<
     Map<number, InsightPayload>
   >(new Map())
+  const [insightsLoadState, setInsightsLoadState] = React.useState<{
+    system?: number
+    settled: boolean
+  }>({ settled: false })
   const [question, setQuestion] = React.useState<string>('')
   const [datacallID, setDatacallID] = React.useState<number>(0)
   const [datacall, setDatacall] = React.useState<string>('')
   const [loadingQuestion, setLoadingQuestion] = React.useState<boolean>(true)
+  const [loadedResponseContextId, setLoadedResponseContextId] =
+    React.useState('')
   const [noQuestions, setNoQuestions] = React.useState<boolean>(false)
   const [categories, setCategories] = React.useState<Category[]>([])
   const [stepFunctionId, setStepFunctionId] = React.useState<number[]>([])
@@ -125,9 +162,11 @@ export default function QuestionnarePage() {
   const [initNotes, setInitNotes] = React.useState<string>('')
   const [notes, setNotes] = React.useState<string>('')
   const [notePrompt, setNotePrompt] = React.useState<string>('')
-  const [priorReviewState, setPriorReviewState] =
-    React.useState<PriorReviewState>('not-required')
-  const priorReviewKeyRef = React.useRef('')
+  const [priorReview, setPriorReview] = React.useState<{
+    contextId: string
+    state: PriorReviewState
+    needsSave: boolean
+  }>({ contextId: '', state: 'not-required', needsSave: false })
   const [description, setDescription] = React.useState<string>('')
   const [stepId, setStepId] = React.useState<number>(0)
   const [selectQuestionOption, setSelectQuestionOption] =
@@ -152,15 +191,8 @@ export default function QuestionnarePage() {
     initQuestionChoice,
     notes,
     initNotes,
-    priorReviewState,
+    priorReviewNeedsSave: false,
   })
-  unsavedRef.current = {
-    selectQuestionOption,
-    initQuestionChoice,
-    notes,
-    initNotes,
-    priorReviewState,
-  }
   // Refs so the out-of-band re-seed effect can read current options and loading
   // state without enrolling them as effect dependencies.
   const optionsRef = React.useRef(options)
@@ -210,11 +242,13 @@ export default function QuestionnarePage() {
           }}
         >
           <Box component="span">{o.label}</Box>
-          <OptionInsightBadges
-            score={o.score}
-            insight={currentInsight}
-            viewedDatacall={datacall}
-          />
+          {!isHhsDatacall && (
+            <OptionInsightBadges
+              score={o.score}
+              insight={currentInsight}
+              viewedDatacall={datacall}
+            />
+          )}
         </Box>
       ),
       value: o.value,
@@ -269,16 +303,79 @@ export default function QuestionnarePage() {
   }>({})
   const systemInfo = fismaSystems.find((s) => s.fismasystemid === system)
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
+  // Keep review and card state scoped to one system x data call x database
+  // question. React reuses this route component as those route values change.
+  const currentDatabaseQuestionId =
+    questionId != null ? questions[questionId]?.questionid : undefined
+  const insightsPending =
+    !!system &&
+    (insightsLoadState.system !== system || !insightsLoadState.settled)
+  const currentInsight =
+    insightsLoadState.system === system && currentDatabaseQuestionId != null
+      ? insightsByQuestion.get(currentDatabaseQuestionId)
+      : undefined
+  const isHhsDatacall =
+    parseDatacallName(datacall.replaceAll('_', ' ')).tenant === 'HHS'
+  const showInsights = Boolean(currentInsight) && !isHhsDatacall
+  const currentSuggestion = !isHhsDatacall
+    ? buildInsightJustification(currentInsight)
+    : undefined
+  const currentPriorResponse = priorResponseFor(currentInsight, datacall)
+  const hasJustificationContext = Boolean(
+    currentPriorResponse || currentSuggestion
+  )
+  const justificationContextId = JSON.stringify([
+    system ?? null,
+    datacallID,
+    currentDatabaseQuestionId ?? null,
+  ])
+  const priorReviewContextId = JSON.stringify([
+    justificationContextId,
+    currentPriorResponse?.text ?? null,
+    isReadOnly,
+  ])
+  // A context that has not yet been evaluated is synchronously treated as
+  // initializing. This keeps the editor and Next button blocked during the
+  // render before the initializer effect runs.
+  const priorReviewState: PriorReviewState =
+    !currentPriorResponse || isReadOnly
+      ? 'not-required'
+      : loadedResponseContextId === justificationContextId &&
+          priorReview.contextId === priorReviewContextId
+        ? priorReview.state
+        : 'initializing'
+  const priorReviewNeedsSave =
+    priorReview.contextId === priorReviewContextId && priorReview.needsSave
+  const updatePriorReviewState = (state: PriorReviewState) => {
+    setPriorReview((current) => ({
+      contextId: priorReviewContextId,
+      state,
+      // Resolving a required review is an unsaved current-call action even if
+      // the resulting text is byte-for-byte identical to the seeded response.
+      needsSave:
+        (current.contextId === priorReviewContextId && current.needsSave) ||
+        priorReviewState === 'pending',
+    }))
+  }
+  unsavedRef.current = {
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+    priorReviewNeedsSave,
+  }
 
   // Fetch ZTMF Insights for this system once (not per question — one call
-  // returns every question's row). Failures and empty responses both leave the
-  // map empty so the questionnaire is never blocked or altered by insights.
+  // returns every question's row). The initial lookup briefly blocks submission
+  // so a carried-forward response cannot be submitted before its required
+  // review UI is known. Failures and empty responses then leave the map empty.
   React.useEffect(() => {
     if (!system) return
     const controller = new AbortController()
     // Clear the previous system's insights up front so a system change can't
     // briefly render stale badges/panel while the new fetch is in flight.
     setInsightsByQuestion(new Map())
+    setInsightsLoadState({ system, settled: false })
     const load = async () => {
       try {
         const res = await axiosInstance.get<{ data: Insight[] }>('insights', {
@@ -297,6 +394,10 @@ export default function QuestionnarePage() {
           // Insights are additive and optional; swallow errors and render the
           // page exactly as it is without them.
           setInsightsByQuestion(new Map())
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setInsightsLoadState({ system, settled: true })
         }
       }
     }
@@ -337,13 +438,13 @@ export default function QuestionnarePage() {
   }
 
   const saveResponse = async () => {
-    // Explicitly accepting carried-forward text is itself a current-call edit,
-    // even when the accepted text is byte-for-byte identical to the seeded
-    // notes. Persist it so the audit trail records that affirmative review.
-    const acceptedPriorResponse =
-      priorReviewState === 'accepted' && selectQuestionOption >= 0
+    // Resolving a required carried-forward review is itself a current-call
+    // action, even when the final text is byte-for-byte identical to the seeded
+    // notes. Persist it so the audit trail records the affirmative review.
+    const resolvedPriorReview =
+      priorReviewNeedsSave && selectQuestionOption >= 0
     if (
-      !acceptedPriorResponse &&
+      !resolvedPriorReview &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -389,6 +490,11 @@ export default function QuestionnarePage() {
       }
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
       clearCurrentDraft()
+      setPriorReview((current) =>
+        current.contextId === priorReviewContextId
+          ? { ...current, needsSave: false }
+          : current
+      )
       fetchQuestionScores(system, setQuestionScores)
     } catch (error) {
       if (isAuthHandled(error)) return
@@ -700,6 +806,13 @@ export default function QuestionnarePage() {
             setDraftStatus('idle')
           }
           setOptions(choices)
+          setLoadedResponseContextId(
+            JSON.stringify([
+              sys ?? null,
+              datacallID,
+              questions[questionId ?? -1]?.questionid ?? null,
+            ])
+          )
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
@@ -787,7 +900,7 @@ export default function QuestionnarePage() {
       const hasPendingEdits =
         shouldPersistResponse(s) ||
         (s.selectQuestionOption === -1 && s.notes !== s.initNotes) ||
-        s.priorReviewState === 'accepted'
+        s.priorReviewNeedsSave
       if (hasPendingEdits) {
         e.preventDefault()
         e.returnValue = ''
@@ -813,7 +926,7 @@ export default function QuestionnarePage() {
         hasUnsavedEdits:
           u.selectQuestionOption !== u.initQuestionChoice ||
           u.notes !== u.initNotes ||
-          u.priorReviewState === 'accepted',
+          u.priorReviewNeedsSave,
         draftRestored: draftStatusRef.current === 'restored',
       })
     ) {
@@ -839,45 +952,42 @@ export default function QuestionnarePage() {
     setRadioKey((k) => k + 1)
   }, [questionScores, questionId])
 
-  // Insight for the question currently on screen. questionId holds the current
-  // functionid; the Question record carries the DB questionid used by Insights.
-  const currentInsight =
-    questionId != null
-      ? insightsByQuestion.get(questions[questionId]?.questionid ?? -1)
-      : undefined
-
   // A score copied from the prior data call has no edit event for the current
   // call. When its notes exactly match last_score_notes, keep that text as
   // context rather than silently treating it as the current submitted answer.
   // The key makes this an initializer: accepting/dismissing cannot be reset by
   // the resulting notes state change, but navigating to a new question can.
   React.useEffect(() => {
-    if (loadingQuestion) return
-    const prior = priorResponseFor(currentInsight, datacall)
+    if (loadingQuestion || loadedResponseContextId !== justificationContextId)
+      return
     const currentScore =
       selectQuestionOption >= 0
         ? questionScores[selectQuestionOption]
         : undefined
-    const reviewKey = `${questionId ?? ''}:${datacall}:${prior?.text ?? ''}`
-    if (priorReviewKeyRef.current === reviewKey) return
-    priorReviewKeyRef.current = reviewKey
+    if (priorReview.contextId === priorReviewContextId) return
 
     const isUnreviewedCarryForward =
       !isReadOnly &&
-      !!prior &&
+      !!currentPriorResponse &&
       !!currentScore &&
       !currentScore.last_edited_at &&
       draftStatus !== 'restored' &&
-      notes.trim() === prior.text.trim()
-    setPriorReviewState(isUnreviewedCarryForward ? 'pending' : 'not-required')
+      notes.trim() === currentPriorResponse.text.trim()
+    setPriorReview({
+      contextId: priorReviewContextId,
+      state: isUnreviewedCarryForward ? 'pending' : 'not-required',
+      needsSave: false,
+    })
   }, [
-    currentInsight,
-    datacall,
+    currentPriorResponse,
     draftStatus,
     isReadOnly,
     loadingQuestion,
+    loadedResponseContextId,
     notes,
-    questionId,
+    priorReview.contextId,
+    priorReviewContextId,
+    justificationContextId,
     questionScores,
     selectQuestionOption,
   ])
@@ -1000,7 +1110,7 @@ export default function QuestionnarePage() {
                                   initQuestionChoice !==
                                     selectQuestionOption) ||
                                   initNotes !== notes ||
-                                  priorReviewState === 'accepted')
+                                  priorReviewNeedsSave)
                               ) {
                                 setOpenAlert(true)
                               } else {
@@ -1045,7 +1155,18 @@ export default function QuestionnarePage() {
               <Typography variant="h6" sx={{ mt: 1, mb: 0 }}>
                 {question}
               </Typography>
-              {currentInsight && <InsightsPanel payload={currentInsight} />}
+              {insightsPending && (
+                <Typography
+                  role="status"
+                  variant="caption"
+                  sx={{ color: 'text.secondary' }}
+                >
+                  Checking for prior responses…
+                </Typography>
+              )}
+              {showInsights && currentInsight && (
+                <InsightsPanel payload={currentInsight} />
+              )}
               {loadingQuestion ? (
                 <Box
                   sx={{
@@ -1062,25 +1183,63 @@ export default function QuestionnarePage() {
                   <Box key={radioKey} sx={{ mb: 2 }}>
                     {renderRadioGroup(options)}
                   </Box>
-                  <JustificationField
-                    label={notePrompt || 'Justification'}
-                    value={notes}
-                    onChange={(value) => {
-                      setNotes(value)
-                      if (draftStatus === 'restored') setDraftStatus('idle')
+                  {hasJustificationContext ? (
+                    <JustificationField
+                      key={justificationContextId}
+                      contextId={justificationContextId}
+                      label={notePrompt || 'Justification'}
+                      value={notes}
+                      onChange={(value) => {
+                        setNotes(value)
+                        if (draftStatus === 'restored') setDraftStatus('idle')
+                      }}
+                      insight={currentInsight}
+                      priorResponse={currentPriorResponse}
+                      showInsightSuggestion={!isHhsDatacall}
+                      viewedDatacall={datacall}
+                      priorReviewState={priorReviewState}
+                      onPriorReview={updatePriorReviewState}
+                      disabled={isReadOnly}
+                      error={needsNotesUpdate}
+                      helperText={
+                        needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
+                      }
+                      maxLength={MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                    />
+                  ) : (
+                    <>
+                      <Typography variant="h6" sx={{ mb: 1 }}>
+                        {notePrompt || ''}
+                      </Typography>
+                      <CssTextField
+                        multiline
+                        rows={4}
+                        fullWidth
+                        value={notes}
+                        disabled={isReadOnly}
+                        error={needsNotesUpdate}
+                        helperText={
+                          needsNotesUpdate
+                            ? NOTES_UPDATE_REQUIRED_MSG
+                            : undefined
+                        }
+                        inputProps={{
+                          maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH,
+                        }}
+                        onChange={(event) => {
+                          setNotes(event.target.value)
+                          if (draftStatus === 'restored') setDraftStatus('idle')
+                        }}
+                      />
+                    </>
+                  )}
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      mt: 0.5,
                     }}
-                    insight={currentInsight}
-                    viewedDatacall={datacall}
-                    priorReviewState={priorReviewState}
-                    onPriorReview={setPriorReviewState}
-                    disabled={isReadOnly}
-                    error={needsNotesUpdate}
-                    helperText={
-                      needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
-                    }
-                    maxLength={MAX_QUESTIONNAIRE_NOTES_LENGTH}
-                  />
-                  <Box sx={{ mt: 0.5 }}>
+                  >
                     <AISummaryBadge
                       show={
                         selectQuestionOption >= 0 &&
@@ -1088,6 +1247,23 @@ export default function QuestionnarePage() {
                           ?.notes_is_ai_summary === true
                       }
                     />
+                    {!hasJustificationContext && !isReadOnly && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          ml: 'auto',
+                          color:
+                            notes.length >= MAX_QUESTIONNAIRE_NOTES_LENGTH
+                              ? 'error.main'
+                              : notes.length >=
+                                  MAX_QUESTIONNAIRE_NOTES_LENGTH * 0.9
+                                ? 'warning.main'
+                                : 'text.secondary',
+                        }}
+                      >
+                        {notes.length}/{MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                      </Typography>
+                    )}
                   </Box>
                   <Box
                     position="relative"
@@ -1103,7 +1279,7 @@ export default function QuestionnarePage() {
                           ((selectQuestionOption !== -1 &&
                             initQuestionChoice !== selectQuestionOption) ||
                             initNotes !== notes ||
-                            priorReviewState === 'accepted')
+                            priorReviewNeedsSave)
                         ) {
                           setStepId(
                             stepFunctionId[functionIdIdx[selectedIndex] - 1]
@@ -1168,7 +1344,10 @@ export default function QuestionnarePage() {
                         }
                       }}
                       disabled={
-                        needsNotesUpdate || priorReviewState === 'pending'
+                        needsNotesUpdate ||
+                        insightsPending ||
+                        priorReviewState === 'pending' ||
+                        priorReviewState === 'initializing'
                       }
                       style={{ marginBottom: '8px', marginTop: '8px' }}
                     >


### PR DESCRIPTION
Rehome of #527 (by @costacalvin) onto the `impl` branch so it can run Analysis CI and deploy to the impl environment — fork PRs can't reach the org secrets those workflows need.

**Base is `impl`, not `main`, on purpose.** The impl line and main have diverged; this change is being taken to impl first, and the impl↔main divergence will be reconciled separately. #527's two commits are replayed onto the current `impl` head (authorship preserved), so the diff here is exactly those changes relative to impl — not a merge of main into impl.

Refs #527.

## Summary

Adds the ZTMF-insights justification field to the questionnaire: a new `JustificationField` component (component, context, and tests), plus error handling and HHS-specific conditionals in `QuestionnairePage`.

## Files

- `src/views/QuestionnairePage/JustificationField/` — new `JustificationField` component, `justificationContext`, and unit tests
- `src/views/QuestionnairePage/QuestionnairePage.tsx` — integrate the field, error handling, HHS conditionals
- `src/views/QuestionnairePage/QuestionnairePage.test.tsx` — page tests

## Deploy path

A PR into `impl` runs Analysis (lint / security / unit tests) only. Squash-merging into `impl` deploys the bundle to the impl environment. This is rehomed from a work-in-progress fork PR to exercise it in impl ahead of the main-line reconciliation.
