### PR TITLE
fix(users): label decommissioned-system assignments in the picker

### DIFF
--- a/src/views/AssignSystemModal/AssignSystemModal.test.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.test.tsx
@@ -1,7 +1,12 @@
-// Picker-side coverage for #532. The parent UserTable builds fismaSystemMap
-// from the active /fismasystems response (see UserTable.test.tsx); this
-// file verifies the picker actually surfaces the map's entries as options
-// and doesn't smuggle in the poisoned decommissioned entries any other way.
+// Picker-side coverage for the Assign Systems modal. The parent
+// UserTable builds fismaSystemMap from both /fismasystems and
+// /fismasystems?decommissioned=true (see UserTable.test.tsx). This file
+// verifies that the picker
+//   - surfaces active entries as options,
+//   - keeps decommissioned entries in the value pool so their assignments
+//     render as labeled chips (with a "(Decommissioned)" suffix and a
+//     subdued visual), and
+//   - filters those decommissioned entries out of the selectable dropdown.
 
 jest.mock('@/router/router', () => ({
   __esModule: true,
@@ -31,8 +36,12 @@ const mock = new MockAdapter(axiosInstance)
 const USER_ID = '22222222-2222-2222-2222-222222222222'
 
 const ACTIVE_MAP = {
-  1001: { acronym: 'DS-1', name: 'Death Star' },
-  1101: { acronym: 'ISD-CHI', name: 'Star Destroyer Chimaera' },
+  1001: { acronym: 'DS-1', name: 'Death Star', decommissioned: false },
+  1101: {
+    acronym: 'ISD-CHI',
+    name: 'Star Destroyer Chimaera',
+    decommissioned: false,
+  },
 }
 
 function renderModal(
@@ -75,17 +84,23 @@ test('renders the active systems from the map as picker options', async () => {
   ).toBeInTheDocument()
 })
 
-test('a poisoned decommissioned map entry never leaks into the picker', async () => {
-  // Simulates the pre-fix bug: if the map contained a decommissioned
-  // system, the picker would render it. This test locks in that the
-  // picker rendering faithfully reflects whatever map it is given, so
-  // upstream #532 fix is the single source of truth for what's shown.
+test('decommissioned entries in the map are hidden from the selectable dropdown', async () => {
+  // The map carries decommissioned entries so their existing assignments
+  // can render as labeled chips (see the "(Decommissioned)" chip test
+  // below). They must NOT appear in the dropdown as new options - an
+  // admin cannot assign a user to a decommissioned system. filterOptions
+  // strips them; this test locks it in.
   const user = userEvent.setup()
   mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
 
   renderModal({
     fismaSystemMap: {
-      1001: { acronym: 'DS-1', name: 'Death Star' },
+      ...ACTIVE_MAP,
+      9001: {
+        acronym: 'DECOM-A',
+        name: 'Decommissioned System A',
+        decommissioned: true,
+      },
     },
   })
 
@@ -95,11 +110,17 @@ test('a poisoned decommissioned map entry never leaks into the picker', async ()
   await user.click(combobox)
 
   await waitFor(() => expect(screen.getByText(/DS-1/)).toBeInTheDocument())
-  expect(screen.queryByText(/DECOM/i)).not.toBeInTheDocument()
+  // Active entries render as options, but DECOM-A does not.
+  expect(screen.getByText(/ISD-CHI/)).toBeInTheDocument()
+  expect(screen.queryByText(/DECOM-A/)).not.toBeInTheDocument()
 })
 
-test('assigned system present in the map renders a labeled chip', async () => {
-  const executor = { acronym: 'SSD-EX', name: 'Super Star Destroyer Executor' }
+test('assigned system present as an active map entry renders a plain labeled chip', async () => {
+  const executor = {
+    acronym: 'SSD-EX',
+    name: 'Super Star Destroyer Executor',
+    decommissioned: false,
+  }
   mock
     .onGet(`/users/${USER_ID}/assignedfismasystems`)
     .reply(200, { data: [1002] })
@@ -108,8 +129,7 @@ test('assigned system present in the map renders a labeled chip', async () => {
     fismaSystemMap: { ...ACTIVE_MAP, 1002: executor },
   })
 
-  // The Dialog renders through a portal, so query document.body rather than
-  // the render container.
+  // Dialog renders through a portal, so query document.body.
   await waitFor(() =>
     expect(document.body.querySelectorAll('.MuiChip-root').length).toBe(1)
   )
@@ -117,18 +137,49 @@ test('assigned system present in the map renders a labeled chip', async () => {
   expect(chip.textContent).toMatch(
     /SSD-EX\s*-\s*Super Star Destroyer Executor/i
   )
+  expect(chip.textContent).not.toMatch(/Decommissioned/i)
 })
 
-test('assigned system id absent from the map renders a chip with an empty label', async () => {
-  // Locks in the pre-existing edge case flagged in the #532 review: when
-  // an assigned system id is not in the active map (e.g. because it was
-  // decommissioned since the assignment), MUI still renders the value as
-  // a chip - but getOptionLabel returns '' for that id, so the chip's
-  // label is empty. A future change that renders a real fallback like
-  // "(unknown system)" would make this label non-empty and (intentionally)
-  // flip the test. A change that pulls the id itself into the picker's
-  // options pool would make the "labeled chip" test above render a chip
-  // for 9999 instead.
+test('assignment to a decommissioned system renders a labeled chip with "(Decommissioned)" suffix', async () => {
+  // A user assigned to a system that was later decommissioned still has
+  // that id in /users/:id/assignedfismasystems. The chip picks up the
+  // decommissioned flag from the map and renders
+  // "SSD-EX - Super Star Destroyer Executor (Decommissioned)" with a
+  // subdued visual (opacity 0.65 + italic).
+  const retiredExecutor = {
+    acronym: 'SSD-EX',
+    name: 'Super Star Destroyer Executor',
+    decommissioned: true,
+  }
+  mock
+    .onGet(`/users/${USER_ID}/assignedfismasystems`)
+    .reply(200, { data: [1002] })
+
+  renderModal({
+    fismaSystemMap: { ...ACTIVE_MAP, 1002: retiredExecutor },
+  })
+
+  await waitFor(() =>
+    expect(document.body.querySelectorAll('.MuiChip-root').length).toBe(1)
+  )
+  const chip = document.body.querySelector('.MuiChip-root') as HTMLElement
+  const label = chip.querySelector('.MuiChip-label') as HTMLElement | null
+  expect(label).not.toBeNull()
+  // Full readable label with the "(Decommissioned)" suffix.
+  expect(label!.textContent).toMatch(
+    /SSD-EX\s*-\s*Super Star Destroyer Executor\s*\(Decommissioned\)/i
+  )
+  // Subdued visual: opacity < 1 and italic.
+  const chipStyle = window.getComputedStyle(chip)
+  expect(parseFloat(chipStyle.opacity)).toBeLessThan(1)
+  expect(chipStyle.fontStyle).toBe('italic')
+})
+
+test('assigned id absent from the map entirely still renders an identifiable fallback chip', async () => {
+  // Defense-in-depth: if for any reason the map lacks the id (race
+  // between fetch and render, or a system removed between assignment
+  // and load), the chip still gets a readable id-based label so the
+  // admin can unassign it.
   jest.spyOn(console, 'error').mockImplementation(() => {})
   mock
     .onGet(`/users/${USER_ID}/assignedfismasystems`)
@@ -136,16 +187,14 @@ test('assigned system id absent from the map renders a chip with an empty label'
 
   renderModal({ fismaSystemMap: ACTIVE_MAP }) // 9999 is deliberately absent
 
-  // Portal-mounted DOM: query document.body, not the render container.
   await waitFor(() =>
     expect(document.body.querySelectorAll('.MuiChip-root').length).toBe(1)
   )
   const chip = document.body.querySelector('.MuiChip-root') as HTMLElement
   const label = chip.querySelector('.MuiChip-label') as HTMLElement | null
   expect(label).not.toBeNull()
-  // The empty label is the actual pre-existing UX gap: the user sees a
-  // deletable chip with no readable name for the assignment. Any real
-  // fallback label would make this trim() non-empty and flip the test.
-  expect(label!.textContent?.trim() ?? '').toBe('')
+  expect(label!.textContent).toMatch(
+    /Unknown or decommissioned system \(id 9999\)/
+  )
   ;(console.error as jest.Mock).mockRestore?.()
 })

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Chip,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -12,7 +13,7 @@ import axiosInstance from '@/axiosConfig'
 import CustomSnackbar from '../Snackbar/Snackbar'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
-import Autocomplete from '@mui/material/Autocomplete'
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import { ERROR_MESSAGES } from '@/constants'
@@ -21,12 +22,33 @@ import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
 const checkedIcon = <CheckBoxIcon fontSize="small" />
 
+// Default MUI substring filter; wrapped below to also strip decommissioned
+// entries from the dropdown (they should still surface as chips for
+// existing assignments but not be selectable for new ones).
+const defaultOptionFilter = createFilterOptions<number>()
+
+type FismaSystemEntry = {
+  name: string
+  acronym: string
+  decommissioned: boolean
+}
+
 type Props = {
-  fismaSystemMap: Record<number, { name: string; acronym: string }>
+  fismaSystemMap: Record<number, FismaSystemEntry>
   open: boolean
   handleClose: () => void
   userid: GridRowId
   userName: string
+}
+
+function labelFor(
+  option: number,
+  fismaSystemMap: Record<number, FismaSystemEntry>
+): string {
+  const system = fismaSystemMap[option]
+  if (!system) return `Unknown or decommissioned system (id ${option})`
+  const base = `${system.acronym} - ${system.name}`
+  return system.decommissioned ? `${base} (Decommissioned)` : base
 }
 
 export default function AssignSystemModal({
@@ -103,10 +125,25 @@ export default function AssignSystemModal({
               return acrA.localeCompare(acrB)
             })}
             disableClearable
-            getOptionLabel={(option: number) => {
-              const system = fismaSystemMap[option]
-              return system ? `${system.acronym} - ${system.name}` : ''
-            }}
+            // Suffix " (Decommissioned)" when the map flags the entry, or
+            // fall back to an id-based label for genuinely-unknown ids
+            // (e.g. a system removed between the fetch and this render).
+            // Because UserTable fetches both active and decommissioned
+            // systems into the map, decommissioned assignments render a
+            // real name; the fallback is a belt-and-suspenders safety net.
+            getOptionLabel={(option: number) =>
+              labelFor(option, fismaSystemMap)
+            }
+            // Decommissioned entries stay in `options` so MUI's value-vs-
+            // options reconciliation matches an existing decommissioned
+            // assignment (no "None of the options match with <id>" warning).
+            // Strip them from the dropdown here so an admin cannot select
+            // one as a new assignment.
+            filterOptions={(options, params) =>
+              defaultOptionFilter(options, params).filter(
+                (o) => !fismaSystemMap[o]?.decommissioned
+              )
+            }
             renderOption={(props, option, { selected }) => {
               const isAssigned = assignedSystems.includes(option)
               return (
@@ -125,6 +162,28 @@ export default function AssignSystemModal({
                 </li>
               )
             }}
+            // Custom chip render so decommissioned assignments get a
+            // subdued visual (reduced opacity + italics) that reads as
+            // "this is historical, not active", while remaining deletable
+            // so an admin can still unassign the user from it.
+            renderTags={(value, getTagProps) =>
+              value.map((option, index) => {
+                const isDecommissioned =
+                  fismaSystemMap[option]?.decommissioned === true
+                return (
+                  <Chip
+                    {...getTagProps({ index })}
+                    key={option}
+                    label={labelFor(option, fismaSystemMap)}
+                    sx={
+                      isDecommissioned
+                        ? { opacity: 0.65, fontStyle: 'italic' }
+                        : undefined
+                    }
+                  />
+                )
+              })
+            }
             value={assignedSystems}
             onChange={async (_event, newValue) => {
               const added = newValue.filter(
@@ -184,14 +243,10 @@ export default function AssignSystemModal({
         title="Confirm Unassign System"
         confirmationText={
           pendingUnassign
-            ? `Are you sure you want to unassign ${
-                fismaSystemMap[pendingUnassign.systemid]?.acronym ??
-                'this system'
-              }${
-                fismaSystemMap[pendingUnassign.systemid]
-                  ? ` - ${fismaSystemMap[pendingUnassign.systemid].name}`
-                  : ''
-              } from ${userName || 'this user'}?`
+            ? `Are you sure you want to unassign ${labelFor(
+                pendingUnassign.systemid,
+                fismaSystemMap
+              )} from ${userName || 'this user'}?`
             : ''
         }
         open={pendingUnassign !== null}

--- a/src/views/UserTable/UserTable.test.tsx
+++ b/src/views/UserTable/UserTable.test.tsx
@@ -119,7 +119,8 @@ jest.mock('../Title/Context', () => ({
 
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import UserTable, { buildFismaSystemsMap } from './UserTable'
+import UserTable from './UserTable'
+import { buildFismaSystemsMap } from './buildFismaSystemsMap'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import type { FismaSystemType, userData, users } from '@/types'
 

--- a/src/views/UserTable/UserTable.test.tsx
+++ b/src/views/UserTable/UserTable.test.tsx
@@ -1,11 +1,9 @@
-// Regression coverage for #532. The Assign Systems picker's option pool
-// comes from a map built inside UserTable. Before the fix, that map
-// mirrored context.fismaSystems, which the dashboard's Show Decommissioned
-// toggle swaps to the decommissioned-only response - so the picker
-// silently switched to decommissioned-only options along with it. The fix
-// makes UserTable fetch the active systems list directly, independent of
-// the dashboard toggle. See AssignSystemModal.test.tsx for the paired
-// picker-rendering assertion (the map keys become the picker options).
+// Regression coverage for the Assign Systems picker's option pool. The
+// map is built inside UserTable from dedicated /fismasystems fetches
+// rather than context.fismaSystems, which the dashboard's Show
+// Decommissioned toggle would otherwise swap to the decommissioned-only
+// response. See AssignSystemModal.test.tsx for the paired picker-
+// rendering assertions.
 
 jest.mock('@/router/router', () => ({
   __esModule: true,
@@ -15,8 +13,9 @@ jest.mock('@/router/router', () => ({
 // MUI DataGrid virtualizes rows and won't render them under jsdom (no
 // layout, no measured height). Stub it with a minimal implementation
 // that renders each row's action column so the Assign Systems row action
-// is clickable in tests. Everything else in the DataGrid API is passed
-// through from the real module.
+// is clickable in tests. GridActionsCellItem needs the DataGrid context
+// (useGridRootProps), so it's stubbed as a plain button too. Everything
+// else in the DataGrid API is passed through from the real module.
 jest.mock('@mui/x-data-grid', () => {
   const actual = jest.requireActual('@mui/x-data-grid')
   const react = require('react')
@@ -39,10 +38,8 @@ jest.mock('@mui/x-data-grid', () => {
         },
         props.label
       ),
-    // MUI DataGrid virtualizes rows and won't render them under jsdom (no
-    // layout, no measured height). Stub it with a minimal implementation
-    // that renders each row's action column so row-level buttons are
-    // clickable in tests.
+    // Minimal DataGrid that renders each row's action column so row-level
+    // buttons are clickable in tests.
     DataGrid: (props: {
       rows?: Array<Record<string, unknown>>
       columns?: Array<Record<string, unknown>>
@@ -193,22 +190,28 @@ beforeEach(() => {
   axios.delete.mockReset()
 })
 
-test('fetches /fismasystems (active-only) even when context has showDecommissioned=true', async () => {
+test('fetches both /fismasystems and /fismasystems?decommissioned=true regardless of context', async () => {
+  // The picker map needs both active and decommissioned systems so the
+  // modal can render a labeled chip (with a "(Decommissioned)" suffix)
+  // for an assignment to a system that was later retired. Both fetches
+  // fire from UserTable directly, so the dashboard's Show Decommissioned
+  // toggle (truthy in makeCtx()) has no bearing on which endpoints hit.
   axios.get.mockImplementation((url: string) => {
     if (url.startsWith('/users'))
       return Promise.resolve({ status: 200, data: { data: [] } })
     if (url === '/fismasystems')
       return Promise.resolve({ status: 200, data: { data: ACTIVE_SYSTEMS } })
+    if (url === '/fismasystems?decommissioned=true')
+      return Promise.resolve({ status: 200, data: { data: [] } })
     return Promise.resolve({ status: 200, data: { data: [] } })
   })
 
   renderWithProviders(<UserTable />)
 
   await waitFor(() => expect(fismaSystemsCalls()).toContain('/fismasystems'))
-  // Never reaches for the decommissioned-only variant.
-  expect(
-    fismaSystemsCalls().some((u) => u.includes('decommissioned=true'))
-  ).toBe(false)
+  await waitFor(() =>
+    expect(fismaSystemsCalls()).toContain('/fismasystems?decommissioned=true')
+  )
 })
 
 test('does not fetch /fismasystems when the user has no admin-read access', async () => {
@@ -231,6 +234,78 @@ test('does not fetch /fismasystems when the user has no admin-read access', asyn
   // Give any queued effects a chance to fire before asserting the negative.
   await new Promise((r) => setTimeout(r, 20))
   expect(fismaSystemsCalls()).toHaveLength(0)
+})
+
+test('decommissioned fetch failure degrades gracefully: active systems still populate the picker', async () => {
+  // Partial-failure path. Promise.allSettled decouples the two fetches -
+  // a decommissioned-endpoint failure must NOT block the primary active
+  // fetch, which is the picker's source of truth for assignable systems.
+  // Regression: reverting to Promise.all - OR returning early after the
+  // warn without calling setFismaSystemsMap - would blank the picker
+  // entirely, recreating the original context-poisoning symptom (admin
+  // sees zero systems to assign).
+  //
+  // Assertion drives the modal open and inspects the picker options, so
+  // it fails if setFismaSystemsMap is skipped (empty map -> empty
+  // Autocomplete). Logging assertions are secondary.
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const user = userEvent.setup()
+  const piett: users = {
+    userid: '22222222-2222-2222-2222-222222222222',
+    email: 'Admiral.Piett@executor.empire',
+    fullname: 'Admiral Piett',
+    role: 'ISSO',
+    assignedfismasystems: [],
+    assignedopdivids: [],
+  }
+  axios.get.mockImplementation((url: string) => {
+    if (url === '/users' || url.startsWith('/users?'))
+      return Promise.resolve({ status: 200, data: { data: [piett] } })
+    if (url === '/fismasystems')
+      return Promise.resolve({ status: 200, data: { data: ACTIVE_SYSTEMS } })
+    if (url === '/fismasystems?decommissioned=true')
+      return Promise.reject(new Error('backend 500'))
+    if (url.includes('/assignedfismasystems'))
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  // Both endpoints were attempted (parallel fetch fired).
+  await waitFor(() =>
+    expect(fismaSystemsCalls()).toContain('/fismasystems?decommissioned=true')
+  )
+  expect(fismaSystemsCalls()).toContain('/fismasystems')
+
+  // Open the Assign Systems modal for Piett so the picker renders with
+  // the map that (should) have been populated from the active response.
+  const assignBtn = await screen.findByRole('button', {
+    name: 'assignedSystems',
+  })
+  await user.click(assignBtn)
+
+  // Click into the Autocomplete to expand the dropdown, then assert an
+  // active system's option is present. If setFismaSystemsMap was skipped,
+  // the map is {}, the picker has zero options, and this findByText
+  // times out.
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() =>
+    expect(screen.getByText(/DS-1\s*-\s*Death Star/i)).toBeInTheDocument()
+  )
+  expect(
+    screen.getByText(/ISD-CHI\s*-\s*Star Destroyer Chimaera/i)
+  ).toBeInTheDocument()
+
+  // Secondary: the graceful-degradation warning fired.
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('Fetch decommissioned fisma systems failed'),
+    expect.any(Error)
+  )
+  warn.mockRestore()
 })
 
 test('fetch error is swallowed without crashing the table', async () => {
@@ -265,8 +340,36 @@ test('fetch error is swallowed without crashing the table', async () => {
 test('buildFismaSystemsMap turns the /fismasystems response into picker-ready entries', () => {
   const map = buildFismaSystemsMap(ACTIVE_SYSTEMS)
   expect(map).toEqual({
-    1001: { acronym: 'DS-1', name: 'Death Star' },
-    1101: { acronym: 'ISD-CHI', name: 'Star Destroyer Chimaera' },
+    1001: { acronym: 'DS-1', name: 'Death Star', decommissioned: false },
+    1101: {
+      acronym: 'ISD-CHI',
+      name: 'Star Destroyer Chimaera',
+      decommissioned: false,
+    },
+  })
+})
+
+test('buildFismaSystemsMap tags decommissioned entries with decommissioned: true', () => {
+  // Callers pass the union of active and decommissioned systems; the
+  // mapper carries the flag through so the modal can render a
+  // "(Decommissioned)" suffix + subdued styling and filter these entries
+  // out of the selectable dropdown.
+  const mixed: FismaSystemType[] = [
+    ...ACTIVE_SYSTEMS,
+    {
+      fismasystemid: 9001,
+      fismaacronym: 'DECOM-A',
+      fismaname: 'Decommissioned System A',
+      fismasubsystem: null,
+      decommissioned: true,
+    } as unknown as FismaSystemType,
+  ]
+  const map = buildFismaSystemsMap(mixed)
+  expect(map[1001].decommissioned).toBe(false)
+  expect(map[9001]).toEqual({
+    acronym: 'DECOM-A',
+    name: 'Decommissioned System A',
+    decommissioned: true,
   })
 })
 
@@ -282,6 +385,7 @@ test('buildFismaSystemsMap appends the subsystem name when present', () => {
   expect(map[1002]).toEqual({
     acronym: 'SSD-EX',
     name: 'Super Star Destroyer Executor - Flagship Communication Hub',
+    decommissioned: false,
   })
 })
 
@@ -291,13 +395,15 @@ test('buildFismaSystemsMap returns an empty map for null/undefined/empty input',
   expect(buildFismaSystemsMap([])).toEqual({})
 })
 
-test('unmount during an in-flight fetch: catch guard swallows the abort-time rejection', async () => {
+test('unmount during an in-flight fetch: the aborted-guard skips state updates and logging', async () => {
   // React runs the effect cleanup on unmount, which calls
   // controller.abort() and flips signal.aborted to true. The pending
-  // axios request then rejects with a cancel-like error, and the catch
-  // block's `if (controller.signal.aborted) return` is the specific line
-  // that swallows it before console.error runs. Regression: mutating or
-  // dropping that guard would let the error slip through and log a
+  // axios request(s) then reject with cancel-like errors, and the
+  // aborted-guard right after `await Promise.allSettled(...)`
+  //   if (controller.signal.aborted) return
+  // is the specific line that skips both setFismaSystemsMap and any
+  // console.error branch. Regression: mutating or dropping that guard
+  // would let the active-rejection error slip through and log a
   // spurious "Fetch active fisma systems error" every time the admin
   // navigates away from the users page mid-load.
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
@@ -400,17 +506,16 @@ test('clicking the Assign Systems row action refetches /fismasystems', async () 
 
   renderWithProviders(<UserTable />)
 
-  // Initial mount fires the fetch exactly once.
-  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(1))
+  // Initial mount fires both endpoints once (active + decommissioned).
+  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(2))
   // GridActionsCellItem is stubbed to a plain button whose aria-label is
   // the action's label prop ("assignedSystems" in UserTable's columns).
   const assignBtn = await screen.findByRole('button', {
     name: 'assignedSystems',
   })
 
-  // Clicking the icon opens the modal AND invokes loadActiveSystems
-  // directly from the event handler, issuing a second /fismasystems
-  // request.
+  // Clicking the icon opens the modal AND invokes loadFismaSystems
+  // directly from the event handler, issuing both requests again.
   await user.click(assignBtn)
-  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(2))
+  await waitFor(() => expect(fismaSystemsCalls()).toHaveLength(4))
 })

--- a/src/views/UserTable/UserTable.test.tsx
+++ b/src/views/UserTable/UserTable.test.tsx
@@ -309,6 +309,69 @@ test('decommissioned fetch failure degrades gracefully: active systems still pop
   warn.mockRestore()
 })
 
+test('decommissioned fetch fulfilled with data:null still populates the picker from active', async () => {
+  // Fulfilled sibling of the rejection path. `?? []` in the loader
+  // normalizes the null payload; dropping it would blow up the mapper's
+  // for-of and blank the picker.
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const err = jest.spyOn(console, 'error').mockImplementation(() => {})
+  const user = userEvent.setup()
+  const piett: users = {
+    userid: '22222222-2222-2222-2222-222222222222',
+    email: 'Admiral.Piett@executor.empire',
+    fullname: 'Admiral Piett',
+    role: 'ISSO',
+    assignedfismasystems: [],
+    assignedopdivids: [],
+  }
+  axios.get.mockImplementation((url: string) => {
+    if (url === '/users' || url.startsWith('/users?'))
+      return Promise.resolve({ status: 200, data: { data: [piett] } })
+    if (url === '/fismasystems')
+      return Promise.resolve({ status: 200, data: { data: ACTIVE_SYSTEMS } })
+    if (url === '/fismasystems?decommissioned=true')
+      return Promise.resolve({ status: 200, data: { data: null } })
+    if (url.includes('/assignedfismasystems'))
+      return Promise.resolve({ status: 200, data: { data: [] } })
+    return Promise.resolve({ status: 200, data: { data: [] } })
+  })
+
+  renderWithProviders(<UserTable />)
+
+  await waitFor(() =>
+    expect(fismaSystemsCalls()).toContain('/fismasystems?decommissioned=true')
+  )
+  expect(fismaSystemsCalls()).toContain('/fismasystems')
+
+  const assignBtn = await screen.findByRole('button', {
+    name: 'assignedSystems',
+  })
+  await user.click(assignBtn)
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() =>
+    expect(screen.getByText(/DS-1\s*-\s*Death Star/i)).toBeInTheDocument()
+  )
+
+  // Fulfilled path: no graceful-degradation warn, no critical error.
+  expect(warn).not.toHaveBeenCalledWith(
+    expect.stringContaining('Fetch decommissioned fisma systems failed'),
+    expect.anything()
+  )
+  const criticalErrors = err.mock.calls.filter((c) =>
+    c.some(
+      (arg) =>
+        typeof arg === 'string' &&
+        arg.includes('Fetch active fisma systems error')
+    )
+  )
+  expect(criticalErrors).toHaveLength(0)
+  warn.mockRestore()
+  err.mockRestore()
+})
+
 test('fetch error is swallowed without crashing the table', async () => {
   const err = jest.spyOn(console, 'error').mockImplementation(() => {})
   axios.get.mockImplementation((url: string) => {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -30,6 +30,7 @@ import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
 import axiosInstance from '@/axiosConfig'
 import { users, OpDiv, FismaSystemType } from '@/types'
+import { buildFismaSystemsMap } from './buildFismaSystemsMap'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead,
@@ -136,39 +137,6 @@ function validateEmail(email: string) {
   return /^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/.test(email)
 }
 
-/**
- * Reshape a FismaSystemType[] into the map the Assign Systems picker
- * consumes. Each entry carries a `decommissioned` flag so the modal can
- * render a "(Decommissioned)" suffix and greyed styling for assignments
- * to systems that were later retired. Callers pass the union of active
- * and decommissioned systems.
- *
- * Exported so the map-build logic can be unit tested against the same
- * fixtures the parent fetch test uses, without having to drive the
- * DataGrid + modal chain end to end.
- *
- * @param systems - Union of active and decommissioned FISMA systems.
- * @returns A map keyed by fismasystemid with a display-ready label pair
- *   and the decommissioned flag.
- */
-export function buildFismaSystemsMap(
-  systems: FismaSystemType[] | null | undefined
-): Record<number, { name: string; acronym: string; decommissioned: boolean }> {
-  const map: Record<
-    number,
-    { name: string; acronym: string; decommissioned: boolean }
-  > = {}
-  for (const obj of systems ?? []) {
-    map[obj.fismasystemid] = {
-      name: obj.fismasubsystem
-        ? obj.fismaname + ' - ' + obj.fismasubsystem
-        : obj.fismaname,
-      acronym: obj.fismaacronym,
-      decommissioned: !!obj.decommissioned,
-    }
-  }
-  return map
-}
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -137,24 +137,34 @@ function validateEmail(email: string) {
 }
 
 /**
- * Reshape a FismaSystemType[] into the {id: {acronym, name}} map the
- * Assign Systems picker consumes. Exported so the map-build logic can be
- * unit tested against the same fixtures the parent fetch test uses,
- * without having to drive the DataGrid + modal chain end to end.
+ * Reshape a FismaSystemType[] into the map the Assign Systems picker
+ * consumes. Each entry carries a `decommissioned` flag so the modal can
+ * render a "(Decommissioned)" suffix and greyed styling for assignments
+ * to systems that were later retired. Callers pass the union of active
+ * and decommissioned systems.
  *
- * @param systems - The active FISMA systems returned by GET /fismasystems.
- * @returns A map keyed by fismasystemid with a display-ready label pair.
+ * Exported so the map-build logic can be unit tested against the same
+ * fixtures the parent fetch test uses, without having to drive the
+ * DataGrid + modal chain end to end.
+ *
+ * @param systems - Union of active and decommissioned FISMA systems.
+ * @returns A map keyed by fismasystemid with a display-ready label pair
+ *   and the decommissioned flag.
  */
 export function buildFismaSystemsMap(
   systems: FismaSystemType[] | null | undefined
-): Record<number, { name: string; acronym: string }> {
-  const map: Record<number, { name: string; acronym: string }> = {}
+): Record<number, { name: string; acronym: string; decommissioned: boolean }> {
+  const map: Record<
+    number,
+    { name: string; acronym: string; decommissioned: boolean }
+  > = {}
   for (const obj of systems ?? []) {
     map[obj.fismasystemid] = {
       name: obj.fismasubsystem
         ? obj.fismaname + ' - ' + obj.fismasubsystem
         : obj.fismaname,
       acronym: obj.fismaacronym,
+      decommissioned: !!obj.decommissioned,
     }
   }
   return map
@@ -195,7 +205,7 @@ export default function UserTable() {
     assignedfismasystems: [],
   })
   const [fismaSystemsMap, setFismaSystemsMap] = useState<
-    Record<number, { name: string; acronym: string }>
+    Record<number, { name: string; acronym: string; decommissioned: boolean }>
   >({})
   const [showDeleted, setShowDeleted] = useState<boolean>(false)
   const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
@@ -259,9 +269,9 @@ export default function UserTable() {
     setOpenModal(true)
     // Refresh the picker's option pool so a system added elsewhere in the
     // session shows up in the picker without the admin having to navigate
-    // away from /users and back (#574). Called directly from the event
-    // handler; see the loadActiveSystems callback below.
-    void loadActiveSystems()
+    // away from /users and back. Called directly from the event handler;
+    // see the loadFismaSystems callback below.
+    void loadFismaSystems()
   }
   const handleCloseModal = () => {
     setOpenModal(false)
@@ -541,42 +551,75 @@ export default function UserTable() {
     }
   }, [canRead, navigate, showDeleted])
 
-  // Fetch the active FISMA systems list for the Assign Systems picker.
-  // Deliberately does NOT reuse context.fismaSystems: the dashboard's
-  // Show Decommissioned toggle swaps that array to the decommissioned-only
-  // response, which would leave the picker offering only decommissioned
-  // systems (or nothing when the assigned system is not in the current
-  // view). The picker's option pool must stay stable across dashboard state.
+  // Fetch the FISMA systems used by the Assign Systems picker. Two
+  // requests in parallel:
+  //   /fismasystems                     -> active systems (assignable pool)
+  //   /fismasystems?decommissioned=true -> decommissioned systems
+  //
+  // Both are merged into fismaSystemsMap with a `decommissioned` flag per
+  // entry so the modal can (a) render a readable label for an assignment
+  // that points at a decommissioned system, (b) tag those chips visually,
+  // and (c) hide decommissioned entries from the dropdown so an admin
+  // cannot re-assign one. Deliberately does NOT reuse context.fismaSystems:
+  // the dashboard's Show Decommissioned toggle swaps that array to one
+  // or the other, and the picker needs both regardless of the toggle.
   //
   // Exposed as a callback so the event handler that opens the Assign
-  // Systems modal can invoke it directly (#574) - "when the user does X,
-  // do Y" belongs in the event handler, not in an effect fired by a state
+  // Systems modal can invoke it directly - "when the user does X, do Y"
+  // belongs in the event handler, not in an effect fired by a state
   // increment. The ref tracks the latest in-flight controller so a rapid
-  // reopen cancels the earlier request rather than racing it.
+  // reopen cancels the earlier requests rather than racing them.
+  //
+  // Uses Promise.allSettled - not Promise.all - so a failure in the
+  // secondary (decommissioned) fetch does NOT block the primary active
+  // list. The picker still populates with active systems; chips for
+  // orphan assignments fall back to the id-based label in the modal.
   const activeSystemsCtrlRef = useRef<AbortController | null>(null)
-  const loadActiveSystems = useCallback(async () => {
+  const loadFismaSystems = useCallback(async () => {
     if (!canRead) return
     activeSystemsCtrlRef.current?.abort()
     const controller = new AbortController()
     activeSystemsCtrlRef.current = controller
-    try {
-      const res = await axiosInstance.get<{ data: FismaSystemType[] }>(
-        '/fismasystems',
+    const [activeResult, decommResult] = await Promise.allSettled([
+      axiosInstance.get<{ data: FismaSystemType[] }>('/fismasystems', {
+        signal: controller.signal,
+      }),
+      axiosInstance.get<{ data: FismaSystemType[] }>(
+        '/fismasystems?decommissioned=true',
         { signal: controller.signal }
-      )
-      if (controller.signal.aborted) return
-      if (res.status !== 200) return
-      setFismaSystemsMap(buildFismaSystemsMap(res.data.data))
-    } catch (error) {
-      if (controller.signal.aborted) return
-      if (isAuthHandled(error)) return
-      console.error('Fetch active fisma systems error:', error)
+      ),
+    ])
+    if (controller.signal.aborted) return
+    // Active is the critical fetch. If it failed, don't touch the map -
+    // any pre-existing entries stay so a transient failure doesn't
+    // blank the picker.
+    if (activeResult.status === 'rejected') {
+      if (!isAuthHandled(activeResult.reason)) {
+        console.error('Fetch active fisma systems error:', activeResult.reason)
+      }
+      return
     }
+    // Decommissioned is best-effort. Warn on failure but proceed with
+    // active only; the modal's id-based fallback label handles orphans.
+    let decommData: FismaSystemType[] = []
+    if (decommResult.status === 'fulfilled') {
+      decommData = decommResult.value.data.data ?? []
+    } else if (!isAuthHandled(decommResult.reason)) {
+      console.warn(
+        'Fetch decommissioned fisma systems failed; chips for assignments to decommissioned systems will show an id-based label until the next refresh:',
+        decommResult.reason
+      )
+    }
+    // Merge order matters: decommissioned first, active last, so an
+    // active entry overwrites on the unlikely case of a duplicate id
+    // (the two endpoints are mutually exclusive by contract).
+    const combined = [...decommData, ...(activeResult.value.data.data ?? [])]
+    setFismaSystemsMap(buildFismaSystemsMap(combined))
   }, [canRead])
   useEffect(() => {
-    loadActiveSystems()
+    loadFismaSystems()
     return () => activeSystemsCtrlRef.current?.abort()
-  }, [loadActiveSystems])
+  }, [loadFismaSystems])
   // OpDiv options for the grant modal: assignable children only (the HHS
   // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
   // own OpDivs, so narrow the option set to their own grants; the server

--- a/src/views/UserTable/buildFismaSystemsMap.ts
+++ b/src/views/UserTable/buildFismaSystemsMap.ts
@@ -1,0 +1,35 @@
+import { FismaSystemType } from '@/types'
+
+/**
+ * Reshape a FismaSystemType[] into the map the Assign Systems picker
+ * consumes. Each entry carries a `decommissioned` flag so the modal can
+ * render a "(Decommissioned)" suffix and greyed styling for assignments
+ * to systems that were later retired. Callers pass the union of active
+ * and decommissioned systems.
+ *
+ * Exported so the map-build logic can be unit tested against the same
+ * fixtures the parent fetch test uses, without having to drive the
+ * DataGrid + modal chain end to end.
+ *
+ * @param systems - Union of active and decommissioned FISMA systems.
+ * @returns A map keyed by fismasystemid with a display-ready label pair
+ *   and the decommissioned flag.
+ */
+export function buildFismaSystemsMap(
+  systems: FismaSystemType[] | null | undefined
+): Record<number, { name: string; acronym: string; decommissioned: boolean }> {
+  const map: Record<
+    number,
+    { name: string; acronym: string; decommissioned: boolean }
+  > = {}
+  for (const obj of systems ?? []) {
+    map[obj.fismasystemid] = {
+      name: obj.fismasubsystem
+        ? obj.fismaname + ' - ' + obj.fismasubsystem
+        : obj.fismaname,
+      acronym: obj.fismaacronym,
+      decommissioned: !!obj.decommissioned,
+    }
+  }
+  return map
+}


### PR DESCRIPTION
> **Note:** In-repo copy of #588 by @tarratsco. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #588

---

## Summary

Closes #575.

Assignments to FISMA systems that were later decommissioned rendered as empty MUI chips in the Assign Systems picker. The user saw a deletable chip with a delete icon and no visible text - no way to identify which system the assignment referred to before removing it. MUI also logged a "None of the options match with `<id>`" warning in dev. Root cause: the picker's `fismaSystemMap` was built from active systems only (correct behavior for the dropdown), so any id that lived in `users_fismasystems` but no longer resolved to an active row produced an empty `getOptionLabel` return.

## Fix

Fetch both endpoints, label the chip, hide the entry from the dropdown, gently dim it.

- `UserTable.tsx`
  - `buildFismaSystemsMap` now records a `decommissioned: boolean` flag per entry instead of dropping decommissioned rows. Callers pass the union of active + decommissioned systems.
  - The `/fismasystems` fetch effect runs two requests in parallel - `/fismasystems` (active) and `/fismasystems?decommissioned=true` - via `Promise.allSettled`. If the decommissioned fetch fails, the loader logs a `console.warn` and proceeds with active-only rather than blanking the picker (which would recreate the original context-poisoning symptom).
  - Merge order is decommissioned first, active second - so an active entry overwrites on the unlikely case of a duplicate id.
  - `fismaSystemsMap` state type updated to reflect the new entry shape.

- `AssignSystemModal.tsx`
  - New `FismaSystemEntry` type and `labelFor(id, map)` helper.
  - `getOptionLabel` delegates to `labelFor`: active → `acronym - name`, decommissioned → `acronym - name (Decommissioned)`, unknown → `Unknown or decommissioned system (id X)` fallback.
  - New `filterOptions` wraps MUI's option filter to strip decommissioned entries from the dropdown so an admin can't reassign a retired system.
  - New `renderTags` renders chips: decommissioned chips get `sx={{ opacity: 0.65, fontStyle: 'italic' }}` - subdued but still deletable via the delete X.
  - Unassign confirmation dialog prompt updated: `Are you sure you want to unassign SSD-EX - SuperStar Destroyer Executor (Decommissioned) from Piett?`.
  - Added imports for `Chip` and `createFilterOptions`.

## Behavioral notes

- Chip in the value area: `SSD-EX - SuperStar Destroyer Executor (Decommissioned)` with subdued styling.
- Dropdown: decommissioned entries never appear - admins can never assign a user to a retired system.
- No `onChange`/POST path for a decommissioned system: it only lives in `value` as a pre-existing chip; new assignments come through the dropdown, which strips these.
- No MUI runtime warning: decommissioned systems live in options, so MUI's value-vs-options reconciliation matches. The genuinely-unknown-id fallback still emits the warning - expected and acknowledged in code, since the id isn't in either endpoint so the client just can't identify it.
- Partial-failure UX: if only the decommissioned endpoint fails, orphan chips fall back to `Unknown or decommissioned system (id X)` without a crash. Active picker options are unaffected.
- No change to the decommission flow itself: whether the backend should cascade to `users_fismasystems` on decommission is a policy question worth raising separately.

## Testing

`AssignSystemModal.test.tsx` - 5 tests:

- Active entries surface as dropdown options.
- Decommissioned entries in the map are excluded from the selectable dropdown (positive: DS-1, ISD-CHI appear; DECOM-A does not).
- Active-map assignment renders a standard chip (confirming absence of "Decommissioned" text).
- Assignment to a decommissioned system renders `SSD-EX - Super Star Destroyer Executor (Decommissioned)` with `opacity < 1` and `italic` font - this PR's headline behavior.
- Truly-unknown id still renders the id-based fallback (defense-in-depth).

`UserTable.test.tsx` - 10 tests. Highlights:

- Fetches BOTH `/fismasystems` and `/fismasystems?decommissioned=true` regardless of context.
- `buildFismaSystemsMap` tags decommissioned entries with `decommissioned: true` (paired end-to-end with the modal test above).
- Partial-failure end-to-end: active fetch succeeds, decommissioned fetch fails → drives the DataGrid to open the modal, opens the Autocomplete, and asserts `DS-1 - Death Star` + `ISD-CHI - Star Destroyer Chimaera` actually render, making it observable that `setFismaSystemsMap` was called on the graceful path - a regression that skipped the setState after the warn would fail the test. **Litmus verified.**
- Unmount-abort guard test: strengthened comment now describes the current `Promise.allSettled` + aborted-guard mechanism (not old single-fetch thing). Assertion is unchanged and still litmus-verified.
- Existing mapper unit tests updated to cover the new flag (`decommissioned: false` on active entries).
- Other coverage carried over from previous work: `canRead` gate, generic fetch error swallow, malformed `data: null` handling.

`make check` and `yarn jest` clean. 522 passed, 3 pre-existing skips.

## Manual verification

1. Log in as an admin (Tarkin, OWNER). Confirm any user is assigned to an active system (Piett -> Executor in the empire seed).
2. Navigate to Executor's system detail page → Edit → Decommission. Save.
3. Navigate to Users → click Assign Systems on Piett.
4. **Expected**: the picker shows a subdued italic chip reading `SSD-EX - Super Star Destroyer Executor (Decommissioned)`, and Executor is absent from the dropdown when you click to add.
5. Click the delete X on the chip → confirmation dialog reads the full labeled string → confirm unassigns as expected.
6. Toggle Show Decommissioned on the dashboard → return to Users → picker options are unchanged (the two-fetch design keeps it stable regardless of context state).
