### PR TITLE
feat(questionnaire): promote ZTMF-insights justification field to main (impl parity)

### DIFF
--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -1,0 +1,527 @@
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { InsightPayload } from '@/types'
+import JustificationField, { PriorReviewState } from './JustificationField'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './justificationContext'
+
+const insight: InsightPayload = {
+  suggested_score: 1,
+  suggested_label: 'Traditional',
+  cfacts_suggested_score: 2,
+  cfacts_auth_methods: 'IDM-Okta',
+  kion_suggested_score: 1,
+  sechub_suggested_score: 1,
+  ars_control_score: 2,
+  ars_controls_satisfied: 4,
+  ars_controls_total: 4,
+  last_score_notes: 'MFA is enforced through Okta policies.',
+  last_datacall: 'FY2025 Q1',
+  findings: {
+    kion: [{ id: 'one' }, { id: 'two' }],
+    sechub: [{ id: 'one' }],
+  },
+}
+
+function Harness({
+  contextId = 'system-1003:question-1',
+}: {
+  contextId?: string
+}) {
+  const initial = insight.last_score_notes ?? ''
+  const [value, setValue] = React.useState(initial)
+  const [review, setReview] = React.useState<PriorReviewState>('pending')
+  return (
+    <JustificationField
+      contextId={contextId}
+      label="Explain the available authentication options"
+      value={value}
+      onChange={setValue}
+      insight={insight}
+      viewedDatacall="FY2025 Q2"
+      priorReviewState={review}
+      onPriorReview={setReview}
+      maxLength={2000}
+    />
+  )
+}
+
+describe('justification context helpers', () => {
+  it('builds a concise source-attributed Insights suggestion', () => {
+    expect(buildInsightJustification(insight)).toBe(
+      'CFACTS (2): IDM-Okta. Kion (1): 2 failing checks. SecurityHub (1): 1 failing control. ARS (2): 4/4 controls satisfied.'
+    )
+  })
+
+  it('prefers a pipeline-authored suggested justification', () => {
+    expect(
+      buildInsightJustification({
+        ...insight,
+        suggested_justification: 'Use the approved MFA language.',
+      })
+    ).toBe('Use the approved MFA language.')
+  })
+
+  it('does not label the viewed data call as a previous response', () => {
+    expect(priorResponseFor(insight, 'FY2025_Q1')).toBeUndefined()
+  })
+
+  it("labels prior content as last year's response", () => {
+    expect(priorResponseFor(insight, 'FY2025 Q2')).toEqual({
+      label: "Last year's response — FY2025 Q1",
+      text: insight.last_score_notes,
+    })
+    expect(
+      priorResponseFor({ last_score_notes: insight.last_score_notes })
+    ).toEqual({
+      label: "Last year's ISSO response",
+      text: insight.last_score_notes,
+    })
+  })
+})
+
+describe('JustificationField', () => {
+  it('keeps carried-forward text out of the current response until accepted', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    expect(textbox).toHaveValue('')
+    expect(textbox).not.toHaveAttribute('readonly')
+    expect(textbox.closest('.MuiTextField-root')).toHaveStyle({
+      flex: '0 0 160px',
+      height: '160px',
+    })
+    expect(screen.getByText('Review required')).toBeInTheDocument()
+    expect(
+      screen.getByText('Only the text in this field will be submitted.')
+    ).toBeInTheDocument()
+  })
+
+  it('copies the previous response into the submitted field after acceptance', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toHaveValue(insight.last_score_notes)
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Review the previous response before continuing.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('preserves a typed response when the ISSO declines the previous response', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.change(textbox, {
+      target: { value: 'The current call uses phishing-resistant MFA.' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+    expect(textbox).toHaveValue('The current call uses phishing-resistant MFA.')
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+  })
+
+  it('appends the previous response without overwriting current input', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.change(textbox, {
+      target: { value: 'Current-call update.' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(textbox).toHaveValue(
+      `Current-call update.\n\n${insight.last_score_notes}`
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+  })
+
+  it('adds the Insights suggestion without silently submitting it', () => {
+    const { unmount } = render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    expect(textbox).toHaveValue('')
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    expect((textbox as HTMLTextAreaElement).value).toContain(
+      'CFACTS (2): IDM-Okta.'
+    )
+    unmount()
+  })
+
+  it('lets the ISSO reopen a dismissed Insights suggestion', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+    expect(screen.getByText(/CFACTS \(2\): IDM-Okta\./)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('lets the ISSO reopen and re-add an accepted Insights suggestion', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.change(textbox, { target: { value: '' } })
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+
+    expect((textbox as HTMLTextAreaElement).value).toContain(
+      'CFACTS (2): IDM-Okta.'
+    )
+  })
+
+  it('disables reinserting an Insights suggestion that is still present', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Already included in the current response.')
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Close suggested justification review',
+      })
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      (
+        screen.getByRole('textbox', {
+          name: 'Current response',
+        }) as HTMLTextAreaElement
+      ).value
+    ).toContain('CFACTS (2): IDM-Okta.')
+  })
+
+  it('keeps an edited Insights suggestion marked as added', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+    fireEvent.change(textbox, {
+      target: {
+        value: (textbox as HTMLTextAreaElement).value.replace(
+          'IDM-Okta.',
+          'IDM-Okta with phishing-resistant MFA.'
+        ),
+      },
+    })
+
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'Close suggested justification review',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('lets the ISSO reopen an accepted previous response', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.change(textbox, { target: { value: '' } })
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
+
+    expect(screen.getByText(insight.last_score_notes ?? '')).toBeInTheDocument()
+  })
+
+  it('disables reinserting a reviewed previous response that is still present', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Already included in the current response.')
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Close previous ISSO response review',
+      })
+    )
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toHaveValue(insight.last_score_notes)
+  })
+
+  it('keeps an edited previous response marked as added', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.change(textbox, {
+      target: {
+        value: (insight.last_score_notes ?? '').replace(
+          'Okta policies.',
+          'phishing-resistant Okta policies.'
+        ),
+      },
+    })
+
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    )
+    expect(
+      screen.getByRole('button', {
+        name: 'Close previous ISSO response review',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('marks only the removed source as not used when other text remains', () => {
+    render(<Harness />)
+    const textbox = screen.getByRole('textbox', { name: 'Current response' })
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    )
+
+    fireEvent.change(textbox, { target: { value: insight.last_score_notes } })
+
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+    expect(screen.getByText('Added to response')).toBeInTheDocument()
+  })
+
+  it('resets card state when the question context changes', () => {
+    const { rerender } = render(<Harness contextId="question-1" />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    expect(screen.getByText('Not used')).toBeInTheDocument()
+
+    rerender(<Harness contextId="question-2" />)
+
+    expect(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/CFACTS \(2\): IDM-Okta\./)).toBeInTheDocument()
+  })
+
+  it('blocks editing while previous-response review is initializing', () => {
+    render(
+      <JustificationField
+        contextId="question-1"
+        label="Justification"
+        value={insight.last_score_notes ?? ''}
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="initializing"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+      />
+    )
+
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Checking the previous response…')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('only shows the expansion control when context text is clipped', () => {
+    render(<Harness />)
+    expect(
+      screen.queryByRole('button', {
+        name: 'Show all: Suggested justification',
+      })
+    ).not.toBeInTheDocument()
+
+    const suggestion = screen.getByText(/CFACTS \(2\): IDM-Okta\./)
+    Object.defineProperty(suggestion, 'clientHeight', {
+      configurable: true,
+      value: 32,
+    })
+    Object.defineProperty(suggestion, 'scrollHeight', {
+      configurable: true,
+      value: 64,
+    })
+    fireEvent(window, new Event('resize'))
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Show all: Suggested justification',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('keeps repeated compact actions source-specific for assistive technology', () => {
+    render(<Harness />)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss suggested justification' })
+    )
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss previous ISSO response',
+      })
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Review again: Suggested justification',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: "Review again: Last year's response — FY2025 Q1",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('explains when contextual text cannot fit in the current response', () => {
+    render(
+      <JustificationField
+        label="Justification"
+        value={'x'.repeat(1990)}
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="not-required"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('Not enough space remaining to insert this suggestion.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Not enough space remaining to insert the previous response.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('shows context without action buttons in read-only mode', () => {
+    render(
+      <JustificationField
+        label="Justification"
+        value="Saved response"
+        onChange={jest.fn()}
+        insight={insight}
+        viewedDatacall="FY2025 Q2"
+        priorReviewState="not-required"
+        onPriorReview={jest.fn()}
+        maxLength={2000}
+        disabled
+      />
+    )
+    expect(
+      screen.queryByRole('button', {
+        name: 'Insert suggested justification into current response',
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'Current response' })
+    ).toBeDisabled()
+  })
+})

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -1,0 +1,614 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { styled } from '@mui/material/styles'
+import type { InsightPayload } from '@/types'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './justificationContext'
+
+export type PriorReviewState =
+  | 'not-required'
+  | 'initializing'
+  | 'pending'
+  | 'accepted'
+  | 'dismissed'
+
+type Props = {
+  contextId?: string
+  label: string
+  value: string
+  onChange: (value: string) => void
+  insight?: InsightPayload
+  priorResponse?: { label: string; text: string }
+  showInsightSuggestion?: boolean
+  viewedDatacall?: string
+  priorReviewState: PriorReviewState
+  onPriorReview: (state: PriorReviewState) => void
+  disabled?: boolean
+  error?: boolean
+  helperText?: string
+  maxLength: number
+}
+
+const ResponseTextField = styled(TextField)({
+  flex: 1,
+  minHeight: 0,
+  '& .MuiOutlinedInput-root': {
+    height: '100%',
+    alignItems: 'flex-start',
+    borderRadius: 0,
+    '& fieldset': {
+      border: 0,
+      borderTop: '1px solid #d6d7d9',
+    },
+    '&.Mui-focused fieldset': {
+      border: 0,
+      borderTop: '1px solid #d6d7d9',
+      boxShadow: 'inset 0 0 0 3px #ffffff, inset 0 0 0 6px #bd13b8',
+    },
+  },
+  '& .MuiInputBase-inputMultiline': {
+    height: '100% !important',
+    overflow: 'auto !important',
+  },
+})
+
+function appendText(current: string, addition: string): string {
+  if (!current.trim()) return addition
+  if (current.includes(addition)) return current
+  return `${current.trimEnd()}\n\n${addition}`
+}
+
+type TextRange = { start: number; end: number }
+
+function exactTextRange(value: string, text?: string): TextRange | null {
+  if (!text) return null
+  const start = value.lastIndexOf(text)
+  return start < 0 ? null : { start, end: start + text.length }
+}
+
+/** Keep an inserted source's range aligned with one textarea replacement. */
+function remapTextRange(
+  before: string,
+  after: string,
+  range: TextRange | null
+): TextRange | null {
+  if (!range || before === after) return range
+
+  let changeStart = 0
+  while (
+    changeStart < before.length &&
+    changeStart < after.length &&
+    before[changeStart] === after[changeStart]
+  ) {
+    changeStart++
+  }
+
+  let oldEnd = before.length
+  let newEnd = after.length
+  while (
+    oldEnd > changeStart &&
+    newEnd > changeStart &&
+    before[oldEnd - 1] === after[newEnd - 1]
+  ) {
+    oldEnd--
+    newEnd--
+  }
+
+  const delta = newEnd - oldEnd
+  if (oldEnd <= range.start) {
+    return { start: range.start + delta, end: range.end + delta }
+  }
+  if (changeStart >= range.end) return range
+
+  const start = changeStart <= range.start ? changeStart : range.start
+  const end = oldEnd >= range.end ? newEnd : range.end + delta
+  if (end <= start || !after.slice(start, end).trim()) return null
+  return { start, end }
+}
+
+function hasTrackedText(value: string, range: TextRange | null): boolean {
+  return Boolean(range && value.slice(range.start, range.end).trim())
+}
+
+type ContextCardProps = {
+  title: string
+  author: string
+  text: string
+  required?: boolean
+  state: 'available' | 'accepted' | 'dismissed'
+  primaryLabel: string
+  primaryAriaLabel: string
+  secondaryLabel: string
+  secondaryAriaLabel: string
+  onPrimary: () => void
+  onSecondary: () => void
+  onRestore?: () => void
+  primaryDisabled?: boolean
+  primaryDisabledReason?: string
+  primaryDisabledReasonSeverity?: 'error' | 'info'
+  disabled?: boolean
+}
+
+function ContextCard({
+  title,
+  author,
+  text,
+  required,
+  state,
+  primaryLabel,
+  primaryAriaLabel,
+  secondaryLabel,
+  secondaryAriaLabel,
+  onPrimary,
+  onSecondary,
+  onRestore,
+  primaryDisabled,
+  primaryDisabledReason,
+  primaryDisabledReasonSeverity = 'error',
+  disabled,
+}: ContextCardProps) {
+  const [expanded, setExpanded] = React.useState(false)
+  const [canExpand, setCanExpand] = React.useState(false)
+  const textRef = React.useRef<HTMLParagraphElement>(null)
+  const primaryDisabledReasonId = React.useId()
+  const restoreLabel = `Review again: ${title}`
+  const expandLabel = `${expanded ? 'Show less' : 'Show all'}: ${title}`
+  const statusLabel = state === 'accepted' ? 'Added to response' : 'Not used'
+
+  const measureOverflow = React.useCallback(() => {
+    if (state !== 'available' || expanded || !text) return
+    const element = textRef.current
+    if (!element) return
+    setCanExpand(element.scrollHeight > element.clientHeight + 1)
+  }, [expanded, state, text])
+
+  React.useLayoutEffect(() => {
+    measureOverflow()
+    window.addEventListener('resize', measureOverflow)
+    const element = textRef.current
+    const observer =
+      element && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(measureOverflow)
+        : undefined
+    if (element) observer?.observe(element)
+    return () => {
+      window.removeEventListener('resize', measureOverflow)
+      observer?.disconnect()
+    }
+  }, [measureOverflow])
+
+  if (state !== 'available') {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          py: 0.75,
+          borderBottom: '1px solid #d6d7d9',
+          bgcolor: '#f5f5f5',
+        }}
+      >
+        <Typography sx={{ fontSize: 12, fontWeight: 700 }}>{title}</Typography>
+        <Chip
+          size="small"
+          label={statusLabel}
+          color={state === 'accepted' ? 'success' : 'default'}
+          sx={{ height: 22, fontSize: 11 }}
+        />
+        {onRestore && !disabled && (
+          <Tooltip title={restoreLabel}>
+            <Button
+              size="small"
+              variant="text"
+              aria-label={restoreLabel}
+              onClick={onRestore}
+              sx={{ ml: 'auto', fontSize: 11 }}
+            >
+              Review again
+            </Button>
+          </Tooltip>
+        )}
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 1,
+        borderBottom: '1px solid #d6d7d9',
+        bgcolor: '#f5f5f5',
+        color: '#454545',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: '1 1 260px',
+            minWidth: 0,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: 11, color: '#666' }}>
+            by {author}
+          </Typography>
+          {required && (
+            <Chip
+              size="small"
+              label="Review required"
+              color="warning"
+              sx={{ height: 22, fontSize: 11 }}
+            />
+          )}
+        </Box>
+        {!disabled && (
+          <Box sx={{ ml: 'auto', display: 'flex', gap: 0.5, flexShrink: 0 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              aria-label={secondaryAriaLabel}
+              onClick={onSecondary}
+              sx={{
+                minHeight: 26,
+                px: 1,
+                py: 0.25,
+                fontSize: 10.5,
+                borderRadius: '6px',
+              }}
+            >
+              {secondaryLabel}
+            </Button>
+            <Button
+              size="small"
+              variant="contained"
+              aria-label={primaryAriaLabel}
+              aria-describedby={
+                primaryDisabled && primaryDisabledReason
+                  ? primaryDisabledReasonId
+                  : undefined
+              }
+              onClick={onPrimary}
+              disabled={primaryDisabled}
+              sx={{
+                minHeight: 26,
+                px: 1,
+                py: 0.25,
+                fontSize: 10.5,
+                borderRadius: '6px',
+              }}
+            >
+              {primaryLabel}
+            </Button>
+          </Box>
+        )}
+      </Box>
+      <Typography
+        ref={textRef}
+        sx={
+          expanded
+            ? { mt: 0.5, fontSize: 13, whiteSpace: 'pre-wrap' }
+            : {
+                mt: 0.5,
+                fontSize: 13,
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+              }
+        }
+      >
+        {text}
+      </Typography>
+      {canExpand && (
+        <Tooltip title={expandLabel}>
+          <Button
+            size="small"
+            variant="text"
+            aria-label={expandLabel}
+            onClick={() => setExpanded((value) => !value)}
+            sx={{ mt: 0.5, minWidth: 0, px: 0.5, fontSize: 11 }}
+          >
+            {expanded ? 'Show less' : 'Show all'}
+          </Button>
+        </Tooltip>
+      )}
+      {primaryDisabled && primaryDisabledReason && (
+        <Typography
+          id={primaryDisabledReasonId}
+          role={primaryDisabledReasonSeverity === 'error' ? 'alert' : 'status'}
+          sx={{
+            mt: 0.5,
+            fontSize: 11,
+            color:
+              primaryDisabledReasonSeverity === 'error'
+                ? 'error.main'
+                : 'text.secondary',
+          }}
+        >
+          {primaryDisabledReason}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default function JustificationField({
+  contextId,
+  label,
+  value,
+  onChange,
+  insight,
+  priorResponse,
+  showInsightSuggestion = true,
+  viewedDatacall,
+  priorReviewState,
+  onPriorReview,
+  disabled = false,
+  error = false,
+  helperText,
+  maxLength,
+}: Props) {
+  const prior = priorResponse ?? priorResponseFor(insight, viewedDatacall)
+  const suggestion = showInsightSuggestion
+    ? buildInsightJustification(insight)
+    : undefined
+  const contextKey = JSON.stringify([
+    contextId ?? null,
+    viewedDatacall ?? null,
+    prior?.text ?? null,
+    suggestion ?? null,
+  ])
+  const [suggestionOpen, setSuggestionOpen] = React.useState(true)
+  const [priorOpen, setPriorOpen] = React.useState(true)
+  const [suggestionRange, setSuggestionRange] =
+    React.useState<TextRange | null>(null)
+  const [priorRange, setPriorRange] = React.useState<TextRange | null>(null)
+
+  React.useEffect(() => {
+    setSuggestionOpen(true)
+    setPriorOpen(true)
+    setSuggestionRange(null)
+    setPriorRange(null)
+  }, [contextKey])
+
+  const priorInitializing = priorReviewState === 'initializing'
+  const priorPending =
+    priorReviewState === 'pending' || priorReviewState === 'initializing'
+  const interactionDisabled = disabled || priorInitializing
+  const displayedValue =
+    priorPending && prior && value.trim() === prior.text.trim() ? '' : value
+  const suggestionResult = suggestion
+    ? appendText(displayedValue, suggestion)
+    : displayedValue
+  const suggestionExactRange = exactTextRange(displayedValue, suggestion)
+  const effectiveSuggestionRange = suggestionExactRange ?? suggestionRange
+  const suggestionAlreadyIncluded = Boolean(suggestionExactRange)
+  const suggestionFits = suggestionResult.length <= maxLength
+  const priorExactRange = exactTextRange(displayedValue, prior?.text)
+  const effectivePriorRange = priorExactRange ?? priorRange
+  const priorTextIncluded = Boolean(priorExactRange)
+  const priorAlreadyIncluded = priorTextIncluded && !priorPending
+  const priorResult = prior
+    ? appendText(displayedValue, prior.text)
+    : displayedValue
+  const hasContext = Boolean(suggestion || prior)
+  const suggestionState =
+    suggestionAlreadyIncluded ||
+    hasTrackedText(displayedValue, effectiveSuggestionRange)
+      ? 'accepted'
+      : 'dismissed'
+  const priorState =
+    priorTextIncluded || hasTrackedText(displayedValue, effectivePriorRange)
+      ? 'accepted'
+      : 'dismissed'
+
+  const changeResponse = (nextValue: string) => {
+    setSuggestionRange(
+      remapTextRange(displayedValue, nextValue, effectiveSuggestionRange)
+    )
+    setPriorRange(
+      remapTextRange(displayedValue, nextValue, effectivePriorRange)
+    )
+    onChange(nextValue)
+  }
+
+  return (
+    <Box>
+      <Typography component="h3" variant="h6" sx={{ mb: 1 }}>
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          height: hasContext ? 'auto' : 400,
+          maxHeight: 400,
+          display: 'flex',
+          flexDirection: 'column',
+          border: `2px solid ${error ? '#b50909' : '#323232'}`,
+          borderRadius: '6px',
+          overflow: 'hidden',
+          bgcolor: '#fff',
+        }}
+      >
+        {hasContext && (
+          <Box sx={{ maxHeight: 190, overflowY: 'auto', flexShrink: 0 }}>
+            {suggestion && (
+              <ContextCard
+                title="Suggested justification"
+                author="ZTMF Insights"
+                text={suggestion}
+                state={suggestionOpen ? 'available' : suggestionState}
+                primaryLabel="Insert into response"
+                primaryAriaLabel="Insert suggested justification into current response"
+                secondaryLabel={
+                  suggestionState === 'dismissed' ? 'Dismiss' : 'Close'
+                }
+                secondaryAriaLabel={
+                  suggestionState === 'dismissed'
+                    ? 'Dismiss suggested justification'
+                    : 'Close suggested justification review'
+                }
+                primaryDisabled={suggestionAlreadyIncluded || !suggestionFits}
+                primaryDisabledReason={
+                  suggestionAlreadyIncluded
+                    ? 'Already included in the current response.'
+                    : 'Not enough space remaining to insert this suggestion.'
+                }
+                primaryDisabledReasonSeverity={
+                  suggestionAlreadyIncluded ? 'info' : 'error'
+                }
+                disabled={interactionDisabled}
+                onPrimary={() => {
+                  setSuggestionRange(
+                    exactTextRange(suggestionResult, suggestion)
+                  )
+                  onChange(suggestionResult)
+                  setSuggestionOpen(false)
+                }}
+                onSecondary={() => setSuggestionOpen(false)}
+                onRestore={() => setSuggestionOpen(true)}
+              />
+            )}
+            {prior && (
+              <ContextCard
+                title={prior.label}
+                author="ISSO"
+                text={prior.text}
+                required={priorPending}
+                state={priorOpen ? 'available' : priorState}
+                primaryLabel="Insert into response"
+                primaryAriaLabel="Insert previous ISSO response into current response"
+                secondaryLabel={
+                  priorState === 'dismissed' ? 'Dismiss' : 'Close'
+                }
+                secondaryAriaLabel={
+                  priorState === 'dismissed'
+                    ? 'Dismiss previous ISSO response'
+                    : 'Close previous ISSO response review'
+                }
+                primaryDisabled={
+                  priorAlreadyIncluded || priorResult.length > maxLength
+                }
+                primaryDisabledReason={
+                  priorAlreadyIncluded
+                    ? 'Already included in the current response.'
+                    : 'Not enough space remaining to insert the previous response.'
+                }
+                primaryDisabledReasonSeverity={
+                  priorAlreadyIncluded ? 'info' : 'error'
+                }
+                disabled={interactionDisabled}
+                onPrimary={() => {
+                  const nextValue =
+                    priorPending && !displayedValue.trim()
+                      ? prior.text
+                      : appendText(displayedValue, prior.text)
+                  setPriorRange(exactTextRange(nextValue, prior.text))
+                  onChange(nextValue)
+                  onPriorReview('accepted')
+                  setPriorOpen(false)
+                }}
+                onSecondary={() => {
+                  if (priorState !== 'dismissed') {
+                    setPriorOpen(false)
+                    return
+                  }
+                  if (priorPending && value.trim() === prior.text.trim()) {
+                    onChange('')
+                  }
+                  onPriorReview('dismissed')
+                  setPriorOpen(false)
+                }}
+                onRestore={() => setPriorOpen(true)}
+              />
+            )}
+          </Box>
+        )}
+        <Box
+          sx={{
+            px: 1.5,
+            pt: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Box>
+            <Typography sx={{ fontSize: 12, fontWeight: 700 }}>
+              Current response
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: '#666' }}>
+              Only the text in this field will be submitted.
+            </Typography>
+          </Box>
+          {!disabled && (
+            <Typography
+              variant="caption"
+              sx={{
+                color:
+                  displayedValue.length >= maxLength
+                    ? 'error.main'
+                    : displayedValue.length >= maxLength * 0.9
+                      ? 'warning.main'
+                      : 'text.secondary',
+              }}
+            >
+              {displayedValue.length}/{maxLength}
+            </Typography>
+          )}
+        </Box>
+        <ResponseTextField
+          multiline
+          fullWidth
+          value={displayedValue}
+          disabled={interactionDisabled}
+          error={error}
+          helperText={helperText}
+          placeholder="Add your current justification here…"
+          inputProps={{
+            maxLength,
+            'aria-label': 'Current response',
+            'aria-describedby': priorPending
+              ? 'previous-response-review-message'
+              : undefined,
+          }}
+          onChange={(event) => changeResponse(event.target.value)}
+          sx={hasContext ? { flex: '0 0 160px', height: 160 } : undefined}
+        />
+      </Box>
+      {priorPending && (
+        <Typography
+          id="previous-response-review-message"
+          role="status"
+          sx={{ mt: 0.5, fontSize: 12, color: '#8a4b00' }}
+        >
+          {priorInitializing
+            ? 'Checking the previous response…'
+            : 'Review the previous response before continuing.'}
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/src/views/QuestionnairePage/JustificationField/justificationContext.ts
+++ b/src/views/QuestionnairePage/JustificationField/justificationContext.ts
@@ -1,0 +1,115 @@
+import type { InsightFinding, InsightPayload } from '@/types'
+
+const cleanText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined
+  const text = value.trim()
+  return text.length ? text : undefined
+}
+
+const sentence = (value: string): string =>
+  /[.!?]$/.test(value) ? value : `${value}.`
+
+const findingCount = (value: unknown): number =>
+  Array.isArray(value)
+    ? value.filter(
+        (finding): finding is InsightFinding =>
+          !!finding && typeof finding === 'object'
+      ).length
+    : 0
+
+const withScore = (label: string, score: unknown): string =>
+  typeof score === 'number' ? `${label} (${score})` : label
+
+/** Build the short, editable justification offered by ZTMF Insights. */
+export function buildInsightJustification(
+  payload?: InsightPayload
+): string | undefined {
+  if (!payload) return undefined
+
+  for (const key of [
+    'suggested_justification',
+    'justification_summary',
+    'insights_summary',
+  ]) {
+    const authored = cleanText(payload[key])
+    if (authored) return authored
+  }
+
+  const parts: string[] = []
+  const cfacts =
+    cleanText(payload.cfacts_auth_methods) ??
+    cleanText(payload.cfacts_reasoning)
+  if (cfacts) {
+    parts.push(
+      sentence(
+        `${withScore('CFACTS', payload.cfacts_suggested_score)}: ${cfacts}`
+      )
+    )
+  }
+
+  const kionCount = findingCount(payload.findings?.kion)
+  if (kionCount > 0) {
+    parts.push(
+      `${withScore('Kion', payload.kion_suggested_score)}: ${kionCount} failing ${kionCount === 1 ? 'check' : 'checks'}.`
+    )
+  }
+  const securityHubCount = findingCount(payload.findings?.sechub)
+  if (securityHubCount > 0) {
+    parts.push(
+      `${withScore('SecurityHub', payload.sechub_suggested_score)}: ${securityHubCount} failing ${securityHubCount === 1 ? 'control' : 'controls'}.`
+    )
+  }
+  const hardenizeCount = findingCount(payload.findings?.hardenize)
+  if (hardenizeCount > 0) {
+    parts.push(
+      `${withScore('Hardenize', payload.hardenize_suggested_score)}: ${hardenizeCount} ${hardenizeCount === 1 ? 'finding' : 'findings'}.`
+    )
+  }
+  if (typeof payload.ars_controls_total === 'number') {
+    const satisfied =
+      typeof payload.ars_controls_satisfied === 'number'
+        ? payload.ars_controls_satisfied
+        : 0
+    parts.push(
+      `${withScore('ARS', payload.ars_control_score)}: ${satisfied}/${payload.ars_controls_total} controls satisfied.`
+    )
+  }
+  if (parts.length) return parts.join(' ')
+
+  const suggested = cleanText(payload.suggested_label)
+  const sources = cleanText(payload.evidence_sources)
+  if (!suggested) return undefined
+  return `ZTMF Insights suggests ${suggested}${
+    typeof payload.suggested_score === 'number'
+      ? ` (${payload.suggested_score})`
+      : ''
+  }${sources ? ` based on ${sources}` : ''}.`
+}
+
+const normalizeDatacall = (value?: string | null): string =>
+  (value ?? '')
+    .replace(/[_\s]+/g, ' ')
+    .trim()
+    .toLowerCase()
+
+export function priorResponseFor(
+  payload?: InsightPayload,
+  viewedDatacall?: string
+): { label: string; text: string } | undefined {
+  const text = cleanText(payload?.last_score_notes)
+  if (!text) return undefined
+  const lastDatacall = cleanText(payload?.last_datacall)
+  if (
+    lastDatacall &&
+    viewedDatacall &&
+    normalizeDatacall(lastDatacall) === normalizeDatacall(viewedDatacall)
+  ) {
+    return undefined
+  }
+  return {
+    label: lastDatacall
+      ? `Last year's response — ${lastDatacall.replaceAll('_', ' ')}`
+      : "Last year's ISSO response",
+    text,
+  }
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
@@ -53,6 +53,23 @@ jest.mock('@/utils/notify', () => {
   return {
     ...actual,
     notify: (...args: unknown[]) => notifyMock(...args),
+  }
+})
+
+// Stub the insights panel and option badges with recognizable text so the
+// justification-integration tests can assert their presence/absence without
+// depending on the real panel's internals. OptionInsightBadges renders nothing
+// when no insight is passed, matching the real component — so the existing
+// effect-path tests (which run with insights disabled) are unaffected.
+jest.mock('./InsightsPanel/InsightsPanel', () => {
+  const react = require('react')
+  return {
+    __esModule: true,
+    default: () => react.createElement('div', null, 'ZTMF Insights panel'),
+    OptionInsightBadges: ({ insight }: { insight?: unknown }) =>
+      insight
+        ? react.createElement('span', null, 'ZTMF Insights option badge')
+        : null,
   }
 })
 
@@ -662,4 +679,222 @@ test('the questionId effect reads live scores via ref and seeds the answer at mo
   // No POST fired - the saved answer was seeded from GET, not written
   // back as a fresh score.
   expect(axios.post).not.toHaveBeenCalled()
+})
+
+// ---------------------------------------------------------------------------
+// 4. ZTMF Insights justification-field wiring (#527/#529).
+//    - HHS data calls render the review-aware JustificationField but hide the
+//      CMS-internal insights layer (panel, option badges, suggestion).
+//    - CMS data calls render both the JustificationField and the insights layer.
+//    - A carried-forward prior response blocks submission until reviewed, and
+//      the initial insights lookup blocks submission until it settles.
+//    - A question with no justification context keeps the plain notes field.
+// ---------------------------------------------------------------------------
+
+const PRIOR_RESPONSE = 'MFA is enforced through Okta policies.'
+
+const JUSTIFICATION_QUESTION = {
+  questionid: 900,
+  question: 'How does the system authenticate users?',
+  notesprompt: 'Explain the authentication mechanisms.',
+  pillar: { pillar: 'Identity' },
+  function: {
+    functionid: 7006,
+    function: 'Imperial Identity Verification',
+    description: 'Authenticate users.',
+    datacenterenvironment: 'Imperial-Fleet',
+  },
+}
+
+const JUSTIFICATION_OPTIONS = [
+  { functionoptionid: 100, description: 'Baseline', score: 1 },
+  { functionoptionid: 101, description: 'Advanced', score: 2 },
+]
+
+// Carried forward from the prior data call: no edit event for the current call
+// (last_edited_at null) and its notes match the insight's last_score_notes, so
+// it is treated as context requiring an explicit review, not a submitted answer.
+const CARRY_FORWARD_SCORE = {
+  scoreid: 5001,
+  fismasystemid: 1002,
+  notes: PRIOR_RESPONSE,
+  functionoptionid: 100,
+  datacallid: 5,
+  last_edited_at: null,
+  last_edited_by: null,
+}
+
+const INSIGHT_ROW = {
+  fismasystemid: 1002,
+  questionid: 900,
+  synced_at: '2026-07-14T00:00:00Z',
+  payload: {
+    suggested_score: 1,
+    suggested_label: 'Baseline',
+    cfacts_auth_methods: 'IDM-Okta',
+    last_score: 1,
+    last_score_notes: PRIOR_RESPONSE,
+    // A prior cycle, distinct from the FY2026 Q1 / FY25 ZTM calls under test, so
+    // the carried-forward response is offered as last year's context.
+    last_datacall: 'FY2025 Q1',
+  },
+}
+
+const HHS_ZTM = {
+  datacallid: 6,
+  datacall: 'FY25 ZTM',
+  datecreated: '',
+  deadline: '2099-12-31T23:59:59Z',
+}
+
+const HHS_DEEP_LINK =
+  '/questionnaire/ssd-ex/FY25_ZTM/identity/imperial-identity-verification'
+
+describe('QuestionnairePage justification integration', () => {
+  type InsightsResponse = { data: { data: unknown[] } }
+
+  function installMocks({
+    insightRows = [INSIGHT_ROW] as unknown[],
+    insightsResponse,
+  }: {
+    insightRows?: unknown[]
+    insightsResponse?: Promise<InsightsResponse>
+  } = {}) {
+    axios.get.mockImplementation((url: string) => {
+      if (url === 'insights') {
+        return (
+          insightsResponse ?? Promise.resolve({ data: { data: insightRows } })
+        )
+      }
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: [JUSTIFICATION_QUESTION] } })
+      if (url.startsWith('scores'))
+        return Promise.resolve({ data: { data: [CARRY_FORWARD_SCORE] } })
+      if (url.includes('/options'))
+        return Promise.resolve({ data: { data: JUSTIFICATION_OPTIONS } })
+      return Promise.resolve({ data: { data: [] } })
+    })
+    axios.post.mockResolvedValue({ data: {} })
+    axios.put.mockResolvedValue({ data: {} })
+  }
+
+  it('renders the justification field but hides the insights layer for an HHS data call, and persists an accepted prior response', async () => {
+    installMocks()
+    setMockCtx(
+      makeCtx({
+        latestDataCallId: 6,
+        latestDatacall: 'FY25 ZTM',
+        selectedDatacall: HHS_ZTM,
+        datacalls: [HHS_ZTM],
+      })
+    )
+
+    renderAt(HHS_DEEP_LINK)
+
+    // The JustificationField appears (there is a prior response to review)...
+    const response = await screen.findByRole('textbox', {
+      name: 'Current response',
+    })
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    // ...but the pending review empties the on-screen value and blocks submit.
+    expect(response).toHaveValue('')
+
+    // The CMS-internal insights layer is suppressed for HHS calls.
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('ZTMF Insights option badge')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Suggested justification')
+    ).not.toBeInTheDocument()
+
+    const complete = screen.getByRole('button', { name: 'Complete' })
+    expect(complete).toBeDisabled()
+
+    // Accepting the required review is a current-call action, so the answer
+    // persists even though the text equals the seeded prior response.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+    expect(response).toHaveValue(PRIOR_RESPONSE)
+    expect(complete).toBeEnabled()
+
+    fireEvent.click(complete)
+
+    await waitFor(() =>
+      expect(axios.put).toHaveBeenCalledWith('scores/5001', {
+        fismasystemid: 1002,
+        notes: PRIOR_RESPONSE,
+        functionoptionid: 100,
+        datacallid: 6,
+        notes_is_ai_summary: false,
+      })
+    )
+  })
+
+  it('shows the insights panel, option badges, and suggestion for a CMS data call', async () => {
+    installMocks()
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
+    expect(
+      (await screen.findAllByText('ZTMF Insights option badge')).length
+    ).toBeGreaterThan(0)
+    expect(
+      await screen.findByText('Suggested justification')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText("Last year's response — FY2025 Q1")
+    ).toBeInTheDocument()
+  })
+
+  it('blocks submission until the initial insights lookup settles', async () => {
+    let resolveInsights: ((value: InsightsResponse) => void) | null = null
+    const insightsResponse = new Promise<InsightsResponse>((resolve) => {
+      resolveInsights = resolve
+    })
+    installMocks({ insightsResponse })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    expect(
+      await screen.findByText('Checking for prior responses…')
+    ).toBeInTheDocument()
+    expect(complete).toBeDisabled()
+
+    await act(async () => {
+      resolveInsights?.({ data: { data: [INSIGHT_ROW] } })
+    })
+
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Checking for prior responses…')
+    ).not.toBeInTheDocument()
+    // Still blocked: the carried-forward response now requires review.
+    expect(complete).toBeDisabled()
+  })
+
+  it('keeps the plain four-row notes field when the question has no justification context', async () => {
+    installMocks({ insightRows: [] })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText('Explain the authentication mechanisms.')
+    ).toBeInTheDocument()
+    const response = screen.getByRole('textbox', {
+      name: 'Justification notes',
+    })
+    expect(response).toHaveAttribute('rows', '4')
+    expect(
+      screen.queryByRole('textbox', { name: 'Current response' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -36,6 +36,7 @@ import {
   NOTES_UPDATE_REQUIRED_MSG,
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
+import { parseDatacallName } from '@/utils/datacallGrouping'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
@@ -49,6 +50,13 @@ import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel from './InsightsPanel/InsightsPanel'
 import QuestionRadioGroup from './QuestionRadioGroup'
+import JustificationField, {
+  type PriorReviewState,
+} from './JustificationField/JustificationField'
+import {
+  buildInsightJustification,
+  priorResponseFor,
+} from './JustificationField/justificationContext'
 import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
@@ -137,10 +145,23 @@ export default function QuestionnarePage() {
   const [insightsByQuestion, setInsightsByQuestion] = React.useState<
     Map<number, InsightPayload>
   >(new Map())
+  // Tracks which system the insights map belongs to and whether that system's
+  // one-shot lookup has settled. The initial lookup briefly blocks submission so
+  // a carried-forward response cannot be submitted before its required-review
+  // UI is known.
+  const [insightsLoadState, setInsightsLoadState] = React.useState<{
+    system?: number
+    settled: boolean
+  }>({ settled: false })
   const [question, setQuestion] = React.useState<string>('')
   const [datacallID, setDatacallID] = React.useState<number>(0)
   const [datacall, setDatacall] = React.useState<string>('')
   const [loadingQuestion, setLoadingQuestion] = React.useState<boolean>(true)
+  // The context (system x data call x question) the current answer/notes were
+  // last seeded for. The prior-review initializer only runs once fetchOptions
+  // has settled this to the on-screen context.
+  const [loadedResponseContextId, setLoadedResponseContextId] =
+    React.useState('')
   const [noQuestions, setNoQuestions] = React.useState<boolean>(false)
   const [categories, setCategories] = React.useState<Category[]>([])
   const [stepFunctionId, setStepFunctionId] = React.useState<number[]>([])
@@ -159,6 +180,15 @@ export default function QuestionnarePage() {
   const [draftStatus, setDraftStatus] = React.useState<
     'idle' | 'restored' | 'saved' | 'error'
   >('idle')
+  // Review state for a carried-forward prior response, scoped to one
+  // system x data call x question x prior-text context. needsSave marks a
+  // resolved required review as an unsaved current-call action even when the
+  // resulting text is byte-for-byte identical to the seeded response.
+  const [priorReview, setPriorReview] = React.useState<{
+    contextId: string
+    state: PriorReviewState
+    needsSave: boolean
+  }>({ contextId: '', state: 'not-required', needsSave: false })
   // Refs read inside setTimeout/event callbacks to get the current value
   // without enrolling the effects in those deps (prevents extra re-runs).
   const draftStatusRef = React.useRef(draftStatus)
@@ -176,13 +206,10 @@ export default function QuestionnarePage() {
     initQuestionChoice,
     notes,
     initNotes,
+    priorReviewNeedsSave: false,
   })
-  unsavedRef.current = {
-    selectQuestionOption,
-    initQuestionChoice,
-    notes,
-    initNotes,
-  }
+  // unsavedRef.current is assigned below, once priorReviewNeedsSave has been
+  // derived, so the beforeunload and re-seed effects read it too.
   // Refs so the out-of-band re-seed effect can read current options and loading
   // state without enrolling them as effect dependencies.
   const optionsRef = React.useRef(options)
@@ -223,6 +250,14 @@ export default function QuestionnarePage() {
     // it carries the same option insight badges plus the FIPS baseline treatment
     // (per-option warn styling, divider, above-baseline badge/notice) that a flat
     // ChoiceList can't express.
+    //
+    // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights layer.
+    // Passing no insight for those calls hides the option-level insight badges
+    // AND the insight-derived FIPS per-option markers together with the
+    // (already-hidden) Insights panel/FIPS strip — matching QuestionRadioGroup's
+    // own "strip and per-option markers appear/vanish together" invariant. For
+    // every CMS (non-HHS) call the insight passes through unchanged, so the FIPS
+    // treatment is identical to before.
     return (
       <QuestionRadioGroup
         options={options}
@@ -230,7 +265,7 @@ export default function QuestionnarePage() {
         selectedValue={selectQuestionOption}
         onChange={handleChoiceChange}
         disabled={isReadOnly}
-        insight={currentInsight}
+        insight={isHhsDatacall ? undefined : currentInsight}
         viewedDatacall={datacall}
       />
     )
@@ -338,14 +373,16 @@ export default function QuestionnarePage() {
   const systemName = systemInfo?.fismaname ?? fismaacronym ?? ''
 
   // Fetch ZTMF Insights for this system once (not per question — one call
-  // returns every question's row). Failures and empty responses both leave the
-  // map empty so the questionnaire is never blocked or altered by insights.
+  // returns every question's row). The initial lookup briefly blocks submission
+  // so a carried-forward response cannot be submitted before its required
+  // review UI is known. Failures and empty responses then leave the map empty.
   React.useEffect(() => {
     if (!system) return
     const controller = new AbortController()
     // Clear the previous system's insights up front so a system change can't
     // briefly render stale badges/panel while the new fetch is in flight.
     setInsightsByQuestion(new Map())
+    setInsightsLoadState({ system, settled: false })
     const load = async () => {
       try {
         const res = await axiosInstance.get<{ data: Insight[] }>('insights', {
@@ -364,6 +401,10 @@ export default function QuestionnarePage() {
           // Insights are additive and optional; swallow errors and render the
           // page exactly as it is without them.
           setInsightsByQuestion(new Map())
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setInsightsLoadState({ system, settled: true })
         }
       }
     }
@@ -403,8 +444,86 @@ export default function QuestionnarePage() {
     setDraftStatus('idle')
   }
 
+  // Keep insight, review, and card state scoped to one system x data call x
+  // database question. React reuses this route component as those route values
+  // change, so everything below is keyed on that context.
+  //
+  // questionId holds the current functionid; the Question record carries the DB
+  // questionid the insight rows are keyed by. currentInsight is undefined for
+  // any question without a synced insight row, in which case the panel is not
+  // rendered and the page is unchanged.
+  const currentDatabaseQuestionId =
+    questionId != null ? questions[questionId]?.questionid : undefined
+  const insightsPending =
+    !!system &&
+    (insightsLoadState.system !== system || !insightsLoadState.settled)
+  const currentInsight =
+    insightsLoadState.system === system && currentDatabaseQuestionId != null
+      ? insightsByQuestion.get(currentDatabaseQuestionId)
+      : undefined
+  // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights UI
+  // (panel, suggestion). The carried-forward prior-response review still
+  // applies so a copied answer is affirmatively reviewed.
+  const isHhsDatacall =
+    parseDatacallName(datacall.replaceAll('_', ' ')).tenant === 'HHS'
+  const showInsights = Boolean(currentInsight) && !isHhsDatacall
+  const currentSuggestion = !isHhsDatacall
+    ? buildInsightJustification(currentInsight)
+    : undefined
+  const currentPriorResponse = priorResponseFor(currentInsight, datacall)
+  const hasJustificationContext = Boolean(
+    currentPriorResponse || currentSuggestion
+  )
+  const justificationContextId = JSON.stringify([
+    system ?? null,
+    datacallID,
+    currentDatabaseQuestionId ?? null,
+  ])
+  const priorReviewContextId = JSON.stringify([
+    justificationContextId,
+    currentPriorResponse?.text ?? null,
+    isReadOnly,
+  ])
+  // A context that has not yet been evaluated is synchronously treated as
+  // initializing. This keeps the editor and Next button blocked during the
+  // render before the initializer effect runs.
+  const priorReviewState: PriorReviewState =
+    !currentPriorResponse || isReadOnly
+      ? 'not-required'
+      : loadedResponseContextId === justificationContextId &&
+          priorReview.contextId === priorReviewContextId
+        ? priorReview.state
+        : 'initializing'
+  const priorReviewNeedsSave =
+    priorReview.contextId === priorReviewContextId && priorReview.needsSave
+  const updatePriorReviewState = (state: PriorReviewState) => {
+    setPriorReview((current) => ({
+      contextId: priorReviewContextId,
+      state,
+      // Resolving a required review is an unsaved current-call action even if
+      // the resulting text is byte-for-byte identical to the seeded response.
+      needsSave:
+        (current.contextId === priorReviewContextId && current.needsSave) ||
+        priorReviewState === 'pending',
+    }))
+  }
+  unsavedRef.current = {
+    selectQuestionOption,
+    initQuestionChoice,
+    notes,
+    initNotes,
+    priorReviewNeedsSave,
+  }
+
   const saveResponse = async () => {
+    // Resolving a required carried-forward review is itself a current-call
+    // action, even when the final text is byte-for-byte identical to the
+    // seeded notes. Persist it so the audit trail records the affirmative
+    // review.
+    const resolvedPriorReview =
+      priorReviewNeedsSave && selectQuestionOption >= 0
     if (
+      !resolvedPriorReview &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -450,6 +569,11 @@ export default function QuestionnarePage() {
       }
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
       clearCurrentDraft()
+      setPriorReview((current) =>
+        current.contextId === priorReviewContextId
+          ? { ...current, needsSave: false }
+          : current
+      )
       fetchQuestionScores(system, setQuestionScores)
     } catch (error) {
       if (isAuthHandled(error)) return
@@ -795,6 +919,16 @@ export default function QuestionnarePage() {
             setDraftStatus('idle')
           }
           setOptions(choices)
+          // Mark this system x data call x question as the context the current
+          // answer/notes were seeded for, so the prior-review initializer runs
+          // only once the loaded state matches what is on screen.
+          setLoadedResponseContextId(
+            JSON.stringify([
+              sys ?? null,
+              datacallID,
+              questions[questionId ?? -1]?.questionid ?? null,
+            ])
+          )
         } catch (error) {
           if (controller.signal.aborted) return
           if (isAuthHandled(error)) return
@@ -881,7 +1015,8 @@ export default function QuestionnarePage() {
       const s = unsavedRef.current
       const hasPendingEdits =
         shouldPersistResponse(s) ||
-        (s.selectQuestionOption === -1 && s.notes !== s.initNotes)
+        (s.selectQuestionOption === -1 && s.notes !== s.initNotes) ||
+        s.priorReviewNeedsSave
       if (hasPendingEdits) {
         e.preventDefault()
         e.returnValue = ''
@@ -906,7 +1041,8 @@ export default function QuestionnarePage() {
         loadingQuestion: loadingQuestionRef.current,
         hasUnsavedEdits:
           u.selectQuestionOption !== u.initQuestionChoice ||
-          u.notes !== u.initNotes,
+          u.notes !== u.initNotes ||
+          u.priorReviewNeedsSave,
         draftRestored: draftStatusRef.current === 'restored',
       })
     ) {
@@ -931,6 +1067,47 @@ export default function QuestionnarePage() {
     setScoreId(sel.scoreid)
     setRadioKey((k) => k + 1)
   }, [questionScores, questionId])
+
+  // A score copied from the prior data call has no edit event for the current
+  // call. When its notes exactly match last_score_notes, keep that text as
+  // context rather than silently treating it as the current submitted answer.
+  // The context id makes this an initializer: accepting/dismissing cannot be
+  // reset by the resulting notes state change, but navigating to a new question
+  // can.
+  React.useEffect(() => {
+    if (loadingQuestion || loadedResponseContextId !== justificationContextId)
+      return
+    const currentScore =
+      selectQuestionOption >= 0
+        ? questionScores[selectQuestionOption]
+        : undefined
+    if (priorReview.contextId === priorReviewContextId) return
+
+    const isUnreviewedCarryForward =
+      !isReadOnly &&
+      !!currentPriorResponse &&
+      !!currentScore &&
+      !currentScore.last_edited_at &&
+      draftStatus !== 'restored' &&
+      notes.trim() === currentPriorResponse.text.trim()
+    setPriorReview({
+      contextId: priorReviewContextId,
+      state: isUnreviewedCarryForward ? 'pending' : 'not-required',
+      needsSave: false,
+    })
+  }, [
+    currentPriorResponse,
+    draftStatus,
+    isReadOnly,
+    loadingQuestion,
+    loadedResponseContextId,
+    notes,
+    priorReview.contextId,
+    priorReviewContextId,
+    justificationContextId,
+    questionScores,
+    selectQuestionOption,
+  ])
 
   const breadcrumbSegmentLabels = fismaacronym
     ? { [fismaacronym]: fismaacronym.toUpperCase() }
@@ -988,14 +1165,6 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
-  // Insight for the question currently on screen. questionId holds the current
-  // functionid; the Question record carries the DB questionid the insight rows
-  // are keyed by. Undefined for any question without a synced insight row, in
-  // which case the panel is not rendered and the page is unchanged.
-  const currentInsight =
-    questionId != null
-      ? insightsByQuestion.get(questions[questionId]?.questionid ?? -1)
-      : undefined
   return (
     <>
       <Box
@@ -1079,7 +1248,8 @@ export default function QuestionnarePage() {
                                   ((selectQuestionOption !== -1 &&
                                     initQuestionChoice !==
                                       selectQuestionOption) ||
-                                    initNotes !== notes)
+                                    initNotes !== notes ||
+                                    priorReviewNeedsSave)
                                 ) {
                                   setOpenAlert(true)
                                 } else {
@@ -1127,7 +1297,18 @@ export default function QuestionnarePage() {
               <Typography variant="h6" component="h1" sx={{ mt: 1, mb: 0 }}>
                 {question}
               </Typography>
-              {currentInsight && <InsightsPanel payload={currentInsight} />}
+              {insightsPending && (
+                <Typography
+                  role="status"
+                  variant="caption"
+                  sx={{ color: 'text.secondary' }}
+                >
+                  Checking for prior responses…
+                </Typography>
+              )}
+              {showInsights && currentInsight && (
+                <InsightsPanel payload={currentInsight} />
+              )}
               {loadingQuestion ? (
                 <Box
                   sx={{
@@ -1144,31 +1325,65 @@ export default function QuestionnarePage() {
                   <Box key={radioKey} sx={{ mb: 2 }}>
                     {renderRadioGroup(options)}
                   </Box>
-                  {/* h2 under the question's h1 so the heading order is valid. */}
-                  <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
-                    {notePrompt || ''}
-                  </Typography>
-                  <CssTextField
-                    multiline
-                    rows={4}
-                    fullWidth
-                    value={notes}
-                    disabled={isReadOnly}
-                    error={needsNotesUpdate}
-                    helperText={
-                      needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
-                    }
-                    inputProps={{
-                      maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH,
-                      // The multiline field has no visible <label>; the prompt
-                      // above is styling-only. Give it an accessible name (508).
-                      'aria-label': 'Justification notes',
-                    }}
-                    onChange={(e) => {
-                      setNotes(e.target.value)
-                      if (draftStatus === 'restored') setDraftStatus('idle')
-                    }}
-                  />
+                  {hasJustificationContext ? (
+                    // Carried-forward prior response and/or an Insights
+                    // suggestion exist: render the review-aware justification
+                    // editor. It owns its own label, char counter, and (for
+                    // CMS calls) the suggestion card.
+                    <JustificationField
+                      key={justificationContextId}
+                      contextId={justificationContextId}
+                      label={notePrompt || 'Justification'}
+                      value={notes}
+                      onChange={(value) => {
+                        setNotes(value)
+                        if (draftStatus === 'restored') setDraftStatus('idle')
+                      }}
+                      insight={currentInsight}
+                      priorResponse={currentPriorResponse}
+                      showInsightSuggestion={!isHhsDatacall}
+                      viewedDatacall={datacall}
+                      priorReviewState={priorReviewState}
+                      onPriorReview={updatePriorReviewState}
+                      disabled={isReadOnly}
+                      error={needsNotesUpdate}
+                      helperText={
+                        needsNotesUpdate ? NOTES_UPDATE_REQUIRED_MSG : undefined
+                      }
+                      maxLength={MAX_QUESTIONNAIRE_NOTES_LENGTH}
+                    />
+                  ) : (
+                    <>
+                      {/* h2 under the question's h1 so the heading order is valid. */}
+                      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+                        {notePrompt || ''}
+                      </Typography>
+                      <CssTextField
+                        multiline
+                        rows={4}
+                        fullWidth
+                        value={notes}
+                        disabled={isReadOnly}
+                        error={needsNotesUpdate}
+                        helperText={
+                          needsNotesUpdate
+                            ? NOTES_UPDATE_REQUIRED_MSG
+                            : undefined
+                        }
+                        inputProps={{
+                          maxLength: MAX_QUESTIONNAIRE_NOTES_LENGTH,
+                          // The multiline field has no visible <label>; the
+                          // prompt above is styling-only. Give it an accessible
+                          // name (508).
+                          'aria-label': 'Justification notes',
+                        }}
+                        onChange={(e) => {
+                          setNotes(e.target.value)
+                          if (draftStatus === 'restored') setDraftStatus('idle')
+                        }}
+                      />
+                    </>
+                  )}
                   <Box
                     sx={{
                       display: 'flex',
@@ -1183,7 +1398,7 @@ export default function QuestionnarePage() {
                           ?.notes_is_ai_summary === true
                       }
                     />
-                    {!isReadOnly && (
+                    {!hasJustificationContext && !isReadOnly && (
                       <Typography
                         variant="caption"
                         sx={{
@@ -1214,7 +1429,8 @@ export default function QuestionnarePage() {
                           !isReadOnly &&
                           ((selectQuestionOption !== -1 &&
                             initQuestionChoice !== selectQuestionOption) ||
-                            initNotes !== notes)
+                            initNotes !== notes ||
+                            priorReviewNeedsSave)
                         ) {
                           setStepId(
                             stepFunctionId[functionIdIdx[selectedIndex] - 1]
@@ -1278,7 +1494,12 @@ export default function QuestionnarePage() {
                           saveResponse()
                         }
                       }}
-                      disabled={needsNotesUpdate}
+                      disabled={
+                        needsNotesUpdate ||
+                        insightsPending ||
+                        priorReviewState === 'pending' ||
+                        priorReviewState === 'initializing'
+                      }
                       style={{ marginBottom: '8px', marginTop: '8px' }}
                     >
                       {selectedIndex ===


### PR DESCRIPTION
## What & why

Promotes the impl-only work up to `main` so **dev reaches parity with `impl`** — the last step before we can retire the `impl` branch (→ dev + prod only, per #545). Cherry-picked onto current `main` (disjoint from #553; no reversion). **Draft for team alignment — please weigh the decisions below before merging.**

## What's included (impl's delta over `main`)

- **ZTMF-insights justification field, wired** into the questionnaire (`JustificationField` component + context + the `QuestionnairePage` wiring): a review-aware justification input with prior-year carry-forward, and — for CMS calls — a suggested justification derived from the insight payload.
- **HHS gate:** for HHS data calls the justification field still shows, but the CMS Insights panel, option insight-badges, and FIPS per-option markers are suppressed.
- **Dev worktree tooling** (`Makefile.impl`/`Makefile.main`, `ZTMF_ENV` auto-detect, `VITE_DEV_PORT`, a `.gitignore` entry). No runtime effect; separable — happy to drop it (it's moot once `impl` retires).

## Decisions to align on before merge

1. **HHS behavior change on dev/prod.** `main` today shows the Insights panel / option badges / FIPS per-option markers for HHS data calls; this PR **suppresses** them for HHS (keeping only the justification field). Confirm that's the intended dev/prod behavior.
2. **Prod visibility.** The justification field has **no feature flag** of its own — merging → `main` → prod makes it live in prod. If prod-visibility isn't wanted yet, we add a config gate first.
3. **Backend payload.** The prior-year carry-forward and the CMS suggestion depend on the `insights` payload carrying `last_score_notes`, `last_datacall`, and `suggested_justification` in dev/prod (verify in the backend; it degrades gracefully to the plain notes field otherwise — no error, just inert).

## Notes

- Repo is squash-only; this squash-merges to a single commit on `main`.
- Tests ride along: `JustificationField.test.tsx` + the `QuestionnairePage` justification-integration block (HHS/CMS gating, carry-forward review-and-persist, no-context fallback). Full CI (the required dev-deploy check) must pass before merge.
