### PR TITLE
feat(#239): display CFACTS data center environment with mismatch flag

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -341,6 +341,9 @@ export type SystemEnrichmentType = {
   fisma_uuid: string
   fisma_acronym: string
   authorization_package_name: string | null
+  // CFACTS-reported data center environment (ztmf#239). Provisional payload
+  // key: absent until the ztmf-insights pipeline ships the field.
+  data_center_environment?: string | null
   primary_isso_name: string | null
   primary_isso_email: string | null
   is_active: boolean | null

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -644,7 +644,10 @@ export default function SystemDetailPage() {
           <Typography variant="h6" sx={{ mb: 2 }}>
             ZTMF Insights
           </Typography>
-          <SystemEnrichmentCard fismaUid={system.fismauid} />
+          <SystemEnrichmentCard
+            fismaUid={system.fismauid}
+            systemDataCenterEnvironment={system.datacenterenvironment}
+          />
         </>
       )}
 

--- a/src/views/SystemDetailPage/SystemEnrichmentCard.test.tsx
+++ b/src/views/SystemDetailPage/SystemEnrichmentCard.test.tsx
@@ -95,6 +95,95 @@ test('500 renders the failed-to-load message', async () => {
   ).toBeInTheDocument()
 })
 
+// Data center environment display + mismatch flag (ztmf#239)
+
+test('renders the CFACTS data center environment and flags a mismatch with the ZTMF value', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+        data_center_environment: 'CMS-Cloud-AWS',
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(
+    <SystemEnrichmentCard
+      fismaUid={FISMA_UID}
+      systemDataCenterEnvironment="CMSDC"
+    />
+  )
+
+  expect(await screen.findByText('CMS-Cloud-AWS')).toBeInTheDocument()
+  expect(screen.getByText('Differs from ZTMF: CMSDC')).toBeInTheDocument()
+})
+
+test('does not flag a case/whitespace-only difference as a mismatch', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+        data_center_environment: ' cms-cloud-aws ',
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(
+    <SystemEnrichmentCard
+      fismaUid={FISMA_UID}
+      systemDataCenterEnvironment="CMS-Cloud-AWS"
+    />
+  )
+
+  expect(await screen.findByText('Test Package')).toBeInTheDocument()
+  expect(screen.queryByText(/differs from ztmf/i)).not.toBeInTheDocument()
+})
+
+test('flags a mismatch when CFACTS has a value but ZTMF has none recorded', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+        data_center_environment: 'SaaS',
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(<SystemEnrichmentCard fismaUid={FISMA_UID} />)
+
+  expect(await screen.findByText('SaaS')).toBeInTheDocument()
+  expect(screen.getByText('Differs from ZTMF: not set')).toBeInTheDocument()
+})
+
+test('renders the placeholder and no mismatch flag while the pipeline has not shipped the field', async () => {
+  mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
+    data: {
+      fisma_uuid: FISMA_UID,
+      payload: {
+        authorization_package_name: 'Test Package',
+      },
+      synced_at: '2026-01-01T00:00:00Z',
+    },
+  })
+
+  renderWithProviders(
+    <SystemEnrichmentCard
+      fismaUid={FISMA_UID}
+      systemDataCenterEnvironment="CMSDC"
+    />
+  )
+
+  expect(await screen.findByText('Test Package')).toBeInTheDocument()
+  expect(screen.getByText('Data Center Environment')).toBeInTheDocument()
+  expect(screen.queryByText(/differs from ztmf/i)).not.toBeInTheDocument()
+})
+
 test('formats a timestamp-format ATO expiration date instead of "Invalid Date"', async () => {
   mock.onGet(`/systemenrichment/${FISMA_UID}`).reply(200, {
     data: {

--- a/src/views/SystemDetailPage/SystemEnrichmentCard.tsx
+++ b/src/views/SystemDetailPage/SystemEnrichmentCard.tsx
@@ -14,6 +14,12 @@ import axiosInstance from '@/axiosConfig'
 
 interface SystemEnrichmentCardProps {
   fismaUid: string
+  /**
+   * The system's own datacenterenvironment value, for comparison against the
+   * CFACTS-reported one in the enrichment payload (ztmf#239). When they
+   * disagree, the card flags the difference.
+   */
+  systemDataCenterEnvironment?: string | null
 }
 
 function FieldDisplay({
@@ -84,8 +90,15 @@ function formatDate(dateStr: string | null): string | null {
   return date.toLocaleDateString()
 }
 
+// normalizeDCE mirrors the backend report's comparison (ztmf#239): trimmed,
+// case-insensitive, with null/undefined and "" both meaning "no value".
+function normalizeDCE(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
 export default function SystemEnrichmentCard({
   fismaUid,
+  systemDataCenterEnvironment,
 }: SystemEnrichmentCardProps) {
   const [enrichment, setEnrichment] = useState<SystemEnrichmentType | null>(
     null
@@ -173,6 +186,14 @@ export default function SystemEnrichmentCard({
 
   const atoColor = getAtoColor(enrichment.ato_expiration_date)
 
+  // Flag when CFACTS reports a data center environment that disagrees with the
+  // system's own value - including when ZTMF has none recorded, which is drift
+  // worth surfacing, same as the backend /datacentermismatches report.
+  const cfactsDCE = enrichment.data_center_environment
+  const dceMismatch =
+    normalizeDCE(cfactsDCE) !== '' &&
+    normalizeDCE(cfactsDCE) !== normalizeDCE(systemDataCenterEnvironment)
+
   return (
     <Grid container spacing={3}>
       {/* Row 1: Identity, Status, Organization — 3 across on md+ */}
@@ -198,6 +219,14 @@ export default function SystemEnrichmentCard({
               label="Lifecycle Phase"
               value={enrichment.lifecycle_phase}
             />
+            <FieldDisplay label="Data Center Environment" value={cfactsDCE} />
+            {dceMismatch && (
+              <Chip
+                label={`Differs from ZTMF: ${systemDataCenterEnvironment?.trim() || 'not set'}`}
+                color="warning"
+                size="small"
+              />
+            )}
           </CardContent>
         </Card>
       </Grid>


### PR DESCRIPTION
## Summary

Displays the CFACTS-reported data center environment on the System Detail page's ZTMF Insights card (CMS-Enterprise/ztmf#239 item 2; companion to backend report CMS-Enterprise/ztmf#452).

- New "Data Center Environment" field in the System Identity card, read from the provisional `data_center_environment` enrichment payload key. Renders the standard placeholder until the ztmf-insights pipeline ships the field.
- When the CFACTS value disagrees with the system's own `datacenterenvironment` (trimmed, case-insensitive, including when ZTMF has no value recorded), a warning chip shows the ZTMF value so the drift is visible in place. The comparison mirrors the backend `/datacentermismatches` report.

## Screenshot

<img width="778" height="592" alt="Screenshot 2026-07-21 at 12 22 37 PM" src="https://github.com/user-attachments/assets/db563191-5201-479b-b35e-e38a71946c86" />


## Testing

- `npx tsc --noEmit`, `eslint`, and the full jest suite green (531 passed; 4 new tests covering the mismatch flag, case/whitespace tolerance, missing ZTMF value, and absent payload key).
- Verified against the local full stack with seeded enrichment data.

Snyk and other secret-dependent checks will show red as usual for fork PRs (no repo secrets).