### PR TITLE
Add FIPS maturity baseline back for HHS systems

### DIFF
--- a/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
@@ -20,10 +20,14 @@ const OPTIONS: QuestionChoice[] = [
 const LOW_FIPS: InsightPayload = { fips_impact_level: 'Low', fips_ceiling: 2 }
 
 // Low FIPS with CMS-specific badge data (suggested + prior answer).
+// suggested_score: 3 (Advanced) is intentionally distinct from fips_ceiling: 2
+// (Initial) so the "ZTMF Insights" badge and "Low baseline" chip land on
+// separate option rows — a bug that suppressed badges only on the baseline
+// option would be visible.
 const LOW_FIPS_WITH_BADGES: InsightPayload = {
   fips_impact_level: 'Low',
   fips_ceiling: 2,
-  suggested_score: 2, // points to Initial answer (the ceiling/baseline option)
+  suggested_score: 3, // Advanced (score 3) — above the ceiling, not at it
   last_score: 1,
   last_datacall: 'FY2025 Q1',
 }

--- a/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.test.tsx
@@ -19,6 +19,15 @@ const OPTIONS: QuestionChoice[] = [
 // Low FIPS → ceiling 2 (Initial): options scoring 3 and 4 are above baseline.
 const LOW_FIPS: InsightPayload = { fips_impact_level: 'Low', fips_ceiling: 2 }
 
+// Low FIPS with CMS-specific badge data (suggested + prior answer).
+const LOW_FIPS_WITH_BADGES: InsightPayload = {
+  fips_impact_level: 'Low',
+  fips_ceiling: 2,
+  suggested_score: 2, // points to Initial answer (the ceiling/baseline option)
+  last_score: 1,
+  last_datacall: 'FY2025 Q1',
+}
+
 const noop = () => {}
 
 function renderGroup(
@@ -107,6 +116,22 @@ describe('QuestionRadioGroup', () => {
         />
       )
       expect(screen.getByText('Above-baseline selection')).toBeInTheDocument()
+    })
+  })
+
+  describe('showInsightBadges=false (HHS-like rendering)', () => {
+    it('shows FIPS baseline but suppresses CMS insight chips', () => {
+      renderGroup({ insight: LOW_FIPS_WITH_BADGES, showInsightBadges: false })
+      // FIPS baseline marker still renders — it is a federal-wide concept.
+      expect(screen.getByText('Low baseline')).toBeInTheDocument()
+      // CMS-internal insight chips are absent.
+      expect(screen.queryByText('ZTMF Insights')).not.toBeInTheDocument()
+    })
+
+    it('shows both baseline and insight chips when showInsightBadges is true', () => {
+      renderGroup({ insight: LOW_FIPS_WITH_BADGES, showInsightBadges: true })
+      expect(screen.getByText('Low baseline')).toBeInTheDocument()
+      expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
     })
   })
 

--- a/src/views/QuestionnairePage/QuestionRadioGroup.tsx
+++ b/src/views/QuestionnairePage/QuestionRadioGroup.tsx
@@ -43,6 +43,9 @@ type Props = {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   disabled?: boolean
   insight?: InsightPayload
+  // When false, suppresses the CMS-specific OptionInsightBadges (suggested +
+  // prior-answer chips) while leaving the FIPS baseline treatment intact.
+  showInsightBadges?: boolean
   viewedDatacall?: string
 }
 
