### PR TITLE
Assign system picker now allows for acronym match

### DIFF
--- a/src/views/AssignSystemModal/AssignSystemModal.test.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.test.tsx
@@ -198,3 +198,102 @@ test('assigned id absent from the map entirely still renders an identifiable fal
   )
   ;(console.error as jest.Mock).mockRestore?.()
 })
+
+test('typing an acronym filters the list to the matching system', async () => {
+  // Regression for #587: the picker must match on the acronym, not just the
+  // system name. Typing "ISD" surfaces ISD-CHI and drops DS-1 / Death Star.
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal()
+
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() =>
+    expect(screen.getByText(/DS-1\s*-\s*Death Star/i)).toBeInTheDocument()
+  )
+
+  await user.type(combobox, 'ISD')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/ISD-CHI\s*-\s*Star Destroyer Chimaera/i)
+    ).toBeInTheDocument()
+  )
+  expect(screen.queryByText(/Death Star/i)).not.toBeInTheDocument()
+})
+
+test('typing a system name filters the list to the matching system', async () => {
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal()
+
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() => expect(screen.getByText(/ISD-CHI/)).toBeInTheDocument())
+
+  await user.type(combobox, 'Death')
+
+  await waitFor(() =>
+    expect(screen.getByText(/DS-1\s*-\s*Death Star/i)).toBeInTheDocument()
+  )
+  expect(screen.queryByText(/ISD-CHI/)).not.toBeInTheDocument()
+})
+
+test('acronym matching is case-insensitive', async () => {
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal()
+
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() => expect(screen.getByText(/DS-1/)).toBeInTheDocument())
+
+  await user.type(combobox, 'isd')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/ISD-CHI\s*-\s*Star Destroyer Chimaera/i)
+    ).toBeInTheDocument()
+  )
+  expect(screen.queryByText(/Death Star/i)).not.toBeInTheDocument()
+})
+
+test('searching by a decommissioned system acronym does not surface it as an option', async () => {
+  // The new acronym/name search composes with the decommissioned-stripping
+  // filter: even an exact acronym match must not offer a decommissioned
+  // system as a selectable option.
+  const user = userEvent.setup()
+  mock.onGet(`/users/${USER_ID}/assignedfismasystems`).reply(200, { data: [] })
+
+  renderModal({
+    fismaSystemMap: {
+      ...ACTIVE_MAP,
+      9001: {
+        acronym: 'DECOM-A',
+        name: 'Decommissioned System A',
+        decommissioned: true,
+      },
+    },
+  })
+
+  const combobox = await screen.findByRole('combobox', {
+    name: /assign fisma systems/i,
+  })
+  await user.click(combobox)
+  await waitFor(() => expect(screen.getByText(/DS-1/)).toBeInTheDocument())
+
+  await user.type(combobox, 'DECOM-A')
+
+  // No option surfaces - the decommissioned entry is stripped even though
+  // its acronym matches the query exactly.
+  expect(screen.queryByText(/DECOM-A/)).not.toBeInTheDocument()
+})

--- a/src/views/AssignSystemModal/AssignSystemModal.tsx
+++ b/src/views/AssignSystemModal/AssignSystemModal.tsx
@@ -22,11 +22,6 @@ import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />
 const checkedIcon = <CheckBoxIcon fontSize="small" />
 
