### PR TITLE
fix(dashboard): "Show Decommissioned" toggle enables and clears via "Clear filters" (#566)

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -208,7 +208,7 @@ export function CustomFooterSaveComponent(
   )
 }
 
-function QuickSearchToolbar(props: {
+export function QuickSearchToolbar(props: {
   filters?: DashboardFilterState
   onFiltersChange?: (next: DashboardFilterState) => void
   envOptions?: string[]
@@ -382,8 +382,17 @@ function QuickSearchToolbar(props: {
         <Button
           size="small"
           startIcon={<CloseIcon />}
-          onClick={() => onFiltersChange(EMPTY_DASHBOARD_FILTERS)}
-          disabled={hasNoActiveFilters(filters)}
+          onClick={() => {
+            onFiltersChange(EMPTY_DASHBOARD_FILTERS)
+            // Show Decommissioned lives in Title context (it gates a refetch),
+            // not in the client-side filter model — so clear it separately or it
+            // would survive "Clear filters".
+            setShowDecommissioned(false)
+          }}
+          // ...and it's an active filter for the button's own enabled state:
+          // without this, toggling only Show Decommissioned left Clear filters
+          // greyed out (#566).
+          disabled={hasNoActiveFilters(filters) && !showDecommissioned}
           sx={{ color: '#004297', textTransform: 'none', mr: 2, flexShrink: 0 }}
         >
           Clear filters

--- a/src/views/FismaTable/QuickSearchToolbar.test.tsx
+++ b/src/views/FismaTable/QuickSearchToolbar.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QuickSearchToolbar } from './FismaTable'
+import {
+  EMPTY_DASHBOARD_FILTERS,
+  type DashboardFilterState,
+} from './dashboardFilters'
+
+// FismaTable's module graph reaches @/axiosConfig, which reads import.meta.env;
+// stub it so Jest can parse the graph (mirrors FismaTable.test.tsx).
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}))
+
+// GridToolbarQuickFilter calls useGridApiContext, which needs a mounted DataGrid.
+// The toolbar renders it, but this test only exercises the filter controls, so
+// stub it to a plain node (mirrors the GridFooter stub in FismaTable.test.tsx).
+jest.mock('@mui/x-data-grid', () => ({
+  ...jest.requireActual('@mui/x-data-grid'),
+  GridToolbarQuickFilter: () => <div data-testid="quick-filter" />,
+}))
+
+// The toolbar reads Show Decommissioned from the Title outlet context (it gates
+// a refetch, so it lives there, not in the client-side filter model). Mock the
+// context hook so we can drive that flag per test.
+const mockSetShowDecommissioned = jest.fn()
+let mockShowDecommissioned = false
+jest.mock('@/views/Title/Context', () => ({
+  __esModule: true,
+  useContextProp: () => ({
+    showDecommissioned: mockShowDecommissioned,
+    setShowDecommissioned: mockSetShowDecommissioned,
+  }),
+}))
+
+function renderToolbar(
+  filters: DashboardFilterState = EMPTY_DASHBOARD_FILTERS,
+  onFiltersChange = jest.fn()
+) {
+  return render(
+    <QuickSearchToolbar filters={filters} onFiltersChange={onFiltersChange} />
+  )
+}
+
+const clearBtn = () => screen.getByRole('button', { name: /clear filters/i })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockShowDecommissioned = false
+})
+
+describe('QuickSearchToolbar — Clear filters vs Show Decommissioned (#566)', () => {
+  it('disables Clear filters when nothing is active', () => {
+    renderToolbar()
+    expect(clearBtn()).toBeDisabled()
+  })
+
+  it('enables Clear filters when only Show Decommissioned is on', () => {
+    // The bug: this toggle lives outside the filter model, so the button used to
+    // stay greyed out even though a filter was effectively active.
+    mockShowDecommissioned = true
+    renderToolbar()
+    expect(clearBtn()).toBeEnabled()
+  })
+
+  it('still enables Clear filters for a normal filter (no regression)', () => {
+    renderToolbar({ ...EMPTY_DASHBOARD_FILTERS, notUpdatedOnly: true })
+    expect(clearBtn()).toBeEnabled()
+  })
+
+  it('Clear filters resets both the filter model and Show Decommissioned', () => {
+    mockShowDecommissioned = true
+    const onFiltersChange = jest.fn()
+    renderToolbar(
+      { ...EMPTY_DASHBOARD_FILTERS, notUpdatedOnly: true },
+      onFiltersChange
+    )
+    fireEvent.click(clearBtn())
+    expect(onFiltersChange).toHaveBeenCalledWith(EMPTY_DASHBOARD_FILTERS)
+    expect(mockSetShowDecommissioned).toHaveBeenCalledWith(false)
+  })
+
+  it('flipping the Show Decommissioned switch drives the context setter', () => {
+    renderToolbar()
+    const toggle = screen.getByRole('checkbox', {
+      name: /show decommissioned/i,
+    })
+    fireEvent.click(toggle)
+    expect(mockSetShowDecommissioned).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
Closes #566.

## Problem

On the Home dashboard filter bar, the **Clear filters** button lit up for an Environment selection or the **Not updated only** switch, but **not** for the **Show Decommissioned** switch — and Clear filters wouldn't reset Show Decommissioned either.

## Cause

`Show Decommissioned` is the odd one out. Environment and Not-updated-only are part of the client-side `DashboardFilterState` object, which is what `hasNoActiveFilters(filters)` (the button's `disabled` source) reads. But Show Decommissioned lives in the Title outlet context, because it gates a server refetch — `Title.tsx` runs `fetchFismaSystems(showDecommissioned)` when it flips, since decommissioned rows are pulled from the API (`?decommissioned=true`), not filtered client-side. So the button never saw it, and `EMPTY_DASHBOARD_FILTERS` never touched it.

## Fix

Treat Show Decommissioned as a de-facto active filter for the button, while leaving it in context where the refetch needs it:

- `disabled={hasNoActiveFilters(filters) && !showDecommissioned}`
- Clear filters also calls `setShowDecommissioned(false)` alongside `onFiltersChange(EMPTY_DASHBOARD_FILTERS)`

Clearing while decommissioned is on drops those rows the correct way — the toggle flip re-runs the fetch without them. When it's already off, the `setShowDecommissioned(false)` is an identical-value set that React short-circuits, so there's no spurious refetch.

## Tests

Exported `QuickSearchToolbar` and added `QuickSearchToolbar.test.tsx`:
- Clear filters disabled when nothing is active
- enabled when only Show Decommissioned is on
- enabled for a normal filter (regression guard)
- Clear filters resets both the filter model and Show Decommissioned
- flipping the switch drives the context setter

## Verified

- `npx tsc --noEmit` clean
- full jest suite green (494 pass)
- lint clean (the one remaining warning is the pre-existing InsightsPanel react-refresh notice)

## Follow-ups (not in this PR)

- A Title-level integration test asserting the clear-triggered refetch drops decommissioned rows (this component's unit tests confirm the setter is called; the refetch itself lives in the Title effect).
- Pre-existing: Clear filters doesn't reset the DataGrid free-text quick-filter — separate from this bug.
