### PR TITLE
Show Kion pass/fail checks as an ARS-style block in the insights panel

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,9 @@ export type InsightFinding = {
   remediation?: string
   severity?: string
   nist_controls?: string
+  // Maturity tier (1-4) of the check. Present on passing-check entries
+  // (`{source}_passing`); the tier that failed/passed is what drives the score.
+  level?: number | null
   instances?: InsightHardenizeInstance[]
 }
 
@@ -459,6 +462,13 @@ export type InsightPayload = {
   ars_failing_controls?: string[] | null
 
   findings?: InsightFindings
+  // Passing checks per source (counterpart to the failing-only `findings`).
+  // Same InsightFinding shape (id, nist_controls, description, level); severity
+  // omitted (a pass isn't a severity event). Kion is live; sechub/hardenize land
+  // later in the identical shape.
+  kion_passing?: InsightFinding[]
+  sechub_passing?: InsightFinding[]
+  hardenize_passing?: InsightFinding[]
 
   // Additive: the pipeline may add keys at any time.
   [key: string]: unknown

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -55,6 +55,7 @@ describe('InsightsPanel', () => {
   it('renders the ZTMF Insights label and all five source chips', () => {
     render(<InsightsPanel payload={fullPayload} />)
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    // Chips render the source name with a trailing colon (e.g. "Kion:").
     for (const source of [
       'Kion',
       'SecurityHub',
@@ -62,7 +63,7 @@ describe('InsightsPanel', () => {
       'CFACTS',
       'ARS',
     ]) {
-      expect(screen.getByText(source)).toBeInTheDocument()
+      expect(screen.getByText(`${source}:`)).toBeInTheDocument()
     }
   })
 
@@ -78,8 +79,9 @@ describe('InsightsPanel', () => {
 
   it('marks a source with no data using a dash instead of a score', () => {
     render(<InsightsPanel payload={fullPayload} />)
-    // Hardenize has has_hardenize_data:false, so its dot renders an en-dash.
-    expect(screen.getByText('–')).toBeInTheDocument()
+    // Hardenize has has_hardenize_data:false, so its badge renders an em-dash
+    // instead of a maturity word.
+    expect(screen.getByText('—')).toBeInTheDocument()
   })
 
   it('shows "No suggestion" when suggested_score is null', () => {
@@ -217,15 +219,15 @@ describe('InsightsPanel', () => {
 
   it('hides findings until details is toggled, then reveals them', () => {
     render(<InsightsPanel payload={fullPayload} />)
-    expect(
-      screen.queryByText(/iam-user-without-mfa-device-enabled/)
-    ).not.toBeInTheDocument()
+    // Nothing in the drawer shows until expanded.
+    expect(screen.queryByText(/IAM\.10/)).not.toBeInTheDocument()
+    expect(screen.queryByText('IA-02')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
 
-    expect(
-      screen.getByText(/iam-user-without-mfa-device-enabled/)
-    ).toBeInTheDocument()
+    // Kion renders as its pass/fail chip block (failing chip labeled by the
+    // NIST tag, ✗); the sechub finding renders as a FindingRow (slug visible).
+    expect(screen.getByText('IA-02').textContent).toContain('✗')
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
   })
 
@@ -495,6 +497,218 @@ describe('FindingRow resilience', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText('IAM.10')).toBeInTheDocument()
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+})
+
+// The maturity score badge inside a source chip shows the tier WORD, not the
+// bare number (a number next to a source name read as a finding count).
+describe('ScoreBadge', () => {
+  it('shows the maturity word in the source chip, not the numeric score', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          has_kion_data: true,
+          kion_suggested_score: 2,
+        }}
+      />
+    )
+    // Kion (score 2) renders "Initial", not "2".
+    expect(screen.getByText('Initial')).toBeInTheDocument()
+    expect(screen.queryByText('2')).not.toBeInTheDocument()
+  })
+})
+
+// The ARS-style pass/fail block: passing checks from `{source}_passing` (green
+// ✓), failing from `findings.{source}` (red ✗), labeled by NIST tag with the
+// slug + description in the hover.
+describe('FeedCheckBlock (feed pass/fail checks)', () => {
+  const kionPassFail: InsightPayload = {
+    suggested_score: 1,
+    has_kion_data: true,
+    kion_suggested_score: 1,
+    kion_passing: [
+      {
+        id: 'account-without-compliant-password-policy',
+        nist_controls: 'IA-5',
+        description: 'Password Policy',
+        level: 1,
+      },
+      {
+        id: 'root-account-without-mfa-enabled',
+        nist_controls: 'AC-2',
+        description: 'Root MFA',
+        level: 1,
+      },
+      {
+        id: 'iam-user-with-password-and-no-mfa',
+        nist_controls: 'AC-2',
+        description: 'User MFA',
+        level: 1,
+      },
+    ],
+    findings: {
+      kion: [
+        {
+          id: 'iam-user-without-mfa-device-enabled',
+          nist_controls: 'IA-2',
+          description: 'MFA device',
+        },
+      ],
+    },
+  }
+
+  const expand = () =>
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+
+  it('renders "N of M checks passed" with one chip per check', () => {
+    render(<InsightsPanel payload={kionPassFail} />)
+    expand()
+    expect(screen.getByText(/3 of 4 checks passed/)).toBeInTheDocument()
+    // 3 passing (green ✓) + 1 failing (red ✗), labeled by NIST tag.
+    expect(screen.getByText('IA-5').textContent).toContain('✓')
+    expect(screen.getByText('IA-2').textContent).toContain('✗')
+  })
+
+  it('renders a chip per check even when a NIST tag repeats (distinct checks)', () => {
+    render(<InsightsPanel payload={kionPassFail} />)
+    expand()
+    const ac2 = screen.getAllByText('AC-2')
+    expect(ac2).toHaveLength(2)
+    ac2.forEach((chip) => expect(chip.textContent).toContain('✓'))
+  })
+
+  it('folds pass/fail status into each chip accessible name', () => {
+    render(<InsightsPanel payload={kionPassFail} />)
+    expand()
+    expect(
+      screen.getByLabelText(
+        /account-without-compliant-password-policy.*Password Policy.*Passed/
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(/iam-user-without-mfa-device-enabled.*Failed/)
+    ).toBeInTheDocument()
+  })
+
+  it('pluralizes the header for a single check', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          kion_passing: [],
+          findings: { kion: [{ id: 'x', nist_controls: 'AC-1' }] },
+        }}
+      />
+    )
+    expand()
+    expect(screen.getByText(/0 of 1 check passed/)).toBeInTheDocument()
+  })
+
+  it('renders a header-only "0 of 0" for an empty passing array with no failures', () => {
+    render(<InsightsPanel payload={{ suggested_score: 2, kion_passing: [] }} />)
+    expand()
+    expect(screen.getByText(/0 of 0 checks passed/)).toBeInTheDocument()
+  })
+
+  it('shows Kion as a chip block (uniform) even with no passing array, labeling failures as findings', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          has_kion_data: true,
+          kion_suggested_score: 1,
+          findings: {
+            kion: [
+              {
+                id: 'iam-role-missing-permissions-boundary',
+                nist_controls: 'AC-6-10',
+                description: 'Permissions boundary',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    expand()
+    // No fabricated pass count — labeled "N finding(s)" — but still the chip
+    // block (NIST tag + ✗), NOT the old verbose FindingRow (slug is not body
+    // text, only reachable via the chip's accessible name).
+    expect(screen.getByText(/1 finding/)).toBeInTheDocument()
+    expect(screen.queryByText(/checks? passed/)).not.toBeInTheDocument()
+    expect(screen.getByText('AC-6-10').textContent).toContain('✗')
+    expect(
+      screen.queryByText('iam-role-missing-permissions-boundary')
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders SecurityHub as the block when its passing array ships', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          has_sechub_data: true,
+          sechub_suggested_score: 2,
+          sechub_passing: [
+            { id: 'IAM.1', nist_controls: 'AC-3', description: 'x', level: 1 },
+          ],
+          findings: {
+            sechub: [{ id: 'IAM.10', nist_controls: 'IA-2', description: 'y' }],
+          },
+        }}
+      />
+    )
+    expand()
+    expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
+    expect(screen.getByText('AC-3').textContent).toContain('✓')
+    expect(screen.getByText('IA-2').textContent).toContain('✗')
+    // As a block the finding slug is not rendered as body text.
+    expect(screen.queryByText('IAM.10')).not.toBeInTheDocument()
+  })
+
+  it('keeps SecurityHub on the FindingRow list until its passing array ships', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          findings: {
+            sechub: [
+              {
+                id: 'IAM.10',
+                title: 'MFA should be enabled',
+                description: 'Enable MFA',
+                severity: 'MEDIUM',
+              },
+            ],
+          },
+        }}
+      />
+    )
+    expand()
+    // No passing array → old FindingRow: slug + title visible as body text.
+    expect(screen.getByText('IAM.10')).toBeInTheDocument()
+    expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+    // Not the block — no "N of M checks passed" header for SecurityHub.
+    expect(screen.queryByText(/checks? passed/)).not.toBeInTheDocument()
+  })
+
+  it('degrades when a passing array arrives as a non-array', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          has_kion_data: true,
+          kion_suggested_score: 1,
+          kion_passing: 'nope' as unknown as [],
+          findings: { kion: [{ id: 'x', nist_controls: 'AC-1' }] },
+        }}
+      />
+    )
+    expand()
+    // asFindingArray drops the bad value → treated as no passing checks; the
+    // failing check still renders and the panel is not blanked.
+    expect(screen.getByText('AC-1').textContent).toContain('✗')
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
   })
 })

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -579,16 +579,21 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     ac2.forEach((chip) => expect(chip.textContent).toContain('✓'))
   })
 
