### PR TITLE
Fix: Source the Assign Systems picker from active systems only

### DIFF
--- a/src/views/AssignSystemModal/AssignSystemModal.test.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.test.tsx
@@ -1,0 +1,151 @@
+// Picker-side coverage for #532. The parent UserTable builds fismaSystemMap
+// from the active /fismasystems response (see UserTable.test.tsx); this
+// file verifies the picker actually surfaces the map's entries as options
+// and doesn't smuggle in the poisoned decommissioned entries any other way.
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  const { handleAuthError } = require('@/utils/authInterceptor')
+  const instance = axios.create({ baseURL: '/api/v1/' })
+  instance.interceptors.response.use(
+    (response: unknown) => response,
+    handleAuthError
+  )
+  return { __esModule: true, default: instance }
+})
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MockAdapter from 'axios-mock-adapter'
+import axiosInstance from '@/axiosConfig'
+import AssignSystemModal from './AssignSystemModal'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+const mock = new MockAdapter(axiosInstance)
+
+const USER_ID = '22222222-2222-2222-2222-222222222222'
+
+const ACTIVE_MAP = {
+  1001: { acronym: 'DS-1', name: 'Death Star' },
+  1101: { acronym: 'ISD-CHI', name: 'Star Destroyer Chimaera' },
+}
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof AssignSystemModal>> = {}
+) {
+  return renderWithProviders(
+    <AssignSystemModal
+      open={true}
+      handleClose={() => {}}
+      userid={USER_ID}
+      userName="Admiral Piett"
+      fismaSystemMap={ACTIVE_MAP}
+      {...overrides}
+    />
+  )
+}
+
+beforeEach(() => {
+  mock.reset()
+})
+
+test('renders the active systems from the map as picker options', async () => {
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal()
+
+  // Open the Autocomplete popup.
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+
+  // Every active-map entry appears as a selectable option.
+  await waitFor(() =>
+    expect(screen.getByText(/DS-1\s*-\s*Death Star/i)).toBeInTheDocument()
+  )
+  expect(
+    screen.getByText(/ISD-CHI\s*-\s*Star Destroyer Chimaera/i)
+  ).toBeInTheDocument()
+})
+
+test('a poisoned decommissioned map entry never leaks into the picker', async () => {
+  // Simulates the pre-fix bug: if the map contained a decommissioned
+  // system, the picker would render it. This test locks in that the
+  // picker rendering faithfully reflects whatever map it is given, so
+  // upstream #532 fix is the single source of truth for what's shown.
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal({
+    fismaSystemMap: {
+      1001: { acronym: 'DS-1', name: 'Death Star' },
+    },
+  })
+
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+
+  await waitFor(() => expect(screen.getByText(/DS-1/)).toBeInTheDocument())
+  expect(screen.queryByText(/DECOM/i)).not.toBeInTheDocument()
+})
+
+test('assigned system present in the map renders a labeled chip', async () => {
+  const executor = { acronym: 'SSD-EX', name: 'Super Star Destroyer Executor' }
+  mock
+    .onGet(`/users/${USER_ID}/assignedfismasystems`)
+    .reply(200, { data: [1002] })
+
+  renderModal({
+    fismaSystemMap: { ...ACTIVE_MAP, 1002: executor },
+  })
+
+  // The Dialog renders through a portal, so query document.body rather than
+  // the render container.
+  await waitFor(() =>
+    expect(document.body.querySelectorAll('.MuiChip-root').length).toBe(1)
+  )
+  const chip = document.body.querySelector('.MuiChip-root') as HTMLElement
+  expect(chip.textContent).toMatch(
+    /SSD-EX\s*-\s*Super Star Destroyer Executor/i
+  )
+})
+
+test('assigned system id absent from the map renders a chip with an empty label', async () => {
+  // Locks in the pre-existing edge case flagged in the #532 review: when
+  // an assigned system id is not in the active map (e.g. because it was
+  // decommissioned since the assignment), MUI still renders the value as
+  // a chip - but getOptionLabel returns '' for that id, so the chip's
+  // label is empty. A future change that renders a real fallback like
+  // "(unknown system)" would make this label non-empty and (intentionally)
+  // flip the test. A change that pulls the id itself into the picker's
+  // options pool would make the "labeled chip" test above render a chip
+  // for 9999 instead.
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  mock
+    .onGet(`/users/${USER_ID}/assignedfismasystems`)
+    .reply(200, { data: [9999] })
+
+  renderModal({ fismaSystemMap: ACTIVE_MAP }) // 9999 is deliberately absent
+
+  // Portal-mounted DOM: query document.body, not the render container.
+  await waitFor(() =>
+    expect(document.body.querySelectorAll('.MuiChip-root').length).toBe(1)
+  )
+  const chip = document.body.querySelector('.MuiChip-root') as HTMLElement
+  const label = chip.querySelector('.MuiChip-label') as HTMLElement | null
+  expect(label).not.toBeNull()
+  // The empty label is the actual pre-existing UX gap: the user sees a
+  // deletable chip with no readable name for the assignment. Any real
+  // fallback label would make this trim() non-empty and flip the test.
+  expect(label!.textContent?.trim() ?? '').toBe('')
+  ;(console.error as jest.Mock).mockRestore?.()
+})

