### PR TITLE
fix test race condition

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -379,10 +379,14 @@ describe('QuestionnairePage justification integration', () => {
     render(<QuestionnarePage />)
 
     expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
-    expect(screen.getByText('ZTMF Insights option badge')).toBeInTheDocument()
-    expect(screen.getByText('Suggested justification')).toBeInTheDocument()
     expect(
-      screen.getByText("Last year's response — FY24 ZTM")
+      await screen.findByText('ZTMF Insights option badge')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText('Suggested justification')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText("Last year's response — FY24 ZTM")
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
# Summary 
https://github.com/CMS-Enterprise/ztmf-ui/pull/529 was merged into IMPL, however the UI/Deploy github action failed due to a failing test. https://github.com/CMS-Enterprise/ztmf-ui/actions/runs/29354714216/job/87159573927

> FAIL  src/views/QuestionnairePage/QuestionnairePage.test.tsx (9.052 s)
>   ● QuestionnairePage justification integration › shows Insights content for a CMS data call

 
 
This specific test is failing due to a race condition, as it can fail when the Insights panel loads before the questionnaire options. The test waits for the panel, then immediately checks for the option badge while the DOM still says Loading.

## Fix
This PR fixes the test by changing getByText to findByText and adding an await which allows for things to load before it checks for the assertion.

## How did this get past review? 
The test was flaky and could fail on certain environments/occasions.
