### PR TITLE
Fix ARS control chips rendering failing controls twice in ZTMF Insights

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -253,6 +253,37 @@ describe('InsightsPanel', () => {
     expect(screen.getByText('IA-02(08)').textContent).toContain('○')
   })
 
+  it('renders a control present in BOTH not-satisfied and failing once, as failing (arrays are not mutually exclusive)', () => {
+    // The pipeline builds ars_not_satisfied_controls as a SUPERSET of
+    // ars_failing_controls, so a flagged control (AC-17 here) arrives in both.
+    // It must render exactly one chip, red ✗ failing — never a second grey ○.
+    render(
+      <InsightsPanel
+        payload={{
+          ...fullPayload,
+          ars_satisfied_controls: ['IA-01'],
+          ars_not_satisfied_controls: ['IA-02(02)', 'AC-17'],
+          ars_failing_controls: ['AC-17'],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // Exactly one AC-17 chip, and it is the failing (✗) one, not a grey ○.
+    const ac17 = screen.getAllByText('AC-17')
+    expect(ac17).toHaveLength(1)
+    expect(ac17[0].textContent).toContain('✗')
+    expect(ac17[0].textContent).not.toContain('○')
+    // The genuinely-not-satisfied control still renders grey.
+    expect(screen.getByText('IA-02(02)').textContent).toContain('○')
+    // Accessible name reflects failing, not not-satisfied.
+    expect(
+      screen.getByRole('img', { name: /^AC-17: Other Than Satisfied/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('img', { name: /^AC-17: Not satisfied/ })
+    ).not.toBeInTheDocument()
+  })
+
   it('gives each ARS control chip a plain-language state reason (role=img name = tooltip) for hover + AT', () => {
     render(
       <InsightsPanel

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -344,6 +344,23 @@ function InsightsPanelInner({ payload }: Props) {
   const arsNotSatisfied = toStringArray(payload.ars_not_satisfied_controls)
   const arsFailing = toStringArray(payload.ars_failing_controls)
 
+  // The three ARS arrays are NOT mutually exclusive: the pipeline builds
+  // ars_not_satisfied_controls as (applicable AND NOT Satisfied), which is a
+  // SUPERSET of ars_failing_controls (Other Than Satisfied) — a failing control
+  // appears in BOTH. Rendering each array on its own would show that control
+  // twice, once grey ○ (not-satisfied) and once red ✗ (failing), or label a
+  // failing control as merely not-satisfied. Assign each control to exactly one
+  // bucket by precedence — failing > satisfied > not-satisfied remainder — so a
+  // flagged control always renders once, in its most-severe state. (Satisfied vs
+  // not-satisfied are already disjoint by the backend's definition; the subtract
+  // is defensive.)
+  const arsFailingSet = new Set(arsFailing)
+  const arsSatisfiedOnly = arsSatisfied.filter((id) => !arsFailingSet.has(id))
+  const arsSatisfiedOnlySet = new Set(arsSatisfiedOnly)
+  const arsNotSatisfiedOnly = arsNotSatisfied.filter(
+    (id) => !arsFailingSet.has(id) && !arsSatisfiedOnlySet.has(id)
+  )
+
   // Per-source pass/fail. A finding = a FAILED check (failing side, `findings`);
   // the PASSING side ships separately as `{source}_passing` (same InsightFinding
   // shape + level). When a source ships its passing array we render an ARS-style
@@ -526,8 +543,8 @@ function InsightsPanelInner({ payload }: Props) {
                 {asText(payload.ars_controls_satisfied) ?? 0} of{' '}
                 {asText(payload.ars_controls_total)} satisfied
               </Typography>
-              {(arsSatisfied.length > 0 ||
-                arsNotSatisfied.length > 0 ||
+              {(arsSatisfiedOnly.length > 0 ||
+                arsNotSatisfiedOnly.length > 0 ||
                 arsFailing.length > 0) && (
                 <Box
                   sx={{
@@ -537,14 +554,14 @@ function InsightsPanelInner({ payload }: Props) {
                     mt: 0.5,
                   }}
                 >
-                  {arsSatisfied.map((id, i) => (
+                  {arsSatisfiedOnly.map((id, i) => (
                     <ControlChip
                       key={`sat-${id}-${i}`}
                       id={id}
                       variant="satisfied"
                     />
                   ))}
-                  {arsNotSatisfied.map((id, i) => (
+                  {arsNotSatisfiedOnly.map((id, i) => (
                     <ControlChip
                       key={`unsat-${id}-${i}`}
                       id={id}


### PR DESCRIPTION
Closes #593

## Problem

The ZTMF Insights drawer builds its ARS control chips from three payload arrays: `ars_satisfied_controls`, `ars_not_satisfied_controls`, and `ars_failing_controls`. These arrays are not mutually exclusive. The pipeline defines `ars_not_satisfied_controls` as every control that is applicable and not Satisfied, which makes it a superset of `ars_failing_controls` (the Other Than Satisfied controls). A failing control therefore arrives in both arrays.

The panel mapped each array to chips on its own, so any flagged control rendered twice: once as a grey not-satisfied chip and once as a red failing chip. On systems where a control is genuinely flagged, the same control showed up in two states with conflicting colors.

This stayed hidden because Other Than Satisfied is rare in Archer, so `ars_failing_controls` is usually empty and the two arrays don't visibly collide. It only surfaces on the systems that actually have a flagged control.

## Fix

Assign each control to exactly one bucket by precedence before rendering:

- failing wins first (red, Other Than Satisfied)
- then satisfied (green)
- then not-satisfied as the remainder (grey, applicable but not yet satisfied)

Each control now renders once, in its most-severe state. This is a frontend-only change. The payload arrays are correct as built; `ars_not_satisfied_controls` is intentionally the superset, and the derivation now accounts for that.

## Tests

Added a regression test with a control present in both `ars_not_satisfied_controls` and `ars_failing_controls`. It asserts a single chip in the failing state, which fails against the old independent-render code and passes now. Full InsightsPanel suite green, typecheck clean.