### PR TITLE
use deadline sort as fallback

### DIFF
--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -3,6 +3,14 @@ import 'jest-fetch-mock'
 import { TextEncoder, TextDecoder } from 'util'
 import { webcrypto } from 'crypto'
 
+// jsdom does not implement ResizeObserver; stub it for components that use it
+// (e.g. Recharts ResponsiveContainer).
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver
+
 // Polyfill for React Router 7 which requires TextEncoder/TextDecoder
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder as typeof global.TextDecoder

--- a/src/components/PillarScoresModal/PillarScoresModal.test.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.test.tsx
@@ -146,7 +146,19 @@ describe('PillarScoresModal', () => {
     expect(
       screen.queryByText('No Score Data Available')
     ).not.toBeInTheDocument()
-    // 4.50 appears in the overall score box, pillar score, and data table — all correct
-    expect(screen.getAllByText('4.50').length).toBeGreaterThan(0)
+    // queryAllByText returns [] on no match (unlike getAllByText which throws),
+    // so this gives a legible failure if the wrong score or no score is shown.
+    expect(screen.queryAllByText('4.50')).not.toHaveLength(0)
+  })
+
+  // Load-order: primary path (selectedDataCallId in scores) must resolve
+  // immediately even when datacalls context is still empty.
+  it('shows score data via primary path when datacalls context is empty', () => {
+    mockUseContextProp.mockReturnValue({ datacalls: [] })
+    renderModal({ selectedDataCallId: 5 })
+    expect(
+      screen.queryByText('No Score Data Available')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('3.75')).toBeInTheDocument()
   })
 })

