### PR TITLE
Highlight FIPS maturity baseline on questionnaire answer options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -476,6 +476,15 @@ export type InsightPayload = {
   sechub_passing?: InsightFinding[]
   hardenize_passing?: InsightFinding[]
 
+  // FIPS maturity baseline (ztmf-ui#547). `fips_ceiling` is the highest maturity
+  // tier this system's FIPS impact level needs (Low→2, Moderate→3, High/HVA→4);
+  // an answer option scoring above it is "above baseline" — warned but still
+  // selectable. `fips_impact_level` drives the "FIPS LOW" badge / divider text.
+  // Fallback for a system with no FIPS on file: level null + ceiling 4, so the
+  // rule (score > ceiling) warns on nothing and the UI never breaks.
+  fips_impact_level?: 'Low' | 'Moderate' | 'High' | null
+  fips_ceiling?: number | null
+
   // Additive: the pipeline may add keys at any time.
   [key: string]: unknown
 }

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -717,3 +717,53 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
   })
 })
+
+describe('FIPS baseline strip', () => {
+  it('shows the FIPS badge + baseline sentence for a system with headroom (Low → Initial)', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          fips_impact_level: 'Low',
+          fips_ceiling: 2,
+        }}
+      />
+    )
+    expect(screen.getByText('FIPS LOW')).toBeInTheDocument()
+    expect(screen.getByText(/Baseline for this system is/)).toBeInTheDocument()
+    expect(screen.getByText('Initial')).toBeInTheDocument()
+  })
+
+  it('hides the strip when there is no headroom (High / ceiling 4)', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 4,
+          fips_impact_level: 'High',
+          fips_ceiling: 4,
+        }}
+      />
+    )
+    expect(screen.queryByText(/FIPS/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Baseline for this system is/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not throw or render the strip for a malformed (non-string) impact level', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 2,
+          fips_impact_level: 3 as unknown as 'Low',
+          fips_ceiling: 2,
+        }}
+      />
+    )
+    // Panel still renders; strip is suppressed rather than crashing.
+    expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Baseline for this system is/)
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -10,8 +10,8 @@ import {
   fipsBadgeText,
   showFipsStrip,
   baselineCeiling,
+  asImpactLevel,
   FIPS_GOLD,
-  type FipsImpactLevel,
 } from '../fipsBaseline'
 
 type Props = {
@@ -392,7 +392,7 @@ function InsightsPanelInner({ payload }: Props) {
           panel → no strip). Only shown when there's headroom above the
           baseline (ceiling < 4). */}
       {showFipsStrip(
-        (payload.fips_impact_level ?? null) as FipsImpactLevel | null,
+        asImpactLevel(payload.fips_impact_level),
         payload.fips_ceiling
       ) && (
         <Box
@@ -415,6 +415,7 @@ function InsightsPanelInner({ payload }: Props) {
           >
             <Box
               component="span"
+              tabIndex={0}
               aria-label={`FIPS impact level: ${payload.fips_impact_level}`}
               sx={{
                 fontSize: 11,
@@ -429,9 +430,7 @@ function InsightsPanelInner({ payload }: Props) {
                 cursor: 'help',
               }}
             >
-              {fipsBadgeText(
-                (payload.fips_impact_level ?? null) as FipsImpactLevel | null
-              )}
+              {fipsBadgeText(asImpactLevel(payload.fips_impact_level))}
             </Box>
           </Tooltip>
           <Box

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -6,6 +6,13 @@ import Collapse from '@mui/material/Collapse'
 import Link from '@mui/material/Link'
 import type { InsightPayload, InsightFinding } from '@/types'
 import CONFIG from '@/utils/config'
+import {
+  fipsBadgeText,
+  showFipsStrip,
+  baselineCeiling,
+  FIPS_GOLD,
+  type FipsImpactLevel,
+} from '../fipsBaseline'
 
 type Props = {
   payload: InsightPayload
@@ -130,7 +137,9 @@ function ScoreBadge({
         color: '#fff',
         lineHeight: 1,
         flexShrink: 0,
-        bgcolor: active ? color : '#ccc',
+        // Inactive badge uses a mid grey (not #ccc) so the white "—" clears
+        // WCAG AA (4.5:1) — #ccc failed at ~1.6:1.
+        bgcolor: active ? color : '#6c757d',
       }}
     >
       {label}
@@ -162,8 +171,9 @@ function SourceChip({ src, floor }: { src: SourceConfig; floor: boolean }) {
           fontWeight: 600,
           bgcolor: floor ? '#fffdf5' : '#fff',
           border: floor ? '1.5px solid #b08d00' : '1px solid #ddd',
-          color: floor ? '#7d6608' : src.active ? '#333' : '#888',
-          opacity: src.active ? 1 : 0.4,
+          // Inactive label a compliant mid grey at full opacity — the old
+          // #888 @ 0.4 opacity blended to ~3:1 on white and failed AA.
+          color: floor ? '#7d6608' : src.active ? '#333' : '#595959',
         }}
       >
         <Box component="span">{src.label}:</Box>
@@ -227,42 +237,58 @@ export function OptionInsightBadges({
       }}
     >
       {isSuggested && (
-        <Box
-          component="span"
-          sx={{
-            px: 0.75,
-            py: 0.125,
-            borderRadius: '4px',
-            fontSize: 10,
-            fontWeight: 700,
-            textTransform: 'uppercase',
-            letterSpacing: '0.3px',
-            color: '#2c5282',
-            bgcolor: '#eaf1fb',
-            border: '1px dashed #5666b8',
-            whiteSpace: 'nowrap',
-          }}
+        <Tooltip
+          title="The answer the automated evidence points to"
+          placement="top"
+          arrow
         >
-          ZTMF Insights
-        </Box>
+          <Box
+            component="span"
+            aria-label="ZTMF Insights — the answer the automated evidence points to"
+            sx={{
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '4px',
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.3px',
+              color: '#2c5282',
+              bgcolor: '#eaf1fb',
+              border: '1px dashed #5666b8',
+              whiteSpace: 'nowrap',
+              cursor: 'help',
+            }}
+          >
+            ZTMF Insights
+          </Box>
+        </Tooltip>
       )}
       {isPrior && (
-        <Box
-          component="span"
-          sx={{
-            px: 0.75,
-            py: 0.125,
-            borderRadius: '4px',
-            fontSize: 10,
-            fontWeight: 600,
-            color: '#555',
-            bgcolor: '#f0f0f0',
-            border: '1px solid #ddd',
-            whiteSpace: 'nowrap',
-          }}
+        <Tooltip
+          title="The answer you gave in a prior data call"
+          placement="top"
+          arrow
         >
-          {priorLabel}
-        </Box>
+          <Box
+            component="span"
+            aria-label={`${priorLabel} — the answer you gave in a prior data call`}
+            sx={{
+              px: 0.75,
+              py: 0.125,
+              borderRadius: '4px',
+              fontSize: 10,
+              fontWeight: 600,
+              color: '#555',
+              bgcolor: '#f0f0f0',
+              border: '1px solid #ddd',
+              whiteSpace: 'nowrap',
+              cursor: 'help',
+            }}
+          >
+            {priorLabel}
+          </Box>
+        </Tooltip>
       )}
     </Box>
   )
@@ -361,6 +387,71 @@ function InsightsPanelInner({ payload }: Props) {
         my: 2,
       }}
     >
+      {/* FIPS baseline strip — lives at the top of the insights panel so it's
+          gated on insight data like everything else here (no insight → no
+          panel → no strip). Only shown when there's headroom above the
+          baseline (ceiling < 4). */}
+      {showFipsStrip(
+        (payload.fips_impact_level ?? null) as FipsImpactLevel | null,
+        payload.fips_ceiling
+      ) && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.25,
+            bgcolor: FIPS_GOLD.box,
+            border: `1px solid ${FIPS_GOLD.border}`,
+            borderRadius: '6px',
+            p: '8px 14px',
+            mb: 1.5,
+            fontSize: 12,
+          }}
+        >
+          <Tooltip
+            title={`FIPS impact level for this system: ${payload.fips_impact_level}`}
+            placement="top"
+            arrow
+          >
+            <Box
+              component="span"
+              aria-label={`FIPS impact level: ${payload.fips_impact_level}`}
+              sx={{
+                fontSize: 11,
+                fontWeight: 700,
+                bgcolor: FIPS_GOLD.badgeBg,
+                color: FIPS_GOLD.badgeText,
+                px: 1,
+                py: 0.25,
+                borderRadius: '3px',
+                letterSpacing: '0.3px',
+                flexShrink: 0,
+                cursor: 'help',
+              }}
+            >
+              {fipsBadgeText(
+                (payload.fips_impact_level ?? null) as FipsImpactLevel | null
+              )}
+            </Box>
+          </Tooltip>
+          <Box
+            component="span"
+            sx={{ color: FIPS_GOLD.text, flex: 1, lineHeight: 1.5 }}
+          >
+            Baseline for this system is{' '}
+            <Box
+              component="span"
+              sx={{ fontWeight: 700, color: FIPS_GOLD.strong }}
+            >
+              {maturityLabel(baselineCeiling(payload.fips_ceiling))}
+            </Box>
+            . Higher maturity levels are available — teams that go above
+            baseline are encouraged to document what&rsquo;s driving that
+            maturity.
+          </Box>
+        </Box>
+      )}
+
       <Box
         sx={{
           display: 'flex',

--- a/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
@@ -124,5 +124,15 @@ describe('QuestionRadioGroup', () => {
       })
       expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument()
     })
