### PR TITLE
remove gold background for above baseline options

### DIFF
--- a/src/views/QuestionnairePage/QuestionRadioGroup.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.tsx
@@ -19,7 +19,8 @@ import {
 //
 // The FIPS *strip* lives in the insights panel (above the chips); this component
 // owns only the per-option markers: a dotted box on the baseline-level option
-// ("where you should be") and solid gold boxes on the above-baseline options.
+// ("where you should be"), a gold divider + badge when an above-baseline option
+// is selected, and a notice box below the list.
 
 const SR_ONLY = {
   position: 'absolute',
@@ -103,9 +104,9 @@ export default function QuestionRadioGroup({
           const above =
             hasBaseline && o.score != null && isAboveBaseline(o.score, ceiling)
           // The option at the ceiling is the baseline level — "where you should
-          // be" — a dotted box, distinct from the solid gold above-baseline ones.
+          // be" — marked with a dotted box. Above-baseline options have no box.
           const atBaseline = hasBaseline && o.score === ceiling
-          const boxed = above || atBaseline
+          const boxed = atBaseline
           const id = `${name}-${o.value}`
           return (
             <React.Fragment key={o.value}>
@@ -153,16 +154,10 @@ export default function QuestionRadioGroup({
                   mx: boxed ? '-10px' : 0,
                   my: boxed ? '2px' : 0,
                   borderRadius: boxed ? '6px' : 0,
-                  border: above
-                    ? `1.5px solid ${GOLD.border}`
-                    : atBaseline
-                      ? `1.5px dashed ${BASELINE.border}`
-                      : '1.5px solid transparent',
-                  bgcolor: above
-                    ? GOLD.box
-                    : atBaseline
-                      ? BASELINE.box
-                      : 'transparent',
+                  border: atBaseline
+                    ? `1.5px dashed ${BASELINE.border}`
+                    : '1.5px solid transparent',
+                  bgcolor: atBaseline ? BASELINE.box : 'transparent',
                 }}
               >
                 <Box


### PR DESCRIPTION
> **Note:** In-repo copy of #551 by @costacalvin. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #551

---

Remove yellow box border from above-baseline radio options
Closes https://github.com/CMS-Enterprise/ztmf-ui/issues/552
## Summary
- Removes the solid gold border and light yellow background introduced in #550 from radio option cards that score above the FIPS baseline
- The baseline option (dotted blue box), divider line, "above X baseline" badge, and warning notice below the list are all unchanged
- Updated inline comments to reflect the new per-option treatment

## Why
The gold box border added in #550 unintentionally made above-baseline options look like the recommended or preferred choice — visually calling them out in a way that could nudge users toward selecting a higher maturity level than their baseline requires. The divider and badge already communicate the above-baseline state; the warning notice below the list handles the consequence.

## UI
### Before
<img width="2178" height="1224" alt="image" src="https://github.com/user-attachments/assets/3b2fdce8-c86e-441c-a581-f5cdde335d67" />
<img width="2200" height="1152" alt="image" src="https://github.com/user-attachments/assets/fb5c140f-71a3-45f5-993f-0bc5cf7fc69b" />

### After
<img width="3234" height="1870" alt="image" src="https://github.com/user-attachments/assets/f5f7e8a8-b45f-4c1d-a57f-e07dc87fd8f1" />
<img width="3188" height="1738" alt="image" src="https://github.com/user-attachments/assets/efb1aef6-b7da-425a-8655-0eccf4f9abeb" />


## Test plan
- [ ] Navigate to a system with a FIPS impact level set and open a questionnaire question
- [ ] Select an at-baseline option — dotted blue box renders, no gold styling anywhere
- [ ] Select an above-baseline option — divider, badge, and warning notice appear; no gold border or background on the card
- [ ] Select a below-baseline option — no baseline treatment visible
- [ ] `yarn test QuestionRadioGroup` passes