--- a/src/components/PillarScoresModal/PillarScoresModal.test.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react'
+import PillarScoresModal from './PillarScoresModal'
+import type { ScoreAggregate, datacall } from '@/types'
+
+jest.mock('@/views/Title/Context', () => ({
+  useContextProp: jest.fn(),
+}))
+
+const mockUseContextProp = require('@/views/Title/Context')
+  .useContextProp as jest.Mock
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DATACALLS: datacall[] = [
+  {
+    datacallid: 5,
+    datacall: 'FY2025 Q4',
+    datecreated: '2025-01-01T00:00:00Z',
+    deadline: '2099-12-31T00:00:00Z',
+  },
+  {
+    datacallid: 4,
+    datacall: 'FY2024 Q4',
+    datecreated: '2024-01-01T00:00:00Z',
+    deadline: '2024-12-31T00:00:00Z',
+  },
+]
+
+const PILLAR_SCORES = [{ pillarid: 1, pillar: 'Identity', score: 3.5 }]
+
+const SCORES: ScoreAggregate[] = [
+  {
+    datacallid: 5,
+    fismasystemid: 1001,
+    systemscore: 3.75,
+    pillarscores: PILLAR_SCORES,
+  },
+  {
+    datacallid: 4,
+    fismasystemid: 1001,
+    systemscore: 3.0,
+    pillarscores: PILLAR_SCORES,
+  },
+]
+
+const DEFAULT_PROPS = {
+  open: true,
+  onClose: jest.fn(),
+  systemName: 'Test System',
+  systemAcronym: 'TS',
+  scores: SCORES,
+  selectedDataCallId: 5,
+}
+
+function renderModal(props: Partial<typeof DEFAULT_PROPS> = {}) {
+  return render(<PillarScoresModal {...DEFAULT_PROPS} {...props} />)
+}
+
+beforeEach(() => {
+  mockUseContextProp.mockReturnValue({ datacalls: DATACALLS })
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PillarScoresModal', () => {
+  it('does not render when open is false', () => {
+    renderModal({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows the system name and acronym in the title', () => {
+    renderModal()
+    expect(
+      screen.getByText(/Test System \(TS\) - Pillar Scores/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows "No Score Data Available" when scores is empty', () => {
+    renderModal({ scores: [] })
+    expect(screen.getByText('No Score Data Available')).toBeInTheDocument()
+  })
+
+  it('shows score data when selectedDataCallId matches a score (primary path)', () => {
+    renderModal({ selectedDataCallId: 5 })
+    expect(
+      screen.queryByText('No Score Data Available')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('3.75')).toBeInTheDocument()
+  })
+
+  // Regression guard for #521: before this fix the fallback used
+  // reduce(max datacallid), which picked the wrong call when re-imported
+  // historical calls have higher ids than the real current call.
+  it('falls back to the deadline-latest scored call when selectedDataCallId is not in scores', () => {
+    renderModal({ selectedDataCallId: 999 })
+    // scoredDatacalls[0] is datacallid=5 (furthest deadline) — score 3.75
+    expect(
+      screen.queryByText('No Score Data Available')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('3.75')).toBeInTheDocument()
+  })
+
+  // #393 regression guard: a re-imported historical call can carry a higher
+  // datacallid than the real current call; deadline order must win.
+  it('fallback picks the furthest-deadline call, not the highest-id call', () => {
+    const OUT_OF_ORDER: datacall[] = [
+      // Highest id but an already-passed deadline (the historical hijacker)
+      {
+        datacallid: 7,
+        datacall: 'FY23 ZTM',
+        datecreated: '2026-01-01T00:00:00Z',
+        deadline: '2023-06-30T00:00:00Z',
+      },
+      // Lower id but furthest-out deadline (the real current call)
+      {
+        datacallid: 6,
+        datacall: 'FY2025 Q3',
+        datecreated: '2025-01-01T00:00:00Z',
+        deadline: '2099-09-30T00:00:00Z',
+      },
+    ]
+    const MIXED_SCORES: ScoreAggregate[] = [
+      {
+        datacallid: 7,
+        fismasystemid: 1001,
+        systemscore: 2.0,
+        pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 2.0 }],
+      },
+      {
+        datacallid: 6,
+        fismasystemid: 1001,
+        systemscore: 4.5,
+        pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 4.5 }],
+      },
+    ]
+    mockUseContextProp.mockReturnValue({ datacalls: OUT_OF_ORDER })
+
+    // selectedDataCallId doesn't match any score — triggers the fallback
+    renderModal({ selectedDataCallId: 999, scores: MIXED_SCORES })
+
+    // Deadline-latest (id=6, score=4.50) must win, not max-id (id=7, score=2.00)
+    expect(
+      screen.queryByText('No Score Data Available')
+    ).not.toBeInTheDocument()
+    // 4.50 appears in the overall score box, pillar score, and data table — all correct
+    expect(screen.getAllByText('4.50').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -33,17 +33,11 @@ import {
   Legend,
   Tooltip,
 } from 'recharts'
-import axiosInstance from '@/axiosConfig'
-import type { ScoreAggregate, datacall as DataCall } from '@/types'
+import type { ScoreAggregate } from '@/types'
 import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
-
-// Static cache for datacalls that persists across component instances
-const datacallsCache: { data: DataCall[] | null; timestamp: number | null } = {
-  data: null,
-  timestamp: null,
-}
+import { useContextProp } from '@/views/Title/Context'
 
 interface PillarScoresModalProps {
   open: boolean
@@ -67,7 +61,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   scores,
   selectedDataCallId,
 }) => {
-  const [datacalls, setDatacalls] = useState<DataCall[]>([])
+  const { datacalls } = useContextProp()
   const [showDataTable, setShowDataTable] = useState(false)
   // undefined = not set by user (use deadline-based default)
   // null      = user explicitly selected "None" (no comparison)
@@ -102,11 +96,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   // "highest datacallid wins" pitfall (#393). When datacalls hasn't loaded yet
   // scoredDatacalls is empty and the expression resolves to null, which is safe.
   const latestScore =
-    scores.length > 0
-      ? scores.find((s) => s.datacallid === selectedDataCallId) ??
-        scores.find((s) => s.datacallid === scoredDatacalls[0]?.datacallid) ??
-        null
-      : null
+    scores.find((s) => s.datacallid === selectedDataCallId) ??
+    scores.find((s) => s.datacallid === scoredDatacalls[0]?.datacallid) ??
+    null
 
   // Check if we have any valid score data
   const hasValidData =
@@ -169,45 +161,6 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
       }
     })
   }, [hasValidData, latestScore, comparisonScoreEntry])
