### PR TITLE
Target maturity isolated save

### DIFF
--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -64,7 +64,7 @@ interface SystemDetailEditViewProps {
   // SystemDetailPage (which reads it from the outlet context).
   datacenterEnvironments: DataCenterEnvironment[]
   // Rendered in the right column between Data Lake Export and Organization,
-  // matching the read view's placement (ztmf#398).
+  // matching the read view's placement.
   targetMaturitySlot?: React.ReactNode
 }
 

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -23,10 +23,6 @@ import SystemDetailHeader from './SystemDetailHeader'
 import SystemDetailReadView from './SystemDetailReadView'
 import SystemDetailEditView from './SystemDetailEditView'
 import TargetMaturityCard from './TargetMaturityCard'
-import {
-  DEFAULT_TARGET_TIER,
-  TARGET_JUSTIFICATION_MAX,
-} from './targetMaturityConfig'
 import { EXTENDED_METADATA_KEYS } from './fieldConfig'
 import CfactsRecordCard from './CfactsRecordCard'
 
@@ -37,13 +33,11 @@ export default function SystemDetailPage() {
 
   const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
-  // Target maturity is the one field pair an assigned ISSO may write
-  // (ztmf#398); the backend enforces assignment/OpDiv scope - this only
-  // gates display. Gate by tier, matching the app convention (the backend
-  // scopes an ISSO's fismaSystems list to their assignments, so a
-  // system-scoped user on this page is by definition assigned; the endpoint
-  // re-checks on write). An ISSO gets the page Edit button, but only the
-  // target card unlocks for them; the system form stays admin-only.
+  // Target maturity is the one field pair an assigned ISSO may write; the
+  // TargetMaturityCard owns its own edit/save lifecycle and this flag only
+  // gates the Edit affordance on that card. The page-level Edit button
+  // below stays admin-only because the system form is admin-only. The
+  // backend re-checks assignment/OpDiv scope on the target-maturity PUT.
   const canEditTarget = isAdmin || isSystemScoped(userInfo)
 
   const system = useMemo(
@@ -86,9 +80,6 @@ export default function SystemDetailPage() {
 
   const [isEditing, setIsEditing] = useState(false)
   const [editedSystem, setEditedSystem] = useState<FismaSystemType | null>(null)
-  // Draft target maturity, edited via the shared page Edit/Save flow
-  const [editedTargetTier, setEditedTargetTier] = useState(DEFAULT_TARGET_TIER)
-  const [editedTargetJustification, setEditedTargetJustification] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
   const [openDecommissionDialog, setOpenDecommissionDialog] = useState(false)
@@ -149,8 +140,6 @@ export default function SystemDetailPage() {
       setShowDecommissionForm(false)
       setReactivationNotes('')
       setShowReactivateForm(false)
-      setEditedTargetTier(system.target_maturity_tier ?? DEFAULT_TARGET_TIER)
-      setEditedTargetJustification(system.target_maturity_justification ?? '')
     }
   }, [isEditing, system])
 
@@ -225,37 +214,10 @@ export default function SystemDetailPage() {
     return true
   }
 
-  // The target draft counts as touched when it differs from what's stored
-  // (NULL stored renders as the Advanced default with empty justification).
-  const targetTouched = (): boolean => {
-    if (!system) return false
-    return (
-      editedTargetTier !==
-        (system.target_maturity_tier ?? DEFAULT_TARGET_TIER) ||
-      editedTargetJustification.trim() !==
-        (system.target_maturity_justification ?? '')
-    )
-  }
-
-  // Justification is required on every explicit target save (it's the GAO
-  // deliverable); an untouched draft is always valid because it won't be sent.
-  const isTargetValid = (): boolean => {
-    if (!targetTouched()) return true
-    const trimmed = editedTargetJustification.trim()
-    return trimmed.length > 0 && trimmed.length <= TARGET_JUSTIFICATION_MAX
-  }
-
-  const isFormValid = (): boolean => {
-    // Non-admin (assigned ISSO) edit sessions only touch the target card, so
-    // the system-form field validity doesn't apply to them.
-    const systemFormValid = isAdmin
-      ? Object.values(formValid).every((v) => v === true)
-      : true
-    return systemFormValid && isTargetValid()
-  }
+  const isFormValid = (): boolean =>
+    Object.values(formValid).every((v) => v === true)
 
   const hasUnsavedChanges = (): boolean => {
-    if (targetTouched()) return true
     if (!editedSystem || !system) return false
     return !_.isEqual(system, editedSystem)
   }
@@ -311,74 +273,62 @@ export default function SystemDetailPage() {
     }
   }
 
