### PR TITLE
Add System Delegate user role

### DIFF
--- a/src/components/EmailModal/EmailModal.test.tsx
+++ b/src/components/EmailModal/EmailModal.test.tsx
@@ -77,6 +77,46 @@ test('success path fires the success snackbar and surfaces sent emails', async (
   expect(mockedNavigate).not.toHaveBeenCalled()
 })
 
+test('offers System Delegate as a targetable email group and posts its key', async () => {
+  // The backend (ztmf#458) accepts a SYSTEM_DELEGATE group key on
+  // /massemails, so the delegate cohort must be selectable here. Assert both
+  // the option exists and the raw key (not the friendly label) is submitted.
+  let posted: Record<string, unknown> = {}
+  mock.onPost('/massemails').reply((config) => {
+    posted = JSON.parse(config.data as string)
+    return [200, { data: ['delegate@example.com'] }]
+  })
+
+  renderWithProviders(<EmailModal openModal={true} closeModal={jest.fn()} />)
+
+  const group = document.querySelector(
+    'select[name="email_group"]'
+  ) as HTMLSelectElement
+  // The option renders with the friendly label but carries the raw role key.
+  const option = group.querySelector(
+    'option[value="SYSTEM_DELEGATE"]'
+  ) as HTMLOptionElement
+  expect(option).not.toBeNull()
+  expect(option.textContent).toBe('System Delegate')
+
+  await userEvent.selectOptions(group, 'SYSTEM_DELEGATE')
+  await userEvent.type(
+    document.querySelector('input[name="email_subject"]') as HTMLInputElement,
+    'hello'
+  )
+  await userEvent.type(
+    document.querySelector(
+      'textarea[name="email_body"]'
+    ) as HTMLTextAreaElement,
+    'world'
+  )
+  await userEvent.click(screen.getByRole('button', { name: /^send$/i }))
+
+  await waitFor(() => {
+    expect(posted.group).toBe('SYSTEM_DELEGATE')
+  })
+})
+
 test('401 redirects to sign-in with the expired-session message and reason', async () => {
   mock.onPost('/massemails').reply(401)
 

--- a/src/components/EmailModal/EmailModal.tsx
+++ b/src/components/EmailModal/EmailModal.tsx
@@ -175,6 +175,10 @@ export default function EmailModal({ openModal, closeModal }: EmailModalProps) {
                   value: 'ISSM',
                 },
                 {
+                  label: 'System Delegate',
+                  value: 'SYSTEM_DELEGATE',
+                },
+                {
                   label: 'ADMIN',
                   value: 'ADMIN',
                 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type UserRole =
   | 'OPDIV_READONLY_ADMIN'
   | 'ISSO'
   | 'ISSM'
+  | 'SYSTEM_DELEGATE'
   | 'ADMIN'
   | 'READONLY_ADMIN'
 

--- a/src/utils/userRoles.test.ts
+++ b/src/utils/userRoles.test.ts
@@ -9,7 +9,9 @@ import {
   isOpDivTier,
   isReadOnlyAdmin,
   isReadOnlyAdminRole,
+  isSystemScoped,
   isWriteAdminRole,
+  selectableRoles,
 } from '@/utils/userRoles'
 
 /**
@@ -38,6 +40,7 @@ const isAdminCases: Case[] = [
   ['READONLY_ADMIN', false], // legacy, removed in Stage D
   ['ISSO', false],
   ['ISSM', false],
+  ['SYSTEM_DELEGATE', false],
 ]
 
 const isReadOnlyAdminCases: Case[] = [
@@ -50,6 +53,7 @@ const isReadOnlyAdminCases: Case[] = [
   ['ADMIN', false],
   ['ISSO', false],
   ['ISSM', false],
+  ['SYSTEM_DELEGATE', false],
 ]
 
 const hasUnscopedReadCases: Case[] = [
@@ -62,6 +66,7 @@ const hasUnscopedReadCases: Case[] = [
   ['OPDIV_READONLY_ADMIN', false],
   ['ISSO', false],
   ['ISSM', false],
+  ['SYSTEM_DELEGATE', false],
 ]
 
 const hasSystemAccessCases: Case[] = [
@@ -74,6 +79,7 @@ const hasSystemAccessCases: Case[] = [
   ['READONLY_ADMIN', true], // legacy, removed in Stage D
   ['ISSO', true],
   ['ISSM', true],
+  ['SYSTEM_DELEGATE', true],
 ]
 
 const isHHSTierCases: Case[] = [
@@ -86,6 +92,7 @@ const isHHSTierCases: Case[] = [
   ['ISSM', false],
   ['ADMIN', false], // legacy is CMS-tenant pre-migration, not HHS tier
   ['READONLY_ADMIN', false],
+  ['SYSTEM_DELEGATE', false],
 ]
 
 const isOpDivTierCases: Case[] = [
@@ -98,6 +105,7 @@ const isOpDivTierCases: Case[] = [
   ['ISSM', false],
   ['ADMIN', false],
   ['READONLY_ADMIN', false],
+  ['SYSTEM_DELEGATE', false],
 ]
 
 test.each(isAdminCases)('isAdmin(%s) === %s', (role, expected) => {
@@ -185,11 +193,40 @@ test('isAdminTierRole returns true for every admin tier (write or read-only)', (
     expect(isAdminTierRole(role)).toBe(true)
   })
 
-  const nonAdmin: UserRole[] = ['ISSO', 'ISSM']
+  const nonAdmin: UserRole[] = ['ISSO', 'ISSM', 'SYSTEM_DELEGATE']
   nonAdmin.forEach((role) => {
     expect(isAdminTierRole(role)).toBe(false)
   })
 })
+
+// SYSTEM_DELEGATE is the frontend mirror of the backend answers-only carve-out
+// (ztmf#455): it gets system-detail access exactly like ISSO/ISSM, but is
+// barred from the target-maturity edit control. hasSystemAccess and
+// isSystemScoped must therefore diverge for this role — that divergence is the
+// whole point of the role, so pin it explicitly.
+test('SYSTEM_DELEGATE has system access but is NOT system-scoped (answers-only)', () => {
+  const delegate = roleUser('SYSTEM_DELEGATE')
+  expect(hasSystemAccess(delegate)).toBe(true)
+  expect(isSystemScoped(delegate)).toBe(false)
+})
+
+test('ISSO and ISSM remain both system-accessible and system-scoped', () => {
+  ;(['ISSO', 'ISSM'] as UserRole[]).forEach((role) => {
+    const user = roleUser(role)
+    expect(hasSystemAccess(user)).toBe(true)
+    expect(isSystemScoped(user)).toBe(true)
+  })
+})
+
+// The role dropdown when adding/editing a user is driven by selectableRoles,
+// narrowed to the acting admin's tier. A delegate must be assignable by every
+// admin tier that can assign the sibling ISSO/ISSM roles.
+test.each(['OWNER', 'ADMIN', 'HHS_ADMIN', 'OPDIV_ADMIN'])(
+  'selectableRoles(%s) offers SYSTEM_DELEGATE',
+  (actor) => {
+    expect(selectableRoles(actor)).toContain('SYSTEM_DELEGATE')
+  }
+)
 
 test('all helpers reject null, undefined, and empty-role placeholder users', () => {
   const placeholder = { role: '' as UserRole }

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -21,6 +21,19 @@ const UNSCOPED_READ_ROLES = new Set<UserRole>([
   'READONLY_ADMIN', // legacy, removed in Stage D
 ])
 
+// Two distinct system concepts, deliberately kept separate:
+//   SYSTEM_ACCESS_ROLES - tiers that get system-detail UI (dashboard, system
+//     pages). Includes SYSTEM_DELEGATE.
+//   SYSTEM_SCOPED_ROLES - tiers allowed to edit a system's target maturity.
+//     Excludes SYSTEM_DELEGATE: a delegate is answers-only, barred from the
+//     target-maturity control (mirrors the backend carve-out for ztmf#455).
+// A delegate has access but is not "scoped" for the target-maturity write.
+const SYSTEM_ACCESS_ROLES = new Set<UserRole>([
+  'ISSO',
+  'ISSM',
+  'SYSTEM_DELEGATE',
+])
+
 const SYSTEM_SCOPED_ROLES = new Set<UserRole>(['ISSO', 'ISSM'])
 
 // Roles an admin may assign, narrowed by the acting admin's own tier so the
@@ -42,6 +55,7 @@ const OWNER_ASSIGNABLE_ROLES: UserRole[] = [
   'OPDIV_READONLY_ADMIN',
   'ISSO',
   'ISSM',
+  'SYSTEM_DELEGATE',
 ]
 
 // HHS_ADMIN sits below OWNER, so it may assign everything except OWNER.
@@ -52,6 +66,7 @@ const HHS_ASSIGNABLE_ROLES: UserRole[] = [
   'OPDIV_READONLY_ADMIN',
   'ISSO',
   'ISSM',
+  'SYSTEM_DELEGATE',
 ]
 
 // An OPDIV_ADMIN cannot mint OWNER/HHS tiers - they may only assign roles at
@@ -61,6 +76,7 @@ const OPDIV_ASSIGNABLE_ROLES: UserRole[] = [
   'OPDIV_READONLY_ADMIN',
   'ISSO',
   'ISSM',
+  'SYSTEM_DELEGATE',
 ]
 
 type UserLike = Pick<userData, 'role'> | null | undefined
@@ -98,10 +114,12 @@ export const isSystemScoped = (user: UserLike): boolean =>
 // Row-level OpDiv scoping is server-enforced - the backend narrows the
 // fismaSystems list before it reaches the frontend, so this gate only needs
 // to decide whether the user belongs to a tier that gets system-detail UI at
-// all (any admin tier + ISSO/ISSM).
+// all (any admin tier + ISSO/ISSM/SYSTEM_DELEGATE). Uses SYSTEM_ACCESS_ROLES,
+// not SYSTEM_SCOPED_ROLES: a delegate gets the system UI but is not
+// target-maturity-scoped (see isSystemScoped).
 export const hasSystemAccess = (user: UserLike): boolean =>
   hasAdminRead(user) ||
-  (!!user && SYSTEM_SCOPED_ROLES.has(user.role as UserRole))
+  (!!user && SYSTEM_ACCESS_ROLES.has(user.role as UserRole))
 
 // Tier membership checks mirror the backend's IsHHSTier and IsOpDivTier
 // helpers. Both cover the read-only variant of the tier, so callers must


### PR DESCRIPTION
## Summary

Adds the new `SYSTEM_DELEGATE` user role to the UI so it is selectable when adding or editing a user and gated correctly. Frontend half of the System Delegate work in CMS-Enterprise/ztmf#455; pairs with backend PR CMS-Enterprise/ztmf#458.

A delegate is scoped to specific FISMA systems the same way ISSO and ISSM are: assigned via users_fismasystems, able to read and write the data-call answers on those systems. The one difference is that a delegate is barred from the target-maturity edit control. It is an answers-only role, intended for contractors and support staff.

## What changed

- **`src/types.ts`** - add `SYSTEM_DELEGATE` to the `UserRole` union.
- **`src/utils/userRoles.ts`**
  - Add `SYSTEM_DELEGATE` to all three assignable-role tiers (OWNER/HHS/OPDIV), beside ISSM. This drives the role dropdown in the add/edit user form and makes the Assign Fisma Systems row action appear for delegate rows.
  - Decouple the two system concepts that were previously conflated in one set. A new `SYSTEM_ACCESS_ROLES` set (ISSO/ISSM/SYSTEM_DELEGATE) backs `hasSystemAccess`, so a delegate gets dashboard and system-detail access. `SYSTEM_SCOPED_ROLES` stays ISSO/ISSM only and backs `isSystemScoped`, so `canEditTarget` on the system detail page stays false for delegates. This mirrors the backend carve-out.

No admin sets were touched, so a non-admin delegate sees no user-management, add-system, create-datacall, or email-users affordances. Questionnaire read/write is writer-agnostic, so a delegate writes answers before the deadline exactly like an ISSO, and the backend re-checks system assignment.

## Tests

Extended `userRoles.test.ts`: SYSTEM_DELEGATE rows across every role predicate, an explicit assertion that `hasSystemAccess` is true while `isSystemScoped` is false (the decoupling that defines the role), and that `selectableRoles` offers it to all three admin tiers. Full UI unit suite passes; typecheck clean.

## Rollout

Draft until backend PR #458 is deployed. The role value has to exist server-side before the UI offers it. Closes #455 once both ship.

### Update: email cohort

Also adds `SYSTEM_DELEGATE` as a targetable group in the Email Users dropdown (shown as "System Delegate", beside ISSO/ISSM). Backend #458 accepts the `SYSTEM_DELEGATE` group key on `/massemails`, so an admin can email the delegate cohort directly instead of only via ALL. Covered by a new EmailModal test asserting the option exists and the raw key is posted.