-
-  // Fetch datacalls when modal opens (with caching)
-  useEffect(() => {
-    if (!open) return
-    const controller = new AbortController()
-    const fetchDatacalls = async () => {
-      try {
-        const now = Date.now()
-        const CACHE_DURATION = 10 * 60 * 1000 // 10 minutes for datacalls
-
-        // Check if cache is still valid
-        if (
-          datacallsCache.data &&
-          datacallsCache.timestamp &&
-          now - datacallsCache.timestamp < CACHE_DURATION
-        ) {
-          setDatacalls(datacallsCache.data)
-        } else {
-          // Fetch fresh data
-          const response = await axiosInstance.get('/datacalls', {
-            signal: controller.signal,
-          })
-          const datacallsData = response.data.data
-          setDatacalls(datacallsData)
-
-          // Update cache
-          datacallsCache.data = datacallsData
-          datacallsCache.timestamp = now
-        }
-      } catch (error) {
-        if (controller.signal.aborted) return
-        console.error('Error fetching datacalls:', error)
-      }
-    }
-    fetchDatacalls()
-    return () => {
-      controller.abort()
-    }
-  }, [open])
 
   // Focus management for accessibility
   useEffect(() => {

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -78,22 +78,6 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
   const dialogRef = useRef<HTMLDivElement>(null)
   const initialFocusRef = useRef<HTMLButtonElement>(null)
 
-  // Use the selected datacall if it exists in the scores, otherwise fall back
-  // to the highest datacallid (e.g. when modal is opened before context loads).
-  const latestScore =
-    scores.length > 0
-      ? scores.find((s) => s.datacallid === selectedDataCallId) ??
-        scores.reduce((latest, current) =>
-          current.datacallid > latest.datacallid ? current : latest
-        )
-      : null
-
-  // Check if we have any valid score data
-  const hasValidData =
-    latestScore &&
-    latestScore.pillarscores &&
-    latestScore.pillarscores.length > 0
-
   // Data calls this system actually has a score for, deadline-sorted. The
   // comparison must be self-scoped: `datacalls` is the full cross-tenant list
   // (CMS quarterly `FY## Q#` and HHS annual `FY## ZTM` interleaved by deadline),
@@ -111,6 +95,24 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
       ),
     [datacalls, scores]
   )
+
+  // Use the selected datacall if it exists in the scores, otherwise fall back
+  // to the deadline-latest scored call. scoredDatacalls[0] is furthest-out by
+  // deadline (same ordering used everywhere else in this modal), avoiding the
+  // "highest datacallid wins" pitfall (#393). When datacalls hasn't loaded yet
+  // scoredDatacalls is empty and the expression resolves to null, which is safe.
+  const latestScore =
+    scores.length > 0
+      ? scores.find((s) => s.datacallid === selectedDataCallId) ??
+        scores.find((s) => s.datacallid === scoredDatacalls[0]?.datacallid) ??
+        null
+      : null
+
+  // Check if we have any valid score data
+  const hasValidData =
+    latestScore &&
+    latestScore.pillarscores &&
+    latestScore.pillarscores.length > 0
 
   // Scored calls strictly older than the anchor by deadline — the valid
   // "previous" candidates. Excludes the anchor itself and anything newer, so a

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -188,7 +188,7 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     return `${datacall.datacall} · ${tenant}`
   }
 
