### PR TITLE
Add an opdiv field to the system details page

### DIFF
--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -518,6 +518,8 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             sx={{ pb: 0 }}
           />
           <CardContent>
+            {/* id must not match renderEditField's `edit-${key}` pattern — if opdiv_id
+                is ever added to fieldConfig it would produce a duplicate DOM id. */}
             <TextField
               id="edit-opdiv_id"
               label="OpDiv"

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -66,6 +66,7 @@ interface SystemDetailEditViewProps {
   // Rendered in the right column between Data Lake Export and Organization,
   // matching the read view's placement.
   targetMaturitySlot?: React.ReactNode
+  opdivName: string | null
 }
 
 function renderEditField(
@@ -517,6 +518,16 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             sx={{ pb: 0 }}
           />
           <CardContent>
+            <TextField
+              id="edit-opdiv_id"
+              label="OpDiv"
+              variant="standard"
+              fullWidth
+              disabled
+              margin="normal"
+              InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
+              value={props.opdivName ?? ''}
+            />
             {orgFields.map((field) => renderEditField(field, props))}
           </CardContent>
         </Card>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -3,7 +3,13 @@ import { useParams } from 'react-router-dom'
 import { Box, CircularProgress, Divider, Typography } from '@mui/material'
 import _ from 'lodash'
 
-import { FismaSystemType, FormValidType, FormValidHelperText } from '@/types'
+import {
+  FismaSystemType,
+  FormValidType,
+  FormValidHelperText,
+  OpDiv,
+} from '@/types'
+import { fetchOpDivs } from '@/utils/opdivs'
 import { useContextProp } from '@/views/Title/Context'
 import axiosInstance from '@/axiosConfig'
 import {
@@ -77,6 +83,21 @@ export default function SystemDetailPage() {
       controller.abort()
     }
   }, [fismaSystems, system, systemId, setFismaSystems])
+
+  const [opdivs, setOpdivs] = useState<OpDiv[]>([])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchOpDivs(true, controller.signal)
+      .then(setOpdivs)
+      .catch((error) => {
+        if (controller.signal.aborted || isAuthHandled(error)) return
+        notify('Failed to load OpDiv list.', 'error')
+      })
+    return () => {
+      controller.abort()
+    }
+  }, [])
 
   const [isEditing, setIsEditing] = useState(false)
   const [editedSystem, setEditedSystem] = useState<FismaSystemType | null>(null)
@@ -311,7 +332,6 @@ export default function SystemDetailPage() {
         datacallcontact: editedSystem.datacallcontact,
         issoemail: editedSystem.issoemail,
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
-        opdiv_id: editedSystem.opdiv_id,
       }
       // Extended metadata fields are editable across all OpDivs; send each,
       // using null to leave a value unchanged (the backend writes only
@@ -540,6 +560,9 @@ export default function SystemDetailPage() {
     )
   }
 
+  const opdivName =
+    opdivs.find((o) => o.opdiv_id === system.opdiv_id)?.name ?? null
+
   // Target maturity owns its own edit/save lifecycle (see TargetMaturityCard).
   // The card is slotted into the right column of whichever view renders
   // (between Data Lake Export and Organization). The card's Edit button is
@@ -602,12 +625,14 @@ export default function SystemDetailPage() {
             )
           }
           targetMaturitySlot={targetMaturityCard}