-  it('folds pass/fail status into each chip accessible name', () => {
+  it('folds pass/fail status into each chip accessible name (role=img so AT exposes it)', () => {
     render(<InsightsPanel payload={kionPassFail} />)
     expand()
+    // Assert via getByRole+name (resolves the real accessible name) rather than
+    // getByLabelText (reads the attribute directly) — the chip carries role=img
+    // so the aria-label is actually announced, not silently dropped by AT.
     expect(
-      screen.getByLabelText(
-        /account-without-compliant-password-policy.*Password Policy.*Passed/
-      )
+      screen.getByRole('img', {
+        name: /account-without-compliant-password-policy.*Password Policy.*Passed/,
+      })
     ).toBeInTheDocument()
     expect(
-      screen.getByLabelText(/iam-user-without-mfa-device-enabled.*Failed/)
+      screen.getByRole('img', {
+        name: /iam-user-without-mfa-device-enabled.*Failed/,
+      })
     ).toBeInTheDocument()
   })
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -598,6 +598,12 @@ function ControlChip({
   const chip = (
     <Box
       component="span"
+      // role="img" only when we supply an accessible name: aria-label on a
+      // role-less generic span is not reliably exposed by AT (NVDA/VoiceOver
+      // often ignore it), so a role is required for the pass/fail context to
+      // actually reach screen-reader users. ARS chips pass no ariaLabel and
+      // stay role-less — they're announced via their visible control-ID text.
+      role={ariaLabel ? 'img' : undefined}
       aria-label={ariaLabel || undefined}
       sx={{
         display: 'inline-flex',

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -49,6 +49,16 @@ type SourceConfig = {
 function buildSources(p: InsightPayload): SourceConfig[] {
   return [
     {
+      // ARS leads — its control-coverage signal (satisfied + not-satisfied) is
+      // the richest, and the drawer renders the ARS Controls block first, so the
+      // chip order matches.
+      key: 'ars',
+      label: 'ARS',
+      color: '#7c5cbf',
+      score: p.ars_control_score,
+      active: p.ars_control_score != null || p.ars_controls_total != null,
+    },
+    {
       key: 'kion',
       label: 'Kion',
       color: '#e86c25',
@@ -77,18 +87,6 @@ function buildSources(p: InsightPayload): SourceConfig[] {
       score: p.cfacts_suggested_score,
       active: p.cfacts_suggested_score != null || p.cfacts_auth_methods != null,
     },
-    {
-      // ARS dot shows the numeric maturity score (ars_control_score, 1-4) —
-      // NOT ars_maturity (the string label like "Initial", which won't fit the
-      // dot) and NOT the controls-satisfied count (which is coverage, not
-      // maturity: 4/4 controls can still be Initial=2). The label is surfaced in
-      // the chip tooltip via maturityLabel(score).
-      key: 'ars',
-      label: 'ARS',
-      color: '#7c5cbf',
-      score: p.ars_control_score,
-      active: p.ars_control_score != null || p.ars_controls_total != null,
-    },
   ]
 }
 
@@ -100,7 +98,11 @@ function isFloor(floorSource: string | null | undefined, label: string) {
   return floorSource.toLowerCase().includes(label.toLowerCase())
 }
 
-function ScoreDot({
+// Score badge inside a source chip. Shows the maturity WORD ("Initial"), not the
+// bare number — a numeric badge next to a source name reads as a finding count
+// ("2 findings") rather than the maturity tier it is. Fixed width so every badge
+// is the same size, wide enough for the longest label ("Traditional").
+function ScoreBadge({
   score,
   color,
   active,
@@ -109,25 +111,29 @@ function ScoreDot({
   color: string
   active: boolean
 }) {
+  const label = active
+    ? maturityLabel(score) ?? (score != null ? `Score ${score}` : '—')
+    : '—'
   return (
     <Box
       component="span"
       sx={{
-        width: 16,
+        width: 74,
         height: 16,
-        borderRadius: '50%',
+        borderRadius: '8px',
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        fontSize: 9,
+        fontSize: 9.5,
         fontWeight: 700,
+        letterSpacing: '0.2px',
         color: '#fff',
         lineHeight: 1,
         flexShrink: 0,
         bgcolor: active ? color : '#ccc',
       }}
     >
-      {score != null ? score : '–'}
+      {label}
     </Box>
   )
 }
@@ -148,8 +154,8 @@ function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
           display: 'inline-flex',
           alignItems: 'center',
           gap: 0.5,
-          pl: 0.5,
-          pr: 1,
+          pl: 1,
+          pr: 0.5,
           py: 0.25,
           borderRadius: '12px',
           fontSize: 11,
@@ -160,8 +166,8 @@ function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
           opacity: src.active ? 1 : 0.4,
         }}
       >
-        <ScoreDot score={src.score} color={src.color} active={src.active} />
-        <Box component="span">{src.label}</Box>
+        <Box component="span">{src.label}:</Box>
+        <ScoreBadge score={src.score} color={src.color} active={src.active} />
       </Box>
     </Tooltip>
   )
@@ -311,8 +317,34 @@ function InsightsPanelInner({ payload }: Props) {
   const arsSatisfied = toStringArray(payload.ars_satisfied_controls)
   const arsNotSatisfied = toStringArray(payload.ars_not_satisfied_controls)
   const arsFailing = toStringArray(payload.ars_failing_controls)
+
+  // Per-source pass/fail. A finding = a FAILED check (failing side, `findings`);
+  // the PASSING side ships separately as `{source}_passing` (same InsightFinding
+  // shape + level). When a source ships its passing array we render an ARS-style
+  // pass/fail block ("N of M checks passed" + ✓/✗ chips); until then it falls
+  // back to the plain failing FindingRows. Generic over all three finding-sources
+  // — Kion is live, sechub/hardenize light up when their arrays land, no code
+  // change. `hasPassing` keys on the array being PRESENT (even empty) so an
+  // all-failing source with a shipped passing array still reads "0 of M".
+  const feedSources = (
+    [
+      { key: 'kion', label: 'Kion', failing: kionFindings },
+      { key: 'sechub', label: 'SecurityHub', failing: sechubFindings },
+      { key: 'hardenize', label: 'Hardenize', failing: hardenizeFindings },
+    ] as const
+  ).map((s) => {
+    const raw = payload[`${s.key}_passing`]
+    return {
+      ...s,
+      passing: asFindingArray(raw),
+      hasPassing: Array.isArray(raw),
+    }
+  })
+  const anyFeedBlock = feedSources.some((s) => s.hasPassing)
+
   const hasDetail =
     hasFindings ||
+    anyFeedBlock ||
     !!payload.cfacts_reasoning ||
     !!payload.ars_controls_total ||
     !!payload.evidence_sources
@@ -392,24 +424,9 @@ function InsightsPanelInner({ payload }: Props) {
 
       <Collapse in={open} unmountOnExit>
         <Box sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid #e0e4f0' }}>
-          {payload.evidence_sources && (
-            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
-              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
-                Based on:
-              </Box>{' '}
-              {asText(payload.evidence_sources)}
-            </Typography>
-          )}
-
-          {payload.cfacts_reasoning && (
-            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
-              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
-                CFACTS:
-              </Box>{' '}
-              {asText(payload.cfacts_reasoning)}
-            </Typography>
-          )}
-
+          {/* ARS Controls first — richest signal (satisfied + not-satisfied
+              control coverage), so it leads the drawer ahead of the other
+              enrichment sources. */}
           {payload.ars_controls_total != null && (
             <Box sx={{ mb: 0.75 }}>
               <Typography sx={{ fontSize: 12, color: '#555' }}>
@@ -456,23 +473,52 @@ function InsightsPanelInner({ payload }: Props) {
             </Box>
           )}
 
-          {kionFindings.map((f, i) => (
-            <FindingRow key={`kion-${f?.id ?? i}`} source="Kion" finding={f} />
-          ))}
-          {sechubFindings.map((f, i) => (
-            <FindingRow
-              key={`sechub-${f?.id ?? i}`}
-              source="SecurityHub"
-              finding={f}
-            />
-          ))}
-          {hardenizeFindings.map((f, i) => (
-            <FindingRow
-              key={`hardenize-${f?.id ?? i}`}
-              source="Hardenize"
-              finding={f}
-            />
-          ))}
+          {payload.evidence_sources && (
+            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                Based on:
+              </Box>{' '}
+              {asText(payload.evidence_sources)}
+            </Typography>
+          )}
+
+          {payload.cfacts_reasoning && (
+            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                CFACTS:
+              </Box>{' '}
+              {asText(payload.cfacts_reasoning)}
+            </Typography>
+          )}
+
+          {feedSources.map((s) => {
+            // Kion renders as the chip block on EVERY question (its passing array
+            // is rolling out and its FindingRow detail is low-value — no
+            // instances, unreliable remediation), so all Kion sections look
+            // uniform even before the passing array ships for a given question.
+            // SecHub/Hardenize keep the richer FindingRow (affected domains,
+            // severity) until their own passing arrays land, at which point
+            // `hasPassing` flips them to the same block automatically.
+            const asBlock = s.hasPassing || s.key === 'kion'
+            if (asBlock) {
+              return s.hasPassing || s.failing.length > 0 ? (
+                <FeedCheckBlock
+                  key={`feed-${s.key}`}
+                  label={s.label}
+                  passing={s.passing}
+                  failing={s.failing}
+                  hasPassing={s.hasPassing}
+                />
+              ) : null
+            }
+            return s.failing.map((f, i) => (
+              <FindingRow
+                key={`${s.key}-${f?.id ?? i}`}
+                source={s.label}
+                finding={f}
+              />
+            ))
+          })}
         </Box>
       </Collapse>
     </Box>
@@ -536,14 +582,23 @@ const CONTROL_CHIP_STYLE: Record<
 function ControlChip({
   id,
   variant,
+  tooltip,
+  ariaLabel,
 }: {
   id: string
   variant: ControlChipVariant
+  // When set, the chip label (a short NIST tag) carries a hover with the fuller
+  // context — used by the feed pass/fail chips whose underlying check slug is
+  // too long to be the label itself. May be rich (multi-line) node.
+  tooltip?: React.ReactNode
+  // Plain-text equivalent of a rich tooltip, for the accessible name.
+  ariaLabel?: string
 }) {
   const style = CONTROL_CHIP_STYLE[variant]
-  return (
+  const chip = (
     <Box
       component="span"
+      aria-label={ariaLabel || undefined}
       sx={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -558,10 +613,129 @@ function ControlChip({
         bgcolor: style.bgcolor,
         color: style.color,
         border: style.border,
+        cursor: tooltip ? 'help' : undefined,
       }}
     >
       <Box component="span">{style.marker}</Box>
       {id}
+    </Box>
+  )
+  return tooltip ? (
+    <Tooltip
+      title={tooltip}
+      placement="top"
+      arrow
+      slotProps={{ tooltip: { sx: { maxWidth: 340 } } }}
+    >
+      {chip}
+    </Tooltip>
+  ) : (
+    chip
+  )
+}
+
+// Rich hover for a feed pass/fail chip: the check slug (mono), its dictionary
+// description, and a footer line with the NIST control, maturity level, and
+// pass/fail status. Wider/multi-line so the description is readable rather than
+// crammed onto the chip's single-line label.
+function CheckTooltip({
+  finding,
+  pass,
+}: {
+  finding: InsightFinding
+  pass: boolean
+}) {
+  const slug = asText(finding?.id) ?? asText(finding?.title)
+  const desc = asText(finding?.description)
+  const nist = asText(finding?.nist_controls)
+  const level = typeof finding?.level === 'number' ? finding.level : null
+  const meta = [
+    nist,
+    level != null ? `Level ${level}` : undefined,
+    pass ? 'Passed' : 'Failed',
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  return (
+    <Box sx={{ py: 0.25 }}>
+      {slug && (
+        <Box sx={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700 }}>
+          {slug}
+        </Box>
+      )}
+      {desc && (
+        <Box sx={{ fontSize: 11, mt: 0.5, lineHeight: 1.5 }}>{desc}</Box>
+      )}
+      {meta && <Box sx={{ fontSize: 10, mt: 0.5, opacity: 0.8 }}>{meta}</Box>}
+    </Box>
+  )
+}
+
+// ARS-style pass/fail block for one finding-source — the SINGLE rendering path
+// for every finding-source, so all questions look uniform (no fallback to the
+// old verbose FindingRow list). One ✓/✗ chip per check: passing from
+// `{source}_passing` (green), failing from `findings.{source}` (red), labeled by
+// the short NIST tag with the slug + description in the hover. Rollup is
+// per-check — a control tag can repeat because each check is distinct.
+//
+// Header adapts to what shipped: when the passing array is present we can state
+// the full "N of M checks passed"; when it's absent (source has only failing
+// findings, passing not yet emitted) we DON'T fabricate a pass count — we label
+// the failing checks honestly instead. Both render the same chip row, so the
+// look is uniform regardless. Normalizes to the full count everywhere once the
+// backend emits `{source}_passing` on every question.
+function FeedCheckBlock({
+  label,
+  passing,
+  failing,
+  hasPassing,
+}: {
+  label: string
+  passing: InsightFinding[]
+  failing: InsightFinding[]
+  hasPassing: boolean
+}) {
+  const chips = [
+    ...passing.map((f) => ({ pass: true, f })),
+    ...failing.map((f) => ({ pass: false, f })),
+  ]
+  const passed = passing.length
+  const total = chips.length
+  const summary = hasPassing
+    ? `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
+    : `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+  return (
+    <Box sx={{ mb: 0.75 }}>
+      <Typography sx={{ fontSize: 12, color: '#555' }}>
+        <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+          {label}:
+        </Box>{' '}
+        {summary}
+      </Typography>
+      {total > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+          {chips.map(({ pass, f }, i) => {
+            const nist = asText(f?.nist_controls)
+            const slug = asText(f?.id) ?? asText(f?.title)
+            const desc = asText(f?.description)
+            // Fold pass/fail into the accessible name — the ✓/✗ + color is the
+            // only other place that distinction lives, and neither is exposed to
+            // a screen reader (508).
+            const ariaLabel = [slug, desc, pass ? 'Passed' : 'Failed']
+              .filter(Boolean)
+              .join(' — ')
+            return (
+              <ControlChip
+                key={`${pass ? 'p' : 'f'}-${slug ?? ''}-${i}`}
+                id={nist ?? slug ?? '—'}
+                variant={pass ? 'satisfied' : 'failing'}
+                tooltip={<CheckTooltip finding={f} pass={pass} />}
+                ariaLabel={ariaLabel || undefined}
+              />
+            )
+          })}
+        </Box>
+      )}
     </Box>
   )
 }
@@ -679,9 +853,12 @@ function FindingRow({
       </Box>
     ) : null
   return (
-    <Box sx={{ fontSize: 12, color: '#555', mb: 0.75, lineHeight: 1.6 }}>
-      <Box component="span" sx={{ fontWeight: 700, color: '#333' }}>
-        {source}
+    <Typography
+      component="div"
+      sx={{ fontSize: 12, color: '#555', mb: 0.75, lineHeight: 1.6 }}
+    >
+      <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+        {source}:
       </Box>
       {code && (
         <Box
@@ -783,6 +960,6 @@ function FindingRow({
           {remediation}
         </Box>
       )}
-    </Box>
+    </Typography>
   )
 }


### PR DESCRIPTION
## What

The ZTMF Insights panel previously rendered only *failing* Kion checks, so a system that passed everything showed nothing — reading as missing data. This adds the passing side and renders Kion as an ARS-style pass/fail block.

This frontend change is the visible tip of a larger pipeline effort. The panel *couldn't* show pass/fail because the enrichment payload didn't carry the passing side, and the failing side's descriptions were unusable. Both were fixed upstream first; this PR consumes the result.

**Scope:** ~230 lines of panel code here, on top of upstream work spanning the Kion sync lambda (new per-check API call + two metadata columns), the Snowflake enrichment view (two versioned revisions), the findings dictionary (re-seed + weekly-task fix + seed-script fix), the CORE snapshot table (schema-safe rebuild + re-grant), and the local dev sync — plus a source-by-source audit to establish which feeds can even express pass/fail. The three files in this diff are the last mile.

## Frontend (this PR)

- Consumes the new passing-check array `kion_passing` (`InsightFinding` shape + a `level`).
- Header mirrors the ARS Controls line — **"N of M checks passed"** — one chip per check: green ✓ passing, red ✗ failing, labeled by the NIST control, with the check slug + description in a hover.
- **Kion always renders the block** so every question looks consistent. SecurityHub and Hardenize keep the detailed finding rows (their sources are failing-only — see below).
- Source chips now show the maturity **word** (e.g. "Initial") instead of a bare number, which read as a finding count. ARS leads the chip row and the drawer.
- Files: `types.ts`, `InsightsPanel.tsx`, `InsightsPanel.test.tsx`.

## Enabling data-pipeline work (upstream, separate repos)

The panel change required a chain of upstream fixes across the Snowflake enrichment view, the findings dictionary, and the Kion sync lambda.

### 1. Kion finding descriptions — control-statement wall → real per-check text

Kion findings rendered a wall of raw NIST control-statement text (e.g. the full AC-2 a–l enumeration, ~1,600 chars), identical across every check mapped to the same control. Root cause: the Kion sync lambda's model only parsed the check name + controls and dropped the API's per-check description, so the dictionary seed fell back to the control statement. Short controls looked fine; long ones (AC-2) dumped a wall.

- **kion-sync lambda (PR #37):** added a per-check detail call (`GET /compliance/check/{id}`); captured `CHECK_DESCRIPTION` + `CHECK_BODY` (the Cloud Custodian policy) into the check-metadata table — additive, existing columns untouched.
- **Findings dictionary:** re-seeded Kion `DESCRIPTION` from the real per-check text; amended the weekly refresh task to mirror `CHECK_DESCRIPTION` (self-healing), and fixed the one-time seed so a full rebuild can't reintroduce the wall.
- Result: each Kion finding shows its own concise description (e.g. *"Identify IAM users without an MFA device enabled"*) + NIST chip — avg ~60 chars vs ~650, max 116 vs 1,665.

### 2. New `kion_passing` payload field (enrichment view v13)

- Added a `KION_PASSING` array column to the insights view: one object per *passing* Kion check — `{ id, nist_controls, description, level }` — exploded from the per-level passing lists and joined to the findings dictionary for the control + real description.
- **Passing-only by design:** the failing side already ships in `findings.kion`; a unified pass+fail list would duplicate it and risk drift. The two halves are paired in the UI.
- Additive contract: the new key flows into the JSONB payload with no change to any existing field, so nothing downstream breaks.

### 3. Pipeline plumbing

- **CORE snapshot rebuilt** to match the widened view. The daily snapshot task does a positional `INSERT ... SELECT *`, so adding a view column requires rebuilding the snapshot table + re-granting the service role — verified the daily task still runs clean (11,856 rows, no drift).
- **Local dev sync** updated so the new array loads as nested JSON, not a JSON string.
- New view validated in a scratch copy before promotion; `kion_passing` confirmed populated end-to-end (view → CORE → local).

### 4. Source pass/fail audit — why only Kion (and ARS) get the block

| source | pass/fail model | result |
|--------|-----------------|--------|
| **Kion** | evaluates every mapped check, reports pass *and* fail | ✅ `kion_passing` shipped |
| **ARS** | already ships satisfied / not-satisfied controls (the "N of M satisfied" block this mirrors) | ✅ already live |
| **SecurityHub / Hardenize** | failing-only at the source — feeds record findings, never passing controls (0 of ~1,900 SecurityHub rows carry any passing set) | ❌ a `*_passing` array would be permanently empty; intentionally not built |
| **CFACTS** | narrative + score, no enumerable checks | ❌ n/a |

## Screenshot

`Kion: 3 of 4 checks passed` — `[✓ IA-5] [✓ AC-2] [✓ AC-2] [✗ IA-2]`, mirroring the ARS Controls block directly above it.

## Testing

- `InsightsPanel.test.tsx`: 41 tests pass, including 10 new for the pass/fail block (header + counts, repeated NIST tags as distinct checks, pass/fail in the accessible name, pluralization, the empty/absent-array gates, SecurityHub block-vs-FindingRow fallback, and opaque-payload degradation).
- `tsc --noEmit` clean; eslint clean (one pre-existing `react-refresh` warning unrelated to this change).

## Follow-up

- **SecurityHub / Hardenize will *not* get passing arrays** — corrected from earlier assumption. Their feeds are failing-only at the source (a control/remark only appears when it fails; 0 of ~1,900 SecurityHub rows carry any passing set), so a `*_passing` array would be permanently empty. They keep detailed finding rows for failures; their positive/clean state is the generic "evaluated, no failing findings" line, not passing chips. There is nothing to "ship" for them.
- **`kion_passing` uniformity:** the view emits the array wherever Kion has passing checks and `NULL` where it doesn't (all checks failed, or no Kion data for that question). If the panel needs a guaranteed-present array to render the block uniformly, the view can `COALESCE` `NULL` → `[]` — a one-line, additive change on request.
