### PR TITLE
fix(datacall-modal): create-datacall UX fixes (#504)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,9 @@ export type editSystemModalProps = {
 export type datacallModalProps = {
   open: boolean
   onClose: () => void
+  // Fired after a successful POST /datacalls so the parent can re-fetch
+  // its data-call list and the new call appears without a manual reload.
+  onCreated?: () => void
 }
 
 export type ScoreData = {

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -27,9 +27,12 @@ import { isAuthHandled, notify } from '@/utils/notify'
 // introduced FY23/FY24/FY25 ZTM datacall names.
 const DATACALL_NAME_PATTERN = /^FY(\d{2}|\d{4}) (Q[1-4]|ZTM)$/
 const DATACALL_MAX_LENGTH = 10 // "FY2025 ZTM" = 10 chars; longest valid form
-const DATACALL_MIN_LENGTH = 7 // "FY23 Q1" / "FY23 ZTM" share the floor
 
-export default function DataCallModal({ open, onClose }: datacallModalProps) {
+export default function DataCallModal({
+  open,
+  onClose,
+  onCreated,
+}: datacallModalProps) {
   const [datacall, setDatacall] = React.useState<string>('')
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
@@ -61,8 +64,11 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       </Typography>
     )
   }
+  // Validates on every change so the user is never left with a disabled
+  // Create button and no explanation. Empty input still resets the error
+  // (an untouched field should not scream at the user).
   function isValidFormat(input: string) {
-    if (input.length < DATACALL_MIN_LENGTH) {
+    if (input.length === 0) {
       setDatacallError('')
       return
     }
@@ -77,11 +83,29 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
     setDatacall(value)
     isValidFormat(value.toUpperCase())
   }
+  // Deadline validation mirrors the blur logic but only fires once the
+  // input has reached the 10-char MM/DD/YYYY shape - partial input stays
+  // quiet so the field does not flash red on every keystroke.
+  const validateDeadlineValue = (value: string) => {
+    if (value.length === 0) {
+      setDeadlineError('')
+      return
+    }
+    if (value.length < 10) {
+      setDeadlineError('')
+      return
+    }
+    if (isNaN(Date.parse(value))) {
+      setDeadlineError('Invalid Deadline')
+      return
+    }
+    setDeadlineError('')
+  }
   const validateDeadline = (e: React.FocusEvent<HTMLInputElement>) => {
     if (e.target.value.length === 10 && !isNaN(Date.parse(e.target.value))) {
       setDeadline(e.target.value)
       setDeadlineError('')
-    } else {
+    } else if (e.target.value.length > 0) {
       setDeadlineError('Invalid Deadline')
     }
   }
@@ -95,6 +119,10 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
       notify('Datacall has successfully been created', 'success', {
         autoHideDuration: 2500,
       })
+      // Refresh the caller's data-call list so the newly created call
+      // appears in the picker without a manual page reload, then close.
+      onCreated?.()
+      onClose()
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)
@@ -173,8 +201,9 @@ export default function DataCallModal({ open, onClose }: datacallModalProps) {
             onBlur={validateDeadline}
             onChange={(e) => {
               setDeadline(e)
+              validateDeadlineValue(e)
             }}
-            value=""
+            value={deadline}
           />
         </DialogContent>
         <DialogActions

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -178,10 +178,6 @@ export default function DataCallModal({
     }
   }
 
-  // Both fields carry a Required indicator (see the requirementLabel
-  // props on each below), so the disabled Create button is
-  // self-explaining for the empty-field case. Invalid input is reported
-  // per-field via the error message.
   const nameValid = DATACALL_NAME_PATTERN.test(datacall.toUpperCase())
   const deadlineComplete = deadline.length === 10 && !deadlineError
   const isCreateDisabled =

--- a/src/views/DatacallModal/DataCallModal.tsx
+++ b/src/views/DatacallModal/DataCallModal.tsx
@@ -27,6 +27,25 @@ import { isAuthHandled, notify } from '@/utils/notify'
 // introduced FY23/FY24/FY25 ZTM datacall names.
 const DATACALL_NAME_PATTERN = /^FY(\d{2}|\d{4}) (Q[1-4]|ZTM)$/
 const DATACALL_MAX_LENGTH = 10 // "FY2025 ZTM" = 10 chars; longest valid form
+const DEADLINE_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4})$/
+
+// Verifies MM/DD/YYYY is a real calendar date - Date.parse silently rolls
+// impossible dates over (02/30 -> Mar 2, 04/31 -> May 1), which would
+// otherwise let the user submit a wrong date without any feedback. Reject
+// unless the parsed date's month/day round-trip exactly.
+function isValidCalendarDate(mdY: string): boolean {
+  const match = mdY.match(DEADLINE_PATTERN)
+  if (!match) return false
+  const month = Number(match[1])
+  const day = Number(match[2])
+  const year = Number(match[3])
+  const d = new Date(year, month - 1, day)
+  return (
+    d.getFullYear() === year &&
+    d.getMonth() === month - 1 &&
+    d.getDate() === day
+  )
+}
 
 export default function DataCallModal({
   open,
@@ -37,6 +56,10 @@ export default function DataCallModal({
   const [datacallError, setDatacallError] = React.useState<string>('')
   const [deadline, setDeadline] = React.useState<string>('')
   const [deadlineError, setDeadlineError] = React.useState<string>('')
+  // Guards against a double-submit (fast double-click or double-Enter) that
+  // would otherwise fire two POSTs before the modal auto-closes and creates
+  // duplicate datacalls server-side.
+  const [submitting, setSubmitting] = React.useState<boolean>(false)
 
   // Reset state when the modal is closed so the next open starts clean.
   // Prevents stale errors and half-typed input from bleeding across sessions
@@ -47,6 +70,7 @@ export default function DataCallModal({
       setDatacallError('')
       setDeadline('')
       setDeadlineError('')
+      setSubmitting(false)
     }
   }, [open])
 
@@ -83,34 +107,46 @@ export default function DataCallModal({
     setDatacall(value)
     isValidFormat(value.toUpperCase())
   }
+  // Fires "Required" only on blur - matches the standard form UX where an
+  // untouched field stays quiet on mount and only complains once the user
+  // has engaged with it and left it empty. The on-change path (above) still
+  // reports format errors as-you-type without touching this branch.
+  const handleDatacallBlur = () => {
+    if (datacall.length === 0) {
+      setDatacallError('Datacall name is required')
+    }
+  }
   // Deadline validation mirrors the blur logic but only fires once the
   // input has reached the 10-char MM/DD/YYYY shape - partial input stays
   // quiet so the field does not flash red on every keystroke.
   const validateDeadlineValue = (value: string) => {
-    if (value.length === 0) {
-      setDeadlineError('')
-      return
-    }
     if (value.length < 10) {
       setDeadlineError('')
       return
     }
-    if (isNaN(Date.parse(value))) {
+    if (!isValidCalendarDate(value)) {
       setDeadlineError('Invalid Deadline')
       return
     }
     setDeadlineError('')
   }
   const validateDeadline = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (e.target.value.length === 10 && !isNaN(Date.parse(e.target.value))) {
-      setDeadline(e.target.value)
+    const value = e.target.value
+    if (value.length === 0) {
+      setDeadlineError('Deadline is required')
+      return
+    }
+    if (value.length === 10 && isValidCalendarDate(value)) {
+      setDeadline(value)
       setDeadlineError('')
-    } else if (e.target.value.length > 0) {
+    } else {
       setDeadlineError('Invalid Deadline')
     }
   }
   const submitDatacall = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    if (submitting) return
+    setSubmitting(true)
     try {
       await axiosInstance.post(`/datacalls`, {
         datacall: datacall.toUpperCase(),
@@ -137,8 +173,23 @@ export default function DataCallModal({
         return
       }
       notify(parsed.message, 'error', { autoHideDuration: 2500 })
+    } finally {
+      setSubmitting(false)
     }
   }
+
+  // Both fields carry a Required indicator (see the requirementLabel
+  // props on each below), so the disabled Create button is
+  // self-explaining for the empty-field case. Invalid input is reported
+  // per-field via the error message.
+  const nameValid = DATACALL_NAME_PATTERN.test(datacall.toUpperCase())
+  const deadlineComplete = deadline.length === 10 && !deadlineError
+  const isCreateDisabled =
+    !nameValid ||
+    !deadlineComplete ||
+    datacallError.length !== 0 ||
+    deadlineError.length !== 0 ||
+    submitting
   return (
     <Dialog
       open={open}
@@ -189,6 +240,7 @@ export default function DataCallModal({
             hint={datacallHint()}
             name="datacall"
             onChange={handleDatacallChange}
+            onBlur={handleDatacallBlur}
             labelClassName="datacall-label"
             errorMessage={datacallError}
           />
@@ -216,14 +268,9 @@ export default function DataCallModal({
           <CmsButton
             variation="solid"
             type="submit"
-            disabled={
-              !DATACALL_NAME_PATTERN.test(datacall.toUpperCase()) ||
-              deadline.length !== 10 ||
-              datacallError.length !== 0 ||
-              deadlineError.length !== 0
-            }
+            disabled={isCreateDisabled}
           >
-            Create
+            {submitting ? 'Creating...' : 'Create'}
           </CmsButton>
         </DialogActions>
       </form>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -129,36 +129,48 @@ export default function Title() {
   // picker updates without a manual page reload. Accepts an optional
   // signal for the mount-effect's abort cleanup; user-triggered refetches
   // (e.g. post-create) invoke it without a signal.
-  const fetchDatacalls = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const res = await axiosInstance.get(
-        '/datacalls',
-        signal ? { signal } : {}
-      )
-      if (signal?.aborted) return
-      // "Latest"/"current" is the call with the furthest-out deadline, not
-      // the highest datacallid: historical loads can carry a higher id than
-      // the real current call. datacallid is only a tiebreak.
-      const sorted: datacall[] = sortDatacallsByDeadline(
-        res.data.data as datacall[]
-      )
-      setDatacalls(sorted)
-      if (sorted.length > 0) {
-        setLatestDataCallId(sorted[0].datacallid)
-        setLatestDatacall(sorted[0].datacall)
-        setLatestDeadline(sorted[0].deadline)
-        // Default to the latest year with data, all of its calls toggled on.
-        const [firstGroup] = groupDatacallsByYear(sorted)
-        if (firstGroup) {
-          setActiveYear(firstGroup.year)
-          setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
+  //
+  // `resetSelection` defaults to true for the initial mount load, which snaps
+  // the active year/toggles to the latest year with data. A post-create
+  // refetch passes false so refreshing the list does not clobber whatever
+  // year/selection the user is currently viewing - that selection flows through
+  // the Outlet context to the dashboard and questionnaire.
+  const fetchDatacalls = useCallback(
+    async (signal?: AbortSignal, resetSelection: boolean = true) => {
+      try {
+        const res = await axiosInstance.get(
+          '/datacalls',
+          signal ? { signal } : {}
+        )
+        if (signal?.aborted) return
+        // "Latest"/"current" is the call with the furthest-out deadline, not
+        // the highest datacallid: historical loads can carry a higher id than
+        // the real current call. datacallid is only a tiebreak.
+        const sorted: datacall[] = sortDatacallsByDeadline(
+          res.data.data as datacall[]
+        )
+        setDatacalls(sorted)
+        if (sorted.length > 0) {
+          setLatestDataCallId(sorted[0].datacallid)
+          setLatestDatacall(sorted[0].datacall)
+          setLatestDeadline(sorted[0].deadline)
+          // Default to the latest year with data, all of its calls toggled on -
+          // initial load only; a post-create refetch keeps the user's selection.
+          if (resetSelection) {
+            const [firstGroup] = groupDatacallsByYear(sorted)
+            if (firstGroup) {
+              setActiveYear(firstGroup.year)
+              setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
+            }
+          }
         }
+      } catch (error) {
+        if (signal?.aborted) return
+        console.error('Fetch latest datacall error:', error)
       }
-    } catch (error) {
-      if (signal?.aborted) return
-      console.error('Fetch latest datacall error:', error)
-    }
-  }, [])
+    },
+    []
+  )
 
   useEffect(() => {
     if (loaderData.status !== 200) return
@@ -651,7 +663,7 @@ export default function Title() {
         <DataCallModal
           open={openDataCallModal}
           onClose={handleDataCallClose}
-          onCreated={fetchDatacalls}
+          onCreated={() => fetchDatacalls(undefined, false)}
         />
       </Container>
       <Footer />

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -124,42 +124,50 @@ export default function Title() {
     if (loaderData.status === 200) void clearOtherUserDrafts(userInfo.userid)
   }, [loaderData.status, userInfo.userid])
 
+  // Hoisted out of the mount effect so it can be re-invoked on demand -
+  // specifically, right after DataCallModal creates a new datacall so the
+  // picker updates without a manual page reload. Accepts an optional
+  // signal for the mount-effect's abort cleanup; user-triggered refetches
+  // (e.g. post-create) invoke it without a signal.
+  const fetchDatacalls = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await axiosInstance.get(
+        '/datacalls',
+        signal ? { signal } : {}
+      )
+      if (signal?.aborted) return
+      // "Latest"/"current" is the call with the furthest-out deadline, not
+      // the highest datacallid: historical loads can carry a higher id than
+      // the real current call. datacallid is only a tiebreak.
+      const sorted: datacall[] = sortDatacallsByDeadline(
+        res.data.data as datacall[]
+      )
+      setDatacalls(sorted)
+      if (sorted.length > 0) {
+        setLatestDataCallId(sorted[0].datacallid)
+        setLatestDatacall(sorted[0].datacall)
+        setLatestDeadline(sorted[0].deadline)
+        // Default to the latest year with data, all of its calls toggled on.
+        const [firstGroup] = groupDatacallsByYear(sorted)
+        if (firstGroup) {
+          setActiveYear(firstGroup.year)
+          setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
+        }
+      }
+    } catch (error) {
+      if (signal?.aborted) return
+      console.error('Fetch latest datacall error:', error)
+    }
+  }, [])
+
   useEffect(() => {
     if (loaderData.status !== 200) return
     const controller = new AbortController()
-    async function fetchDatacalls() {
-      try {
-        const res = await axiosInstance.get('/datacalls', {
-          signal: controller.signal,
-        })
-        // "Latest"/"current" is the call with the furthest-out deadline, not
-        // the highest datacallid: historical loads can carry a higher id than
-        // the real current call (#393). datacallid is only a tiebreak.
-        const sorted: datacall[] = sortDatacallsByDeadline(
-          res.data.data as datacall[]
-        )
-        setDatacalls(sorted)
-        if (sorted.length > 0) {
-          setLatestDataCallId(sorted[0].datacallid)
-          setLatestDatacall(sorted[0].datacall)
-          setLatestDeadline(sorted[0].deadline)
-          // Default to the latest year with data, all of its calls toggled on.
-          const [firstGroup] = groupDatacallsByYear(sorted)
-          if (firstGroup) {
-            setActiveYear(firstGroup.year)
-            setActiveDatacallIds(firstGroup.calls.map((c) => c.datacallid))
-          }
-        }
-      } catch (error) {
-        if (controller.signal.aborted) return
-        console.error('Fetch latest datacall error:', error)
-      }
-    }
-    fetchDatacalls()
+    fetchDatacalls(controller.signal)
     return () => {
       controller.abort()
     }
-  }, [loaderData.status])
+  }, [loaderData.status, fetchDatacalls])
 
   // Datacenter-environment vocabulary is reference data shared by the system
   // form (dropdown) and the questionnaire pillar filter, so it is fetched
@@ -640,7 +648,11 @@ export default function Title() {
           openModal={openEmailModal}
           closeModal={handleCloseEmailModal}
         />
-        <DataCallModal open={openDataCallModal} onClose={handleDataCallClose} />
+        <DataCallModal
+          open={openDataCallModal}
+          onClose={handleDataCallClose}
+          onCreated={fetchDatacalls}
+        />
       </Container>
       <Footer />
     </>


### PR DESCRIPTION
Rehome of #528 (by @tarratsco) into an in-repo branch so CI and the dev deployment can run — fork PRs can't reach the org secrets those workflows need. tarratsco's two commits are replayed onto current main (authorship preserved); one follow-up fix is added on top (below).

Closes #504.

## Summary

UX fixes for the Create Data Call modal: real calendar-date validation (rejects roll-over dates like `02/30`), a double-submit guard, required-on-blur messaging, and an `onCreated` callback so a newly created call appears in the picker without a manual reload. Also makes the deadline field properly controlled (`value={deadline}` — it was previously frozen to `""`).

## Follow-up fix in this branch

The post-create refetch reused the mount-time `fetchDatacalls`, which resets the active year/selection to the latest year group. Creating a datacall while viewing an older year would snap the selection back to the latest — and since that selection flows through the shared Outlet context, it discarded the user's filter across the dashboard and questionnaire. Gated the reset behind a `resetSelection` flag (default true for the initial mount load; false for the post-create refetch).

## Known follow-ups (not blocking)

- Deadline validation runs on the raw `updatedValue` rather than the design system's zero-padded `formattedValue`, so a single-digit month (e.g. `7/14/2026`) never reaches 10 characters — Create stays disabled while typing, then shows "Invalid Deadline" on blur for a calendar-valid date. Pre-existing pattern; worth a follow-up.
- A code comment references a "Required indicator" (`requirementLabel`) that neither field actually passes.

## Test plan

- [ ] `yarn typecheck`, `eslint`, `jest`
- [ ] Create a datacall while viewing an older fiscal year → selection is preserved (not snapped to the latest year)
- [ ] Create a datacall → the new call appears in the picker without a reload
- [ ] Double-click Create → a single POST fires
- [ ] Invalid calendar date (`02/30`) → "Invalid Deadline"; valid `MM/DD/YYYY` → accepted