-// Default MUI substring filter; wrapped below to also strip decommissioned
-// entries from the dropdown (they should still surface as chips for
-// existing assignments but not be selectable for new ones).
-const defaultOptionFilter = createFilterOptions<number>()
-
 type FismaSystemEntry = {
   name: string
   acronym: string
@@ -65,6 +60,24 @@ export default function AssignSystemModal({
     systemid: number
     nextValue: number[]
   } | null>(null)
+  // Substring filter that matches on the raw acronym + name rather than the
+  // display label. `labelFor` decorates the label ("(Decommissioned)" suffix,
+  // "Unknown or decommissioned system (id X)" fallback), so filtering off the
+  // label would couple search to that formatting. Wrapped below to also strip
+  // decommissioned entries from the dropdown (they still surface as chips for
+  // existing assignments but are not selectable for new ones). MUI defaults
+  // (ignoreCase: true, matchFrom: 'any') give case-insensitive substring match.
+  const optionFilter = React.useMemo(
+    () =>
+      createFilterOptions<number>({
+        stringify: (option) => {
+          const system = fismaSystemMap[option]
+          if (!system) return String(option)
+          return `${system.acronym} ${system.name}`
+        },
+      }),
+    [fismaSystemMap]
+  )
   React.useEffect(() => {
     if (!open || !userid) return
     const controller = new AbortController()
@@ -140,7 +153,7 @@ export default function AssignSystemModal({
             // Strip them from the dropdown here so an admin cannot select
             // one as a new assignment.
             filterOptions={(options, params) =>
-              defaultOptionFilter(options, params).filter(
+              optionFilter(options, params).filter(
                 (o) => !fismaSystemMap[o]?.decommissioned
               )
             }


### PR DESCRIPTION
> **Note:** In-repo copy of #602 by @costacalvin. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #602

---

## Summary

Hardens the search/filter in the "Assign FISMA Systems" picker (`AssignSystemModal`) so matching runs against the raw `acronym` + `name` fields via an explicit `filterOptions`, instead of implicitly relying on the formatted display label.

Closes #587.

> **Note:** acronym search already worked on `main`. This is a robustness/decoupling change, **not** a fix for broken behavior — see below.

## Why acronym search already worked

The previous code used `createFilterOptions<number>()` with no `stringify`. When `stringify` is omitted, MUI falls back to `getOptionLabel` to produce the text it matches against (`(stringify || getOptionLabel)(option)` in `useAutocomplete`). Here `getOptionLabel` is `labelFor`, which returns `"ACRONYM - Name"` — so the acronym was already part of the searched string, and typing an acronym alone (or a name alone) already surfaced the matching system.

## What this change does

Instead of matching on the *formatted, decorated* label, it supplies an explicit `stringify` that concatenates the raw `${acronym} ${name}` from `fismaSystemMap`:

- **Decouples search from display formatting.** The old searched text included the `" - "` glue plus decorations like `" (Decommissioned)"` and the `"Unknown or decommissioned system (id X)"` fallback. That meant search could incidentally match those decoration tokens, and would silently break if `labelFor`'s formatting ever changed. Matching now depends only on the underlying data.
- **Satisfies the acceptance criteria in #587** explicitly: an intentional `filterOptions` (`createFilterOptions` with a `stringify` concatenating acronym + name), independent of label formatting.
- MUI defaults (`ignoreCase: true`, `matchFrom: 'any'`) preserve the case-insensitive substring behavior.
- The existing decommissioned-stripping filter is preserved and composes on top of search, so decommissioned systems are still never offered as selectable options.

No change to `getOptionLabel`, chip rendering, or the decommissioned display behavior. Frontend only — no backend change.

## UI
<img width="1712" height="868" alt="image" src="https://github.com/user-attachments/assets/5f94cb77-5c19-4f4d-b595-8d9f3e329f4b" />


### Behavioral delta

| | Before | After |
|---|---|---|
| Searched text | `"DS-1 - Death Star (Decommissioned)"` | `"DS-1 Death Star"` |
| Acronym alone | ✅ | ✅ |
| Name alone | ✅ | ✅ |
| Matches label decoration ("Decommissioned", "id N", `" - "`) | ⚠️ yes | ✅ no |
| Breaks if `labelFor` formatting changes | ⚠️ yes | ✅ no |

## Acceptance criteria

- [x] The picker filters on **both** the acronym and the system name, case-insensitive substring.
- [x] Matching uses an explicit `filterOptions` (MUI `createFilterOptions` with a `stringify` that concatenates acronym and name) so it does not depend on the display-label formatting.
- [x] A system is findable by typing its acronym alone, its name alone, or any substring of either.

## Testing

- Added regression tests in `AssignSystemModal.test.tsx` to lock in the intended behavior:
  - filter by acronym
  - filter by system name
  - case-insensitive acronym match
  - decommissioned system not surfaced even on an exact acronym match
- All 9 tests in the suite pass (`yarn jest src/views/AssignSystemModal`).
- Verified manually in the running app.