@@ -53,6 +56,7 @@ export default function QuestionRadioGroup({
   onChange,
   disabled,
   insight,
+  showInsightBadges = true,
   viewedDatacall,
 }: Props) {
   const ceiling = baselineCeiling(insight?.fips_ceiling)
@@ -257,11 +261,13 @@ export default function QuestionRadioGroup({
                       </Box>
                     </Tooltip>
                   )}
-                  <OptionInsightBadges
-                    score={o.score}
-                    insight={insight}
-                    viewedDatacall={viewedDatacall}
-                  />
+                  {showInsightBadges && (
+                    <OptionInsightBadges
+                      score={o.score}
+                      insight={insight}
+                      viewedDatacall={viewedDatacall}
+                    />
+                  )}
                 </Box>
               </Box>
             </React.Fragment>

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -737,6 +737,9 @@ const INSIGHT_ROW = {
     // A prior cycle, distinct from the FY2026 Q1 / FY25 ZTM calls under test, so
     // the carried-forward response is offered as last year's context.
     last_datacall: 'FY2025 Q1',
+    // FIPS data is a federal-wide concept; must render for both CMS and HHS.
+    fips_impact_level: 'Low',
+    fips_ceiling: 2,
   },
 }
 
@@ -798,6 +801,9 @@ describe('QuestionnairePage justification integration', () => {
     expect(await screen.findByText('Review required')).toBeInTheDocument()
     // ...but the pending review empties the on-screen value and blocks submit.
     expect(response).toHaveValue('')
+
+    // The FIPS baseline is a federal-wide concept and must appear for HHS too.
+    expect(await screen.findByText('Low baseline')).toBeInTheDocument()
 
     // The CMS-internal insights layer is suppressed for HHS calls.
     expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -255,8 +255,9 @@ export default function QuestionnarePage() {
     // Always pass insight so the FIPS baseline markers (a federal-wide concept)
     // render for all systems including HHS. showInsightBadges suppresses the
     // CMS-specific option chips (suggested + prior-answer) for HHS calls while
-    // leaving the baseline treatment intact. The Insights panel and suggestion
-    // are separately gated by showInsights / showInsightSuggestion.
+    // leaving the baseline treatment intact. The Insights panel, suggestion,
+    // and per-option insight badges are each separately gated (showInsights /
+    // showInsightSuggestion / showInsightBadges) — all derive from showCmsInsights.
     return (
       <QuestionRadioGroup
         options={options}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -252,12 +252,11 @@ export default function QuestionnarePage() {
     // ChoiceList can't express.
     //
     // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights layer.
-    // Passing no insight for those calls hides the option-level insight badges
-    // AND the insight-derived FIPS per-option markers together with the
-    // (already-hidden) Insights panel/FIPS strip — matching QuestionRadioGroup's
-    // own "strip and per-option markers appear/vanish together" invariant. For
-    // every CMS (non-HHS) call the insight passes through unchanged, so the FIPS
-    // treatment is identical to before.
+    // Always pass insight so the FIPS baseline markers (a federal-wide concept)
+    // render for all systems including HHS. showInsightBadges suppresses the
+    // CMS-specific option chips (suggested + prior-answer) for HHS calls while
+    // leaving the baseline treatment intact. The Insights panel and suggestion
+    // are separately gated by showInsights / showInsightSuggestion.
     return (
       <QuestionRadioGroup
         options={options}
@@ -265,7 +264,8 @@ export default function QuestionnarePage() {
         selectedValue={selectQuestionOption}
         onChange={handleChoiceChange}
         disabled={isReadOnly}
-        insight={isHhsDatacall ? undefined : currentInsight}
+        insight={currentInsight}
+        showInsightBadges={!isHhsDatacall}
         viewedDatacall={datacall}
       />
     )

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -265,7 +265,7 @@ export default function QuestionnarePage() {
         onChange={handleChoiceChange}
         disabled={isReadOnly}
         insight={currentInsight}
-        showInsightBadges={!isHhsDatacall}
+        showInsightBadges={showCmsInsights}
         viewedDatacall={datacall}
       />
     )
@@ -466,8 +466,10 @@ export default function QuestionnarePage() {
   // applies so a copied answer is affirmatively reviewed.
   const isHhsDatacall =
     parseDatacallName(datacall.replaceAll('_', ' ')).tenant === 'HHS'
-  const showInsights = Boolean(currentInsight) && !isHhsDatacall
-  const currentSuggestion = !isHhsDatacall
+  // Single source of truth for all CMS-internal insight UI gates.
+  const showCmsInsights = !isHhsDatacall
+  const showInsights = Boolean(currentInsight) && showCmsInsights
+  const currentSuggestion = showCmsInsights
     ? buildInsightJustification(currentInsight)
     : undefined
   const currentPriorResponse = priorResponseFor(currentInsight, datacall)
@@ -1341,7 +1343,7 @@ export default function QuestionnarePage() {
                       }}
                       insight={currentInsight}
                       priorResponse={currentPriorResponse}
-                      showInsightSuggestion={!isHhsDatacall}
+                      showInsightSuggestion={showCmsInsights}
                       viewedDatacall={datacall}
                       priorReviewState={priorReviewState}
                       onPriorReview={updatePriorReviewState}


### PR DESCRIPTION
## Summary

Closes #560 — a follow-up to #559. 

PR #559 suppressed the CMS Insights layer for HHS data calls by passing `insight={isHhsDatacall ? undefined : currentInsight}` into `QuestionRadioGroup`. That worked for the CMS-specific option badges (suggested answer, prior-answer chips), but it also silently suppressed the **FIPS maturity baseline markers** (dashed box on the baseline option, impact-level chip, above-baseline divider/notice). The FIPS baseline is a federal-wide concept — HHS systems are subject to it just like CMS systems — so the markers should be visible regardless of data call type.

## What changed

**`QuestionRadioGroup`** — new additive `showInsightBadges?: boolean` prop (default `true`):
- When `false`, gates only the `OptionInsightBadges` render (the CMS-specific suggested + prior-answer chips).
- All FIPS baseline logic (`hasBaseline`, `atBaseline`, divider, tooltips, notice box) reads from `insight?.fips_*` and is untouched — it renders whenever FIPS data is present, regardless of the prop.

**`QuestionnairePage`** — two call-site changes in `renderRadioGroup`:
- `insight={currentInsight}` — always forwarded so FIPS data reaches the component for HHS too.
- `showInsightBadges={showCmsInsights}` — suppresses CMS-specific chips for HHS.

**`QuestionnairePage`** — extracted `const showCmsInsights = !isHhsDatacall` as a single named constant. All four CMS-insight gates (`showInsights`, `currentSuggestion`, `showInsightBadges`, `showInsightSuggestion`) now reference it instead of inverting `isHhsDatacall` independently.

## Acceptance Criteria

- [ ] HHS data call: FIPS baseline visible; no Insights panel / badges / suggestion.
- [ ] CMS data call: unchanged (baseline + full insights).
- [ ] Tests updated to assert the HHS-shows-baseline case (currently the HHS test asserts the baseline is absent).

## UI
### Before
No ZTMF Insights or Moderate Baseline for HHS systems
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/2b7db768-1fc8-4b2e-a0cb-f344a642c53f" />

CMS Systems contain full insights + baseline
<img width="1728" height="957" alt="image" src="https://github.com/user-attachments/assets/818bf30a-eed7-46ee-bfad-17b5779bd983" />

### After
Moderate Baseline is now shown on HHS systems questionnaire page.
<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/284466f3-711c-4d21-b1d1-16b88f242749" />

CMS Systems still contain full insights + baseline
<img width="1728" height="958" alt="image" src="https://github.com/user-attachments/assets/f9303400-2e19-478d-aea8-1d7a723b6cbf" />


## Tests

- **`QuestionnairePage.test.tsx`** — added `fips_impact_level`/`fips_ceiling` to `INSIGHT_ROW` fixture; added assertion in the HHS integration test that `Low baseline` is present (previously untested, and the baseline was in fact absent before this fix).
- **`QuestionRadioGroup.test.tsx`** — new `showInsightBadges=false` describe block with two unit tests:
  - `false`: FIPS `Low baseline` chip renders; `ZTMF Insights` badge is absent.
  - `true`: both render — confirms the gate works in both directions.