+          opdivName={opdivName}
         />
       ) : (
         <SystemDetailReadView
           system={system}
           decommissionedByName={decommissionedByName}
           targetMaturitySlot={targetMaturityCard}
+          opdivName={opdivName}
         />
       )}
 

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -1,0 +1,49 @@
+import { screen } from '@testing-library/react'
+import SystemDetailReadView from './SystemDetailReadView'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType } from '@/types'
+
+const BASE_SYSTEM = {
+  fismasystemid: 1,
+  fismaname: 'Test System',
+  fismaacronym: 'TS',
+  decommissioned: false,
+  sdl_sync_enabled: null,
+  groupacronym: 'CMS-CCS',
+  groupname: 'Center for Consumer Strategies',
+  divisionname: null,
+} as unknown as FismaSystemType
+
+function renderView(opdivName: string | null) {
+  return renderWithProviders(
+    <SystemDetailReadView
+      system={BASE_SYSTEM}
+      decommissionedByName=""
+      opdivName={opdivName}
+    />
+  )
+}
+
+test('renders the OpDiv name in the Organization section', () => {
+  renderView('CMS')
+  expect(screen.getByText('OpDiv')).toBeInTheDocument()
+  expect(screen.getByText('CMS')).toBeInTheDocument()
+})
+
+test('shows the em-dash fallback when opdivName is null', () => {
+  renderView(null)
+  // Label always present; value falls back to — via FieldDisplay
+  expect(screen.getByText('OpDiv')).toBeInTheDocument()
+  expect(screen.queryByText('CMS')).not.toBeInTheDocument()
+})
+
+test('OpDiv label appears before Group Acronym in the Organization card', () => {
+  renderView('CMS')
+  const opdivLabel = screen.getByText('OpDiv')
+  const groupLabel = screen.getByText('Group Acronym')
+  // DOCUMENT_POSITION_FOLLOWING (4): groupLabel comes after opdivLabel in the DOM
+  expect(
+    opdivLabel.compareDocumentPosition(groupLabel) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+  ).toBeTruthy()
+})

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -23,6 +23,7 @@ interface SystemDetailReadViewProps {
   // Rendered in the right column between Data Lake Export and Organization.
   // The page owns the card so its edit state is independent of this view.
   targetMaturitySlot?: ReactNode
+  opdivName: string | null
 }
 
 function FieldDisplay({
@@ -56,6 +57,7 @@ export default function SystemDetailReadView({
   system,
   decommissionedByName,
   targetMaturitySlot,
+  opdivName,
 }: SystemDetailReadViewProps) {
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
@@ -193,7 +195,10 @@ export default function SystemDetailReadView({
             titleTypographyProps={{ variant: 'h6' }}
             sx={{ pb: 0 }}
           />
-          <CardContent>{renderFields(orgFields, system)}</CardContent>
+          <CardContent>
+            <FieldDisplay label="OpDiv" value={opdivName} />
+            {renderFields(orgFields, system)}
+          </CardContent>
         </Card>
       </Grid>
 


### PR DESCRIPTION
> **Note:** In-repo copy of #556 by @costacalvin. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #556

---

## Summary

Closes #458.

Adds the OpDiv as the lead field in the Organization section of the system detail page, in both read and edit views. Previously the section only showed CMS-hierarchy fields (Group Acronym, Group Name, Division Name) with no indication of which OpDiv the system belonged to — making it impossible to tell at a glance whether you were looking at a CMS, HHS/OS, CDC, or other OpDiv system.

Estimated Time Taken: 1 hour

## Changes

- **Read view**: `FieldDisplay` showing the resolved OpDiv name above the existing Group/Division fields. Renders `—` when no OpDiv is set.
- **Edit view**: Disabled `TextField` showing the resolved OpDiv name — display-only, matching the `isso_name` treatment, because the backend makes `opdiv_id` immutable on `PUT /fismasystems/{id}` (assignment is managed separately).
- **OpDiv resolution**: `fetchOpDivs(true)` (includes inactive) so systems assigned to a since-deactivated OpDiv still display their name rather than showing blank.
- **PUT body cleanup**: Removed the pre-existing `opdiv_id` field from the system detail `PUT` payload — confirmed the backend's UPDATE path ignores it entirely (comment in `fismasystems.go`: *"Update path of Save() is already immutable on opdiv_id"*).
- **Type safety**: `opdivName` prop is `string | null` (required, not optional) in both `SystemDetailReadViewProps` and `SystemDetailEditViewProps`.

## Acceptance Criteria

- [x] The system detail Organization section shows the OpDiv name (from `opdiv_id`) as its top/lead item, in both read and edit views
- [x] Works for all OpDivs (not CMS-specific), resolved via the existing opdivs endpoint
- [x] Existing Group Acronym / Group Name / Division Name fields remain, below the OpDiv
- [x] Graceful when the sub-hierarchy fields are null (common for non-CMS systems)

## UI
OpDiv field added to Organization section of the system details page
<img width="1626" height="896" alt="image" src="https://github.com/user-attachments/assets/11e3ca2b-a64e-4dcb-81d4-19197ad590c2" />

Disabled field on Edit, matching ISSO Name field.
<img width="1619" height="956" alt="image" src="https://github.com/user-attachments/assets/512c6dbd-da29-41dc-bbe8-88d11be92bb7" />


## Possible Follow-up

1. **Hoist `opdivs` into the shared Outlet context** (same pattern as `datacenterEnvironments` in #459): `fetchOpDivs` is now independently called in four places — `FismaTable`, `EditSystemModal`, `UserTable`, and `SystemDetailPage` — with no shared cache. Each page mount fires a fresh `GET /opdivs`. The fix is to fetch once in `Title.tsx` and distribute via `useContextProp()`, eliminating the redundant calls.