+
+    it('malformed level (a number on the opaque payload) is ignored — no throw, no treatment', () => {
+      renderGroup({
+        insight: {
+          fips_impact_level: 3 as unknown as null,
+          fips_ceiling: 2,
+        },
+      })
+      expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import QuestionRadioGroup from './QuestionRadioGroup'
+import type { QuestionChoice, InsightPayload } from '@/types'
+
+// QuestionRadioGroup pulls in OptionInsightBadges → InsightsPanel → @/utils/config,
+// which reads import.meta.env; stub it so Jest can parse the module graph.
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+const OPTIONS: QuestionChoice[] = [
+  { label: 'Traditional answer', value: 11, score: 1 },
+  { label: 'Initial answer', value: 12, score: 2 },
+  { label: 'Advanced answer', value: 13, score: 3 },
+  { label: 'Optimal answer', value: 14, score: 4 },
+]
+
+// Low FIPS → ceiling 2 (Initial): options scoring 3 and 4 are above baseline.
+const LOW_FIPS: InsightPayload = { fips_impact_level: 'Low', fips_ceiling: 2 }
+
+const noop = () => {}
+
+function renderGroup(
+  props: Partial<React.ComponentProps<typeof QuestionRadioGroup>> = {}
+) {
+  return render(
+    <QuestionRadioGroup
+      options={OPTIONS}
+      name="q"
+      selectedValue={-1}
+      onChange={noop}
+      {...props}
+    />
+  )
+}
+
+describe('QuestionRadioGroup', () => {
+  it('renders each option as a keyboard radio with the option text as its name', () => {
+    renderGroup()
+    expect(screen.getAllByRole('radio')).toHaveLength(4)
+    expect(
+      screen.getByRole('radio', { name: /Advanced answer/i })
+    ).toBeInTheDocument()
+  })
+
+  it('passes the chosen option value through onChange (drop-in for the old ChoiceList)', () => {
+    const onChange = jest.fn()
+    renderGroup({ onChange })
+    fireEvent.click(screen.getByRole('radio', { name: /Advanced answer/i }))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    // The page's handleChoiceChange does Number(event.target.value); the input
+    // must carry the option's functionoptionid (13) as its value.
+    expect(onChange.mock.calls[0][0].target.value).toBe('13')
+  })
+
+  it('renders disabled radios when disabled (read-only)', () => {
+    renderGroup({ disabled: true })
+    screen
+      .getAllByRole('radio')
+      .forEach((radio) => expect(radio).toBeDisabled())
+  })
+
+  describe('with no FIPS data', () => {
+    it('renders plain radios — no baseline treatment at all', () => {
+      renderGroup()
+      expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('with a FIPS baseline (Low → ceiling 2)', () => {
+    it('marks the ceiling option as the baseline and flags options above it', () => {
+      renderGroup({ insight: LOW_FIPS })
+      // The Initial option (score 2 == ceiling) gets the "Low baseline" chip.
+      expect(screen.getByText('Low baseline')).toBeInTheDocument()
+      // Advanced + Optimal (scores 3, 4) each carry the sr-only above-baseline cue.
+      expect(screen.getAllByText(/above the Low baseline/i)).toHaveLength(2)
+    })
+
+    it('escalates when an above-baseline option is selected: divider, badge, and notice', () => {
+      renderGroup({ insight: LOW_FIPS, selectedValue: 13 }) // Advanced (score 3)
+      expect(screen.getByText('Above-baseline selection')).toBeInTheDocument()
+      // The visible "above Low baseline" appears (divider label + per-option badges).
+      expect(screen.getAllByText(/above Low baseline/i).length).toBeGreaterThan(
+        0
+      )
+    })
+
+    it('shows no escalation notice when an at/below-baseline option is selected', () => {
+      renderGroup({ insight: LOW_FIPS, selectedValue: 12 }) // Initial (at ceiling)
+      expect(
+        screen.queryByText('Above-baseline selection')
+      ).not.toBeInTheDocument()
+    })
+
+    it('reflects a pre-loaded (defaultChecked) above-baseline answer as escalated', () => {
+      const preloaded = OPTIONS.map((o) =>
+        o.value === 14 ? { ...o, defaultChecked: true } : o
+      )
+      render(
+        <QuestionRadioGroup
+          options={preloaded}
+          name="q"
+          selectedValue={-1}
+          onChange={noop}
+          insight={LOW_FIPS}
+        />
+      )
+      expect(screen.getByText('Above-baseline selection')).toBeInTheDocument()
+    })
+  })
+
+  describe('fallbacks (feature stays invisible)', () => {
+    it('High / ceiling 4 (no headroom) shows no baseline treatment', () => {
+      renderGroup({
+        insight: { fips_impact_level: 'High', fips_ceiling: 4 },
+      })
+      expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument()
+    })
+
+    it('null FIPS (no impact level) shows no baseline treatment', () => {
+      renderGroup({
+        insight: { fips_impact_level: null, fips_ceiling: null },
+      })
+      expect(screen.queryByText(/baseline/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/views/QuestionnairePage/QuestionRadioGroup.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.tsx
@@ -1,0 +1,310 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import { QuestionChoice, InsightPayload } from '@/types'
+import { OptionInsightBadges } from './InsightsPanel/InsightsPanel'
+import {
+  baselineCeiling,
+  isAboveBaseline,
+  FIPS_GOLD as GOLD,
+  FIPS_BASELINE as BASELINE,
+  type FipsImpactLevel,
+} from './fipsBaseline'
+
+// Maturity answer options as a native-radio fieldset (not CMSDS ChoiceList) so
+// we can layer the FIPS baseline treatment — a per-option box, an in-list
+// divider, and per-option badges — which a flat ChoiceList can't express. Native
+// <input type="radio"> keeps keyboard operation and the focus ring for free
+// (508); styling is MUI-only so the CMSDS CSS/JS version drift never touches it.
+//
+// The FIPS *strip* lives in the insights panel (above the chips); this component
+// owns only the per-option markers: a dotted box on the baseline-level option
+// ("where you should be") and solid gold boxes on the above-baseline options.
+
+const SR_ONLY = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const
+
+type Props = {
+  options: QuestionChoice[]
+  name: string
+  // Currently selected option value (functionoptionid), from the page's
+  // selectQuestionOption state; -1 when nothing is chosen yet.
+  selectedValue: number
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  disabled?: boolean
+  insight?: InsightPayload
+  viewedDatacall?: string
+}
+
+export default function QuestionRadioGroup({
+  options,
+  name,
+  selectedValue,
+  onChange,
+  disabled,
+  insight,
+  viewedDatacall,
+}: Props) {
+  const ceiling = baselineCeiling(insight?.fips_ceiling)
+  const level = (insight?.fips_impact_level ?? null) as FipsImpactLevel | null
+  const anyAbove = options.some(
+    (o) => o.score != null && isAboveBaseline(o.score, ceiling)
+  )
+  // Per-option markers only when there's a real impact level AND some option
+  // sits above the ceiling (a High/ceiling-4 or null-FIPS system shows nothing).
+  const hasBaseline = level != null && anyAbove
+
+  // Effective selection: the page state once the user has chosen, otherwise the
+  // option flagged defaultChecked (the saved answer) so a pre-loaded above-
+  // baseline answer reflects its state on first paint.
+  const effectiveSelected =
+    selectedValue >= 0
+      ? selectedValue
+      : options.find((o) => o.defaultChecked)?.value ?? -1
+  const selectedScore = options.find(
+    (o) => o.value === effectiveSelected
+  )?.score
+  const selectedAbove =
+    hasBaseline &&
+    selectedScore != null &&
+    isAboveBaseline(selectedScore, ceiling)
+
+  const firstAboveIdx = options.findIndex(
+    (o) => o.score != null && isAboveBaseline(o.score, ceiling)
+  )
+
+  const dashedLine = (
+    <Box
+      sx={{
+        flex: 1,
+        height: '1px',
+        background: `repeating-linear-gradient(to right, ${GOLD.dividerLine} 0 6px, transparent 6px 12px)`,
+      }}
+    />
+  )
+
+  return (
+    <Box>
+      <Box
+        component="fieldset"
+        sx={{ border: 0, p: 0, m: 0, minInlineSize: 'auto' }}
+      >
+        <Box component="legend" sx={SR_ONLY}>
+          Select a maturity level
+        </Box>
+        {options.map((o, i) => {
+          const above =
+            hasBaseline && o.score != null && isAboveBaseline(o.score, ceiling)
+          // The option at the ceiling is the baseline level — "where you should
+          // be" — a dotted box, distinct from the solid gold above-baseline ones.
+          const atBaseline = hasBaseline && o.score === ceiling
+          const boxed = above || atBaseline
+          const id = `${name}-${o.value}`
+          return (
+            <React.Fragment key={o.value}>
+              {above && selectedAbove && i === firstAboveIdx && (
+                <Box
+                  aria-hidden="true"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                    my: 0.75,
+                    mx: '-10px',
+                  }}
+                >
+                  {dashedLine}
+                  <Box
+                    sx={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      color: GOLD.dividerLabel,
+                      whiteSpace: 'nowrap',
+                      bgcolor: GOLD.box,
+                      px: 1,
+                      py: '1px',
+                      border: `1px solid ${GOLD.border}`,
+                      borderRadius: '3px',
+                      letterSpacing: '0.3px',
+                    }}
+                  >
+                    &#9650; above {level} baseline
+                  </Box>
+                  {dashedLine}
+                </Box>
+              )}
+              <Box
+                component="label"
+                htmlFor={id}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 1.25,
+                  cursor: disabled ? 'default' : 'pointer',
+                  minHeight: 44,
+                  p: boxed ? '8px 10px' : '8px 0',
+                  mx: boxed ? '-10px' : 0,
+                  my: boxed ? '2px' : 0,
+                  borderRadius: boxed ? '6px' : 0,
+                  border: above
+                    ? `1.5px solid ${GOLD.border}`
+                    : atBaseline
+                      ? `1.5px dashed ${BASELINE.border}`
+                      : '1.5px solid transparent',
+                  bgcolor: above
+                    ? GOLD.box
+                    : atBaseline
+                      ? BASELINE.box
+                      : 'transparent',
+                }}
+              >
+                <Box
+                  component="input"
+                  type="radio"
+                  id={id}
+                  name={name}
+                  value={o.value}
+                  checked={o.value === effectiveSelected}
+                  onChange={onChange}
+                  disabled={disabled}
+                  sx={{
+                    mt: '2px',
+                    width: 20,
+                    height: 20,
+                    flexShrink: 0,
+                    accentColor: above ? GOLD.dividerLabel : '#1b1b4f',
+                    cursor: disabled ? 'default' : 'pointer',
+                  }}
+                />
+                {/* Normal inline flow (not flex) so a trailing chip sits at the
+                    end of the last wrapped line, not dropped onto its own row. */}
+                <Box
+                  component="span"
+                  sx={{ fontSize: 14, lineHeight: 1.5, flex: 1 }}
+                >
+                  {o.label}
+                  {/* Non-color cues for AT: expose the baseline relationship to
+                      assistive tech regardless of the visible (color) treatment. */}
+                  {above && (
+                    <Box component="span" sx={SR_ONLY}>
+                      {` (above the ${level} baseline)`}
+                    </Box>
+                  )}
+                  {atBaseline && (
+                    <Tooltip
+                      title={`Your baseline — the maturity level a ${level}-impact system is expected to reach`}
+                      placement="top"
+                      arrow
+                    >
+                      <Box
+                        component="span"
+                        aria-label={`${level} baseline — your system's expected maturity level`}
+                        sx={{
+                          display: 'inline-block',
+                          verticalAlign: 'middle',
+                          ml: 0.75,
+                          fontSize: 10,
+                          fontWeight: 700,
+                          bgcolor: BASELINE.badgeBg,
+                          color: BASELINE.badgeText,
+                          px: 0.75,
+                          py: 0.125,
+                          borderRadius: '4px',
+                          letterSpacing: '0.3px',
+                          textTransform: 'uppercase',
+                          whiteSpace: 'nowrap',
+                          cursor: 'help',
+                        }}
+                      >
+                        {level} baseline
+                      </Box>
+                    </Tooltip>
+                  )}
+                  {above && selectedAbove && (
+                    <Tooltip
+                      title={`Above your ${level} baseline — optional, not required to reach; worth documenting what's driving it`}
+                      placement="top"
+                      arrow
+                    >
+                      <Box
+                        component="span"
+                        aria-label={`above the ${level} baseline — optional`}
+                        sx={{
+                          display: 'inline-block',
+                          verticalAlign: 'middle',
+                          ml: 0.75,
+                          fontSize: 10,
+                          fontWeight: 700,
+                          bgcolor: GOLD.badgeBg,
+                          color: GOLD.badgeText,
+                          px: 0.75,
+                          py: 0.125,
+                          borderRadius: '4px',
+                          letterSpacing: '0.3px',
+                          textTransform: 'uppercase',
+                          whiteSpace: 'nowrap',
+                          cursor: 'help',
+                        }}
+                      >
+                        above {level} baseline
+                      </Box>
+                    </Tooltip>
+                  )}
+                  <OptionInsightBadges
+                    score={o.score}
+                    insight={insight}
+                    viewedDatacall={viewedDatacall}
+                  />
+                </Box>
+              </Box>
+            </React.Fragment>
+          )
+        })}
+      </Box>
+
+      {/* Live region is always mounted (only its content toggles) so screen
+          readers reliably announce the notice when an above-baseline option is
+          selected — a region added at the same tick as its text is sometimes
+          skipped. */}
+      <Box role="status" aria-live="polite">
+        {selectedAbove && (
+          <Box
+            sx={{
+              bgcolor: GOLD.box,
+              border: `1px solid ${GOLD.border}`,
+              borderRadius: '6px',
+              p: '10px 14px',
+              mt: 2,
+              fontSize: 12,
+              color: GOLD.text,
+              lineHeight: 1.5,
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                fontWeight: 700,
+                color: GOLD.strong,
+                display: 'block',
+                mb: 0.5,
+              }}
+            >
+              Above-baseline selection
+            </Box>
+            This system is operating above the {level} baseline. Consider adding
+            a note below describing what&rsquo;s driving this maturity level.
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/views/QuestionnairePage/QuestionRadioGroup.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.tsx
@@ -6,9 +6,9 @@ import { OptionInsightBadges } from './InsightsPanel/InsightsPanel'
 import {
   baselineCeiling,
   isAboveBaseline,
+  asImpactLevel,
   FIPS_GOLD as GOLD,
   FIPS_BASELINE as BASELINE,
-  type FipsImpactLevel,
 } from './fipsBaseline'
 
 // Maturity answer options as a native-radio fieldset (not CMSDS ChoiceList) so
@@ -55,13 +55,11 @@ export default function QuestionRadioGroup({
   viewedDatacall,
 }: Props) {
   const ceiling = baselineCeiling(insight?.fips_ceiling)
-  const level = (insight?.fips_impact_level ?? null) as FipsImpactLevel | null
-  const anyAbove = options.some(
-    (o) => o.score != null && isAboveBaseline(o.score, ceiling)
-  )
-  // Per-option markers only when there's a real impact level AND some option
-  // sits above the ceiling (a High/ceiling-4 or null-FIPS system shows nothing).
-  const hasBaseline = level != null && anyAbove
+  const level = asImpactLevel(insight?.fips_impact_level)
+  // Same gate as the panel strip (showFipsStrip): a real impact level plus
+  // headroom above the baseline. A High/ceiling-4 or null-FIPS system has no
+  // baseline treatment, so strip and per-option markers appear/vanish together.
+  const hasBaseline = level != null && ceiling < 4
 
   // Effective selection: the page state once the user has chosen, otherwise the
   // option flagged defaultChecked (the saved answer) so a pre-loaded above-
@@ -192,9 +190,12 @@ export default function QuestionRadioGroup({
                   sx={{ fontSize: 14, lineHeight: 1.5, flex: 1 }}
                 >
                   {o.label}
-                  {/* Non-color cues for AT: expose the baseline relationship to
-                      assistive tech regardless of the visible (color) treatment. */}
-                  {above && (
+                  {/* Non-color cue for AT: expose the baseline relationship to
+                      assistive tech regardless of the visible (color) treatment.
+                      Suppressed when the option is selected — the visible chip
+                      below is focusable and carries the same aria-label, so this
+                      would double-announce on the selected above-baseline row. */}
+                  {above && !selectedAbove && (
                     <Box component="span" sx={SR_ONLY}>
                       {` (above the ${level} baseline)`}
                     </Box>
@@ -207,6 +208,7 @@ export default function QuestionRadioGroup({
                     >
                       <Box
                         component="span"
+                        tabIndex={0}
                         aria-label={`${level} baseline — your system's expected maturity level`}
                         sx={{
                           display: 'inline-block',
@@ -237,6 +239,7 @@ export default function QuestionRadioGroup({
                     >
                       <Box
                         component="span"
+                        tabIndex={0}
                         aria-label={`above the ${level} baseline — optional`}
                         sx={{
                           display: 'inline-block',

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -2,11 +2,12 @@ import * as React from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import ListSubheader from '@mui/material/ListSubheader'
 import { useParams } from 'react-router-dom'
-import { Button as CmsButton, ChoiceList, Spinner } from '@cmsgov/design-system'
+import { Button as CmsButton, Spinner } from '@cmsgov/design-system'
 import Grid from '@mui/material/Grid'
 import Alert from '@mui/material/Alert'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
@@ -46,9 +47,8 @@ import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
 import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
-import InsightsPanel, {
-  OptionInsightBadges,
-} from './InsightsPanel/InsightsPanel'
+import InsightsPanel from './InsightsPanel/InsightsPanel'
+import QuestionRadioGroup from './QuestionRadioGroup'
 import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
@@ -189,9 +189,10 @@ export default function QuestionnarePage() {
   optionsRef.current = options
   const loadingQuestionRef = React.useRef(loadingQuestion)
   loadingQuestionRef.current = loadingQuestion
-  // Bumped when a re-seed changes the answer so the uncontrolled radio ChoiceList
-  // (which only reflects defaultChecked on mount) remounts and shows the
-  // corrected selection.
+  // Bumped on a re-seed to remount the radio group. QuestionRadioGroup is now
+  // controlled (reflects selectQuestionOption directly), so this is no longer
+  // strictly required for the selection to update, but it is retained as a clean
+  // reset of the subtree when a re-seed changes the answer out of band.
   const [radioKey, setRadioKey] = React.useState(0)
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
@@ -218,49 +219,20 @@ export default function QuestionnarePage() {
     if (draftStatus === 'restored') setDraftStatus('idle')
   }
   const renderRadioGroup = (options: QuestionChoice[]) => {
-    // Enrich each option label with insight badges (recommended answer / last
-    // year's answer). When there is no insight for this question, the badge
-    // component renders nothing and labels are just the option text.
-    const choices = options.map((o) => ({
-      label: (
-        <Box
-          component="span"
-          sx={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-          }}
-        >
-          <Box component="span">{o.label}</Box>
-          <OptionInsightBadges
-            score={o.score}
-            insight={currentInsight}
-            viewedDatacall={datacall}
-          />
-        </Box>
-      ),
-      value: o.value,
-      defaultChecked: o.defaultChecked,
-    }))
+    // Native-radio group (see QuestionRadioGroup) rather than CMSDS ChoiceList:
+    // it carries the same option insight badges plus the FIPS baseline treatment
+    // (per-option warn styling, divider, above-baseline badge/notice) that a flat
+    // ChoiceList can't express.
     return (
-      <Box
-        sx={{
-          '& .ds-c-choice-wrapper': {
-            maxWidth: 'none',
-          },
-        }}
-      >
-        <ChoiceList
-          choices={choices}
-          name={'radio-choices'}
-          type={'radio'}
-          label={undefined}
-          className="ds-u-margin-top--05"
-          size="small"
-          onChange={handleChoiceChange}
-          disabled={isReadOnly}
-        />
-      </Box>
+      <QuestionRadioGroup
+        options={options}
+        name="radio-choices"
+        selectedValue={selectQuestionOption}
+        onChange={handleChoiceChange}
+        disabled={isReadOnly}
+        insight={currentInsight}
+        viewedDatacall={datacall}
+      />
     )
   }
 
@@ -1090,42 +1062,48 @@ export default function QuestionnarePage() {
                         text.length > 33 ? '0.9rem' : '1rem'
                       // TODO: refactor this code such that it's going to be a single component instead of being rerendered everytime
                       return (
-                        <ListItemButton
+                        <ListItem
                           key={`item-${pillar.name}-${func.function.functionid}`}
-                          selected={selectedIndex === func.function.functionid}
-                          onClick={() => {
-                            // prevent clicking on the same question to break list
-                            if (selectedIndex !== func.function.functionid) {
-                              setStepId(func.function.functionid)
-                              if (
-                                !isReadOnly &&
-                                ((selectQuestionOption !== -1 &&
-                                  initQuestionChoice !==
-                                    selectQuestionOption) ||
-                                  initNotes !== notes)
-                              ) {
-                                setOpenAlert(true)
-                              } else {
-                                navigate(
-                                  `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(pillar.name)}/${toSlug(func.function.function)}`,
-                                  {
-                                    state: {
-                                      fismasystemid: system,
-                                      ...datacallStateRef.current,
-                                    },
-                                    replace: true,
-                                  }
-                                )
-                                handleListItemClick(func.function.functionid)
-                              }
-                            }
-                          }}
+                          disablePadding
                         >
-                          <ListItemText
-                            primary={`${text}`}
-                            sx={{ fontSize: customFontSize }}
-                          />
-                        </ListItemButton>
+                          <ListItemButton
+                            selected={
+                              selectedIndex === func.function.functionid
+                            }
+                            onClick={() => {
+                              // prevent clicking on the same question to break list
+                              if (selectedIndex !== func.function.functionid) {
+                                setStepId(func.function.functionid)
+                                if (
+                                  !isReadOnly &&
+                                  ((selectQuestionOption !== -1 &&
+                                    initQuestionChoice !==
+                                      selectQuestionOption) ||
+                                    initNotes !== notes)
+                                ) {
+                                  setOpenAlert(true)
+                                } else {
+                                  navigate(
+                                    `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(pillar.name)}/${toSlug(func.function.function)}`,
+                                    {
+                                      state: {
+                                        fismasystemid: system,
+                                        ...datacallStateRef.current,
+                                      },
+                                      replace: true,
+                                    }
+                                  )
+                                  handleListItemClick(func.function.functionid)
+                                }
+                              }
+                            }}
+                          >
+                            <ListItemText
+                              primary={`${text}`}
+                              sx={{ fontSize: customFontSize }}
+                            />
+                          </ListItemButton>
+                        </ListItem>
                       )
                     })}
                   </ul>
@@ -1144,7 +1122,9 @@ export default function QuestionnarePage() {
               >
                 {description}
               </Box>
-              <Typography variant="h6" sx={{ mt: 1, mb: 0 }}>
+              {/* The question is the page's main heading — render as <h1>
+                  (keeping the h6 styling) so the page has a level-one heading. */}
+              <Typography variant="h6" component="h1" sx={{ mt: 1, mb: 0 }}>
                 {question}
               </Typography>
               {currentInsight && <InsightsPanel payload={currentInsight} />}
@@ -1164,7 +1144,8 @@ export default function QuestionnarePage() {
                   <Box key={radioKey} sx={{ mb: 2 }}>
                     {renderRadioGroup(options)}
                   </Box>
-                  <Typography variant="h6" sx={{ mb: 1 }}>
+                  {/* h2 under the question's h1 so the heading order is valid. */}
+                  <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
                     {notePrompt || ''}
                   </Typography>
                   <CssTextField
@@ -1177,7 +1158,12 @@ export default function QuestionnarePage() {
                     helperText={
                       needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
                     }
-                    inputProps={{ maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH }}
+                    inputProps={{
+                      maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH,
+                      // The multiline field has no visible <label>; the prompt
+                      // above is styling-only. Give it an accessible name (508).
+                      'aria-label': 'Justification notes',
+                    }}
                     onChange={(e) => {
                       setNotes(e.target.value)
                       if (draftStatus === 'restored') setDraftStatus('idle')

--- a/src/views/QuestionnairePage/fipsBaseline.test.ts
+++ b/src/views/QuestionnairePage/fipsBaseline.test.ts
@@ -1,0 +1,53 @@
+import {
+  isAboveBaseline,
+  baselineCeiling,
+  fipsBadgeText,
+  showFipsStrip,
+} from './fipsBaseline'
+
+describe('fipsBaseline', () => {
+  describe('isAboveBaseline', () => {
+    it('warns on options scoring above the ceiling, not at/below it (Low → ceiling 2)', () => {
+      expect(isAboveBaseline(1, 2)).toBe(false) // Traditional — floor
+      expect(isAboveBaseline(2, 2)).toBe(false) // at baseline
+      expect(isAboveBaseline(3, 2)).toBe(true) // Advanced — above
+      expect(isAboveBaseline(4, 2)).toBe(true) // Optimal — above
+    })
+
+    it('Moderate (ceiling 3) warns only on Optimal', () => {
+      expect(isAboveBaseline(3, 3)).toBe(false)
+      expect(isAboveBaseline(4, 3)).toBe(true)
+    })
+
+    it('High (ceiling 4) warns on nothing', () => {
+      expect([1, 2, 3, 4].some((s) => isAboveBaseline(s, 4))).toBe(false)
+    })
+
+    it('null/undefined ceiling (no FIPS on file) falls back to 4 → warns on nothing', () => {
+      expect(isAboveBaseline(4, null)).toBe(false)
+      expect(isAboveBaseline(4, undefined)).toBe(false)
+      expect(baselineCeiling(null)).toBe(4)
+    })
+  })
+
+  describe('text bindings', () => {
+    it('badge is "FIPS <LEVEL>", or null with no level', () => {
+      expect(fipsBadgeText('Low')).toBe('FIPS LOW')
+      expect(fipsBadgeText('Moderate')).toBe('FIPS MODERATE')
+      expect(fipsBadgeText(null)).toBeNull()
+    })
+
+    it('badge is null (never throws) on a non-string level from the opaque payload', () => {
+      expect(fipsBadgeText(3 as unknown as null)).toBeNull()
+      expect(fipsBadgeText({} as unknown as null)).toBeNull()
+    })
+
+    it('showFipsStrip only when a level is set and there is headroom (ceiling < 4)', () => {
+      expect(showFipsStrip('Low', 2)).toBe(true)
+      expect(showFipsStrip('Moderate', 3)).toBe(true)
+      expect(showFipsStrip('High', 4)).toBe(false) // already at the top
+      expect(showFipsStrip(null, 2)).toBe(false) // no impact level
+      expect(showFipsStrip(null, null)).toBe(false) // no FIPS on file
+    })
+  })
+})

--- a/src/views/QuestionnairePage/fipsBaseline.test.ts
+++ b/src/views/QuestionnairePage/fipsBaseline.test.ts
@@ -3,6 +3,7 @@ import {
   baselineCeiling,
   fipsBadgeText,
   showFipsStrip,
+  asImpactLevel,
 } from './fipsBaseline'
 
 describe('fipsBaseline', () => {
@@ -27,6 +28,33 @@ describe('fipsBaseline', () => {
       expect(isAboveBaseline(4, null)).toBe(false)
       expect(isAboveBaseline(4, undefined)).toBe(false)
       expect(baselineCeiling(null)).toBe(4)
+    })
+
+    it('out-of-range ceiling falls back to 4 (a stray 0 must not invert the fail-safe)', () => {
+      // 0 serialized in place of null would make score > ceiling true for every
+      // option; clamp it — and anything outside 1–4 — back to the safe ceiling.
+      expect(baselineCeiling(0)).toBe(4)
+      expect(baselineCeiling(-1)).toBe(4)
+      expect(baselineCeiling(5)).toBe(4)
+      expect(baselineCeiling(NaN)).toBe(4)
+      expect(isAboveBaseline(1, 0)).toBe(false) // floor stays the floor
+      // valid range still passes through untouched
+      expect(baselineCeiling(1)).toBe(1)
+      expect(baselineCeiling(4)).toBe(4)
+    })
+  })
+
+  describe('asImpactLevel', () => {
+    it('narrows the three valid literals, nulls everything else', () => {
+      expect(asImpactLevel('Low')).toBe('Low')
+      expect(asImpactLevel('Moderate')).toBe('Moderate')
+      expect(asImpactLevel('High')).toBe('High')
+      // malformed values from the opaque payload → null (feature stays invisible)
+      expect(asImpactLevel(null)).toBeNull()
+      expect(asImpactLevel(undefined)).toBeNull()
+      expect(asImpactLevel(3)).toBeNull()
+      expect(asImpactLevel('low')).toBeNull() // case-sensitive
+      expect(asImpactLevel({})).toBeNull()
     })
   })
 

--- a/src/views/QuestionnairePage/fipsBaseline.ts
+++ b/src/views/QuestionnairePage/fipsBaseline.ts
@@ -7,6 +7,20 @@
 
 export type FipsImpactLevel = 'Low' | 'Moderate' | 'High'
 
+const IMPACT_LEVELS: readonly FipsImpactLevel[] = ['Low', 'Moderate', 'High']
+
+// `fips_impact_level` rides on the opaque payload, so a TS `as` cast buys
+// nothing at runtime. Narrow it to one of the three literals (or null) here so
+// every surface — the strip and the per-option markers — reads it the same way
+// and suppresses together on a malformed value, rather than interpolating a
+// number into "▲ above 3 baseline".
+export function asImpactLevel(x: unknown): FipsImpactLevel | null {
+  return typeof x === 'string' &&
+    (IMPACT_LEVELS as readonly string[]).includes(x)
+    ? (x as FipsImpactLevel)
+    : null
+}
+
 // Shared palette for the FIPS baseline treatment, used by both the strip (in the
 // insights panel) and the per-option markers (in the radio group). Gold =
 // "above your baseline" (attention, optional); the dotted blue baseline box =
@@ -43,10 +57,15 @@ export function showFipsStrip(
 
 // A system with no FIPS on file arrives with ceiling null/undefined; treat it as
 // 4 so nothing scores above it and the UI warns on nothing (never breaks).
+// Clamp to the valid 1–4 maturity range too: a stray 0 (a zero serialized in
+// place of null) would make `score > ceiling` true for every option — the exact
+// inverse of the fail-safe — so any out-of-range number also falls back to 4.
 export function baselineCeiling(
   fipsCeiling: number | null | undefined
 ): number {
-  return typeof fipsCeiling === 'number' ? fipsCeiling : 4
+  return typeof fipsCeiling === 'number' && fipsCeiling >= 1 && fipsCeiling <= 4
+    ? fipsCeiling
+    : 4
 }
 
 // The core rule: an option is above baseline when its maturity score exceeds the

--- a/src/views/QuestionnairePage/fipsBaseline.ts
+++ b/src/views/QuestionnairePage/fipsBaseline.ts
@@ -1,0 +1,69 @@
+// FIPS maturity-baseline logic for the questionnaire (ztmf-ui#547). Pure and
+// styling-independent: given an insight payload's `fips_ceiling` / `fips_impact_level`
+// and a maturity answer option's score, decide whether the option is "above
+// baseline" (warned but still selectable), and produce the badge / strip /
+// divider copy. The rendering layer consumes these; the rule lives here so it's
+// unit-testable on its own.
+
+export type FipsImpactLevel = 'Low' | 'Moderate' | 'High'
+
+// Shared palette for the FIPS baseline treatment, used by both the strip (in the
+// insights panel) and the per-option markers (in the radio group). Gold =
+// "above your baseline" (attention, optional); the dotted blue baseline box =
+// "where you should be". All text/background pairs clear WCAG AA (>= 4.5:1).
+export const FIPS_GOLD = {
+  box: '#fffdf5',
+  border: '#e8d87a',
+  text: '#6b5700',
+  strong: '#4a3c00',
+  badgeBg: '#f5e642',
+  badgeText: '#5a4a00',
+  dividerLine: '#c9a800',
+  dividerLabel: '#8b6e00',
+}
+
+export const FIPS_BASELINE = {
+  box: '#fafaff',
+  border: '#8b93cc',
+  badgeBg: '#eef0fb',
+  badgeText: '#3a4a8f',
+}
+
+// The strip only makes sense when a real impact level is set AND there is
+// headroom above the baseline (ceiling < 4) — a High/Optimal system is already
+// at the top, so "higher maturity levels are available" would be false.
+export function showFipsStrip(
+  level: FipsImpactLevel | null | undefined,
+  fipsCeiling: number | null | undefined
+): boolean {
+  // typeof-string (not just != null) so a malformed non-string level from the
+  // opaque payload suppresses the strip rather than rendering it badge-less.
+  return typeof level === 'string' && baselineCeiling(fipsCeiling) < 4
+}
+
+// A system with no FIPS on file arrives with ceiling null/undefined; treat it as
+// 4 so nothing scores above it and the UI warns on nothing (never breaks).
+export function baselineCeiling(
+  fipsCeiling: number | null | undefined
+): number {
+  return typeof fipsCeiling === 'number' ? fipsCeiling : 4
+}
+
+// The core rule: an option is above baseline when its maturity score exceeds the
+// system's FIPS ceiling. Score 1 (Traditional) is always the floor, never above.
+export function isAboveBaseline(
+  score: number,
+  fipsCeiling: number | null | undefined
+): boolean {
+  return score > baselineCeiling(fipsCeiling)
+}
+
+// Chrome copy — all gated on a real impact level. A null level (no FIPS on file)
+// means no badge/strip/divider at all, so the feature is invisible there.
+export function fipsBadgeText(
+  level: FipsImpactLevel | null | undefined
+): string | null {
+  // level rides on an opaque payload; guard against a truthy non-string so
+  // `.toUpperCase()` can't throw and blank the whole insights panel.
+  return typeof level === 'string' ? `FIPS ${level.toUpperCase()}` : null
+}


### PR DESCRIPTION
Closes #547.

## What

Surfaces each system's FIPS-derived maturity **baseline** in the questionnaire's ZTMF Insights flow. A system's FIPS impact level sets a ceiling — **Low → Initial, Moderate → Advanced, High → Optimal** — and the answer options are marked against it:

- Options **above** the baseline: gold "above baseline" styling, still selectable (optional, not required). Selecting one reveals a divider, an `ABOVE X BASELINE` badge, and a short justification notice.
- The option **at** the ceiling: a dotted "**LOW/MODERATE BASELINE**" box — "where you should be."
- A **FIPS strip** at the top of the insights panel states the baseline in plain language.

Decision origin: ztmf-misc#137 (Option 2 — warn, don't block).

## Data

Two additive fields on the insight payload: `fips_impact_level` (Low/Moderate/High/null) and `fips_ceiling` (1–4). Because they ride on the insight payload, the whole treatment is **gated on insight data** exactly like the rest of the insights UI — no data, nothing renders. A system with no FIPS on file (`fips_ceiling` null → treated as 4) warns on nothing.

## Implementation

- Replaces the CMSDS `ChoiceList` for answer options with a native-radio `<fieldset>` (`QuestionRadioGroup`) so the per-option baseline treatment can render; preserves the existing selection, save, read-only, and option-insight-badge behavior.
- FIPS logic is isolated in `fipsBaseline.ts` (pure, unit-tested); opaque-payload reads are guarded (a malformed level suppresses the strip rather than throwing).

## Accessibility (508)

Native radios in a labeled fieldset; above-baseline state carries a screen-reader cue independent of color; tooltips paired with `aria-label`; an always-mounted `aria-live` region for the notice. This PR also clears the **pre-existing** 508 findings on the questionnaire page: greyed-chip contrast, sidebar list semantics (`ListItem`), `h1`/`h2` heading order, and the notes-textarea label. Axe on the page is clean except two intentionally-left app-shell items (the logo contrast and a header `region`).

## Testing

- tsc + eslint clean; **161** questionnaire tests pass, incl. new coverage for the baseline logic (`fipsBaseline.test.ts`), the radio group (`QuestionRadioGroup.test.tsx`), and the strip (`InsightsPanel.test.tsx`).
- Verified end-to-end against real dev data (a Low-FIPS system) via headless click-through.

Opened as a regular PR (not draft) so it deploys to **dev** for review/approval before merge.
