### PR TITLE
Refetch active systems when the Assign Systems modal opens

### DIFF
--- a/src/views/UserTable/UserTable.test.tsx
+++ b/src/views/UserTable/UserTable.test.tsx
@@ -12,6 +12,74 @@ jest.mock('@/router/router', () => ({
   default: { navigate: jest.fn() },
 }))
 
+// MUI DataGrid virtualizes rows and won't render them under jsdom (no
+// layout, no measured height). Stub it with a minimal implementation
+// that renders each row's action column so the Assign Systems row action
+// is clickable in tests. Everything else in the DataGrid API is passed
+// through from the real module.
+jest.mock('@mui/x-data-grid', () => {
+  const actual = jest.requireActual('@mui/x-data-grid')
+  const react = require('react')
+  return {
+    ...actual,
+    // GridActionsCellItem uses useGridRootProps and only works inside a
+    // real DataGrid. Replace it with a plain button so it renders under
+    // our mocked DataGrid below.
+    GridActionsCellItem: (props: {
+      icon?: React.ReactNode
+      label?: string
+      onClick?: () => void
+    }) =>
+      react.createElement(
+        'button',
+        {
+          type: 'button',
+          'aria-label': props.label,
+          onClick: props.onClick,
+        },
+        props.label
+      ),
+    // MUI DataGrid virtualizes rows and won't render them under jsdom (no
+    // layout, no measured height). Stub it with a minimal implementation
+    // that renders each row's action column so row-level buttons are
+    // clickable in tests.
+    DataGrid: (props: {
+      rows?: Array<Record<string, unknown>>
+      columns?: Array<Record<string, unknown>>
+      getRowId?: (row: Record<string, unknown>) => string | number
+    }) => {
+      const { rows = [], columns = [], getRowId } = props
+      return react.createElement(
+        'div',
+        { 'data-testid': 'datagrid-mock' },
+        rows.map((row) => {
+          const id = getRowId ? getRowId(row) : (row.id as string | number)
+          return react.createElement(
+            'div',
+            { key: String(id), 'data-testid': `datagrid-row-${id}` },
+            columns.map((col) => {
+              const getActions = col.getActions as
+                | ((params: {
+                    id: string | number
+                    row: Record<string, unknown>
+                  }) => React.ReactNode[])
+                | undefined
+              if (col.type === 'actions' && getActions) {
+                return react.createElement(
+                  'div',
+                  { key: String(col.field) },
+                  getActions({ id, row })
+                )
+              }
+              return null
+            })
+          )
+        })
+      )
+    },
+  }
+})
+
 jest.mock('@/utils/config', () => ({
   __esModule: true,
   default: { IDP_ENABLED: false },
@@ -52,10 +120,11 @@ jest.mock('../Title/Context', () => ({
   },
 }))
 
-import { waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import UserTable, { buildFismaSystemsMap } from './UserTable'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
-import type { FismaSystemType, userData } from '@/types'
+import type { FismaSystemType, userData, users } from '@/types'
 
 const ACTIVE_SYSTEMS: FismaSystemType[] = [
   {
@@ -300,4 +369,48 @@ test('malformed response (data: null) does not crash the map build', async () =>
   // No throw = pass. If the for-of loop had iterated over null, jest would
   // have failed the test with a "not iterable" TypeError.
   await new Promise((r) => setTimeout(r, 20))
+})
+
+// ---------------------------------------------------------------------------
+// #574: opening the Assign Systems modal refetches so any system added
+// elsewhere in the session shows up in the picker without the admin having
+// to navigate away from /users and back. handleOpenModal invokes
+// loadActiveSystems directly (no state-as-signal), so this test also
+// implicitly locks in "no spurious refetch on unrelated interactions" by
+// counting requests - only clicking the row action bumps the count.
+// ---------------------------------------------------------------------------
+
+test('clicking the Assign Systems row action refetches /fismasystems', async () => {
+  const user = userEvent.setup()
+  const piett: users = {
+    userid: '22222222-2222-2222-2222-222222222222',
+    email: 'Admiral.Piett@executor.empire',
+    fullname: 'Admiral Piett',
+    role: 'ISSO',
+    assignedfismasystems: [1002],
+    assignedopdivids: [],
+  }
+  axios.get.mockImplementation((url: string) => {
+    if (url.startsWith('/users'))
+      return Promise.resolve({ status: 200, data: { data: [piett] } })
+    if (url === '/fismasystems')
+      return Promise.resolve({ status: 200, data: { data: ACTIVE_SYSTEMS } })
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  // Initial mount fires the fetch exactly once.
+  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(1))
+  // GridActionsCellItem is stubbed to a plain button whose aria-label is
+  // the action's label prop ("assignedSystems" in UserTable's columns).
+  const assignBtn = await screen.findByRole('button', {
+    name: 'assignedSystems',
+  })
+
+  // Clicking the icon opens the modal AND invokes loadActiveSystems
+  // directly from the event handler, issuing a second /fismasystems
+  // request.
+  await user.click(assignBtn)
+  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(2))
 })

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
@@ -257,6 +257,11 @@ export default function UserTable() {
     const row = rows.find((r) => r.userid === id)
     setAssignModalUserName(row?.fullname ?? '')
     setOpenModal(true)
+    // Refresh the picker's option pool so a system added elsewhere in the
+    // session shows up in the picker without the admin having to navigate
+    // away from /users and back (#574). Called directly from the event
+    // handler; see the loadActiveSystems callback below.
+    void loadActiveSystems()
   }
   const handleCloseModal = () => {
     setOpenModal(false)
@@ -542,26 +547,36 @@ export default function UserTable() {
   // response, which would leave the picker offering only decommissioned
   // systems (or nothing when the assigned system is not in the current
   // view). The picker's option pool must stay stable across dashboard state.
-  useEffect(() => {
+  //
+  // Exposed as a callback so the event handler that opens the Assign
+  // Systems modal can invoke it directly (#574) - "when the user does X,
+  // do Y" belongs in the event handler, not in an effect fired by a state
+  // increment. The ref tracks the latest in-flight controller so a rapid
+  // reopen cancels the earlier request rather than racing it.
+  const activeSystemsCtrlRef = useRef<AbortController | null>(null)
+  const loadActiveSystems = useCallback(async () => {
     if (!canRead) return
+    activeSystemsCtrlRef.current?.abort()
     const controller = new AbortController()
-    async function loadActiveSystems() {
-      try {
-        const res = await axiosInstance.get<{ data: FismaSystemType[] }>(
-          '/fismasystems',
-          { signal: controller.signal }
-        )
-        if (res.status !== 200) return
-        setFismaSystemsMap(buildFismaSystemsMap(res.data.data))
-      } catch (error) {
-        if (controller.signal.aborted) return
-        if (isAuthHandled(error)) return
-        console.error('Fetch active fisma systems error:', error)
-      }
+    activeSystemsCtrlRef.current = controller
+    try {
+      const res = await axiosInstance.get<{ data: FismaSystemType[] }>(
+        '/fismasystems',
+        { signal: controller.signal }
+      )
+      if (controller.signal.aborted) return
+      if (res.status !== 200) return
+      setFismaSystemsMap(buildFismaSystemsMap(res.data.data))
+    } catch (error) {
+      if (controller.signal.aborted) return
+      if (isAuthHandled(error)) return
+      console.error('Fetch active fisma systems error:', error)
     }
-    loadActiveSystems()
-    return () => controller.abort()
   }, [canRead])
+  useEffect(() => {
+    loadActiveSystems()
+    return () => activeSystemsCtrlRef.current?.abort()
+  }, [loadActiveSystems])
   // OpDiv options for the grant modal: assignable children only (the HHS
   // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
   // own OpDivs, so narrow the option set to their own grants; the server


### PR DESCRIPTION
## Summary

Closes #574.

The Assign Systems picker on the Users page fetched `GET /fismasystems` once at mount and never refreshed. A FISMA system created elsewhere in the session was invisible in the picker until the admin navigated away from `/users` and back - self-heals on nav, but wrong for a picker whose whole job is to show currently assignable systems. This PR fires the fetch when the modal opens so the picker's option pool always reflects the current server state.

## Root cause

The `/fismasystems` fetch effect added in #532 keyed on `[canRead]` only. No dep changes when the modal opens or when the global systems list mutates, so once the map was built at mount, nothing re-ran the fetch. Fast-follow from the review of #532 - not a regression from that fix; #532 correctly decoupled the picker from `context.fismaSystems` and surfaced this pre-existing gap.

## Fix
- `UserTable.tsx` - extracted the `loadActiveSystems` `useCallback` keyed on `canRead`. The mount effect calls it once; `handleOpenModal` calls it directly on each open. An `activeSystemsCtrlRef` (`useRef<AbortController | null>`) holds the latest in-flight controller so a rapid reopen aborts the earlier request rather than racing it. Effect cleanup on unmount aborts via the same ref.
- Removed: intermediate `assignModalOpenTick` state (state-as-signal antipattern).
- Added: `useCallback` and `useRef`.

## Behavioral notes

- Picker's option pool now refreshes every time the modal opens. Adding a system elsewhere in the session shows up in the picker on the next open, no page reload or nav-away/back required.
- No spurious refetches: the fetch is triggered only by mount / `canRead` flip / modal open. Closing the modal does nothing. Other Users-page interactions (Show Deleted toggle, sort, filter) are unaffected.
- Bonus: rapid modal reopen no longer risks a stale earlier response clobbering a later one - the AbortController ref cancels the previous request the moment a new one starts. Visible under DevTools throttling as the earlier request marked `(canceled)`.
- All #532 regression behavior preserved: fetch is still unparameterized (active-only), `canRead` still gates, the catch guard on `signal.aborted` still suppresses spurious console.error on unmount.

## Testing

`UserTable.test.tsx` gets one new test; the existing 8 are unchanged and still pass.

- New: `clicking the Assign Systems row action refetches /fismasystems` - renders UserTable, waits for initial fetch (count = 1), clicks the row's Assign Systems button, asserts count becomes 2. Because MUI DataGrid virtualizes rows and won't render them under jsdom (no layout / no measured height), the test stubs `@mui/x-data-grid`'s `DataGrid` with a minimal row renderer and `GridActionsCellItem` with a plain `<button>` - the actions column is the only surface the test needs, and the DataGrid API is otherwise passed through.
- **Litmus verified**: temporarily removing the `void loadActiveSystems()` call from `handleOpenModal` flipped the new test red. Restored, back to green. So the assertion genuinely protects the fix - a future refactor that drops the direct call will fail this test.
- Existing tests still pass:
  - Fetches `/fismasystems` unparameterized even with `showDecommissioned: true` in context (the #532 regression).
  - `canRead=false` (non-admin) fires zero `/fismasystems` calls.
  - Fetch error is swallowed cleanly (`console.error`, no uncaught rejection).
  - Unmount during an in-flight fetch: the effect cleanup aborts via the ref; the catch guard suppresses `console.error`. Same litmus test on the guard line.
  - Malformed response (`data: null`) doesn't crash the map build.
  - Three `buildFismaSystemsMap` unit tests (base mapping, subsystem concatenation, null/undefined/empty safety).

`make check` and full `yarn jest` clean. 520 tests pass, 3 pre-existing skips.

## Manual verification

1. Log in as an admin, navigate to `/users`, click Assign Systems on any user, note the picker options and close the modal.
2. In a second tab, create a new FISMA system via the Add Fisma System flow.
3. Return to the Users tab (never reloaded), reopen the Assign Systems modal on the same user.
4. **Expected**: the new system appears in the picker options alongside everything from step 1. Before this fix, the new system was absent until the admin navigated away from `/users` and back.