-  // Show 'Current'/'Previous' until the datacalls fetch resolves so labels
+  // Show 'Current'/'Previous' until the context datacalls populate so labels
   // don't flash 'Datacall {id}' during the initial load.
   const currentDatacallName =
     latestScore && datacalls.length > 0
@@ -292,9 +292,9 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
           <Box>
             {/* Comparison selector — shown whenever other scores exist (synchronous
                 check so the picker appears on the first render, not after the
-                async datacalls fetch resolves). Dropdown options use
+                context datacalls populate). Dropdown options use
                 olderScoredDatacalls (the system's scored calls before the
-                anchor) which may briefly be empty while the fetch is in flight. */}
+                anchor) which may briefly be empty while datacalls is still []. */}
             {scores.length > 1 && (
               <Box
                 display="flex"


### PR DESCRIPTION
## Summary

Closes #521. Follow-up hardening to the Pillar Scores comparison work (#468 / #520).

`latestScore` in `PillarScoresModal` resolves to the score matching `selectedDataCallId`, with a fallback when that id is absent from the fetched scores. Previously the fallback selected the entry with the highest `datacallid`:

```ts
scores.reduce((latest, current) =>
  current.datacallid > latest.datacallid ? current : latest
)
```

As flagged in #393, a re-imported historical data call can carry a higher `datacallid` than the true current call by deadline, making this ordering unreliable. The fallback was inconsistent with how every other part of the modal (`scoredDatacalls`, `olderScoredDatacalls`, the comparison selector) already determines ordering.

A reviewer also flagged a load-order issue: the new fallback depends on `scoredDatacalls`, which required `datacalls` to be populated by the modal's own async fetch. On the first open (before `/datacalls` resolved), `scoredDatacalls` was `[]` and the fallback produced `null` — showing "No Score Data Available" for systems that have data. A failed fetch would permanently break the fallback for the session.

## Changes

**Fallback ordering fix (`PillarScoresModal.tsx`)**
- Moved the `scoredDatacalls` useMemo above `latestScore` so it's in scope as a fallback source
- Replaced `reduce(max datacallid)` with `scores.find(s => s.datacallid === scoredDatacalls[0]?.datacallid)` — `scoredDatacalls[0]` is the deadline-latest call this system has a score for, using the same `sortDatacallsByDeadline` ordering used throughout the rest of the modal
- No new utilities or files — `sortDatacallsByDeadline` was already imported and `scoredDatacalls` was already computed

**Load-order fix (`PillarScoresModal.tsx`)**
- Replaced the modal's independent `/datacalls` fetch (37-line `useEffect` with `AbortController`, module-level `datacallsCache`, and local `useState`) with `const { datacalls } = useContextProp()`
- `datacalls` is now sourced from the Title outlet context — the same data `FismaTable` already consumes, populated before the user can open the modal
- Removed the `axiosInstance` import — no remaining network calls in this component
- Stale comments referencing "async datacalls fetch" updated to reflect the context-based source

**Tests (`PillarScoresModal.test.tsx` — first test file for this component)**
- 7 tests covering: dialog closed state, title rendering, empty scores, primary path, fallback path (#521 regression), deadline-vs-max-id ordering (#393 regression), and load-order guard (primary path resolves immediately when `datacalls` context is `[]`)
- Added `global.ResizeObserver` stub to `config/jest/setupTests.ts` for Recharts' `ResponsiveContainer`

## Test plan

- [ ] Open the Pillar Scores modal for a system with scores across multiple data calls — confirm the "Current" label and overall score reflect the expected deadline-latest call
- [ ] Confirm the comparison selector defaults to the correct predecessor call
- [ ] Confirm no visible regression in the happy path (modal opens, scores display correctly, trend arrows render)
- [ ] Confirm "No Score Data Available" renders correctly for a system with no scores
- [ ] `npx jest --no-coverage` — all 422 tests pass