+  // Called by TargetMaturityCard after its own save succeeds. Overlays the
+  // two target fields onto the system in fismaSystems so the read view
+  // reflects the change without a refetch. Target maturity lives on its own
+  // endpoint, so the page-level Save below never touches these fields.
+  const handleTargetMaturitySaved = (saved: FismaSystemType) => {
+    setFismaSystems((prev) =>
+      prev.map((s) =>
+        s.fismasystemid !== saved.fismasystemid
+          ? s
+          : {
+              ...s,
+              target_maturity_tier: saved.target_maturity_tier,
+              target_maturity_justification:
+                saved.target_maturity_justification,
+            }
+      )
+    )
+  }
+
   const handleSave = async () => {
     if (!editedSystem) return
     setIsSaving(true)
     try {
-      // Target maturity goes first: it's the smaller, dedicated,
-      // ISSO-writable endpoint. Only sent when actually changed so an
-      // untouched save doesn't record a spurious audit event. Firing it
-      // before the full-system PUT means a failure here leaves nothing
-      // persisted yet, instead of silently persisting the system form
-      // while the UI reports "Not Saved".
-      let savedTarget: FismaSystemType | null = null
-      if (canEditTarget && targetTouched()) {
-        const res = await axiosInstance.put(
-          `fismasystems/${editedSystem.fismasystemid}/target-maturity`,
-          {
-            target_maturity_tier: editedTargetTier,
-            target_maturity_justification: editedTargetJustification.trim(),
-          }
-        )
-        savedTarget = res.data?.data ?? null
+      // Full-system PUT. The page-level Edit button is gated on isAdmin,
+      // so this handler is unreachable for non-admins.
+      const putBody: Record<string, unknown> = {
+        fismauid: editedSystem.fismauid,
+        fismaacronym: editedSystem.fismaacronym,
+        fismaname: editedSystem.fismaname,
+        fismasubsystem: editedSystem.fismasubsystem,
+        component: editedSystem.component,
+        groupacronym: editedSystem.groupacronym,
+        groupname: editedSystem.groupname,
+        divisionname: editedSystem.divisionname,
+        datacenterenvironment: editedSystem.datacenterenvironment,
+        datacallcontact: editedSystem.datacallcontact,
+        issoemail: editedSystem.issoemail,
+        sdl_sync_enabled: editedSystem.sdl_sync_enabled,
+        opdiv_id: editedSystem.opdiv_id,
       }
-
-      // The full-system PUT is admin-only on the backend; an assigned ISSO's
-      // edit session can only have touched the target card above.
-      if (isAdmin) {
-        const putBody: Record<string, unknown> = {
-          fismauid: editedSystem.fismauid,
-          fismaacronym: editedSystem.fismaacronym,
-          fismaname: editedSystem.fismaname,
-          fismasubsystem: editedSystem.fismasubsystem,
-          component: editedSystem.component,
-          groupacronym: editedSystem.groupacronym,
-          groupname: editedSystem.groupname,
-          divisionname: editedSystem.divisionname,
-          datacenterenvironment: editedSystem.datacenterenvironment,
-          datacallcontact: editedSystem.datacallcontact,
-          issoemail: editedSystem.issoemail,
-          sdl_sync_enabled: editedSystem.sdl_sync_enabled,
-          opdiv_id: editedSystem.opdiv_id,
-        }
-        // Extended metadata fields are editable across all OpDivs; send each,
-        // using null to leave a value unchanged (the backend writes only
-        // non-null fields, so imported data isn't clobbered).
-        for (const key of EXTENDED_METADATA_KEYS) {
-          putBody[key] = editedSystem[key] ?? null
-        }
-        await axiosInstance.put(
-          `fismasystems/${editedSystem.fismasystemid}`,
-          putBody
-        )
+      // Extended metadata fields are editable across all OpDivs; send each,
+      // using null to leave a value unchanged (the backend writes only
+      // non-null fields, so imported data isn't clobbered).
+      for (const key of EXTENDED_METADATA_KEYS) {
+        putBody[key] = editedSystem[key] ?? null
       }
+      await axiosInstance.put(
+        `fismasystems/${editedSystem.fismasystemid}`,
+        putBody
+      )
 
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
       setFismaSystems((prev) =>
-        prev.map((s) => {
-          if (s.fismasystemid !== editedSystem.fismasystemid) return s
-          // editedSystem carries the target values from when edit began, so
-          // overlay the endpoint's response last.
-          const base = isAdmin ? editedSystem : s
-          return savedTarget
-            ? {
-                ...base,
-                target_maturity_tier: savedTarget.target_maturity_tier,
-                target_maturity_justification:
-                  savedTarget.target_maturity_justification,
-              }
-            : base
-        })
+        prev.map((s) =>
+          s.fismasystemid !== editedSystem.fismasystemid ? s : editedSystem
+        )
       )
     } catch (error) {
       if (isAuthHandled(error)) return
@@ -590,18 +540,15 @@ export default function SystemDetailPage() {
     )
   }
 
-  // Target maturity edits ride the page-level Edit/Save flow above, but save to
-  // the dedicated ISSO-writable endpoint. The card is slotted into the right
-  // column of whichever view renders (between Data Lake Export and
-  // Organization); for a non-admin assigned ISSO only this card unlocks.
+  // Target maturity owns its own edit/save lifecycle (see TargetMaturityCard).
+  // The card is slotted into the right column of whichever view renders
+  // (between Data Lake Export and Organization); the page's Edit button is
+  // for the admin-only system form and has no effect on this card.
   const targetMaturityCard = (
     <TargetMaturityCard
       system={system}
-      isEditing={isEditing && canEditTarget}
-      tier={editedTargetTier}
-      justification={editedTargetJustification}
-      onTierChange={setEditedTargetTier}
-      onJustificationChange={setEditedTargetJustification}
+      canEdit={canEditTarget}
+      onSaved={handleTargetMaturitySaved}
     />
   )
 
@@ -611,7 +558,7 @@ export default function SystemDetailPage() {
 
       <SystemDetailHeader
         systemName={system.fismaname}
-        canEdit={canEditTarget}
+        canEdit={isAdmin}
         isEditing={isEditing}
         isSaving={isSaving}
         isFormValid={isFormValid()}

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -542,12 +542,15 @@ export default function SystemDetailPage() {
 
   // Target maturity owns its own edit/save lifecycle (see TargetMaturityCard).
   // The card is slotted into the right column of whichever view renders
-  // (between Data Lake Export and Organization); the page's Edit button is
-  // for the admin-only system form and has no effect on this card.
+  // (between Data Lake Export and Organization). The card's Edit button is
+  // hidden while the page is in Edit mode so an admin can't run both
+  // edit flows at once: saving the card mid-page-edit would fire the
+  // isEditing/system useEffect and reset editedSystem, wiping any
+  // in-progress page-form edits.
   const targetMaturityCard = (
     <TargetMaturityCard
       system={system}
-      canEdit={canEditTarget}
+      canEdit={canEditTarget && !isEditing}
       onSaved={handleTargetMaturitySaved}
     />
   )

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -21,8 +21,7 @@ interface SystemDetailReadViewProps {
   system: FismaSystemType
   decommissionedByName: string
   // Rendered in the right column between Data Lake Export and Organization.
-  // The page owns it (its edit state is independent of this view) and slots it
-  // here so it sits with the other system cards (ztmf#398).
+  // The page owns the card so its edit state is independent of this view.
   targetMaturitySlot?: ReactNode
 }
 

--- a/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
@@ -288,6 +288,25 @@ test('Cancel with dirty draft opens the ConfirmDialog; confirming discards', asy
 // Error handling
 // ---------------------------------------------------------------------------
 
+test('200 with no body surfaces an error and keeps the user in edit mode', async () => {
+  const user = userEvent.setup()
+  mock
+    .onPut(`/fismasystems/${BASE_SYSTEM.fismasystemid}/target-maturity`)
+    .reply(200, {})
+
+  const { onSaved } = renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  await user.type(screen.getByLabelText('Justification'), 'reason')
+  await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  expect(onSaved).not.toHaveBeenCalled()
+  // Still in edit mode - the missing body was flagged, not swallowed
+  expect(screen.getByLabelText('Justification')).toBeInTheDocument()
+})
+
 test('server error keeps the user in edit mode and does not call onSaved', async () => {
   const user = userEvent.setup()
   mock

--- a/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.test.tsx
@@ -1,11 +1,31 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+// jest.mock calls must precede the imports of the mocked modules.
 jest.mock('@/router/router', () => ({
   __esModule: true,
   default: { navigate: jest.fn() },
 }))
 
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  isAuthHandled: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  const { handleAuthError } = require('@/utils/authInterceptor')
+  const instance = axios.create({ baseURL: '/api/v1/' })
+  instance.interceptors.response.use(
+    (response: unknown) => response,
+    handleAuthError
+  )
+  return { __esModule: true, default: instance }
+})
+
+import MockAdapter from 'axios-mock-adapter'
+import axiosInstance from '@/axiosConfig'
 import TargetMaturityCard from './TargetMaturityCard'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import type { FismaSystemType } from '@/types'
@@ -18,36 +38,45 @@ const BASE_SYSTEM = {
   target_maturity_justification: null,
 } as unknown as FismaSystemType
 
-const noop = () => {}
+const mock = new MockAdapter(axiosInstance)
 
 function renderCard(
   overrides: Partial<Parameters<typeof TargetMaturityCard>[0]> = {}
 ) {
   const props = {
     system: BASE_SYSTEM,
-    isEditing: false,
-    tier: 'Advanced',
-    justification: '',
-    onTierChange: noop,
-    onJustificationChange: noop,
+    canEdit: true,
+    onSaved: jest.fn(),
     ...overrides,
   }
-  return renderWithProviders(<TargetMaturityCard {...props} />)
+  return {
+    ...renderWithProviders(<TargetMaturityCard {...props} />),
+    onSaved: props.onSaved,
+  }
 }
 
+beforeEach(() => {
+  mock.reset()
+})
+
+// ---------------------------------------------------------------------------
+// View mode
+// ---------------------------------------------------------------------------
+
 test('no target set renders the Advanced default with the default caption', () => {
-  renderCard()
+  renderCard({ canEdit: false })
   expect(screen.getByText('3 — Advanced (default)')).toBeInTheDocument()
   expect(
     screen.getByText(/Default — no target has been set/)
   ).toBeInTheDocument()
-  // Read mode: no form controls, no justification block
+  // No form controls in view mode
   expect(screen.queryByLabelText('Target level')).not.toBeInTheDocument()
   expect(screen.queryByText('Justification')).not.toBeInTheDocument()
 })
 
 test('explicit target renders tier chip and justification', () => {
   renderCard({
+    canEdit: false,
     system: {
       ...BASE_SYSTEM,
       target_maturity_tier: 'Optimal',
@@ -59,34 +88,50 @@ test('explicit target renders tier chip and justification', () => {
   expect(screen.queryByText(/Default — no target/)).not.toBeInTheDocument()
 })
 
-test('isEditing renders the controlled tier select and justification field', async () => {
+// ---------------------------------------------------------------------------
+// Edit affordance gating
+// ---------------------------------------------------------------------------
+
+test('canEdit=false hides the Edit button in view mode', () => {
+  renderCard({ canEdit: false })
+  expect(screen.queryByRole('button', { name: /^edit$/i })).toBeNull()
+})
+
+test('canEdit=true shows the Edit button in view mode', () => {
+  renderCard({ canEdit: true })
+  expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+})
+
+// ---------------------------------------------------------------------------
+// Enter edit mode
+// ---------------------------------------------------------------------------
+
+test('clicking Edit swaps view mode for the tier + justification form seeded from the system', async () => {
   const user = userEvent.setup()
-  const onTierChange = jest.fn()
-  const onJustificationChange = jest.fn()
   renderCard({
-    isEditing: true,
-    tier: 'Advanced',
-    justification: '',
-    onTierChange,
-    onJustificationChange,
+    system: {
+      ...BASE_SYSTEM,
+      target_maturity_tier: 'Optimal',
+      target_maturity_justification: 'Internet-facing HVA.',
+    },
   })
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
 
-  // Empty justification is flagged as required while editing
-  expect(screen.getByLabelText('Justification')).toBeInvalid()
-
-  // Selecting a tier lifts the change to the page
-  await user.click(screen.getByLabelText('Target level'))
-  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
-  expect(onTierChange).toHaveBeenCalledWith('Optimal')
-
-  // Typing lifts justification changes to the page
-  await user.type(screen.getByLabelText('Justification'), 'B')
-  expect(onJustificationChange).toHaveBeenCalledWith('B')
+  expect(screen.getByLabelText('Target level')).toBeInTheDocument()
+  expect(screen.getByLabelText('Justification')).toBeInTheDocument()
+  // Seeded from the system
+  expect(screen.getByLabelText('Justification')).toHaveValue(
+    'Internet-facing HVA.'
+  )
+  // Save + Cancel buttons appear
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
 })
 
 test('only Initial, Advanced, and Optimal are offered - no Traditional', async () => {
   const user = userEvent.setup()
-  renderCard({ isEditing: true })
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
   await user.click(screen.getByLabelText('Target level'))
   const options = await screen.findAllByRole('option')
   expect(options.map((o) => o.textContent)).toEqual([
@@ -96,13 +141,168 @@ test('only Initial, Advanced, and Optimal are offered - no Traditional', async (
   ])
 })
 
-test('over-limit justification shows the length error', () => {
+// ---------------------------------------------------------------------------
+// Save flow
+// ---------------------------------------------------------------------------
+
+test('Save is disabled when nothing has changed', async () => {
+  const user = userEvent.setup()
   renderCard({
-    isEditing: true,
-    justification: 'x'.repeat(1001),
+    system: {
+      ...BASE_SYSTEM,
+      target_maturity_tier: 'Optimal',
+      target_maturity_justification: 'Existing reason.',
+    },
   })
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('Save is disabled when the draft is dirty but the justification is empty', async () => {
+  const user = userEvent.setup()
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  // Pick a different tier so isDirty flips true
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+test('successful save PUTs to /target-maturity, calls onSaved, exits edit mode', async () => {
+  const user = userEvent.setup()
+  const saved: FismaSystemType = {
+    ...BASE_SYSTEM,
+    target_maturity_tier: 'Optimal',
+    target_maturity_justification: 'Internet-facing HVA.',
+  }
+  mock
+    .onPut(`/fismasystems/${BASE_SYSTEM.fismasystemid}/target-maturity`)
+    .reply(200, { data: saved })
+
+  const { onSaved } = renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  await user.type(
+    screen.getByLabelText('Justification'),
+    'Internet-facing HVA.'
+  )
+  await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body).toEqual({
+    target_maturity_tier: 'Optimal',
+    target_maturity_justification: 'Internet-facing HVA.',
+  })
+  await waitFor(() => expect(onSaved).toHaveBeenCalledWith(saved))
+  // Back in view mode
+  await waitFor(() =>
+    expect(screen.queryByLabelText('Justification')).not.toBeInTheDocument()
+  )
+})
+
+test('save trims the justification before sending', async () => {
+  const user = userEvent.setup()
+  mock
+    .onPut(`/fismasystems/${BASE_SYSTEM.fismasystemid}/target-maturity`)
+    .reply(200, {
+      data: {
+        ...BASE_SYSTEM,
+        target_maturity_tier: 'Optimal',
+        target_maturity_justification: 'trimmed',
+      },
+    })
+
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  await user.type(screen.getByLabelText('Justification'), '  trimmed  ')
+  await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.target_maturity_justification).toBe('trimmed')
+})
+
+test('over-limit justification blocks Save and shows the length error', async () => {
+  const user = userEvent.setup()
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  const field = screen.getByLabelText('Justification') as HTMLInputElement
+  // userEvent.type on a 1001-char string is very slow; write directly
+  // via fireEvent through the underlying input.
+  field.focus()
+  Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    'value'
+  )?.set?.call(field, 'x'.repeat(1001))
+  field.dispatchEvent(new Event('input', { bubbles: true }))
+
   expect(
     screen.getByText('Must be 1000 characters or fewer')
   ).toBeInTheDocument()
-  expect(screen.getByLabelText('Justification')).toBeInvalid()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+// ---------------------------------------------------------------------------
+// Cancel flow
+// ---------------------------------------------------------------------------
+
+test('Cancel with no changes exits edit mode immediately (no confirm dialog)', async () => {
+  const user = userEvent.setup()
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+  expect(screen.queryByLabelText('Justification')).not.toBeInTheDocument()
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
+test('Cancel with dirty draft opens the ConfirmDialog; confirming discards', async () => {
+  const user = userEvent.setup()
+  renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  // Dirty the draft: swap tier + add justification
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  await user.type(screen.getByLabelText('Justification'), 'draft')
+
+  await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+  // ConfirmDialog uses "Confirm" as the default confirm-button label
+  const confirmButton = await screen.findByRole('button', {
+    name: /^confirm$/i,
+  })
+  await user.click(confirmButton)
+
+  // Back in view mode, drafts discarded
+  await waitFor(() =>
+    expect(screen.queryByLabelText('Justification')).not.toBeInTheDocument()
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+test('server error keeps the user in edit mode and does not call onSaved', async () => {
+  const user = userEvent.setup()
+  mock
+    .onPut(`/fismasystems/${BASE_SYSTEM.fismasystemid}/target-maturity`)
+    .reply(500)
+
+  const { onSaved } = renderCard()
+  await user.click(screen.getByRole('button', { name: /^edit$/i }))
+  await user.click(screen.getByLabelText('Target level'))
+  await user.click(await screen.findByRole('option', { name: '4 — Optimal' }))
+  await user.type(screen.getByLabelText('Justification'), 'reason')
+  await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  expect(onSaved).not.toHaveBeenCalled()
+  // Still in edit mode
+  expect(screen.getByLabelText('Justification')).toBeInTheDocument()
 })

--- a/src/views/SystemDetailPage/TargetMaturityCard.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import {
   Box,
+  Button,
   Card,
   CardContent,
   CardHeader,
@@ -9,6 +11,15 @@ import {
   Typography,
 } from '@mui/material'
 import { FismaSystemType } from '@/types'
+import axiosInstance from '@/axiosConfig'
+import { parseApiError } from '@/utils/apiErrors'
+import { isAuthHandled, notify } from '@/utils/notify'
+import {
+  CONFIRMATION_MESSAGE,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
+} from '@/constants'
+import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import {
   TIER_OPTIONS,
   DEFAULT_TARGET_TIER,
@@ -24,123 +35,234 @@ function tierLabel(tier: string): string {
 
 interface TargetMaturityCardProps {
   system: FismaSystemType
-  /** Controlled by the page-level Edit button (ztmf#398 change request):
-   * true only while the page is in edit mode AND the user may write the
-   * target (admin or assigned ISSO). */
-  isEditing: boolean
-  tier: string
-  justification: string
-  onTierChange: (tier: string) => void
-  onJustificationChange: (justification: string) => void
+  /**
+   * Whether the current user may edit target maturity for this system.
+   * Admins and assigned ISSOs both qualify; the backend re-checks on
+   * write. Gates only the "Edit" button - view mode is universal.
+   */
+  canEdit: boolean
+  /**
+   * Fired after a successful save so the parent can update its
+   * fismaSystems context with the new target_maturity_* values.
+   */
+  onSaved: (updated: FismaSystemType) => void
 }
 
 /**
- * Card for the system's risk-based target maturity level (ztmf#398).
- * Fully controlled: edit state and the Save action live with the page's
- * single Edit/Save flow. The page decides who may edit (assigned ISSOs get
- * only this card unlocked; admins get the full form as well) and PUTs to
- * the dedicated /target-maturity endpoint on save.
+ * Card for the system's risk-based target maturity level.
+ *
+ * Owns its own view / edit / save lifecycle independently of the
+ * page-level Edit button. An ISSO who is otherwise not allowed to edit
+ * the system form can still update the target maturity here; an admin
+ * can bump it without entering full-page Edit mode. Saves fire
+ * `PUT /fismasystems/:id/target-maturity` which validates only the
+ * tier + justification, so blank required fields elsewhere on the page
+ * never block a target-maturity change.
  */
 export default function TargetMaturityCard({
   system,
-  isEditing,
-  tier,
-  justification,
-  onTierChange,
-  onJustificationChange,
+  canEdit,
+  onSaved,
 }: TargetMaturityCardProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [tier, setTier] = useState(
+    system.target_maturity_tier ?? DEFAULT_TARGET_TIER
+  )
+  const [justification, setJustification] = useState(
+    system.target_maturity_justification ?? ''
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const [openConfirmDialog, setOpenConfirmDialog] = useState(false)
+
   const hasExplicitTarget = !!system.target_maturity_tier
+  const trimmedJustification = justification.trim()
   const justificationTooLong =
-    justification.trim().length > TARGET_JUSTIFICATION_MAX
-  // Required once the draft differs from what's stored; the page-level
-  // isFormValid applies the same rule to gate Save.
-  const justificationMissing = isEditing && justification.trim().length === 0
+    trimmedJustification.length > TARGET_JUSTIFICATION_MAX
+  const justificationMissing = isEditing && trimmedJustification.length === 0
+
+  // The draft counts as touched when it differs from what's stored;
+  // NULL stored renders as the Advanced default with empty justification.
+  const isDirty =
+    tier !== (system.target_maturity_tier ?? DEFAULT_TARGET_TIER) ||
+    trimmedJustification !== (system.target_maturity_justification ?? '')
+
+  // Justification is required on every dirty save (GAO deliverable) and
+  // must fit under the max. An untouched draft is trivially valid because
+  // the Save button short-circuits before firing.
+  const isSavable =
+    isDirty &&
+    trimmedJustification.length > 0 &&
+    !justificationTooLong &&
+    !isSaving
+
+  const seedFromSystem = () => {
+    setTier(system.target_maturity_tier ?? DEFAULT_TARGET_TIER)
+    setJustification(system.target_maturity_justification ?? '')
+  }
+
+  const handleEdit = () => {
+    seedFromSystem()
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    if (isDirty) {
+      setOpenConfirmDialog(true)
+    } else {
+      setIsEditing(false)
+    }
+  }
+
+  const handleConfirmDiscard = (confirm: boolean) => {
+    setOpenConfirmDialog(false)
+    if (confirm) {
+      seedFromSystem()
+      setIsEditing(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!isSavable) return
+    setIsSaving(true)
+    try {
+      const res = await axiosInstance.put(
+        `fismasystems/${system.fismasystemid}/target-maturity`,
+        {
+          target_maturity_tier: tier,
+          target_maturity_justification: trimmedJustification,
+        }
+      )
+      const saved = (res.data?.data ?? null) as FismaSystemType | null
+      if (saved) onSaved(saved)
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      setIsEditing(false)
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      const parsed = parseApiError(error)
+      notify(parsed.message || ERROR_MESSAGES.error, 'error', {
+        autoHideDuration: 2000,
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
 
   return (
-    <Card variant="outlined" sx={{ mb: 3 }}>
-      <CardHeader
-        title="Target Maturity Level"
-        titleTypographyProps={{ variant: 'h6' }}
-        subheader="Risk-based target this system's answers are compared against"
-        sx={{ pb: 0 }}
-      />
-      <CardContent sx={{ pt: 0 }}>
-        {isEditing ? (
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              maxWidth: 640,
-            }}
-          >
-            {/* variant="standard" + marginTop:0 on the label matches
-                SystemDetailEditView: the CMS design-system global CSS breaks
-                MUI's outlined floating label (it overlays the value). */}
-            <TextField
-              select
-              label="Target level"
-              variant="standard"
-              value={tier}
-              onChange={(e) => onTierChange(e.target.value)}
-              InputLabelProps={{ sx: { marginTop: 0 } }}
-              inputProps={{ 'aria-label': 'Target level' }}
-            >
-              {TIER_OPTIONS.map((o) => (
-                <MenuItem key={o.value} value={o.value}>
-                  {o.label}
-                </MenuItem>
-              ))}
-            </TextField>
-            <TextField
-              label="Justification"
-              variant="standard"
-              required
-              multiline
-              minRows={2}
-              value={justification}
-              onChange={(e) => onJustificationChange(e.target.value)}
-              helperText={
-                justificationTooLong
-                  ? `Must be ${TARGET_JUSTIFICATION_MAX} characters or fewer`
-                  : JUSTIFICATION_HELPER
-              }
-              error={justificationTooLong || justificationMissing}
-              InputLabelProps={{ sx: { marginTop: 0 } }}
-              inputProps={{ 'aria-label': 'Justification' }}
-            />
-          </Box>
-        ) : (
-          <Box>
+    <>
+      <Card variant="outlined" sx={{ mb: 3 }}>
+        <CardHeader
+          title="Target Maturity Level"
+          titleTypographyProps={{ variant: 'h6' }}
+          subheader="Risk-based target this system's answers are compared against"
+          action={
+            canEdit && !isEditing ? (
+              <Button size="small" onClick={handleEdit}>
+                Edit
+              </Button>
+            ) : undefined
+          }
+          sx={{ pb: 0 }}
+        />
+        <CardContent sx={{ pt: 0 }}>
+          {isEditing ? (
             <Box
-              sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2.5 }}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                maxWidth: 640,
+              }}
             >
-              <Chip
-                label={tierLabel(
-                  system.target_maturity_tier ?? DEFAULT_TARGET_TIER
-                )}
-                color="primary"
-                size="small"
+              {/* variant="standard" + marginTop:0 on the label matches
+                  SystemDetailEditView: the CMS design-system global CSS breaks
+                  MUI's outlined floating label (it overlays the value). */}
+              <TextField
+                select
+                label="Target level"
+                variant="standard"
+                value={tier}
+                onChange={(e) => setTier(e.target.value)}
+                InputLabelProps={{ sx: { marginTop: 0 } }}
+                inputProps={{ 'aria-label': 'Target level' }}
+              >
+                {TIER_OPTIONS.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Justification"
+                variant="standard"
+                required
+                multiline
+                minRows={2}
+                value={justification}
+                onChange={(e) => setJustification(e.target.value)}
+                helperText={
+                  justificationTooLong
+                    ? `Must be ${TARGET_JUSTIFICATION_MAX} characters or fewer`
+                    : JUSTIFICATION_HELPER
+                }
+                error={justificationTooLong || justificationMissing}
+                InputLabelProps={{ sx: { marginTop: 0 } }}
+                inputProps={{ 'aria-label': 'Justification' }}
               />
-              {!hasExplicitTarget && (
-                <Typography variant="caption" color="text.secondary">
-                  Default — no target has been set for this system yet
-                </Typography>
+              <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                <Button
+                  onClick={handleCancel}
+                  disabled={isSaving}
+                  color="inherit"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={handleSave}
+                  disabled={!isSavable}
+                >
+                  {isSaving ? 'Saving...' : 'Save'}
+                </Button>
+              </Box>
+            </Box>
+          ) : (
+            <Box>
+              <Box
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2.5 }}
+              >
+                <Chip
+                  label={tierLabel(
+                    system.target_maturity_tier ?? DEFAULT_TARGET_TIER
+                  )}
+                  color="primary"
+                  size="small"
+                />
+                {!hasExplicitTarget && (
+                  <Typography variant="caption" color="text.secondary">
+                    Default — no target has been set for this system yet
+                  </Typography>
+                )}
+              </Box>
+              {hasExplicitTarget && (
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Justification
+                  </Typography>
+                  <Typography variant="body1">
+                    {system.target_maturity_justification || '—'}
+                  </Typography>
+                </Box>
               )}
             </Box>
-            {hasExplicitTarget && (
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Justification
-                </Typography>
-                <Typography variant="body1">
-                  {system.target_maturity_justification || '—'}
-                </Typography>
-              </Box>
-            )}
-          </Box>
-        )}
-      </CardContent>
-    </Card>
+          )}
+        </CardContent>
+      </Card>
+      <ConfirmDialog
+        confirmationText={CONFIRMATION_MESSAGE}
+        open={openConfirmDialog}
+        onClose={() => setOpenConfirmDialog(false)}
+        confirmClick={handleConfirmDiscard}
+      />
+    </>
   )
 }

--- a/src/views/SystemDetailPage/TargetMaturityCard.tsx
+++ b/src/views/SystemDetailPage/TargetMaturityCard.tsx
@@ -132,8 +132,15 @@ export default function TargetMaturityCard({
           target_maturity_justification: trimmedJustification,
         }
       )
-      const saved = (res.data?.data ?? null) as FismaSystemType | null
-      if (saved) onSaved(saved)
+      // The endpoint contract is to echo the updated record. If a 200 ever
+      // comes back without one, the view would silently diverge from the
+      // server, so surface it as an error rather than a success toast.
+      const saved = res.data?.data as FismaSystemType | undefined
+      if (!saved) {
+        notify(ERROR_MESSAGES.error, 'error', { autoHideDuration: 2000 })
+        return
+      }
+      onSaved(saved)
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
       setIsEditing(false)
     } catch (error) {

--- a/src/views/SystemDetailPage/targetMaturityConfig.ts
+++ b/src/views/SystemDetailPage/targetMaturityConfig.ts
@@ -1,7 +1,7 @@
-// Target-maturity vocabulary shared by the card and the page save flow
-// (ztmf#398). Mirrors the backend's validTargetMaturityTiers: the tier NAME is
-// the stored value; the CISA stage number is display-only. Traditional (1) is
-// deliberately not offered.
+// Target-maturity vocabulary used by TargetMaturityCard. Mirrors the
+// backend's validTargetMaturityTiers: the tier NAME is the stored value;
+// the CISA stage number is display-only. Traditional (1) is deliberately
+// not offered.
 export const TIER_OPTIONS = [
   { value: 'Initial', label: '2 — Initial' },
   { value: 'Advanced', label: '3 — Advanced (default)' },


### PR DESCRIPTION
## Summary

Closes #525.
Refs CMS-Enterprise/ztmf#398, CMS-Enterprise/ztmf#405

Target maturity now has its own Save button and its own edit flow, independent of the page-level Edit button. An assigned ISSO can update the target level even when other required fields on the system page are blank; those fields are validated by the page-level PUT and were previously blocking every ISSO save.

## Root cause

Target maturity lived inside the page-level Edit/Save flow. Entering Edit snapshotted the whole system into `editedSystem`, and Save PUT the full `/fismasystems/:id` body, which the backend validates for required fields (`issoemail`, `datacallcontact`, etc.). ISSOs typically inherit systems with legacy blanks in those fields, so their target-maturity change couldn't get through: the page's `isFormValid` check disabled Save, and even if it hadn't, the backend would 400 on the missing required fields. The problem wasn't really an ISSO permission gap, it was a validation-scope mismatch - the page save was doing a full-system validate for a two-field change.

## Fix

Extract target maturity into a self-managing card:

- `TargetMaturityCard` owns its own view/edit/save state. Save fires `PUT /fismasystems/:id/target-maturity`, which validates only the two fields it writes. Justification stays required.
- Page-level Edit becomes admin-only. Target maturity was the only field ISSOs could write there, so `SystemDetailHeader.canEdit` is now `isAdmin`.
- The card's Edit button is gated on `!isEditing` so an admin can't run both flows at once. Saving the card mid-page-edit would fire the `[isEditing, system]` useEffect and re-seed `editedSystem`, wiping any in-progress page-form edits.
- Save guards a 200 with no body: the endpoint contract is to echo the updated record, so a missing payload now surfaces an error toast instead of a silent success that diverges from the server.

`SystemDetailPage`'s target-maturity state, useEffect seeding, and `hasUnsavedChanges` / `isFormValid` target checks are all removed. The card writes back into `fismaSystems` via a new `handleTargetMaturitySaved` callback.

## Known tradeoff

Opening the card's Edit, then clicking the page Edit button, causes the card to unmount and drop any typed justification with no confirm. The reverse order is safe (card's Edit is hidden while page is in edit mode). This is a minor edge case left for a follow-up if it surfaces.

## Testing

- 15 tests in `TargetMaturityCard.test.tsx` cover view mode, editing, seed-on-Edit, save success, save with server error, save with an empty 200 body, cancel-clean vs cancel-dirty with ConfirmDialog, tier option filtering, and justification validation (required, over-limit, trim before send).
- `make check` and `make test` clean.
- Manual: verified the ISSO save unblocks; admin dual-flow is gated; card cancel-with-dirty prompts before discarding.