### PR TITLE
fix(dashboard): Data Call Progress "Complete" chip for past calls, not "0/40 Not updated"

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,11 @@ export type SystemScoreEntry = {
 export type ScoreProgress = {
   fismasystemid: number
   questionsexpected: number
+  // Distinct applicable questions with an answer at all, any status (ztmf#437).
+  // The completion signal a closed call needs: imported/carried answers are
+  // answered but never "updated this cycle". Optional so the UI degrades to the
+  // prior score-presence proxy until the backend field is deployed.
+  questionsanswered?: number
   questionsupdated: number
   lastupdatedat?: string | null
   updatedsincestart: boolean

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -26,7 +26,7 @@ import {
   Button,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
 import FileDownloadSharpIcon from '@mui/icons-material/FileDownloadSharp'
@@ -415,6 +415,21 @@ export default function FismaTable({
     datacenterEnvironments,
   } = useContextProp()
   const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
+  // Whether the call a given row is displaying (chosen by most-recently-updated
+  // in buildDashboardMaps) is the current/active one — the call with the
+  // furthest-out deadline (latestDataCallId). The Data Call Progress column's
+  // current-cycle framing (the "0/40 Not updated" laggard chip and the
+  // not-updated filter) only makes sense for that call; a past call shows a
+  // neutral Complete chip instead (ztmf#537). Rows without a chosen call, or
+  // before latestDataCallId has loaded, keep the current-cycle rendering.
+  const isRowCurrentCall = useCallback(
+    (fismasystemid: number): boolean => {
+      const chosen = chosenCallMap[fismasystemid]
+      if (!latestDataCallId || chosen == null) return true
+      return chosen === latestDataCallId
+    },
+    [chosenCallMap, latestDataCallId]
+  )
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
   const [selectedRow, setSelectedRow] = useState<FismaSystemType | null>(null)
@@ -532,8 +547,14 @@ export default function FismaTable({
 
   const filteredRows = useMemo(
     () =>
-      applyDashboardFilters(fismaSystems, progress ?? {}, categoryMap, filters),
-    [fismaSystems, progress, categoryMap, filters]
+      applyDashboardFilters(
+        fismaSystems,
+        progress ?? {},
+        categoryMap,
+        filters,
+        isRowCurrentCall
+      ),
+    [fismaSystems, progress, categoryMap, filters, isRowCurrentCall]
   )
   const [pillarScoresModal, setPillarScoresModal] = useState<{
     open: boolean
@@ -715,7 +736,11 @@ export default function FismaTable({
       valueGetter: (value) =>
         progressSortValue(progress?.[value.row.fismasystemid]),
       renderCell: (params) => (
-        <ProgressCell entry={progress?.[params.row.fismasystemid]} />
+        <ProgressCell
+          entry={progress?.[params.row.fismasystemid]}
+          isCurrentCall={isRowCurrentCall(params.row.fismasystemid)}
+          hasScore={Boolean(scores[params.row.fismasystemid])}
+        />
       ),
     },
     {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -415,20 +415,32 @@ export default function FismaTable({
     datacenterEnvironments,
   } = useContextProp()
   const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
+  // "Latest by deadline" is not the same as "still open". Once the newest
+  // call's deadline has passed there is no active cycle at all, so nothing is
+  // "current" - every row must render past-call (Complete/Incomplete) rather
+  // than the "0/40 Not updated" laggard framing. This mirrors the
+  // Current-while-open / Latest-once-closed distinction the call picker already
+  // makes (ztmf#393). Without this gate the newest *closed* call stays labeled
+  // current and shows 0/40 forever (ztmf-ui#542).
+  const latestDeadlinePassed = useMemo(() => {
+    if (!latestDataCallId) return false
+    const latest = datacalls.find((d) => d.datacallid === latestDataCallId)
+    return latest ? new Date() > new Date(latest.deadline) : false
+  }, [datacalls, latestDataCallId])
   // Whether the call a given row is displaying (chosen by most-recently-updated
-  // in buildDashboardMaps) is the current/active one — the call with the
-  // furthest-out deadline (latestDataCallId). The Data Call Progress column's
+  // in buildDashboardMaps) is the current/active one: the latest-by-deadline
+  // call AND that call is still open. The Data Call Progress column's
   // current-cycle framing (the "0/40 Not updated" laggard chip and the
-  // not-updated filter) only makes sense for that call; a past call shows a
-  // neutral Complete chip instead (ztmf#537). Rows without a chosen call, or
-  // before latestDataCallId has loaded, keep the current-cycle rendering.
+  // not-updated filter) only makes sense then; a past/closed call shows a
+  // neutral Complete/Incomplete chip instead (ztmf#537). Rows without a chosen
+  // call, or before latestDataCallId has loaded, keep the current rendering.
   const isRowCurrentCall = useCallback(
     (fismasystemid: number): boolean => {
       const chosen = chosenCallMap[fismasystemid]
       if (!latestDataCallId || chosen == null) return true
-      return chosen === latestDataCallId
+      return chosen === latestDataCallId && !latestDeadlinePassed
     },
-    [chosenCallMap, latestDataCallId]
+    [chosenCallMap, latestDataCallId, latestDeadlinePassed]
   )
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
@@ -734,7 +746,10 @@ export default function FismaTable({
       align: 'center',
       headerAlign: 'center',
       valueGetter: (value) =>
-        progressSortValue(progress?.[value.row.fismasystemid]),
+        progressSortValue(
+          progress?.[value.row.fismasystemid],
+          isRowCurrentCall(value.row.fismasystemid)
+        ),
       renderCell: (params) => (
         <ProgressCell
           entry={progress?.[params.row.fismasystemid]}

--- a/src/views/FismaTable/dashboardFilters.test.ts
+++ b/src/views/FismaTable/dashboardFilters.test.ts
@@ -93,6 +93,37 @@ test('isNotUpdated classifies each progress bucket correctly', () => {
   expect(isNotUpdated(undefined)).toBe(false) // no data
 })
 
+test('isNotUpdated is current-call-only: a past-call laggard is not a laggard', () => {
+  // ztmf#537: "Not updated" is a current-cycle signal. On a past call the same
+  // 0-updates row is not a laggard - it read 0 because the call is closed.
+  expect(isNotUpdated(prog(1, 40, 0), true)).toBe(true)
+  expect(isNotUpdated(prog(1, 40, 0), false)).toBe(false)
+})
+
+test('not-updated filter excludes rows on a past call', () => {
+  // sys1 is the only 0-updates laggard, but here it is displaying a past call,
+  // so the not-updated facet must not surface it.
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ notUpdatedOnly: true }),
+    (id) => id !== 1 // sys1 on a past call, everyone else current
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([])
+})
+
+test('not-updated filter still surfaces current-call laggards when a predicate is passed', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ notUpdatedOnly: true }),
+    () => true // every row on the current call
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
 test('facets combine with AND', () => {
   const out = applyDashboardFilters(
     ROWS,

--- a/src/views/FismaTable/dashboardFilters.ts
+++ b/src/views/FismaTable/dashboardFilters.ts
@@ -40,10 +40,21 @@ export function hasNoActiveFilters(filters: DashboardFilterState): boolean {
  * own classifier (`progressSortValue === -1`) so the filter and the Data Call
  * Progress chip never disagree — the 0/0 "N/A" case and systems with no
  * progress data are intentionally excluded.
+ *
+ * "Not updated" is a current-cycle laggard signal, so it only applies to the
+ * current/active call: a past call reads 0 updates for everyone (ztmf#537) and
+ * has no laggards to surface. A row on a past call is never a laggard.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @param {boolean} [isCurrentCall=true] - Whether the row's displayed call is
+ *   the current/active one. Defaults true so callers without call context keep
+ *   the original behavior.
  * @returns {boolean} True when the system is not updated but has a questionnaire.
  */
-export function isNotUpdated(entry: ScoreProgress | undefined): boolean {
+export function isNotUpdated(
+  entry: ScoreProgress | undefined,
+  isCurrentCall: boolean = true
+): boolean {
+  if (!isCurrentCall) return false
   return progressSortValue(entry) === -1
 }
 
@@ -55,13 +66,18 @@ export function isNotUpdated(entry: ScoreProgress | undefined): boolean {
  * @param {Record<number, ScoreProgress>} progress - Progress keyed by fismasystemid.
  * @param {Record<string, string>} categoryMap - Raw datacenterenvironment -> category.
  * @param {DashboardFilterState} filters - The active selections.
+ * @param {(fismasystemid: number) => boolean} [isCurrentCall] - Whether a row's
+ *   displayed call is the current/active one. The "Not updated" facet only
+ *   matches current-call laggards (ztmf#537); defaults to treating every row as
+ *   current so callers without call context keep the original behavior.
  * @returns {FismaSystemType[]} The subset of rows passing every active facet.
  */
 export function applyDashboardFilters(
   rows: FismaSystemType[],
   progress: Record<number, ScoreProgress>,
   categoryMap: Record<string, string>,
-  filters: DashboardFilterState
+  filters: DashboardFilterState,
+  isCurrentCall: (fismasystemid: number) => boolean = () => true
 ): FismaSystemType[] {
   if (hasNoActiveFilters(filters)) return rows
 
@@ -76,7 +92,13 @@ export function applyDashboardFilters(
     if (opdivSet.size > 0) {
       if (row.opdiv_id == null || !opdivSet.has(row.opdiv_id)) return false
     }
-    if (filters.notUpdatedOnly && !isNotUpdated(progress[row.fismasystemid])) {
+    if (
+      filters.notUpdatedOnly &&
+      !isNotUpdated(
+        progress[row.fismasystemid],
+        isCurrentCall(row.fismasystemid)
+      )
+    ) {
       return false
     }
     return true

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -112,6 +112,20 @@ describe('progressTooltip', () => {
       'No questionnaire applies to this system'
     )
   })
+
+  it('reads "complete" for a past-call cell without a usable timestamp', () => {
+    // A completed past call has 0 updates this cycle, so the current-cycle
+    // fallback would wrongly say "No updates" - the completed flag must win.
+    expect(progressTooltip(untouchedEntry, { completed: true })).toBe(
+      'Data call complete'
+    )
+  })
+
+  it('still prefers a real last-update time over the completed fallback', () => {
+    expect(progressTooltip(updatedEntry, { completed: true })).toMatch(
+      /^Last updated /
+    )
+  })
 })
 
 describe('ProgressCell', () => {
@@ -147,5 +161,50 @@ describe('ProgressCell', () => {
     expect(screen.getByText('N/A')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
+  })
+
+  it('renders a neutral Complete chip for a scored past-call system', () => {
+    // ztmf#537: a past call reads 0 updates this cycle for everyone. A system
+    // with a score for that call was completed - show a neutral Complete chip,
+    // never the orange "0/40 Not updated" laggard chip.
+    render(
+      <ProgressCell
+        entry={untouchedEntry}
+        isCurrentCall={false}
+        hasScore={true}
+      />
+    )
+    expect(screen.getByText('Complete')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('0/41')).not.toBeInTheDocument()
+  })
+
+  it('keeps the current-cycle chip for the same entry on the active call', () => {
+    // Same untouched entry, but on the current call it is a genuine laggard.
+    render(
+      <ProgressCell
+        entry={untouchedEntry}
+        isCurrentCall={true}
+        hasScore={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('renders an em-dash for a past-call system with no score', () => {
+    // Defensive: a past-call row must never show the orange laggard chip even
+    // without a score to prove completion.
+    render(
+      <ProgressCell
+        entry={untouchedEntry}
+        isCurrentCall={false}
+        hasScore={false}
+      />
+    )
+    expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 })

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -76,6 +76,28 @@ describe('progressSortValue', () => {
       progressSortValue(untouchedEntry)
     )
   })
+
+  it('does not sort a past-call row to the laggard top', () => {
+    // ztmf-ui#542: on a past call, questionsupdated is 0 for everyone, so the
+    // current-call -1 "needs a nudge" rank would wrongly sort every historical
+    // row above real current-call laggards. Past calls rank by completion.
+    const pastComplete: ScoreProgress = {
+      ...untouchedEntry,
+      questionsanswered: 41,
+    }
+    const pastPartial: ScoreProgress = {
+      ...untouchedEntry,
+      questionsanswered: 10,
+    }
+    // Not at the -1 laggard rank...
+    expect(progressSortValue(pastComplete, false)).toBeGreaterThan(
+      progressSortValue(untouchedEntry, true)
+    )
+    // ...and a less-complete past call sorts ahead of a more-complete one.
+    expect(progressSortValue(pastPartial, false)).toBeLessThan(
+      progressSortValue(pastComplete, false)
+    )
+  })
 })
 
 describe('progressTooltip', () => {
@@ -206,5 +228,37 @@ describe('ProgressCell', () => {
     expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('renders Complete for a fully-answered past call even with zero updates', () => {
+    // ztmf#437: completion is answered/total, not updated/total. An imported or
+    // carried-over call is fully answered (answered == expected) but never
+    // "updated this cycle" - it must read Complete, not Incomplete.
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 41 }}
+        isCurrentCall={false}
+        hasScore={true}
+      />
+    )
+    expect(screen.getByText('Complete')).toBeInTheDocument()
+    expect(screen.queryByText('Incomplete')).not.toBeInTheDocument()
+  })
+
+  it('renders answered/total + Incomplete for a partially-answered past call', () => {
+    // Jono's blocker (ztmf-ui#542): a past call that was only 10/41 answered
+    // must NOT read Complete just because it has a score. QuestionsAnswered
+    // exposes the truth - show the honest fraction and an Incomplete chip.
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 10 }}
+        isCurrentCall={false}
+        hasScore={true}
+      />
+    )
+    expect(screen.getByText('10/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
 })

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -11,19 +11,43 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * data call do not count as updated - the fraction reflects genuine edits
  * this cycle (ztmf#299).
  *
- * Three states:
+ * "Updated this cycle" only has meaning for the current/active data call. For a
+ * past call nobody has touched anything this cycle, so questionsupdated is 0 for
+ * every system - showing "0/40 Not updated" wrongly reads a completed historical
+ * call as missing (ztmf#537). A past call with a score for that system was
+ * completed, so it gets a neutral "Complete" chip instead of the current-cycle
+ * fraction and Updated/Not-updated chip.
+ *
+ * States:
+ *   - past call (isCurrentCall false) with a score: neutral "Complete" chip -
+ *     the score is the completion signal (ScoreProgress has no "total answered"
+ *     field); the orange laggard chip never appears off the active call;
  *   - a system with no applicable questionnaire (0/0) renders a neutral
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
- *   - a system with any genuine edit reads "Updated" (green);
- *   - otherwise "Not updated" (orange). The chip is derived from
+ *   - current call, any genuine edit: "Updated" (green);
+ *   - current call, otherwise: "Not updated" (orange). The chip is derived from
  *     questionsupdated so it can never disagree with the fraction.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
+ * @param {boolean} [props.isCurrentCall=true] - Whether the row's displayed call
+ *   is the current/active one. Defaults true so callers without call context
+ *   keep the original current-cycle rendering.
+ * @param {boolean} [props.hasScore=false] - Whether the system has a score for
+ *   the displayed call. Used only for a past call, where a score means the call
+ *   was completed.
  * @returns {JSX.Element} The progress cell.
  */
-export function ProgressCell({ entry }: { entry: ScoreProgress | undefined }) {
+export function ProgressCell({
+  entry,
+  isCurrentCall = true,
+  hasScore = false,
+}: {
+  entry: ScoreProgress | undefined
+  isCurrentCall?: boolean
+  hasScore?: boolean
+}) {
   if (!entry) {
     return <span aria-label="No progress data">—</span>
   }
@@ -31,6 +55,21 @@ export function ProgressCell({ entry }: { entry: ScoreProgress | undefined }) {
     return (
       <Tooltip title={progressTooltip(entry)}>
         <Chip size="small" label="N/A" variant="outlined" />
+      </Tooltip>
+    )
+  }
+  // A past data call is closed: "updated this cycle" is meaningless, so never
+  // show the orange laggard chip here. A score for the call means it was
+  // completed - show a neutral "Complete" chip. Without a score (should not
+  // happen for a row the table drew from score data) fall back to the em-dash
+  // rather than a misleading fraction.
+  if (!isCurrentCall) {
+    if (!hasScore) {
+      return <span aria-label="No progress data">—</span>
+    }
+    return (
+      <Tooltip title={progressTooltip(entry, { completed: true })}>
+        <Chip size="small" label="Complete" variant="outlined" />
       </Tooltip>
     )
   }

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -59,17 +59,46 @@ export function ProgressCell({
     )
   }
   // A past data call is closed: "updated this cycle" is meaningless, so never
-  // show the orange laggard chip here. A score for the call means it was
-  // completed - show a neutral "Complete" chip. Without a score (should not
-  // happen for a row the table drew from score data) fall back to the em-dash
-  // rather than a misleading fraction.
+  // show the orange laggard chip here. But completion is answered/total, NOT
+  // updated/total - imported and carried-over answers are answered yet never
+  // "updated this cycle", so gating on updates (or on mere score presence)
+  // would either drop them or, worse, mask a partially-answered historical
+  // call as done. Prefer QuestionsAnswered (ztmf#437): a fully-answered past
+  // call is a neutral "Complete"; a partially-answered one shows an honest
+  // answered/total with an "Incomplete" chip. Until the backend field ships,
+  // fall back to the prior score-presence proxy.
   if (!isCurrentCall) {
-    if (!hasScore) {
-      return <span aria-label="No progress data">—</span>
+    const answered = entry.questionsanswered
+    if (answered == null) {
+      if (!hasScore) {
+        return <span aria-label="No progress data">—</span>
+      }
+      return (
+        <Tooltip title={progressTooltip(entry, { completed: true })}>
+          <Chip size="small" label="Complete" variant="outlined" />
+        </Tooltip>
+      )
+    }
+    if (answered >= entry.questionsexpected) {
+      return (
+        <Tooltip title={progressTooltip(entry, { completed: true })}>
+          <Chip size="small" label="Complete" variant="outlined" />
+        </Tooltip>
+      )
     }
     return (
-      <Tooltip title={progressTooltip(entry, { completed: true })}>
-        <Chip size="small" label="Complete" variant="outlined" />
+      <Tooltip title={progressTooltip(entry)}>
+        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+          <span>
+            {answered}/{entry.questionsexpected}
+          </span>
+          <Chip
+            size="small"
+            label="Incomplete"
+            color="warning"
+            variant="outlined"
+          />
+        </Box>
       </Tooltip>
     )
   }

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -25,12 +25,29 @@ export function hasNoQuestionnaire(entry: ScoreProgress | undefined): boolean {
  * The 0/0 (no-questionnaire) case is classified BEFORE the not-updated branch:
  * such a system is technically "not updated," but it has nothing to update, so
  * it must not sort to the triage top alongside genuine laggards.
+ *
+ * For a PAST call the "-1 needs a nudge" ranking is wrong - a closed call has no
+ * updates to chase, so ranking by questionsupdated would sort every historical
+ * row to the laggard top, contradicting its own Complete/Incomplete chip. Past
+ * calls are ranked by completion (answered/total) instead, never -1. Prefer
+ * QuestionsAnswered (ztmf#437); without it, a past-call row with progress is
+ * treated as complete (1) so it never ranks as urgent.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @param {boolean} [isCurrentCall=true] - Whether the row's displayed call is
+ *   the current/active one. Past calls sort by completion, not updates.
  * @returns {number} Sortable rank (see above).
  */
-export function progressSortValue(entry: ScoreProgress | undefined): number {
+export function progressSortValue(
+  entry: ScoreProgress | undefined,
+  isCurrentCall: boolean = true
+): number {
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
+  if (!isCurrentCall) {
+    const answered = entry.questionsanswered
+    if (answered == null) return 1
+    return Math.min(Math.max(answered, 0) / entry.questionsexpected, 1)
+  }
   if (entry.questionsupdated <= 0) return -1
   return entry.questionsupdated / entry.questionsexpected
 }

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -40,15 +40,24 @@ export function progressSortValue(entry: ScoreProgress | undefined): number {
  * otherwise a state description that never contradicts the chip (an "Updated"
  * system with an unusable timestamp reads "time unavailable," not "no updates").
  * @param {ScoreProgress | undefined} entry - The system's progress row.
+ * @param {object} [opts] - Display context.
+ * @param {boolean} [opts.completed] - True when the cell shows a past-call
+ *   "Complete" chip (ztmf#537). The current-cycle fallbacks below describe
+ *   this-cycle activity, which is meaningless for a closed call, so a completed
+ *   cell without a usable timestamp reads "Data call complete" instead.
  * @returns {string} Human-readable description of the cell's state.
  */
-export function progressTooltip(entry: ScoreProgress | undefined): string {
+export function progressTooltip(
+  entry: ScoreProgress | undefined,
+  opts: { completed?: boolean } = {}
+): string {
   if (!entry) return 'No progress data for this data call'
   if (entry.lastupdatedat) {
     const at = new Date(entry.lastupdatedat)
     if (!isNaN(at.getTime())) return `Last updated ${at.toLocaleString()}`
   }
   // No usable timestamp: describe the state without contradicting the chip.
+  if (opts.completed) return 'Data call complete'
   if (hasNoQuestionnaire(entry))
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'


### PR DESCRIPTION
This is the in-repo version of #542 by @voidspooks, with follow-up fixes from @danielbowne, moved onto an in-repo branch so the org-secret CI gates (Snyk, Infrastructure/Deploy) run and it can deploy to dev on green. The commits are carried over unchanged with authorship preserved.

@danielbowne's refinement (`b579da7`) additionally gates the past-call **Complete** chip on answered counts — a past call with zero or partial answers no longer shows Complete — and adds a closed-late gate so a call stops being treated as "current" once its own deadline has passed.

Closes #537. Refs #542.

---

## Problem

On the Home dashboard, selecting a **past** year (e.g. `FY24 ZTM`) showed `0/40 Not updated` (orange) for systems that were in fact **complete** in that call — making completed historical data look missing.

## Root cause (frontend only)

The Data Call Progress chip is a **this-cycle** metric: it derives from `entry.questionsupdated`, the count of functions with a genuine edit event this cycle (ztmf#299 — answers carried over from a prior call don't count until re-saved). A past call has no edits this cycle, so `questionsupdated = 0` for those systems → `0/40 Not updated`, regardless of whether the call was completed. "Updated this cycle" has no meaning once a call is closed.

## Fix

Gate the current-cycle framing to the **current/active** data call. A row's displayed call is current when `chosenCallMap[fismasystemid] === latestDataCallId` (both already available — `chosenCallMap` from `buildDashboardMaps`, `latestDataCallId` from context).

- **Past call, complete** → neutral **Complete** chip (gated on answered counts per the follow-up fix, with a score as the fallback completion signal until the backend answered-count field lands).
- **Current call** → unchanged `N/40` fraction + Updated/Not-updated chip.
- The orange "Not updated" chip and the "Not updated only" filter are now **current-call-only**, so a past year surfaces no false laggards.
- The `0/0` **N/A** case and the Zero Trust Score column are unchanged.

Nothing is hardcoded to a specific call: `latestDataCallId` is derived dynamically (furthest-out deadline), so this stays correct for every future cycle, including the 2026+ single-call-per-year setup.

## Changes

- `progressColumn.tsx` — `ProgressCell` takes `isCurrentCall` / `hasScore`; renders the Complete chip for a completed past call (defaults preserve current behavior for existing callers).
- `progressHelpers.ts` — `progressTooltip` gains a `{ completed }` option so its fallback ("Data call complete") doesn't contradict the Complete chip; the past-call sort value is gated on `isCurrentCall` so a complete past row doesn't sort to the laggard top.
- `dashboardFilters.ts` — `isNotUpdated` / `applyDashboardFilters` take an `isCurrentCall` signal; the not-updated facet only matches current-call laggards.
- `FismaTable.tsx` — derives the per-row `isRowCurrentCall` predicate (including the closed-late gate) and wires it into the column and the filter.
- `types.ts` — adds the optional per-call answered-count field consumed by the Complete gate.

## Acceptance criteria

- [x] Past year: systems that are complete show a neutral **Complete** chip, not `0/40 Not updated`.
- [x] Orange "Not updated" / `0/40` appears **only** on the current/active call.
- [x] Zero Trust Score column continues to reflect each system's call for the selected year.
- [x] 2026 single-call-per-year renders correctly (no regression).

## Testing

- `progressColumn.test.tsx` — past-call Complete chip vs current-call Updated/Not-updated; past-call no-score em-dash; past-call incomplete; sort-order for past vs current; tooltip completed cases.
- `dashboardFilters.test.ts` — the laggard filter is current-call-only.
- `aggregateScores.test.ts` — untouched; the fix doesn't alter the maps (best-call selection unchanged).
- `tsc --noEmit` clean, `eslint` 0 errors, full `jest` suite green.

Original fork PR #542 (by @voidspooks, with fixes by @danielbowne): https://github.com/CMS-Enterprise/ztmf-ui/pull/542
