### PR TITLE
ZTMF Insights: explain ARS control state on hover (+ 508 keyboard/heading fixes)

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -253,6 +253,48 @@ describe('InsightsPanel', () => {
     expect(screen.getByText('IA-02(08)').textContent).toContain('○')
   })
 
+  it('gives each ARS control chip a plain-language state reason (role=img name = tooltip) for hover + AT', () => {
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: ['IA-01'],
+          ars_not_satisfied_controls: ['IA-02(02)'],
+          ars_failing_controls: ['AC-17'],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // The chip's accessible name is "<id>: <state reason>" — the same string the
+    // Tooltip surfaces on hover — so passed / not-satisfied / failed is exposed
+    // both visually (✓/○/✗ + colour) and to a screen reader, keyed off which
+    // array the control came from.
+    expect(
+      screen.getByRole('img', { name: /^IA-01: Satisfied/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: /^IA-02\(02\): Not satisfied/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: /^AC-17: Other Than Satisfied/ })
+    ).toBeInTheDocument()
+  })
+
+  it('makes each ARS control chip keyboard-focusable so its tooltip is not mouse-only (508)', async () => {
+    render(
+      <InsightsPanel
+        payload={{ ...fullPayload, ars_satisfied_controls: ['IA-01'] }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    const chip = screen.getByRole('img', { name: /^IA-01: Satisfied/ })
+    // Focusable, and the MUI Tooltip fires on focus (not just hover) so a
+    // keyboard-only sighted user can read the state reason.
+    expect(chip).toHaveAttribute('tabindex', '0')
+    fireEvent.focus(chip)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(/Satisfied/)
+  })
+
   it('renders non-satisfied ARS controls even when the satisfied array is absent', () => {
     render(
       <InsightsPanel

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -669,6 +669,18 @@ const CONTROL_CHIP_STYLE: Record<
   },
 }
 
+// Plain-language reason behind each ARS chip's state, surfaced on hover and as the
+// chip's accessible name. The three arrays the pipeline emits ARE the reason: a
+// control lands in exactly one of satisfied / not-satisfied / failing, so the
+// variant fully determines why it's coloured the way it is — no per-control text
+// needed. Ordered passed / not-assessed / failed to match ✓ / ○ / ✗.
+const CONTROL_CHIP_HELP: Record<ControlChipVariant, string> = {
+  satisfied: 'Satisfied — assessed and met (per CFACTS/Archer).',
+  unsatisfied:
+    'Not satisfied — applies to this question but is not marked Satisfied (may be unassessed).',
+  failing: 'Other Than Satisfied — Archer flagged this control as failing.',
+}
+
 function ControlChip({
   id,
   variant,
@@ -685,16 +697,25 @@ function ControlChip({
   ariaLabel?: string
 }) {
   const style = CONTROL_CHIP_STYLE[variant]
+  // Callers may pass their own tooltip/ariaLabel (the feed pass/fail chips do,
+  // with a rich CheckTooltip); ARS chips pass neither, so fall back to the
+  // variant's plain-language reason. Either way the chip always carries a hover
+  // and an accessible name.
+  const effectiveTooltip = tooltip ?? CONTROL_CHIP_HELP[variant]
+  const effectiveAriaLabel = ariaLabel ?? `${id}: ${CONTROL_CHIP_HELP[variant]}`
   const chip = (
     <Box
       component="span"
-      // role="img" only when we supply an accessible name: aria-label on a
-      // role-less generic span is not reliably exposed by AT (NVDA/VoiceOver
-      // often ignore it), so a role is required for the pass/fail context to
-      // actually reach screen-reader users. ARS chips pass no ariaLabel and
-      // stay role-less — they're announced via their visible control-ID text.
-      role={ariaLabel ? 'img' : undefined}
-      aria-label={ariaLabel || undefined}
+      // role="img" + aria-label carries the pass/fail context to screen readers:
+      // the ✓/○/✗ marker and colour are otherwise the only place the state lives
+      // and neither is exposed to AT. A role is required — aria-label on a
+      // role-less generic span is not reliably announced (NVDA/VoiceOver).
+      role="img"
+      aria-label={effectiveAriaLabel}
+      // tabIndex makes the chip keyboard-focusable so the MUI Tooltip (which
+      // listens for focus, not just hover) reaches keyboard-only sighted users —
+      // the hover text would otherwise be mouse-only (508 / WCAG 1.4.13, 2.1.1).
+      tabIndex={0}
       sx={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -709,24 +730,28 @@ function ControlChip({
         bgcolor: style.bgcolor,
         color: style.color,
         border: style.border,
-        cursor: tooltip ? 'help' : undefined,
+        cursor: 'help',
+        // Visible focus indicator (WCAG 2.4.7). Reuses the chip's own text colour,
+        // which already meets contrast against its background.
+        '&:focus-visible': {
+          outline: `2px solid ${style.color}`,
+          outlineOffset: '1px',
+        },
       }}
     >
       <Box component="span">{style.marker}</Box>
       {id}
     </Box>
   )
-  return tooltip ? (
+  return (
     <Tooltip
-      title={tooltip}
+      title={effectiveTooltip}
       placement="top"
       arrow
       slotProps={{ tooltip: { sx: { maxWidth: 340 } } }}
     >
       {chip}
     </Tooltip>
-  ) : (
-    chip
   )
 }
 

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -55,6 +55,16 @@ describe('justification context helpers', () => {
     )
   })
 
+  it('renders the prompt as an h2 so the heading order stays sequential under the question h1 (508)', () => {
+    render(<Harness />)
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Explain the available authentication options',
+      })
+    ).toBeInTheDocument()
+  })
+
   it('prefers a pipeline-authored suggested justification', () => {
     expect(
       buildInsightJustification({

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -437,7 +437,11 @@ export default function JustificationField({
 
   return (
     <Box>
-      <Typography component="h3" variant="h6" sx={{ mb: 1 }}>
+      {/* h2 under the question's h1: this prompt sits directly beneath the
+          question heading, so it must be h2 (not h3) to keep the heading order
+          sequential (508 / WCAG 1.3.1). Mirrors the non-justification note
+          prompt in QuestionnairePage, which is already h2. */}
+      <Typography component="h2" variant="h6" sx={{ mb: 1 }}>
         {label}
       </Typography>
       <Box


### PR DESCRIPTION
## What

ARS control chips in the ZTMF Insights details drawer now explain each control's state on hover, and the chips are reachable by keyboard and screen readers.

Backend already surfaces ARS coverage on every mapped question (per-question ARS mapping, logged in #579). This PR is the frontend piece that makes the control chips self-explanatory.

## Changes

**ARS control hover.** Each chip (satisfied, not-satisfied, failing) carries a tooltip and accessible name describing its state, derived from which payload array the control came from. No payload or shape change; it is a pure passthrough of the existing insights data.

- Satisfied: assessed and met.
- Not satisfied: applies to this question but is not marked Satisfied (may be unassessed).
- Other Than Satisfied: flagged as failing.

**Accessibility (508)**
- Chips expose `role="img"` plus `aria-label`, so the pass/fail state reaches assistive tech. It previously lived only in the colour and the marker, neither exposed to a screen reader.
- Chips are keyboard-focusable with a visible focus ring, and the tooltip fires on focus, so the hover text is no longer mouse-only (WCAG 1.4.13, 2.1.1, 2.4.7).
- Fixed a heading-order skip in the justification prompt: it rendered as `h3` directly under the question's `h1`, skipping `h2`. It is now `h2`, matching the non-justification note prompt, so the heading order is sequential (WCAG 1.3.1).

## Backend / SDL enrichment (already shipped, data side, tracking only)

These changes are already live in the enrichment pipeline and require no frontend change (the payload contract stayed additive). Recorded here and in #579 so the whole effort is tracked against this PR. Pipeline for each: `VW_ZTMF_INSIGHTS` (view), CTAS rebuild `CORE.ZTMF_ENRICHMENT_INSIGHTS`, nightly sync, app `system_insights`.

- **ARS controls per-question.** The ARS join was previously hardcoded to the Authentication function. It is now driven by a per-question ARS mapping (decoder-ring standardized control catalog), with applicability from the CMS ARS 5.2 baseline versus the system FIPS level. Coverage went from one question to roughly 39 of 40. This is what feeds the chips in this PR.
- **Kion finding descriptions.** Replaced the raw NIST control-statement text with real per-check descriptions; dictionary re-seeded and the weekly refresh mirrors it.
- **`kion_passing[]`.** New payload array of passing Kion checks (enables an "N of M checks passed" block). SecurityHub and Hardenize are failing-only sources, so no passing arrays are built for them by design.
- **Hardenize timing fix.** A latest-report-pinned view, so Hardenize no longer blanks for all systems when a daily upstream load is late.
- **FIPS baseline highlight.** New `fips_ceiling` (1 to 4) and `fips_impact_level` scalars; ceiling maps Low to 2, Moderate to 3, High to 4, HVA to 4. Rides the CFACTS fallback until record metadata is seeded, then auto-upgrades.

Payload fields added or fixed (all additive, no rename or retype): `ars_satisfied_controls[]`, `ars_not_satisfied_controls[]`, `ars_failing_controls[]`, `ars_controls_satisfied` / `ars_controls_total` (now per-question); `kion_passing[]`, `fips_ceiling`, `fips_impact_level` (new); `findings.kion[].description` (real per-check text).

Full detail in #579.

## Testing

- `tsc --noEmit` clean
- Full jest suite green; added tests for the ARS chip state reason, keyboard focus plus focus-triggered tooltip, and the justification heading level
- Independent review pass: no blocking issues

Closes #579