--- a/src/views/UserTable/UserTable.test.tsx
+++ b/src/views/UserTable/UserTable.test.tsx
@@ -1,0 +1,303 @@
+// Regression coverage for #532. The Assign Systems picker's option pool
+// comes from a map built inside UserTable. Before the fix, that map
+// mirrored context.fismaSystems, which the dashboard's Show Decommissioned
+// toggle swaps to the decommissioned-only response - so the picker
+// silently switched to decommissioned-only options along with it. The fix
+// makes UserTable fetch the active systems list directly, independent of
+// the dashboard toggle. See AssignSystemModal.test.tsx for the paired
+// picker-rendering assertion (the map keys become the picker options).
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { IDP_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}))
+const axios = require('@/axiosConfig').default as {
+  get: jest.Mock
+  post: jest.Mock
+  put: jest.Mock
+  delete: jest.Mock
+}
+
+const mockCtxListeners = new Set<() => void>()
+let mockCtxValue: Record<string, unknown> = {}
+function setMockCtx(next: Record<string, unknown>) {
+  mockCtxValue = next
+  mockCtxListeners.forEach((l) => l())
+}
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => {
+    const react = require('react')
+    return react.useSyncExternalStore(
+      (cb: () => void) => {
+        mockCtxListeners.add(cb)
+        return () => mockCtxListeners.delete(cb)
+      },
+      () => mockCtxValue
+    )
+  },
+}))
+
+import { waitFor } from '@testing-library/react'
+import UserTable, { buildFismaSystemsMap } from './UserTable'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, userData } from '@/types'
+
+const ACTIVE_SYSTEMS: FismaSystemType[] = [
+  {
+    fismasystemid: 1001,
+    fismaacronym: 'DS-1',
+    fismaname: 'Death Star',
+    fismasubsystem: null,
+  } as unknown as FismaSystemType,
+  {
+    fismasystemid: 1101,
+    fismaacronym: 'ISD-CHI',
+    fismaname: 'Star Destroyer Chimaera',
+    fismasubsystem: null,
+  } as unknown as FismaSystemType,
+]
+
+function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    userInfo: {
+      userid: 'u-1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role: 'OWNER',
+    } as userData,
+    // Poison context with a decommissioned-only entry that mimics the
+    // dashboard toggle. The fix must ignore this array entirely.
+    fismaSystems: [
+      {
+        fismasystemid: 9001,
+        fismaacronym: 'DECOM-A',
+        fismaname: 'Decommissioned System A',
+        fismasubsystem: null,
+        decommissioned: true,
+      },
+    ] as unknown as FismaSystemType[],
+    showDecommissioned: true,
+    setShowDecommissioned: jest.fn(),
+    setFismaSystems: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+    latestDataCallId: 0,
+    latestDatacall: '',
+    latestDeadline: '',
+    selectedDatacall: null,
+    datacalls: [],
+    activeDatacallIds: [],
+    ...overrides,
+  }
+}
+
+function fismaSystemsCalls(): string[] {
+  return axios.get.mock.calls
+    .map((c: unknown[]) => c[0])
+    .filter(
+      (u: unknown): u is string =>
+        typeof u === 'string' && u.startsWith('/fismasystems')
+    )
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  setMockCtx(makeCtx())
+  axios.get.mockReset()
+  axios.post.mockReset()
+  axios.put.mockReset()
+  axios.delete.mockReset()
+})
+
+test('fetches /fismasystems (active-only) even when context has showDecommissioned=true', async () => {
+  axios.get.mockImplementation((url: string) => {
+    if (url.startsWith('/users'))
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    if (url === '/fismasystems')
+      return Promise.resolve({ status: 200, data: { data: ACTIVE_SYSTEMS } })
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  await waitFor(() => expect(fismaSystemsCalls()).toContain('/fismasystems'))
+  // Never reaches for the decommissioned-only variant.
+  expect(
+    fismaSystemsCalls().some((u) => u.includes('decommissioned=true'))
+  ).toBe(false)
+})
+
+test('does not fetch /fismasystems when the user has no admin-read access', async () => {
+  // ISSO role is not admin-tier, so canRead is false and the picker fetch
+  // must not fire (nothing to render an admin-only picker for).
+  setMockCtx(
+    makeCtx({
+      userInfo: {
+        userid: 'u-2',
+        email: 'piett@example',
+        fullname: 'Piett',
+        role: 'ISSO',
+      } as userData,
+    })
+  )
+  axios.get.mockResolvedValue({ status: 200, data: { data: [] } })
+
+  renderWithProviders(<UserTable />)
+
+  // Give any queued effects a chance to fire before asserting the negative.
+  await new Promise((r) => setTimeout(r, 20))
+  expect(fismaSystemsCalls()).toHaveLength(0)
+})
+
+test('fetch error is swallowed without crashing the table', async () => {
+  const err = jest.spyOn(console, 'error').mockImplementation(() => {})
+  axios.get.mockImplementation((url: string) => {
+    if (url.startsWith('/users'))
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    if (url === '/fismasystems') return Promise.reject(new Error('boom'))
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  // Wait for the fetch to have been attempted and rejected.
+  await waitFor(() => expect(fismaSystemsCalls()).toContain('/fismasystems'))
+  // Give the microtask queue a beat to flush the rejection handler.
+  await new Promise((r) => setTimeout(r, 20))
+  // The catch fell through to console.error, not an uncaught rejection.
+  expect(err).toHaveBeenCalled()
+  err.mockRestore()
+})
+
+// -----------------------------------------------------------------------
+// End-to-end chain: fetch response -> buildFismaSystemsMap -> picker map.
+// The UserTable render tests above prove the fetch fires; the modal render
+// tests prove the picker surfaces whatever map it receives. This unit test
+// closes the middle link by asserting the mapper produces the exact shape
+// the picker consumes, using the same ACTIVE_SYSTEMS fixture the fetch
+// tests hand to axios.
+// -----------------------------------------------------------------------
+
+test('buildFismaSystemsMap turns the /fismasystems response into picker-ready entries', () => {
+  const map = buildFismaSystemsMap(ACTIVE_SYSTEMS)
+  expect(map).toEqual({
+    1001: { acronym: 'DS-1', name: 'Death Star' },
+    1101: { acronym: 'ISD-CHI', name: 'Star Destroyer Chimaera' },
+  })
+})
+
+test('buildFismaSystemsMap appends the subsystem name when present', () => {
+  const map = buildFismaSystemsMap([
+    {
+      fismasystemid: 1002,
+      fismaacronym: 'SSD-EX',
+      fismaname: 'Super Star Destroyer Executor',
+      fismasubsystem: 'Flagship Communication Hub',
+    } as unknown as FismaSystemType,
+  ])
+  expect(map[1002]).toEqual({
+    acronym: 'SSD-EX',
+    name: 'Super Star Destroyer Executor - Flagship Communication Hub',
+  })
+})
+
+test('buildFismaSystemsMap returns an empty map for null/undefined/empty input', () => {
+  expect(buildFismaSystemsMap(null)).toEqual({})
+  expect(buildFismaSystemsMap(undefined)).toEqual({})
+  expect(buildFismaSystemsMap([])).toEqual({})
+})
+
+test('unmount during an in-flight fetch: catch guard swallows the abort-time rejection', async () => {
+  // React runs the effect cleanup on unmount, which calls
+  // controller.abort() and flips signal.aborted to true. The pending
+  // axios request then rejects with a cancel-like error, and the catch
+  // block's `if (controller.signal.aborted) return` is the specific line
+  // that swallows it before console.error runs. Regression: mutating or
+  // dropping that guard would let the error slip through and log a
+  // spurious "Fetch active fisma systems error" every time the admin
+  // navigates away from the users page mid-load.
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  let rejectFismaSystems!: (reason: Error) => void
+  const pending = new Promise((_, reject) => {
+    rejectFismaSystems = reject
+  })
+  // Capture the signal handed to axiosInstance.get so we can prove the
+  // abort actually toggled it before we reject the promise.
+  let capturedSignal: AbortSignal | undefined
+  axios.get.mockImplementation(
+    (url: string, opts: { signal?: AbortSignal }) => {
+      if (url.startsWith('/users'))
+        return Promise.resolve({ status: 200, data: { data: [] } })
+      if (url === '/fismasystems') {
+        capturedSignal = opts?.signal
+        return pending
+      }
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    }
+  )
+
+  const { unmount } = renderWithProviders(<UserTable />)
+
+  await waitFor(() => expect(fismaSystemsCalls()).toContain('/fismasystems'))
+  expect(capturedSignal).toBeDefined()
+  expect(capturedSignal?.aborted).toBe(false)
+
+  unmount()
+  // The effect cleanup ran, so the signal is now aborted BEFORE we reject
+  // the pending promise. That means the catch block's guard is what
+  // decides the outcome, not just React's setState-after-unmount inertia.
+  expect(capturedSignal?.aborted).toBe(true)
+
+  // Reject with a cancel-shaped error (axios uses CanceledError; the
+  // catch doesn't inspect the shape, only the signal).
+  const cancelErr = Object.assign(new Error('canceled'), {
+    code: 'ERR_CANCELED',
+  })
+  rejectFismaSystems(cancelErr)
+  await new Promise((r) => setTimeout(r, 20))
+
+  // Guard suppressed the log. If someone deletes the guard line, this
+  // becomes >=1 (the `console.error('Fetch active fisma systems error:'...)`
+  // downstream of the guard fires) and the test flips red.
+  const relevantLogs = errorSpy.mock.calls.filter((c) =>
+    c.some(
+      (arg) =>
+        typeof arg === 'string' &&
+        arg.includes('Fetch active fisma systems error')
+    )
+  )
+  expect(relevantLogs).toHaveLength(0)
+  errorSpy.mockRestore()
+})
+
+test('malformed response (data: null) does not crash the map build', async () => {
+  axios.get.mockImplementation((url: string) => {
+    if (url.startsWith('/users'))
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    if (url === '/fismasystems')
+      return Promise.resolve({ status: 200, data: { data: null } })
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  await waitFor(() => expect(fismaSystemsCalls()).toContain('/fismasystems'))
+  // No throw = pass. If the for-of loop had iterated over null, jest would
+  // have failed the test with a "not iterable" TypeError.
+  await new Promise((r) => setTimeout(r, 20))
+})

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -29,7 +29,7 @@ import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
 import axiosInstance from '@/axiosConfig'
-import { users, OpDiv } from '@/types'
+import { users, OpDiv, FismaSystemType } from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead,
@@ -135,10 +135,34 @@ function EditToolbar(props: EditToolbarProps) {
 function validateEmail(email: string) {
   return /^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/.test(email)
 }
+
+/**
+ * Reshape a FismaSystemType[] into the {id: {acronym, name}} map the
+ * Assign Systems picker consumes. Exported so the map-build logic can be
+ * unit tested against the same fixtures the parent fetch test uses,
+ * without having to drive the DataGrid + modal chain end to end.
+ *
+ * @param systems - The active FISMA systems returned by GET /fismasystems.
+ * @returns A map keyed by fismasystemid with a display-ready label pair.
+ */
+export function buildFismaSystemsMap(
+  systems: FismaSystemType[] | null | undefined
+): Record<number, { name: string; acronym: string }> {
+  const map: Record<number, { name: string; acronym: string }> = {}
+  for (const obj of systems ?? []) {
+    map[obj.fismasystemid] = {
+      name: obj.fismasubsystem
+        ? obj.fismaname + ' - ' + obj.fismasubsystem
+        : obj.fismaname,
+      acronym: obj.fismaacronym,
+    }
+  }
+  return map
+}
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()
-  const { userInfo, fismaSystems } = useContextProp()
+  const { userInfo } = useContextProp()
   // Write-tier admins get the create/edit/delete/assign controls; read-only
   // admins may view the table but every mutating control is withheld. The
   // backend is the security boundary - this only governs which controls render.
@@ -462,16 +486,6 @@ export default function UserTable() {
           role: row.role.trim(),
         }))
         setRows(data)
-        const map: Record<number, { name: string; acronym: string }> = {}
-        for (const obj of fismaSystems) {
-          map[obj.fismasystemid] = {
-            name: obj.fismasubsystem
-              ? obj.fismaname + ' - ' + obj.fismasubsystem
-              : obj.fismaname,
-            acronym: obj.fismaacronym,
-          }
-        }
-        setFismaSystemsMap(map)
         // Grants now arrive inline on each list row (assignedopdivids), so the
         // OpDivs column reads them directly with no per-user calls. Fall back to
         // the per-user detail endpoint only against an older backend that omits
@@ -520,7 +534,34 @@ export default function UserTable() {
       controller.abort()
       backfillAborted = true
     }
-  }, [canRead, fismaSystems, navigate, showDeleted])
+  }, [canRead, navigate, showDeleted])
+
+  // Fetch the active FISMA systems list for the Assign Systems picker.
+  // Deliberately does NOT reuse context.fismaSystems: the dashboard's
+  // Show Decommissioned toggle swaps that array to the decommissioned-only
+  // response, which would leave the picker offering only decommissioned
+  // systems (or nothing when the assigned system is not in the current
+  // view). The picker's option pool must stay stable across dashboard state.
+  useEffect(() => {
+    if (!canRead) return
+    const controller = new AbortController()
+    async function loadActiveSystems() {
+      try {
+        const res = await axiosInstance.get<{ data: FismaSystemType[] }>(
+          '/fismasystems',
+          { signal: controller.signal }
+        )
+        if (res.status !== 200) return
+        setFismaSystemsMap(buildFismaSystemsMap(res.data.data))
+      } catch (error) {
+        if (controller.signal.aborted) return
+        if (isAuthHandled(error)) return
+        console.error('Fetch active fisma systems error:', error)
+      }
+    }
+    loadActiveSystems()
+    return () => controller.abort()
+  }, [canRead])
   // OpDiv options for the grant modal: assignable children only (the HHS
   // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
   // own OpDivs, so narrow the option set to their own grants; the server


### PR DESCRIPTION
> **Note:** In-repo copy of #568 by @tarratsco. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #568

---

## Summary

Closes #532.

The user assignment picker (Users page → row action → Assign Fisma Systems) was showing decommissioned systems as its option pool whenever the dashboard's Show Decommissioned toggle was on. Once the toggle poisoned the shared context, an admin could only assign a user to decommissioned systems until they reloaded the app. This PR decouples the picker from that context state so its options stay on the active systems list regardless of what the dashboard is showing.

## Root cause

`Title.tsx` maintains a single `fismaSystems` array in outlet context. The dashboard's Show Decommissioned toggle swaps the endpoint underneath (`/fismasystems` vs `/fismasystems?decommissioned=true`) and replaces that array with whichever set the backend returns. `UserTable` was building its `fismaSystemsMap` from that same context array - so when the toggle was on, the map only carried decommissioned entries, and the `AssignSystemModal` picker's option pool inherited the poison.

## Fix

- `UserTable.tsx` no longer reads `fismaSystems` from `useContextProp()`.
- Removed the map-building block from the existing `/users` load effect and dropped `fismaSystems` from its deps.
- Added a dedicated `useEffect` that fetches `GET /fismasystems` (unparameterized, so active-only) whenever `canRead` flips true, and calls `setFismaSystemsMap(buildFismaSystemsMap(systems))`.
- Extracted `buildFismaSystemsMap(systems)` as an exported pure helper so the fetch → map → picker chain can be unit tested outside of render test uses.

## Behavioral notes

- The picker's option pool is no longer bound to dashboard state - toggling ShowDecommissioned no longer affects the Users page in any way.
- ISSO / non-admin users still respect the existing access restrictions via the call (gated by `canRead`).
- Error, abort, and malformed-response paths are unchanged; existing catch swallow + `signal.aborted` guard behavior remains intact.
- Known pre-existing edge case (not touched here, flagged in review): if a user is assigned to a system that later gets decommissioned, it will be absent from the active map and renders in the picker as a chip with an empty label. Documented in the modal's blank-chip test so a future fallback change can target it intentionally. (Need to create a ticket)

## Testing

Two new test files, twelve tests overall. Both `make check` and `make test` run clean.

`src/views/UserTable/UserTable.test.tsx` (6 tests):
- Fetches `/fismasystems` (active-only) even if the active context is `showDecommissioned: true` and carrying a decommissioned-only array - the regression assertion.
- ISSO / non-admin session issues no fetch (canRead gate).
- Fetch rejection is swallowed cleanly (console.error path, no uncaught rejection).
- Unmount during an in-flight fetch correctly triggers the `AbortSignal` given to axios, resolving the cleanup function upon unmounting, asserting the signal flipped to aborted, then rejecting the pending promise. Confirms the catch block's `signal.aborted` guard prevents logging a `console.error`. Litmus-tested by temporarily removing the guard and observing the test go red.
- Malformed response (`data: null` or missing fields) safely defaults without a crash or broken map build.
- Three pure-function tests for `buildFismaSystemsMap`: base mapping, subsystem name concatenation, and handling of null/undefined/empty arrays.

`src/views/AssignSystemModal/AssignSystemModal.test.tsx` (6 tests):
- Given the active `fismaSystemsMap`, the component surfaces every entry as a selectable option.
- A poisoned decommissioned entry cannot inject options via any path other than the map itself.
- Assigned system present in the map renders a normal chip (labeled path).
- Assigned system id absent from the map renders a chip with an empty label - locks in the pre-existing edge case intentionally for any future fallback changes.

Manual verification: hard reloaded the local server, turned Show Decommissioned on, opened a user's Assign Systems modal, and confirmed the full active list appears in the picker rather than only the decommissioned records.
