### PR TITLE
System Delegate self-service UI (rehome of #607)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,30 @@ export type OpDiv = {
   name: string
   is_parent: boolean
   active: boolean
+  // Per-OpDiv "Add System Delegate Role" capability. NOT NULL on the backend
+  // (defaults false), so every OpDiv resolves to a real boolean. Gates the
+  // ISSO delegate self-service surface for systems in this OpDiv.
+  system_delegate_enabled: boolean
+}
+
+// A system delegate as returned by GET /fismasystems/:id/delegates (the
+// roster). access_expires_at is RFC3339; null means never expires (only
+// non-delegate users are null, so a delegate row always carries a date).
+export type DelegateRow = {
+  userid: string
+  fullname: string
+  email: string
+  access_expires_at: string | null
+}
+
+// An attachable delegate candidate from
+// GET /fismasystems/:id/delegate-candidates. The backend returns only
+// eligible users (already a delegate, in the system's OpDiv, not deleted,
+// not already attached), so the picker trusts the list as-is.
+export type DelegateCandidate = {
+  userid: string
+  fullname: string
+  email: string
 }
 
 // One known datacenter environment from GET /api/v1/datacenterenvironments.

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,11 @@ export type DelegateCandidate = {
   userid: string
   fullname: string
   email: string
+  // The candidate query returns the full user row, so this always arrives
+  // (null only for a non-expiring account). Optional here so fixtures can
+  // omit it. An expired candidate can still be attached, but stays denied at
+  // auth until renewed, so the picker flags it.
+  access_expires_at?: string | null
 }
 
 // One known datacenter environment from GET /api/v1/datacenterenvironments.

--- a/src/utils/decommission.ts
+++ b/src/utils/decommission.ts
@@ -13,6 +13,24 @@ export function getTodayISO(): string {
   return `${yyyy}-${mm}-${dd}`
 }
 
+/**
+ * Returns the date `months` months from today as an ISO date string
+ * (YYYY-MM-DD) in local time. Used to seed the delegate expiration picker
+ * with its +3-month default. Day-of-month overflow (e.g. Aug 31 + 6mo)
+ * rolls forward via the Date constructor, which is fine for a default.
+ *
+ * @param months - Number of months to add to today.
+ * @returns The shifted date as a YYYY-MM-DD string.
+ */
+export function addMonthsISO(months: number): string {
+  const d = new Date()
+  d.setMonth(d.getMonth() + months)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
 /** Truncates notes for display in confirmation dialogs */
 export function truncateNotes(notes: string): string {
   const trimmed = notes.trim()

--- a/src/utils/delegates.ts
+++ b/src/utils/delegates.ts
@@ -76,7 +76,12 @@ export async function addSystemDelegate(
   systemId: number,
   body: AddDelegateBody
 ): Promise<void> {
-  await axiosInstance.post(`/fismasystems/${systemId}/delegates`, body)
+  // skipAuthHandling so the capability-off 403 reaches this caller instead of the
+  // global interceptor swallowing it into a generic toast; the component keys on
+  // the DELEGATE_NOT_ENABLED code to render an in-dialog guard.
+  await axiosInstance.post(`/fismasystems/${systemId}/delegates`, body, {
+    skipAuthHandling: true,
+  })
 }
 
 /**

--- a/src/utils/delegates.ts
+++ b/src/utils/delegates.ts
@@ -1,0 +1,135 @@
+import axiosInstance from '@/axiosConfig'
+import type { DelegateRow, DelegateCandidate, OpDiv } from '@/types'
+
+/**
+ * System-delegate self-service API (ztmf-ui#598, backend ztmf#462).
+ *
+ * Every delegate call the UI makes lives here, so moving from the mocked
+ * contract to the real endpoints once the backend ships is a change to this
+ * one file. All paths are system-anchored; the backend gates each on the
+ * caller being assigned to the system (admins pass) and returns 404 for a
+ * system the caller cannot manage.
+ *
+ * Payload the backend expects for the add call. Both flows are keyed by
+ * email; the backend resolves it to a new-person invite or an attach of an
+ * existing eligible delegate. userid / role / opdiv must never be sent -
+ * unknown fields are rejected. access_expires_at is RFC3339; when omitted
+ * the backend defaults it to three months out.
+ */
+export type AddDelegateBody = {
+  email: string
+  fullname?: string
+  access_expires_at?: string
+}
+
+/**
+ * Reads the current delegates assigned to a system (the roster).
+ *
+ * @param systemId - The fismasystemid to read delegates for.
+ * @param signal - Optional AbortSignal to cancel the request.
+ * @returns The system's delegate rows (empty array when none).
+ */
+export async function fetchSystemDelegates(
+  systemId: number,
+  signal?: AbortSignal
+): Promise<DelegateRow[]> {
+  const res = await axiosInstance.get<{ data: DelegateRow[] | null }>(
+    `/fismasystems/${systemId}/delegates`,
+    { signal }
+  )
+  return res.data.data ?? []
+}
+
+/**
+ * Searches users eligible to be attached to a system as a delegate. The
+ * backend returns only attachable candidates (already a delegate, in the
+ * system's OpDiv, not deleted, not already attached), so the caller can
+ * trust the list without re-filtering.
+ *
+ * @param systemId - The fismasystemid to find candidates for.
+ * @param q - Case-insensitive substring on name/email; empty returns all eligible.
+ * @param signal - Optional AbortSignal to cancel the request.
+ * @returns The eligible candidate rows (empty array when none).
+ */
+export async function searchDelegateCandidates(
+  systemId: number,
+  q: string,
+  signal?: AbortSignal
+): Promise<DelegateCandidate[]> {
+  const res = await axiosInstance.get<{ data: DelegateCandidate[] | null }>(
+    `/fismasystems/${systemId}/delegate-candidates`,
+    { params: q ? { q } : undefined, signal }
+  )
+  return res.data.data ?? []
+}
+
+/**
+ * Adds a delegate to a system - either inviting a new person (email +
+ * fullname) or attaching an existing eligible delegate (email only). On an
+ * attach the backend ignores access_expires_at; renew changes it instead.
+ * Resolves on 201; the caller refetches the roster to reflect the add.
+ *
+ * @param systemId - The fismasystemid to add the delegate to.
+ * @param body - Email-keyed add payload (see AddDelegateBody).
+ */
+export async function addSystemDelegate(
+  systemId: number,
+  body: AddDelegateBody
+): Promise<void> {
+  await axiosInstance.post(`/fismasystems/${systemId}/delegates`, body)
+}
+
+/**
+ * Renews or changes a delegate's expiration. Expiry is per-user, so this
+ * affects the delegate on every system they are assigned to.
+ *
+ * @param systemId - The fismasystemid the delegate is assigned to.
+ * @param userid - The delegate's user UUID.
+ * @param accessExpiresAt - New expiration (RFC3339); omit to default +3mo.
+ * @returns The updated delegate row.
+ */
+export async function renewSystemDelegate(
+  systemId: number,
+  userid: string,
+  accessExpiresAt?: string
+): Promise<DelegateRow> {
+  const res = await axiosInstance.patch<{ data: DelegateRow }>(
+    `/fismasystems/${systemId}/delegates/${userid}`,
+    { access_expires_at: accessExpiresAt }
+  )
+  return res.data.data
+}
+
+/**
+ * Removes a delegate from a system. The user row and their assignments to
+ * other systems are retained.
+ *
+ * @param systemId - The fismasystemid to remove the delegate from.
+ * @param userid - The delegate's user UUID.
+ */
+export async function removeSystemDelegate(
+  systemId: number,
+  userid: string
+): Promise<void> {
+  await axiosInstance.delete(`/fismasystems/${systemId}/delegates/${userid}`)
+}
+
+/**
+ * Toggles the per-OpDiv System Delegate capability. Dedicated endpoint,
+ * authorized for Owner / HHS admin only (distinct from the Owner-only OpDiv
+ * create/update).
+ *
+ * @param opdivId - The opdiv_id to toggle.
+ * @param enabled - Whether the capability should be on.
+ * @returns The updated OpDiv row.
+ */
+export async function setOpDivDelegateEnabled(
+  opdivId: number,
+  enabled: boolean
+): Promise<OpDiv> {
+  const res = await axiosInstance.put<{ data: OpDiv }>(
+    `/opdivs/${opdivId}/system-delegate-enabled`,
+    { enabled }
+  )
+  return res.data.data
+}

--- a/src/utils/userRoles.test.ts
+++ b/src/utils/userRoles.test.ts
@@ -6,9 +6,11 @@ import {
   isAdmin,
   isAdminTierRole,
   isHHSTier,
+  isISSO,
   isOpDivTier,
   isReadOnlyAdmin,
   isReadOnlyAdminRole,
+  isSystemDelegate,
   isSystemScoped,
   isWriteAdminRole,
   selectableRoles,
@@ -215,6 +217,44 @@ test('ISSO and ISSM remain both system-accessible and system-scoped', () => {
     const user = roleUser(role)
     expect(hasSystemAccess(user)).toBe(true)
     expect(isSystemScoped(user)).toBe(true)
+  })
+})
+
+// isSystemDelegate gates the delegate self-service surface's "hide from
+// delegates" rule; only the delegate role qualifies.
+const isSystemDelegateCases: Case[] = [
+  ['SYSTEM_DELEGATE', true],
+  ['ISSO', false],
+  ['ISSM', false],
+  ['OWNER', false],
+  ['OPDIV_ADMIN', false],
+]
+test.each(isSystemDelegateCases)(
+  'isSystemDelegate(%s) === %s',
+  (role, expected) => {
+    expect(isSystemDelegate(roleUser(role))).toBe(expected)
+  }
+)
+
+// isISSO is split out from isSystemScoped (which also covers ISSM) so the
+// delegate section can gate MANAGE controls to ISSO + admin while ISSM stays
+// read-only. It must be true for ISSO alone among the system-scoped tiers.
+const isISSOCases: Case[] = [
+  ['ISSO', true],
+  ['ISSM', false],
+  ['SYSTEM_DELEGATE', false],
+  ['OWNER', false],
+  ['OPDIV_ADMIN', false],
+]
+test.each(isISSOCases)('isISSO(%s) === %s', (role, expected) => {
+  expect(isISSO(roleUser(role))).toBe(expected)
+})
+
+test('isISSO and isSystemDelegate reject null, undefined, and placeholder', () => {
+  const placeholder = { role: '' as UserRole }
+  ;[null, undefined, placeholder].forEach((user) => {
+    expect(isISSO(user)).toBe(false)
+    expect(isSystemDelegate(user)).toBe(false)
   })
 })
 

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -111,6 +111,17 @@ export const hasUnscopedRead = (user: UserLike): boolean =>
 export const isSystemScoped = (user: UserLike): boolean =>
   !!user && SYSTEM_SCOPED_ROLES.has(user.role as UserRole)
 
+// A system delegate - answers-only, and the one tier the delegate
+// self-service surface is hidden from (a delegate cannot manage delegates).
+export const isSystemDelegate = (user: UserLike): boolean =>
+  !!user && user.role === 'SYSTEM_DELEGATE'
+
+// ISSO specifically, split out from isSystemScoped (which also covers ISSM).
+// The delegate self-service actor scope is ISSO-only among non-admins (epic
+// decision 5), so ISSM sees the roster read-only while ISSO can manage it.
+export const isISSO = (user: UserLike): boolean =>
+  !!user && user.role === 'ISSO'
+
 // Row-level OpDiv scoping is server-enforced - the backend narrows the
 // fismaSystems list before it reaches the frontend, so this gate only needs
 // to decide whether the user belongs to a tier that gets system-detail UI at

--- a/src/views/OpDivAdmin/OpDivAdmin.test.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.test.tsx
@@ -1,0 +1,243 @@
+// Coverage for the Manage OpDivs "Add System Delegate Role" toggle and its
+// role-based access (ztmf-ui#598). OWNER manages OpDivs fully; HHS admin
+// reaches the page only to flip the delegate toggle; every other role is
+// bounced. The toggle writes through the dedicated setOpDivDelegateEnabled
+// endpoint, never the OWNER-only OpDiv update.
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+// MUI DataGrid virtualizes rows and won't render them under jsdom. Stub it
+// with a minimal grid that renders the toolbar plus, for each row, every
+// column's renderCell / getActions output so the toggle Switch and the
+// OWNER-only row actions are queryable.
+jest.mock('@mui/x-data-grid', () => {
+  const actual = jest.requireActual('@mui/x-data-grid')
+  const react = require('react')
+  return {
+    ...actual,
+    // GridToolbarContainer / QuickFilter need the real DataGrid context
+    // (useGridRootProps); replace with plain passthroughs so the custom
+    // CreateToolbar renders under the mocked grid below.
+    GridToolbarContainer: (props: { children?: React.ReactNode }) =>
+      react.createElement('div', null, props.children),
+    GridToolbarQuickFilter: () => null,
+    GridActionsCellItem: (props: { label?: string; onClick?: () => void }) =>
+      react.createElement(
+        'button',
+        { type: 'button', 'aria-label': props.label, onClick: props.onClick },
+        props.label
+      ),
+    DataGrid: (props: {
+      rows?: Array<Record<string, unknown>>
+      columns?: Array<Record<string, unknown>>
+      getRowId?: (row: Record<string, unknown>) => string | number
+      slots?: { toolbar?: (p: unknown) => React.ReactNode }
+      slotProps?: { toolbar?: Record<string, unknown> }
+    }) => {
+      const { rows = [], columns = [], getRowId, slots, slotProps } = props
+      const Toolbar = slots?.toolbar
+      return react.createElement(
+        'div',
+        { 'data-testid': 'datagrid-mock' },
+        Toolbar
+          ? react.createElement(Toolbar, {
+              key: 'toolbar',
+              ...(slotProps?.toolbar ?? {}),
+            })
+          : null,
+        rows.map((row) => {
+          const id = getRowId ? getRowId(row) : (row.id as string | number)
+          return react.createElement(
+            'div',
+            { key: String(id), 'data-testid': `row-${id}` },
+            columns.map((col) => {
+              const field = String(col.field)
+              const getActions = col.getActions as
+                | ((p: {
+                    id: string | number
+                    row: Record<string, unknown>
+                  }) => React.ReactNode[])
+                | undefined
+              if (col.type === 'actions' && getActions) {
+                return react.createElement(
+                  'div',
+                  { key: field },
+                  getActions({ id, row })
+                )
+              }
+              const renderCell = col.renderCell as
+                | ((p: {
+                    row: Record<string, unknown>
+                    id: string | number
+                    value: unknown
+                  }) => React.ReactNode)
+                | undefined
+              if (renderCell) {
+                return react.createElement(
+                  'div',
+                  { key: field },
+                  renderCell({ row, id, value: row[field] })
+                )
+              }
+              return null
+            })
+          )
+        })
+      )
+    },
+  }
+})
+
+jest.mock('@/utils/opdivs', () => ({
+  __esModule: true,
+  fetchOpDivs: jest.fn(),
+  createOpDiv: jest.fn(),
+  updateOpDiv: jest.fn(),
+}))
+jest.mock('@/utils/delegates', () => ({
+  __esModule: true,
+  setOpDivDelegateEnabled: jest.fn(),
+}))
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+const mockCtxListeners = new Set<() => void>()
+let mockCtxValue: Record<string, unknown> = {}
+function setMockCtx(next: Record<string, unknown>) {
+  mockCtxValue = next
+  mockCtxListeners.forEach((l) => l())
+}
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => {
+    const react = require('react')
+    return react.useSyncExternalStore(
+      (cb: () => void) => {
+        mockCtxListeners.add(cb)
+        return () => mockCtxListeners.delete(cb)
+      },
+      () => mockCtxValue
+    )
+  },
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OpDivAdmin from './OpDivAdmin'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { fetchOpDivs } from '@/utils/opdivs'
+import { setOpDivDelegateEnabled } from '@/utils/delegates'
+import type { OpDiv, UserRole, userData } from '@/types'
+
+const fetchOpDivsMock = fetchOpDivs as jest.Mock
+const setEnabledMock = setOpDivDelegateEnabled as jest.Mock
+
+const EMPIRE: OpDiv = {
+  opdiv_id: 3,
+  code: 'EMPIRE',
+  name: 'Galactic Empire',
+  is_parent: false,
+  active: true,
+  system_delegate_enabled: false,
+}
+
+function ctx(role: UserRole) {
+  return {
+    userInfo: {
+      userid: 'u-1',
+      email: 'a@b.gov',
+      fullname: 'Tester',
+      role,
+    } as userData,
+  }
+}
+
+function renderAs(role: UserRole) {
+  setMockCtx(ctx(role))
+  return renderWithProviders(<OpDivAdmin />)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  fetchOpDivsMock.mockResolvedValue([EMPIRE])
+  setEnabledMock.mockResolvedValue({ ...EMPIRE, system_delegate_enabled: true })
+})
+
+test('OWNER sees the delegate toggle plus Create and row actions', async () => {
+  renderAs('OWNER')
+
+  expect(
+    await screen.findByRole('checkbox', {
+      name: /add system delegate role for empire/i,
+    })
+  ).toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: /create opdiv/i })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: /deactivate/i })
+  ).toBeInTheDocument()
+})
+
+test('HHS admin sees the grid and toggle but not Create / Edit / Deactivate', async () => {
+  renderAs('HHS_ADMIN')
+
+  expect(
+    await screen.findByRole('checkbox', {
+      name: /add system delegate role for empire/i,
+    })
+  ).toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /create opdiv/i })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /^edit$/i })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /deactivate/i })
+  ).not.toBeInTheDocument()
+})
+
+test('flipping the toggle confirms then calls the dedicated enable endpoint', async () => {
+  const user = userEvent.setup()
+  renderAs('OWNER')
+
+  const toggle = await screen.findByRole('checkbox', {
+    name: /add system delegate role for empire/i,
+  })
+  await user.click(toggle)
+
+  // Nothing is written until the admin confirms.
+  expect(setEnabledMock).not.toHaveBeenCalled()
+  await user.click(screen.getByRole('button', { name: /^enable$/i }))
+
+  await waitFor(() => expect(setEnabledMock).toHaveBeenCalledTimes(1))
+  // Toggled from false -> true for EMPIRE (opdiv_id 3).
+  expect(setEnabledMock).toHaveBeenCalledWith(3, true)
+})
+
+test('cancelling the toggle confirmation writes nothing', async () => {
+  const user = userEvent.setup()
+  renderAs('OWNER')
+
+  const toggle = await screen.findByRole('checkbox', {
+    name: /add system delegate role for empire/i,
+  })
+  await user.click(toggle)
+  await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+  expect(setEnabledMock).not.toHaveBeenCalled()
+})
+
+test('an OPDIV_ADMIN is bounced - no Manage OpDivs grid renders', () => {
+  renderAs('OPDIV_ADMIN')
+
+  expect(screen.queryByTestId('datagrid-mock')).not.toBeInTheDocument()
+  expect(screen.queryByText(/manage opdivs/i)).not.toBeInTheDocument()
+  expect(fetchOpDivsMock).not.toHaveBeenCalled()
+})

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -35,6 +35,8 @@ import {
   updateOpDiv,
   type OpDivInput,
 } from '@/utils/opdivs'
+import { setOpDivDelegateEnabled } from '@/utils/delegates'
+import { isUnscopedWriteAdmin } from '@/utils/userRoles'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import type { OpDiv } from '@/types'
@@ -45,18 +47,26 @@ const NAME_MAX = 128
 type FormState = { code: string; name: string; is_parent: boolean }
 const EMPTY_FORM: FormState = { code: '', name: '', is_parent: false }
 
-function CreateToolbar({ onCreate }: { onCreate: () => void }) {
+function CreateToolbar({
+  onCreate,
+  canCreate,
+}: {
+  onCreate: () => void
+  canCreate: boolean
+}) {
   return (
     <GridToolbarContainer sx={{ justifyContent: 'space-between' }}>
       <GridToolbarQuickFilter debounceMs={250} />
-      <Button
-        color="primary"
-        startIcon={<AddIcon />}
-        onClick={onCreate}
-        sx={{ color: '#5666b8' }}
-      >
-        Create OpDiv
-      </Button>
+      {canCreate && (
+        <Button
+          color="primary"
+          startIcon={<AddIcon />}
+          onClick={onCreate}
+          sx={{ color: '#5666b8' }}
+        >
+          Create OpDiv
+        </Button>
+      )}
     </GridToolbarContainer>
   )
 }
@@ -64,7 +74,14 @@ function CreateToolbar({ onCreate }: { onCreate: () => void }) {
 export default function OpDivAdmin() {
   const navigate = useNavigate()
   const { userInfo } = useContextProp()
+  // OWNER manages OpDivs fully (create / edit / activate). HHS admin reaches
+  // the page only to flip the per-OpDiv System Delegate toggle - every other
+  // control stays OWNER-only. The backend enforces both boundaries (OpDiv
+  // CRUD is OWNER-only; the delegate-toggle endpoint is OWNER + HHS admin).
   const isOwner = userInfo.role === 'OWNER'
+  const canAccess = isUnscopedWriteAdmin(userInfo)
+  const canManage = isOwner
+  const canToggleDelegate = canAccess
 
   const [rows, setRows] = useState<OpDiv[]>([])
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -72,14 +89,17 @@ export default function OpDivAdmin() {
   const [form, setForm] = useState<FormState>(EMPTY_FORM)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [pendingToggle, setPendingToggle] = useState<OpDiv | null>(null)
+  const [pendingDelegateToggle, setPendingDelegateToggle] =
+    useState<OpDiv | null>(null)
 
-  // OWNER is the tenant boundary - everyone else is bounced, mirroring the
-  // redirect guard UserTable uses. The backend also returns 403.
+  // Unscoped write admins (OWNER + HHS admin) reach the page; everyone else is
+  // bounced, mirroring the redirect guard UserTable uses. The backend also
+  // returns 403 on any mutation the caller isn't allowed to make.
   useEffect(() => {
-    if (userInfo.role && !isOwner) {
+    if (userInfo.role && !canAccess) {
       navigate(Routes.ROOT, { replace: true })
     }
-  }, [userInfo.role, isOwner, navigate])
+  }, [userInfo.role, canAccess, navigate])
 
   const loadOpDivs = useCallback(() => {
     fetchOpDivs(true)
@@ -92,8 +112,8 @@ export default function OpDivAdmin() {
   }, [])
 
   useEffect(() => {
-    if (isOwner) loadOpDivs()
-  }, [isOwner, loadOpDivs])
+    if (canAccess) loadOpDivs()
+  }, [canAccess, loadOpDivs])
 
   const openCreate = () => {
     setEditing(null)
@@ -180,8 +200,29 @@ export default function OpDivAdmin() {
       })
   }
 
-  const columns: GridColDef[] = useMemo(
-    () => [
+  const handleConfirmDelegateToggle = (confirm: boolean) => {
+    const target = pendingDelegateToggle
+    setPendingDelegateToggle(null)
+    if (!confirm || !target) return
+    setOpDivDelegateEnabled(target.opdiv_id, !target.system_delegate_enabled)
+      .then(() => {
+        notify(
+          target.system_delegate_enabled
+            ? 'Saved - System Delegate disabled'
+            : 'Saved - System Delegate enabled',
+          'success'
+        )
+        loadOpDivs()
+      })
+      .catch((error) => {
+        if (isAuthHandled(error)) return
+        const parsed = parseApiError(error)
+        notify(parsed.message, 'error')
+      })
+  }
+
+  const columns: GridColDef[] = useMemo(() => {
+    const cols: GridColDef[] = [
       { field: 'code', headerName: 'Code', flex: 0.6 },
       { field: 'name', headerName: 'Name', flex: 1.4 },
       {
@@ -197,6 +238,29 @@ export default function OpDivAdmin() {
         valueGetter: (params) => (params.row.active ? 'Active' : 'Inactive'),
       },
       {
+        field: 'system_delegate_enabled',
+        headerName: 'System Delegate',
+        flex: 0.7,
+        sortable: false,
+        renderCell: (params) => {
+          const row = params.row as OpDiv
+          return (
+            <Switch
+              checked={row.system_delegate_enabled}
+              disabled={!canToggleDelegate}
+              onChange={() => setPendingDelegateToggle(row)}
+              inputProps={{
+                'aria-label': `Add System Delegate Role for ${row.code}`,
+              }}
+            />
+          )
+        },
+      },
+    ]
+    // Create / edit / activate stay OWNER-only; HHS admin sees the grid but can
+    // only flip the delegate toggle above.
+    if (canManage) {
+      cols.push({
         field: 'actions',
         type: 'actions',
         headerName: 'Actions',
@@ -231,12 +295,12 @@ export default function OpDivAdmin() {
             </Tooltip>,
           ]
         },
-      },
-    ],
-    []
-  )
+      })
+    }
+    return cols
+  }, [canManage, canToggleDelegate])
 
-  if (!isOwner) return null
+  if (!canAccess) return null
 
   return (
     <>
@@ -254,7 +318,9 @@ export default function OpDivAdmin() {
             sorting: { sortModel: [{ field: 'code', sort: 'asc' }] },
           }}
           slots={{ toolbar: CreateToolbar }}
-          slotProps={{ toolbar: { onCreate: openCreate } }}
+          slotProps={{
+            toolbar: { onCreate: openCreate, canCreate: canManage },
+          }}
           disableColumnSelector
           sx={{
             '& .MuiDataGrid-columnHeaders': {
@@ -340,6 +406,27 @@ export default function OpDivAdmin() {
         onClose={() => setPendingToggle(null)}
         confirmClick={handleConfirmToggle}
         confirmLabel={pendingToggle?.active ? 'Deactivate' : 'Reactivate'}
+      />
+
+      <ConfirmDialog
+        title={
+          pendingDelegateToggle?.system_delegate_enabled
+            ? 'Disable System Delegate'
+            : 'Enable System Delegate'
+        }
+        confirmationText={
+          pendingDelegateToggle
+            ? pendingDelegateToggle.system_delegate_enabled
+              ? `Turn off System Delegate self-service for ${pendingDelegateToggle.code} - ${pendingDelegateToggle.name}? ISSOs will no longer be able to add delegates to systems in this OpDiv.`
+              : `Turn on System Delegate self-service for ${pendingDelegateToggle.code} - ${pendingDelegateToggle.name}? ISSOs will be able to add delegates to systems in this OpDiv.`
+            : ''
+        }
+        open={pendingDelegateToggle !== null}
+        onClose={() => setPendingDelegateToggle(null)}
+        confirmClick={handleConfirmDelegateToggle}
+        confirmLabel={
+          pendingDelegateToggle?.system_delegate_enabled ? 'Disable' : 'Enable'
+        }
       />
     </>
   )

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -239,7 +239,11 @@ export default function OpDivAdmin() {
       },
       {
         field: 'system_delegate_enabled',
+        // Short visible header; the full spec label "Add System Delegate Role"
+        // rides along as the header tooltip (description) and the switch's
+        // aria-label, so it fits the grid without losing the exact wording.
         headerName: 'System Delegate',
+        description: 'Add System Delegate Role',
         flex: 0.7,
         sortable: false,
         renderCell: (params) => {

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -42,6 +42,7 @@ const opdivOptions: OpDiv[] = [
     name: 'Division A',
     is_parent: false,
     active: true,
+    system_delegate_enabled: false,
   },
   {
     opdiv_id: 2,
@@ -49,6 +50,7 @@ const opdivOptions: OpDiv[] = [
     name: 'Division B',
     is_parent: false,
     active: true,
+    system_delegate_enabled: false,
   },
 ]
 

--- a/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
@@ -1,7 +1,7 @@
 // Coverage for the delegates section on the system detail page
 // (ztmf-ui#598). Backend calls are mocked at the util seam
 // (src/utils/delegates). Verifies the roster + expired badge, attach /
-// invite / remove / renew round-trips, the administrator-required and
+// attach / provision / remove / renew round-trips, the administrator-
 // capability-off inline guards, the +3mo expiry default, and that a
 // non-manager (ISSM) sees the roster without any controls.
 
@@ -114,18 +114,20 @@ test('a delegate within 30 days of expiry shows an Expiring soon chip', async ()
   expect(within(soonRow).getByText('Expiring soon')).toBeInTheDocument()
 })
 
-test('the invite control opens a dialog rather than an inline form', async () => {
+test('the provision control opens a dialog rather than an inline form', async () => {
   const user = userEvent.setup()
   renderSection()
   await screen.findByText('Active Delegate')
 
-  // No invite form fields until the dialog is opened.
+  // No provision form fields until the dialog is opened.
   expect(screen.queryByLabelText(/^name/i)).not.toBeInTheDocument()
 
-  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.click(
+    screen.getByRole('button', { name: /provision new delegate/i })
+  )
 
   const dialog = await screen.findByRole('dialog', {
-    name: /invite new delegate/i,
+    name: /provision new delegate/i,
   })
   expect(within(dialog).getByLabelText(/^name/i)).toBeInTheDocument()
   expect(within(dialog).getByLabelText(/^email/i)).toBeInTheDocument()
@@ -153,25 +155,45 @@ test('attaching an existing candidate POSTs just the email and refetches', async
   await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
 })
 
-test('the invite expiry defaults to three months out', async () => {
+test('a field-map error on attach is surfaced rather than swallowed', async () => {
+  const user = userEvent.setup()
+  addMock.mockRejectedValueOnce(
+    axiosError(400, { data: { email: 'not attachable' } })
+  )
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('combobox', { name: /attach an existing delegate/i })
+  )
+  await user.click(await screen.findByText(/Wilhuff Tarkin/i))
+
+  expect(await screen.findByText(/not attachable/i)).toBeInTheDocument()
+})
+
+test('the provision expiry defaults to three months out', async () => {
   const user = userEvent.setup()
   renderSection()
   await screen.findByText('Active Delegate')
 
-  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.click(
+    screen.getByRole('button', { name: /provision new delegate/i })
+  )
   const dateInput = screen.getByLabelText(/access expires/i) as HTMLInputElement
   expect(dateInput.value).toBe(addMonthsISO(3))
 })
 
-test('inviting a new person POSTs email, name, and expiry', async () => {
+test('provisioning a new person POSTs email, name, and expiry', async () => {
   const user = userEvent.setup()
   renderSection()
   await screen.findByText('Active Delegate')
 
-  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.click(
+    screen.getByRole('button', { name: /provision new delegate/i })
+  )
   await user.type(screen.getByLabelText(/^name/i), 'Moff Jerjerrod')
   await user.type(screen.getByLabelText(/^email/i), 'jerjerrod@empire.gov')
-  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+  await user.click(screen.getByRole('button', { name: /^provision$/i }))
 
   await waitFor(() => expect(addMock).toHaveBeenCalledTimes(1))
   const [, body] = addMock.mock.calls[0]
@@ -180,7 +202,7 @@ test('inviting a new person POSTs email, name, and expiry', async () => {
   expect(typeof body.access_expires_at).toBe('string')
 })
 
-test('an administrator-required email shows an inline guard, not an invite', async () => {
+test('an administrator-required email shows an inline guard, not a provision', async () => {
   const user = userEvent.setup()
   addMock.mockRejectedValueOnce(
     axiosError(400, {
@@ -191,14 +213,16 @@ test('an administrator-required email shows an inline guard, not an invite', asy
   renderSection()
   await screen.findByText('Active Delegate')
 
-  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.click(
+    screen.getByRole('button', { name: /provision new delegate/i })
+  )
   await user.type(screen.getByLabelText(/^name/i), 'Existing Person')
   await user.type(screen.getByLabelText(/^email/i), 'existing@empire.gov')
-  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+  await user.click(screen.getByRole('button', { name: /^provision$/i }))
 
-  // Guard renders inside the still-open invite dialog (not as a card alert or
-  // toast), so the ISSO sees why the invite was refused where they acted.
-  const dialog = screen.getByRole('dialog', { name: /invite new delegate/i })
+  // Guard renders inside the still-open provision dialog (not as a card alert
+  // or toast), so the ISSO sees why the provision was refused where they acted.
+  const dialog = screen.getByRole('dialog', { name: /provision new delegate/i })
   expect(
     await within(dialog).findByText(/must be handled by an administrator/i)
   ).toBeInTheDocument()
@@ -210,12 +234,14 @@ test('a capability-off 403 shows the OpDiv-disabled inline guard', async () => {
   renderSection()
   await screen.findByText('Active Delegate')
 
-  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.click(
+    screen.getByRole('button', { name: /provision new delegate/i })
+  )
   await user.type(screen.getByLabelText(/^name/i), 'Someone')
   await user.type(screen.getByLabelText(/^email/i), 'someone@empire.gov')
-  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+  await user.click(screen.getByRole('button', { name: /^provision$/i }))
 
-  const dialog = screen.getByRole('dialog', { name: /invite new delegate/i })
+  const dialog = screen.getByRole('dialog', { name: /provision new delegate/i })
   expect(
     await within(dialog).findByText(/not enabled for this OpDiv/i)
   ).toBeInTheDocument()
@@ -264,7 +290,7 @@ test('a non-manager (ISSM) sees the roster but no controls', async () => {
     screen.queryByRole('combobox', { name: /attach an existing delegate/i })
   ).not.toBeInTheDocument()
   expect(
-    screen.queryByRole('button', { name: /invite new delegate/i })
+    screen.queryByRole('button', { name: /provision new delegate/i })
   ).not.toBeInTheDocument()
   expect(
     screen.queryByRole('button', { name: /remove Active Delegate/i })

--- a/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
@@ -1,0 +1,272 @@
+// Coverage for the delegates section on the system detail page
+// (ztmf-ui#598). Backend calls are mocked at the util seam
+// (src/utils/delegates). Verifies the roster + expired badge, attach /
+// invite / remove / renew round-trips, the administrator-required and
+// capability-off inline guards, the +3mo expiry default, and that a
+// non-manager (ISSM) sees the roster without any controls.
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: { navigate: jest.fn() },
+}))
+
+jest.mock('@/utils/delegates', () => ({
+  __esModule: true,
+  fetchSystemDelegates: jest.fn(),
+  searchDelegateCandidates: jest.fn(),
+  addSystemDelegate: jest.fn(),
+  removeSystemDelegate: jest.fn(),
+  renewSystemDelegate: jest.fn(),
+}))
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SystemDelegatesSection from './SystemDelegatesSection'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { addMonthsISO } from '@/utils/decommission'
+import {
+  fetchSystemDelegates,
+  searchDelegateCandidates,
+  addSystemDelegate,
+  removeSystemDelegate,
+  renewSystemDelegate,
+} from '@/utils/delegates'
+import type { FismaSystemType, DelegateRow, DelegateCandidate } from '@/types'
+
+const fetchMock = fetchSystemDelegates as jest.Mock
+const searchMock = searchDelegateCandidates as jest.Mock
+const addMock = addSystemDelegate as jest.Mock
+const removeMock = removeSystemDelegate as jest.Mock
+const renewMock = renewSystemDelegate as jest.Mock
+
+const SYSTEM_ID = 1002
+const SYSTEM = { fismasystemid: SYSTEM_ID } as unknown as FismaSystemType
+
+const ACTIVE: DelegateRow = {
+  userid: 'd-active',
+  fullname: 'Active Delegate',
+  email: 'active@empire.gov',
+  access_expires_at: '2099-12-31T23:59:59Z',
+}
+const EXPIRED: DelegateRow = {
+  userid: 'd-expired',
+  fullname: 'Expired Delegate',
+  email: 'expired@empire.gov',
+  access_expires_at: '2000-01-01T00:00:00Z',
+}
+const CANDIDATE: DelegateCandidate = {
+  userid: 'c-1',
+  fullname: 'Wilhuff Tarkin',
+  email: 'tarkin@empire.gov',
+}
+
+// Minimal axios-style error so parseApiError treats it as one.
+function axiosError(status: number, data: unknown) {
+  return Object.assign(new Error('request failed'), {
+    isAxiosError: true,
+    response: { status, data },
+  })
+}
+
+function renderSection(canManage = true) {
+  return renderWithProviders(
+    <SystemDelegatesSection system={SYSTEM} canManage={canManage} />
+  )
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  fetchMock.mockResolvedValue([ACTIVE, EXPIRED])
+  searchMock.mockResolvedValue([CANDIDATE])
+  addMock.mockResolvedValue(undefined)
+  removeMock.mockResolvedValue(undefined)
+  renewMock.mockResolvedValue(ACTIVE)
+})
+
+test('renders the roster with per-row status chips (Active / Expired)', async () => {
+  renderSection()
+
+  expect(await screen.findByText('Active Delegate')).toBeInTheDocument()
+  const expiredRow = screen.getByText('Expired Delegate').closest('li')!
+  expect(within(expiredRow).getByText('Expired')).toBeInTheDocument()
+  const activeRow = screen.getByText('Active Delegate').closest('li')!
+  expect(within(activeRow).getByText('Active')).toBeInTheDocument()
+  expect(within(activeRow).queryByText('Expired')).not.toBeInTheDocument()
+})
+
+test('a delegate within 30 days of expiry shows an Expiring soon chip', async () => {
+  const soon = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString()
+  fetchMock.mockResolvedValue([
+    {
+      ...ACTIVE,
+      userid: 'd-soon',
+      fullname: 'Soon Delegate',
+      access_expires_at: soon,
+    },
+  ])
+  renderSection()
+
+  const soonRow = (await screen.findByText('Soon Delegate')).closest('li')!
+  expect(within(soonRow).getByText('Expiring soon')).toBeInTheDocument()
+})
+
+test('the invite control opens a dialog rather than an inline form', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  // No invite form fields until the dialog is opened.
+  expect(screen.queryByLabelText(/^name/i)).not.toBeInTheDocument()
+
+  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+
+  const dialog = await screen.findByRole('dialog', {
+    name: /invite new delegate/i,
+  })
+  expect(within(dialog).getByLabelText(/^name/i)).toBeInTheDocument()
+  expect(within(dialog).getByLabelText(/^email/i)).toBeInTheDocument()
+  expect(within(dialog).getByLabelText(/access expires/i)).toBeInTheDocument()
+})
+
+test('attaching an existing candidate POSTs just the email and refetches', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('combobox', { name: /attach an existing delegate/i })
+  )
+  const option = await screen.findByText(
+    /Wilhuff Tarkin \(tarkin@empire\.gov\)/i
+  )
+  await user.click(option)
+
+  await waitFor(() => expect(addMock).toHaveBeenCalledTimes(1))
+  expect(addMock).toHaveBeenCalledWith(SYSTEM_ID, {
+    email: 'tarkin@empire.gov',
+  })
+  // Roster refetched (initial load + after attach).
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+})
+
+test('the invite expiry defaults to three months out', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  const dateInput = screen.getByLabelText(/access expires/i) as HTMLInputElement
+  expect(dateInput.value).toBe(addMonthsISO(3))
+})
+
+test('inviting a new person POSTs email, name, and expiry', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.type(screen.getByLabelText(/^name/i), 'Moff Jerjerrod')
+  await user.type(screen.getByLabelText(/^email/i), 'jerjerrod@empire.gov')
+  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+
+  await waitFor(() => expect(addMock).toHaveBeenCalledTimes(1))
+  const [, body] = addMock.mock.calls[0]
+  expect(body.email).toBe('jerjerrod@empire.gov')
+  expect(body.fullname).toBe('Moff Jerjerrod')
+  expect(typeof body.access_expires_at).toBe('string')
+})
+
+test('an administrator-required email shows an inline guard, not an invite', async () => {
+  const user = userEvent.setup()
+  addMock.mockRejectedValueOnce(
+    axiosError(400, {
+      error: 'admin required',
+      code: 'DELEGATE_REQUIRES_ADMIN',
+    })
+  )
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.type(screen.getByLabelText(/^name/i), 'Existing Person')
+  await user.type(screen.getByLabelText(/^email/i), 'existing@empire.gov')
+  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+
+  // Guard renders inside the still-open invite dialog (not as a card alert or
+  // toast), so the ISSO sees why the invite was refused where they acted.
+  const dialog = screen.getByRole('dialog', { name: /invite new delegate/i })
+  expect(
+    await within(dialog).findByText(/must be handled by an administrator/i)
+  ).toBeInTheDocument()
+})
+
+test('a capability-off 403 shows the OpDiv-disabled inline guard', async () => {
+  const user = userEvent.setup()
+  addMock.mockRejectedValueOnce(axiosError(403, { error: 'forbidden' }))
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(screen.getByRole('button', { name: /invite new delegate/i }))
+  await user.type(screen.getByLabelText(/^name/i), 'Someone')
+  await user.type(screen.getByLabelText(/^email/i), 'someone@empire.gov')
+  await user.click(screen.getByRole('button', { name: /^invite$/i }))
+
+  const dialog = screen.getByRole('dialog', { name: /invite new delegate/i })
+  expect(
+    await within(dialog).findByText(/not enabled for this OpDiv/i)
+  ).toBeInTheDocument()
+})
+
+test('removing a delegate confirms then DELETEs and refetches', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('button', { name: /remove Active Delegate/i })
+  )
+  // Not deleted until confirmed.
+  expect(removeMock).not.toHaveBeenCalled()
+  await user.click(screen.getByRole('button', { name: /^remove$/i }))
+
+  await waitFor(() =>
+    expect(removeMock).toHaveBeenCalledWith(SYSTEM_ID, 'd-active')
+  )
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+})
+
+test('renewing a delegate PATCHes the new expiration', async () => {
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('button', { name: /renew Active Delegate/i })
+  )
+  await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(renewMock).toHaveBeenCalledTimes(1))
+  const [sysId, userId, expiresAt] = renewMock.mock.calls[0]
+  expect(sysId).toBe(SYSTEM_ID)
+  expect(userId).toBe('d-active')
+  expect(typeof expiresAt).toBe('string')
+})
+
+test('a non-manager (ISSM) sees the roster but no controls', async () => {
+  renderSection(false)
+  await screen.findByText('Active Delegate')
+
+  expect(
+    screen.queryByRole('combobox', { name: /attach an existing delegate/i })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /invite new delegate/i })
+  ).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('button', { name: /remove Active Delegate/i })
+  ).not.toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
@@ -134,6 +134,54 @@ test('the provision control opens a dialog rather than an inline form', async ()
   expect(within(dialog).getByLabelText(/access expires/i)).toBeInTheDocument()
 })
 
+test('an expired candidate carries the same Expired chip as the roster', async () => {
+  const user = userEvent.setup()
+  searchMock.mockResolvedValue([
+    { ...CANDIDATE, access_expires_at: '2000-01-01T00:00:00Z' },
+  ])
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('combobox', { name: /attach an existing delegate/i })
+  )
+  const option = (await screen.findByText(/Wilhuff Tarkin/i)).closest('li')!
+  expect(within(option).getByText('Expired')).toBeInTheDocument()
+})
+
+test('an active candidate carries an Active chip', async () => {
+  const user = userEvent.setup()
+  searchMock.mockResolvedValue([
+    { ...CANDIDATE, access_expires_at: '2099-12-31T23:59:59Z' },
+  ])
+  renderSection()
+  await screen.findByText('Active Delegate')
+
+  await user.click(
+    screen.getByRole('combobox', { name: /attach an existing delegate/i })
+  )
+  const option = (await screen.findByText(/Wilhuff Tarkin/i)).closest('li')!
+  expect(within(option).getByText('Active')).toBeInTheDocument()
+  expect(within(option).queryByText('Expired')).not.toBeInTheDocument()
+})
+
+test('removing a delegate refreshes the candidate list', async () => {
+  // A removed delegate becomes eligible again, so the picker must refetch
+  // rather than stay stale until a page reload.
+  const user = userEvent.setup()
+  renderSection()
+  await screen.findByText('Active Delegate')
+  await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1))
+
+  await user.click(
+    screen.getByRole('button', { name: /remove Active Delegate/i })
+  )
+  await user.click(screen.getByRole('button', { name: /^remove$/i }))
+
+  await waitFor(() => expect(removeMock).toHaveBeenCalledTimes(1))
+  await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(2))
+})
+
 test('attaching an existing candidate POSTs just the email and refetches', async () => {
   const user = userEvent.setup()
   renderSection()

--- a/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.test.tsx
@@ -278,7 +278,14 @@ test('an administrator-required email shows an inline guard, not a provision', a
 
 test('a capability-off 403 shows the OpDiv-disabled inline guard', async () => {
   const user = userEvent.setup()
-  addMock.mockRejectedValueOnce(axiosError(403, { error: 'forbidden' }))
+  // The add call opts out of the global auth interceptor (skipAuthHandling), so
+  // the coded 403 reaches the component and classifyAddError keys on the code.
+  addMock.mockRejectedValueOnce(
+    axiosError(403, {
+      error: 'system delegate role is not enabled for this opdiv',
+      code: 'DELEGATE_NOT_ENABLED',
+    })
+  )
   renderSection()
   await screen.findByText('Active Delegate')
 

--- a/src/views/SystemDetailPage/SystemDelegatesSection.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.tsx
@@ -1,0 +1,525 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import EventRepeatIcon from '@mui/icons-material/EventRepeat'
+import { FismaSystemType, DelegateRow, DelegateCandidate } from '@/types'
+import {
+  fetchSystemDelegates,
+  searchDelegateCandidates,
+  addSystemDelegate,
+  removeSystemDelegate,
+  renewSystemDelegate,
+} from '@/utils/delegates'
+import { parseApiError } from '@/utils/apiErrors'
+import { isAuthHandled, notify } from '@/utils/notify'
+import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
+import { getTodayISO, addMonthsISO } from '@/utils/decommission'
+
+// Same shape UserTable validates against; the backend is the authority, this
+// only catches obvious typos before the round-trip.
+const EMAIL_RE = /^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/
+
+const ADMIN_REQUIRED_MSG =
+  'That email belongs to an existing account that must be handled by an administrator. Ask an admin to add this user.'
+const CAPABILITY_OFF_MSG =
+  'System Delegate self-service is not enabled for this OpDiv.'
+
+// A picked YYYY-MM-DD expires at the end of that day (UTC), so the delegate
+// keeps access through the date shown.
+function dateToExpiryISO(date: string): string {
+  return new Date(`${date}T23:59:59.000Z`).toISOString()
+}
+
+// A delegate within this many days of expiry is flagged "Expiring soon" so a
+// manager can renew before access lapses.
+const EXPIRING_SOON_DAYS = 30
+
+function daysUntil(iso: string | null): number | null {
+  if (!iso) return null
+  const ms = new Date(iso).getTime()
+  if (isNaN(ms)) return null
+  return Math.ceil((ms - Date.now()) / (1000 * 60 * 60 * 24))
+}
+
+// At-a-glance roster status. Delegates always carry an expiry, so the null
+// case (a non-expiring account) simply reads as Active.
+function delegateStatus(iso: string | null): {
+  label: string
+  color: 'success' | 'warning' | 'error'
+} {
+  const days = daysUntil(iso)
+  if (days === null) return { label: 'Active', color: 'success' }
+  if (days < 0) return { label: 'Expired', color: 'error' }
+  if (days <= EXPIRING_SOON_DAYS)
+    return { label: 'Expiring soon', color: 'warning' }
+  return { label: 'Active', color: 'success' }
+}
+
+function formatExpiry(iso: string | null): string {
+  if (!iso) return 'No expiration'
+  const d = new Date(iso)
+  return isNaN(d.getTime()) ? iso : d.toLocaleDateString()
+}
+
+interface Props {
+  system: FismaSystemType
+  /**
+   * Whether the current user may add/invite/remove/renew delegates. ISSO and
+   * admins qualify; ISSM (and other assigned viewers) see the roster read-only.
+   * The backend re-checks on every write.
+   */
+  canManage: boolean
+}
+
+/**
+ * Delegates section for the FISMA system detail page. Lists the system's
+ * current delegates with their expiration, and - for a manager - lets an
+ * ISSO attach an existing eligible delegate, invite a new person, renew an
+ * expiration, or remove a delegate. All scope is the one system in `system`;
+ * the backend enforces assignment and OpDiv rules.
+ */
+export default function SystemDelegatesSection({ system, canManage }: Props) {
+  const systemId = system.fismasystemid
+
+  const [delegates, setDelegates] = useState<DelegateRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Attach-existing picker.
+  const [candidates, setCandidates] = useState<DelegateCandidate[]>([])
+  const [candidateInput, setCandidateInput] = useState('')
+  const [attaching, setAttaching] = useState(false)
+
+  // Invite-new dialog.
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [inviteName, setInviteName] = useState('')
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteExpiry, setInviteExpiry] = useState(addMonthsISO(3))
+  const [inviteErrors, setInviteErrors] = useState<Record<string, string>>({})
+  const [inviteGuard, setInviteGuard] = useState('')
+  const [inviting, setInviting] = useState(false)
+
+  // Inline guard for administrator-required / capability-off on the ATTACH
+  // path (card-level). The invite path shows its own guard inside the dialog.
+  const [guardMessage, setGuardMessage] = useState('')
+
+  const [pendingRemove, setPendingRemove] = useState<DelegateRow | null>(null)
+
+  const [renewTarget, setRenewTarget] = useState<DelegateRow | null>(null)
+  const [renewDate, setRenewDate] = useState('')
+  const [renewError, setRenewError] = useState('')
+
+  const loadRoster = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        const rows = await fetchSystemDelegates(systemId, signal)
+        if (signal?.aborted) return
+        setDelegates(rows)
+      } catch (error) {
+        if (signal?.aborted || isAuthHandled(error)) return
+        notify(parseApiError(error).message, 'error')
+      } finally {
+        if (!signal?.aborted) setLoading(false)
+      }
+    },
+    [systemId]
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    loadRoster(controller.signal)
+    return () => controller.abort()
+  }, [loadRoster])
+
+  // Debounced candidate search; only managers see the picker.
+  useEffect(() => {
+    if (!canManage) return
+    const controller = new AbortController()
+    const t = setTimeout(() => {
+      searchDelegateCandidates(systemId, candidateInput, controller.signal)
+        .then((rows) => {
+          if (!controller.signal.aborted) setCandidates(rows)
+        })
+        .catch(() => {
+          // Non-fatal: an empty option list just means nothing to attach.
+        })
+    }, 250)
+    return () => {
+      clearTimeout(t)
+      controller.abort()
+    }
+  }, [systemId, candidateInput, canManage])
+
+  // Classify an add failure so the caller can place it: administrator-required
+  // and capability-off become an inline guard string; a 400 field map is
+  // returned for the invite form; anything else is toasted here. Returns null
+  // when there is nothing to render inline (auth-handled, or already toasted).
+  const classifyAddError = (
+    error: unknown
+  ): { guard?: string; fieldErrors?: Record<string, string> } | null => {
+    if (isAuthHandled(error)) return null
+    const parsed = parseApiError(error)
+    if (parsed.code === 'DELEGATE_REQUIRES_ADMIN')
+      return { guard: ADMIN_REQUIRED_MSG }
+    if (parsed.status === 403) return { guard: CAPABILITY_OFF_MSG }
+    if (parsed.fieldErrors) return { fieldErrors: parsed.fieldErrors }
+    notify(parsed.message, 'error')
+    return null
+  }
+
+  const handleAttach = async (candidate: DelegateCandidate) => {
+    setGuardMessage('')
+    setAttaching(true)
+    try {
+      await addSystemDelegate(systemId, { email: candidate.email })
+      await loadRoster()
+      setCandidateInput('')
+      notify('Saved - delegate added', 'success', { autoHideDuration: 1500 })
+    } catch (error) {
+      const c = classifyAddError(error)
+      if (c?.guard) setGuardMessage(c.guard)
+    } finally {
+      setAttaching(false)
+    }
+  }
+
+  const validateInvite = (): boolean => {
+    const errors: Record<string, string> = {}
+    if (!inviteName.trim()) errors.fullname = 'Name is required'
+    if (!EMAIL_RE.test(inviteEmail.trim()))
+      errors.email = 'A valid email is required'
+    if (!inviteExpiry) errors.access_expires_at = 'Expiration is required'
+    else if (inviteExpiry < getTodayISO())
+      errors.access_expires_at = 'Expiration cannot be in the past'
+    setInviteErrors(errors)
+    return Object.keys(errors).length === 0
+  }
+
+  const openInvite = () => {
+    setGuardMessage('')
+    setInviteName('')
+    setInviteEmail('')
+    setInviteExpiry(addMonthsISO(3))
+    setInviteErrors({})
+    setInviteGuard('')
+    setInviteOpen(true)
+  }
+
+  const handleInvite = async () => {
+    setInviteGuard('')
+    if (!validateInvite()) return
+    setInviting(true)
+    try {
+      await addSystemDelegate(systemId, {
+        email: inviteEmail.trim(),
+        fullname: inviteName.trim(),
+        access_expires_at: dateToExpiryISO(inviteExpiry),
+      })
+      await loadRoster()
+      setInviteOpen(false)
+      notify('Saved - delegate invited', 'success', { autoHideDuration: 1500 })
+    } catch (error) {
+      const c = classifyAddError(error)
+      if (c?.guard) setInviteGuard(c.guard)
+      if (c?.fieldErrors) setInviteErrors(c.fieldErrors)
+    } finally {
+      setInviting(false)
+    }
+  }
+
+  const handleConfirmRemove = async (confirm: boolean) => {
+    const target = pendingRemove
+    setPendingRemove(null)
+    if (!confirm || !target) return
+    try {
+      await removeSystemDelegate(systemId, target.userid)
+      await loadRoster()
+      notify('Saved - delegate removed', 'success', { autoHideDuration: 1500 })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(parseApiError(error).message, 'error', { autoHideDuration: 1500 })
+    }
+  }
+
+  const openRenew = (row: DelegateRow) => {
+    setRenewTarget(row)
+    setRenewDate(addMonthsISO(3))
+    setRenewError('')
+  }
+
+  const handleRenew = async () => {
+    if (!renewTarget) return
+    if (!renewDate || renewDate < getTodayISO()) {
+      setRenewError('Expiration cannot be in the past')
+      return
+    }
+    try {
+      await renewSystemDelegate(
+        systemId,
+        renewTarget.userid,
+        dateToExpiryISO(renewDate)
+      )
+      setRenewTarget(null)
+      await loadRoster()
+      notify('Saved - expiration updated', 'success', {
+        autoHideDuration: 1500,
+      })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      notify(parseApiError(error).message, 'error', { autoHideDuration: 1500 })
+    }
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardHeader
+        title="Delegates"
+        titleTypographyProps={{ variant: 'h6' }}
+        subheader="Contractor and support-staff access to this system's data-call answers"
+        sx={{ pb: 0 }}
+      />
+      <CardContent>
+        {guardMessage && (
+          <Alert
+            severity="warning"
+            sx={{ mb: 2 }}
+            onClose={() => setGuardMessage('')}
+          >
+            {guardMessage}
+          </Alert>
+        )}
+
+        {canManage && (
+          <Box sx={{ mb: 3, maxWidth: 640 }}>
+            <Autocomplete
+              options={candidates}
+              value={null}
+              blurOnSelect
+              clearOnBlur
+              disabled={attaching}
+              filterOptions={(x) => x}
+              getOptionLabel={(o) => `${o.fullname} (${o.email})`}
+              isOptionEqualToValue={(a, b) => a.userid === b.userid}
+              inputValue={candidateInput}
+              onInputChange={(_e, v) => setCandidateInput(v)}
+              onChange={(_e, value) => {
+                if (value) handleAttach(value)
+              }}
+              noOptionsText="No eligible delegates"
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Attach an existing delegate"
+                  placeholder="Search by name or email"
+                  variant="standard"
+                  InputLabelProps={{ sx: { marginTop: 0 } }}
+                />
+              )}
+            />
+
+            <Button size="small" sx={{ mt: 1.5 }} onClick={openInvite}>
+              + Invite new delegate
+            </Button>
+
+            <Divider sx={{ mt: 3 }} />
+          </Box>
+        )}
+
+        {loading ? (
+          <Typography variant="body2" color="text.secondary">
+            Loading delegates...
+          </Typography>
+        ) : delegates.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No delegates on this system.
+          </Typography>
+        ) : (
+          <List disablePadding>
+            {delegates.map((d) => {
+              const status = delegateStatus(d.access_expires_at)
+              return (
+                <ListItem
+                  key={d.userid}
+                  divider
+                  secondaryAction={
+                    canManage ? (
+                      <Box sx={{ display: 'flex', gap: 0.5 }}>
+                        <Tooltip title="Renew expiration">
+                          <IconButton
+                            edge="end"
+                            aria-label={`Renew ${d.fullname}`}
+                            onClick={() => openRenew(d)}
+                          >
+                            <EventRepeatIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Remove delegate">
+                          <IconButton
+                            edge="end"
+                            aria-label={`Remove ${d.fullname}`}
+                            onClick={() => setPendingRemove(d)}
+                          >
+                            <DeleteOutlineIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    ) : undefined
+                  }
+                >
+                  <ListItemText
+                    primary={
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                      >
+                        <span>{d.fullname}</span>
+                        <Chip
+                          label={status.label}
+                          color={status.color}
+                          size="small"
+                          variant={
+                            status.color === 'success' ? 'outlined' : 'filled'
+                          }
+                        />
+                      </Box>
+                    }
+                    secondary={`${d.email} - Expires ${formatExpiry(
+                      d.access_expires_at
+                    )}`}
+                  />
+                </ListItem>
+              )
+            })}
+          </List>
+        )}
+      </CardContent>
+
+      <ConfirmDialog
+        title="Confirm Remove Delegate"
+        confirmationText={
+          pendingRemove
+            ? `Remove ${pendingRemove.fullname} (${pendingRemove.email}) as a delegate on this system? Their access to other systems is unaffected.`
+            : ''
+        }
+        open={pendingRemove !== null}
+        onClose={() => setPendingRemove(null)}
+        confirmClick={handleConfirmRemove}
+        confirmLabel="Remove"
+      />
+
+      <Dialog
+        open={renewTarget !== null}
+        onClose={() => setRenewTarget(null)}
+        maxWidth="xs"
+        fullWidth
+        aria-label="Renew delegate expiration"
+      >
+        <DialogTitle>Renew Delegate Expiration</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            {renewTarget
+              ? `Set a new expiration for ${renewTarget.fullname}. Expiration is per-user, so this applies to every system they are a delegate on.`
+              : ''}
+          </Typography>
+          <TextField
+            label="Access expires"
+            type="date"
+            variant="standard"
+            fullWidth
+            value={renewDate}
+            onChange={(e) => setRenewDate(e.target.value)}
+            error={!!renewError}
+            helperText={renewError}
+            InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <CmsButton onClick={() => setRenewTarget(null)}>Cancel</CmsButton>
+          <CmsButton onClick={handleRenew}>Save</CmsButton>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        maxWidth="xs"
+        fullWidth
+        aria-label="Invite new delegate"
+      >
+        <DialogTitle>Invite New Delegate</DialogTitle>
+        <DialogContent>
+          {inviteGuard && (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              {inviteGuard}
+            </Alert>
+          )}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            <TextField
+              label="Name"
+              variant="standard"
+              required
+              value={inviteName}
+              onChange={(e) => setInviteName(e.target.value)}
+              error={!!inviteErrors.fullname}
+              helperText={inviteErrors.fullname}
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+            />
+            <TextField
+              label="Email"
+              variant="standard"
+              required
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              error={!!inviteErrors.email}
+              helperText={inviteErrors.email}
+              InputLabelProps={{ sx: { marginTop: 0 } }}
+            />
+            <TextField
+              label="Access expires"
+              type="date"
+              variant="standard"
+              required
+              value={inviteExpiry}
+              onChange={(e) => setInviteExpiry(e.target.value)}
+              error={!!inviteErrors.access_expires_at}
+              helperText={
+                inviteErrors.access_expires_at ??
+                'Defaults to three months from today'
+              }
+              InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <CmsButton onClick={() => setInviteOpen(false)} disabled={inviting}>
+            Cancel
+          </CmsButton>
+          <CmsButton onClick={handleInvite} disabled={inviting}>
+            {inviting ? 'Inviting...' : 'Invite'}
+          </CmsButton>
+        </DialogActions>
+      </Dialog>
+    </Card>
+  )
+}

--- a/src/views/SystemDetailPage/SystemDelegatesSection.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.tsx
@@ -83,6 +83,10 @@ function formatExpiry(iso: string | null): string {
   return isNaN(d.getTime()) ? iso : d.toLocaleDateString()
 }
 
+function candidateLabel(o: DelegateCandidate): string {
+  return `${o.fullname} (${o.email})`
+}
+
 interface Props {
   system: FismaSystemType
   /**
@@ -108,6 +112,10 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
 
   const [delegates, setDelegates] = useState<DelegateRow[]>([])
   const [loading, setLoading] = useState(true)
+  // Bumped on every successful roster load. The candidate search keys off
+  // this rather than the `delegates` array so the refresh does not depend on
+  // the array's referential identity changing.
+  const [rosterVersion, setRosterVersion] = useState(0)
 
   // Attach-existing picker.
   const [candidates, setCandidates] = useState<DelegateCandidate[]>([])
@@ -141,6 +149,7 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
         const rows = await fetchSystemDelegates(systemId, signal)
         if (signal?.aborted) return
         setDelegates(rows)
+        setRosterVersion((v) => v + 1)
       } catch (error) {
         if (signal?.aborted || isAuthHandled(error)) return
         notify(parseApiError(error).message, 'error')
@@ -158,7 +167,11 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
     return () => controller.abort()
   }, [loadRoster])
 
-  // Debounced candidate search; only managers see the picker.
+  // Debounced candidate search; only managers see the picker. Re-runs on
+  // rosterVersion because the eligible set excludes anyone already on the
+  // system: removing a delegate makes them a candidate again, and attaching
+  // one drops them from the list, so the picker has to refresh whenever the
+  // roster does rather than going stale until a page reload.
   useEffect(() => {
     if (!canManage) return
     const controller = new AbortController()
@@ -175,7 +188,7 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
       clearTimeout(t)
       controller.abort()
     }
-  }, [systemId, candidateInput, canManage])
+  }, [systemId, candidateInput, canManage, rosterVersion])
 
   // Classify an add failure so the caller can place it: administrator-required
   // and capability-off become an inline guard string; a 400 field map is
@@ -341,8 +354,29 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
               clearOnBlur
               disabled={attaching}
               filterOptions={(x) => x}
-              getOptionLabel={(o) => `${o.fullname} (${o.email})`}
+              getOptionLabel={(o) => candidateLabel(o)}
               isOptionEqualToValue={(a, b) => a.userid === b.userid}
+              // Same status chip the roster uses, so an expiring or expired
+              // candidate reads the same way in both places. Attaching an
+              // expired one is allowed but still needs a renew to grant access.
+              renderOption={(props, option) => {
+                const status = delegateStatus(option.access_expires_at ?? null)
+                return (
+                  <li {...props} key={option.userid}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <span>{candidateLabel(option)}</span>
+                      <Chip
+                        label={status.label}
+                        color={status.color}
+                        size="small"
+                        variant={
+                          status.color === 'success' ? 'outlined' : 'filled'
+                        }
+                      />
+                    </Box>
+                  </li>
+                )
+              }}
               inputValue={candidateInput}
               onInputChange={(_e, v) => setCandidateInput(v)}
               onChange={(_e, value) => {

--- a/src/views/SystemDetailPage/SystemDelegatesSection.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.tsx
@@ -12,7 +12,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   List,
   ListItem,
@@ -22,6 +21,7 @@ import {
   Typography,
 } from '@mui/material'
 import { Button as CmsButton } from '@cmsgov/design-system'
+import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import EventRepeatIcon from '@mui/icons-material/EventRepeat'
 import { FismaSystemType, DelegateRow, DelegateCandidate } from '@/types'
@@ -86,9 +86,9 @@ function formatExpiry(iso: string | null): string {
 interface Props {
   system: FismaSystemType
   /**
-   * Whether the current user may add/invite/remove/renew delegates. ISSO and
-   * admins qualify; ISSM (and other assigned viewers) see the roster read-only.
-   * The backend re-checks on every write.
+   * Whether the current user may attach/provision/remove/renew delegates.
+   * ISSO and admins qualify; ISSM (and other assigned viewers) see the roster
+   * read-only. The backend re-checks on every write.
    */
   canManage: boolean
 }
@@ -96,9 +96,12 @@ interface Props {
 /**
  * Delegates section for the FISMA system detail page. Lists the system's
  * current delegates with their expiration, and - for a manager - lets an
- * ISSO attach an existing eligible delegate, invite a new person, renew an
+ * ISSO attach an existing eligible delegate, provision a new one, renew an
  * expiration, or remove a delegate. All scope is the one system in `system`;
  * the backend enforces assignment and OpDiv rules.
+ *
+ * "Provision" (not "invite") is deliberate: the backend creates the account
+ * directly; no email is sent, and the person signs in through SSO afterward.
  */
 export default function SystemDelegatesSection({ system, canManage }: Props) {
   const systemId = system.fismasystemid
@@ -111,17 +114,19 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
   const [candidateInput, setCandidateInput] = useState('')
   const [attaching, setAttaching] = useState(false)
 
-  // Invite-new dialog.
-  const [inviteOpen, setInviteOpen] = useState(false)
-  const [inviteName, setInviteName] = useState('')
-  const [inviteEmail, setInviteEmail] = useState('')
-  const [inviteExpiry, setInviteExpiry] = useState(addMonthsISO(3))
-  const [inviteErrors, setInviteErrors] = useState<Record<string, string>>({})
-  const [inviteGuard, setInviteGuard] = useState('')
-  const [inviting, setInviting] = useState(false)
+  // Provision-new dialog.
+  const [provisionOpen, setProvisionOpen] = useState(false)
+  const [provisionName, setProvisionName] = useState('')
+  const [provisionEmail, setProvisionEmail] = useState('')
+  const [provisionExpiry, setProvisionExpiry] = useState(addMonthsISO(3))
+  const [provisionErrors, setProvisionErrors] = useState<
+    Record<string, string>
+  >({})
+  const [provisionGuard, setProvisionGuard] = useState('')
+  const [provisioning, setProvisioning] = useState(false)
 
   // Inline guard for administrator-required / capability-off on the ATTACH
-  // path (card-level). The invite path shows its own guard inside the dialog.
+  // path (card-level). The provision path shows its own guard in the dialog.
   const [guardMessage, setGuardMessage] = useState('')
 
   const [pendingRemove, setPendingRemove] = useState<DelegateRow | null>(null)
@@ -174,8 +179,8 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
 
   // Classify an add failure so the caller can place it: administrator-required
   // and capability-off become an inline guard string; a 400 field map is
-  // returned for the invite form; anything else is toasted here. Returns null
-  // when there is nothing to render inline (auth-handled, or already toasted).
+  // returned for the provision form; anything else is toasted here. Returns
+  // null when there is nothing to render inline (auth-handled, or toasted).
   const classifyAddError = (
     error: unknown
   ): { guard?: string; fieldErrors?: Record<string, string> } | null => {
@@ -200,52 +205,59 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
     } catch (error) {
       const c = classifyAddError(error)
       if (c?.guard) setGuardMessage(c.guard)
+      // The attach call sends only a validated email, so a 400 field map is
+      // not expected here - but surface it rather than swallowing it if the
+      // backend ever returns one (no provision form to route it into).
+      else if (c?.fieldErrors)
+        setGuardMessage(Object.values(c.fieldErrors).join(' '))
     } finally {
       setAttaching(false)
     }
   }
 
-  const validateInvite = (): boolean => {
+  const validateProvision = (): boolean => {
     const errors: Record<string, string> = {}
-    if (!inviteName.trim()) errors.fullname = 'Name is required'
-    if (!EMAIL_RE.test(inviteEmail.trim()))
+    if (!provisionName.trim()) errors.fullname = 'Name is required'
+    if (!EMAIL_RE.test(provisionEmail.trim()))
       errors.email = 'A valid email is required'
-    if (!inviteExpiry) errors.access_expires_at = 'Expiration is required'
-    else if (inviteExpiry < getTodayISO())
+    if (!provisionExpiry) errors.access_expires_at = 'Expiration is required'
+    else if (provisionExpiry < getTodayISO())
       errors.access_expires_at = 'Expiration cannot be in the past'
-    setInviteErrors(errors)
+    setProvisionErrors(errors)
     return Object.keys(errors).length === 0
   }
 
-  const openInvite = () => {
+  const openProvision = () => {
     setGuardMessage('')
-    setInviteName('')
-    setInviteEmail('')
-    setInviteExpiry(addMonthsISO(3))
-    setInviteErrors({})
-    setInviteGuard('')
-    setInviteOpen(true)
+    setProvisionName('')
+    setProvisionEmail('')
+    setProvisionExpiry(addMonthsISO(3))
+    setProvisionErrors({})
+    setProvisionGuard('')
+    setProvisionOpen(true)
   }
 
-  const handleInvite = async () => {
-    setInviteGuard('')
-    if (!validateInvite()) return
-    setInviting(true)
+  const handleProvision = async () => {
+    setProvisionGuard('')
+    if (!validateProvision()) return
+    setProvisioning(true)
     try {
       await addSystemDelegate(systemId, {
-        email: inviteEmail.trim(),
-        fullname: inviteName.trim(),
-        access_expires_at: dateToExpiryISO(inviteExpiry),
+        email: provisionEmail.trim(),
+        fullname: provisionName.trim(),
+        access_expires_at: dateToExpiryISO(provisionExpiry),
       })
       await loadRoster()
-      setInviteOpen(false)
-      notify('Saved - delegate invited', 'success', { autoHideDuration: 1500 })
+      setProvisionOpen(false)
+      notify('Saved - delegate provisioned', 'success', {
+        autoHideDuration: 1500,
+      })
     } catch (error) {
       const c = classifyAddError(error)
-      if (c?.guard) setInviteGuard(c.guard)
-      if (c?.fieldErrors) setInviteErrors(c.fieldErrors)
+      if (c?.guard) setProvisionGuard(c.guard)
+      if (c?.fieldErrors) setProvisionErrors(c.fieldErrors)
     } finally {
-      setInviting(false)
+      setProvisioning(false)
     }
   }
 
@@ -292,12 +304,21 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
     }
   }
 
+  const count = !loading && delegates.length > 0 ? ` (${delegates.length})` : ''
+
   return (
     <Card variant="outlined">
       <CardHeader
-        title="Delegates"
+        title={`Delegates${count}`}
         titleTypographyProps={{ variant: 'h6' }}
         subheader="Contractor and support-staff access to this system's data-call answers"
+        action={
+          canManage ? (
+            <Button startIcon={<AddIcon />} onClick={openProvision}>
+              Provision new delegate
+            </Button>
+          ) : undefined
+        }
         sx={{ pb: 0 }}
       />
       <CardContent>
@@ -338,12 +359,6 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
                 />
               )}
             />
-
-            <Button size="small" sx={{ mt: 1.5 }} onClick={openInvite}>
-              + Invite new delegate
-            </Button>
-
-            <Divider sx={{ mt: 3 }} />
           </Box>
         )}
 
@@ -461,38 +476,42 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
       </Dialog>
 
       <Dialog
-        open={inviteOpen}
-        onClose={() => setInviteOpen(false)}
+        open={provisionOpen}
+        onClose={() => setProvisionOpen(false)}
         maxWidth="xs"
         fullWidth
-        aria-label="Invite new delegate"
+        aria-label="Provision new delegate"
       >
-        <DialogTitle>Invite New Delegate</DialogTitle>
+        <DialogTitle>Provision new delegate</DialogTitle>
         <DialogContent>
-          {inviteGuard && (
+          {provisionGuard && (
             <Alert severity="warning" sx={{ mb: 2 }}>
-              {inviteGuard}
+              {provisionGuard}
             </Alert>
           )}
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            Creates a delegate account for this system. No email is sent; the
+            person signs in through the usual login.
+          </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
             <TextField
               label="Name"
               variant="standard"
               required
-              value={inviteName}
-              onChange={(e) => setInviteName(e.target.value)}
-              error={!!inviteErrors.fullname}
-              helperText={inviteErrors.fullname}
+              value={provisionName}
+              onChange={(e) => setProvisionName(e.target.value)}
+              error={!!provisionErrors.fullname}
+              helperText={provisionErrors.fullname}
               InputLabelProps={{ sx: { marginTop: 0 } }}
             />
             <TextField
               label="Email"
               variant="standard"
               required
-              value={inviteEmail}
-              onChange={(e) => setInviteEmail(e.target.value)}
-              error={!!inviteErrors.email}
-              helperText={inviteErrors.email}
+              value={provisionEmail}
+              onChange={(e) => setProvisionEmail(e.target.value)}
+              error={!!provisionErrors.email}
+              helperText={provisionErrors.email}
               InputLabelProps={{ sx: { marginTop: 0 } }}
             />
             <TextField
@@ -500,11 +519,11 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
               type="date"
               variant="standard"
               required
-              value={inviteExpiry}
-              onChange={(e) => setInviteExpiry(e.target.value)}
-              error={!!inviteErrors.access_expires_at}
+              value={provisionExpiry}
+              onChange={(e) => setProvisionExpiry(e.target.value)}
+              error={!!provisionErrors.access_expires_at}
               helperText={
-                inviteErrors.access_expires_at ??
+                provisionErrors.access_expires_at ??
                 'Defaults to three months from today'
               }
               InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
@@ -512,11 +531,14 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
           </Box>
         </DialogContent>
         <DialogActions>
-          <CmsButton onClick={() => setInviteOpen(false)} disabled={inviting}>
+          <CmsButton
+            onClick={() => setProvisionOpen(false)}
+            disabled={provisioning}
+          >
             Cancel
           </CmsButton>
-          <CmsButton onClick={handleInvite} disabled={inviting}>
-            {inviting ? 'Inviting...' : 'Invite'}
+          <CmsButton onClick={handleProvision} disabled={provisioning}>
+            {provisioning ? 'Provisioning...' : 'Provision'}
           </CmsButton>
         </DialogActions>
       </Dialog>

--- a/src/views/SystemDetailPage/SystemDelegatesSection.tsx
+++ b/src/views/SystemDetailPage/SystemDelegatesSection.tsx
@@ -201,7 +201,8 @@ export default function SystemDelegatesSection({ system, canManage }: Props) {
     const parsed = parseApiError(error)
     if (parsed.code === 'DELEGATE_REQUIRES_ADMIN')
       return { guard: ADMIN_REQUIRED_MSG }
-    if (parsed.status === 403) return { guard: CAPABILITY_OFF_MSG }
+    if (parsed.code === 'DELEGATE_NOT_ENABLED')
+      return { guard: CAPABILITY_OFF_MSG }
     if (parsed.fieldErrors) return { fieldErrors: parsed.fieldErrors }
     notify(parsed.message, 'error')
     return null

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -23,7 +23,13 @@ import { isAuthHandled, notify } from '@/utils/notify'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import { getTodayISO, truncateNotes } from '@/utils/decommission'
-import { isAdmin as checkIsAdmin, isSystemScoped } from '@/utils/userRoles'
+import {
+  isAdmin as checkIsAdmin,
+  isSystemScoped,
+  isSystemDelegate,
+  isISSO,
+  hasSystemAccess,
+} from '@/utils/userRoles'
 
 import SystemDetailHeader from './SystemDetailHeader'
 import SystemDetailReadView from './SystemDetailReadView'
@@ -31,6 +37,7 @@ import SystemDetailEditView from './SystemDetailEditView'
 import TargetMaturityCard from './TargetMaturityCard'
 import { EXTENDED_METADATA_KEYS } from './fieldConfig'
 import SystemEnrichmentCard from './SystemEnrichmentCard'
+import SystemDelegatesSection from './SystemDelegatesSection'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
@@ -560,8 +567,19 @@ export default function SystemDetailPage() {
     )
   }
 
-  const opdivName =
-    opdivs.find((o) => o.opdiv_id === system.opdiv_id)?.name ?? null
+  const systemOpDiv = opdivs.find((o) => o.opdiv_id === system.opdiv_id)
+  const opdivName = systemOpDiv?.name ?? null
+
+  // Delegates section: visible to any assigned non-delegate (incl. ISSM) when
+  // the system's OpDiv has the capability enabled; hidden from delegates.
+  // Managing (add/invite/remove/renew) is ISSO + admin only - ISSM sees the
+  // roster read-only (the backend would 404 an ISSM write). The toggle read
+  // comes from the already-fetched opdivs list.
+  const canViewDelegates =
+    hasSystemAccess(userInfo) &&
+    !isSystemDelegate(userInfo) &&
+    !!systemOpDiv?.system_delegate_enabled
+  const canManageDelegates = isAdmin || isISSO(userInfo)
 
   // Target maturity owns its own edit/save lifecycle (see TargetMaturityCard).
   // The card is slotted into the right column of whichever view renders
@@ -647,6 +665,16 @@ export default function SystemDetailPage() {
           <SystemEnrichmentCard
             fismaUid={system.fismauid}
             systemDataCenterEnvironment={system.datacenterenvironment}
+          />
+        </>
+      )}
+
+      {canViewDelegates && (
+        <>
+          <Divider sx={{ my: 4 }} />
+          <SystemDelegatesSection
+            system={system}
+            canManage={canManageDelegates}
           />
         </>
       )}

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -73,9 +73,15 @@ export default function SystemDetailReadView({
 
   return (
     <Grid container spacing={3}>
-      {/* System Identity */}
-      <Grid item xs={12} md={7}>
-        <Card variant="outlined">
+      {/* Left column: System Identity, then Contacts. Contacts fills the
+          vertical space the taller right column would otherwise leave blank. */}
+      <Grid
+        item
+        xs={12}
+        md={7}
+        sx={{ display: 'flex', flexDirection: 'column' }}
+      >
+        <Card variant="outlined" sx={{ mb: 3 }}>
           <CardHeader
             title="System Identity"
             titleTypographyProps={{ variant: 'h6' }}
@@ -89,6 +95,25 @@ export default function SystemDetailReadView({
             sx={{ pb: 0 }}
           />
           <CardContent>{renderFields(identityFields, system)}</CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardHeader
+            title="Contacts"
+            titleTypographyProps={{ variant: 'h6' }}
+            sx={{ pb: 0 }}
+          />
+          <CardContent>
+            <Grid container spacing={3}>
+              {contactFields.map((field) => (
+                <Grid item xs={12} sm={6} key={field.key}>
+                  <FieldDisplay
+                    label={field.label}
+                    value={String(system[field.key] ?? '')}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          </CardContent>
         </Card>
       </Grid>
 
@@ -198,29 +223,6 @@ export default function SystemDetailReadView({
           <CardContent>
             <FieldDisplay label="OpDiv" value={opdivName} />
             {renderFields(orgFields, system)}
-          </CardContent>
-        </Card>
-      </Grid>
-
-      {/* Contacts — full width, fields horizontal */}
-      <Grid item xs={12}>
-        <Card variant="outlined">
-          <CardHeader
-            title="Contacts"
-            titleTypographyProps={{ variant: 'h6' }}
-            sx={{ pb: 0 }}
-          />
-          <CardContent>
-            <Grid container spacing={3}>
-              {contactFields.map((field) => (
-                <Grid item xs={12} sm={6} key={field.key}>
-                  <FieldDisplay
-                    label={field.label}
-                    value={String(system[field.key] ?? '')}
-                  />
-                </Grid>
-              ))}
-            </Grid>
           </CardContent>
         </Card>
       </Grid>

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -464,7 +464,9 @@ export default function Title() {
                       <MenuItem onClick={() => handleOption()}>Users</MenuItem>
                     </Link>
                   )}
-                  {userInfo.role === 'OWNER' && (
+                  {/* OWNER manages OpDivs fully; HHS admin reaches the page
+                      only to flip the per-OpDiv System Delegate toggle. */}
+                  {isUnscopedWriteAdmin(userInfo) && (
                     <Link
                       to={Routes.ADMIN_OPDIVS}
                       style={{ textDecoration: 'none', color: 'black' }}


### PR DESCRIPTION
## Summary

In-repo rehome of #607 by @tarratsco (Onix Tarrats Calderon) so the repository CI gates (which fork PRs can't run) execute against these commits. Original authorship is preserved across all 5 commits; the original PR #607 stays open as a draft until this merges.

**Closes #598** · part of epic CMS-Enterprise/ztmf#467 · paired backend is the rehome **CMS-Enterprise/ztmf#474** (rehome of #473).

Frontend for **System Delegate self-service**: the ISSO Delegates section on the FISMA system detail page, and the per-OpDiv "Add System Delegate Role" toggle on the Manage OpDivs panel.

## ⚠️ Merge order

This must merge **after** the backend rehome **ztmf#474** — the UI consumes the delegate endpoints that PR adds. Do not merge this first.

## What changed

- New `SystemDelegatesSection.tsx` (delegate roster + picker) on the system detail read view; Contacts moved to the left column.
- Per-OpDiv System Delegate toggle in `OpDivAdmin`.
- Role gating in `userRoles.ts`: managing delegates is **ISSO + admin only**; ISSM sees the roster **read-only** by design (per epic #467 decision 5; the backend overrode #598's original ISSM-inclusive text).
- `delegates.ts` / `decommission.ts` utils, `types.ts` additions, roster-refresh fix + status chips.

## Status

**Opened as a draft pending review.** It will be converted to a ready PR once the review verdict is Go; if issues are found it stays draft with the findings noted.

## Provenance / verification

5 commits cherry-picked verbatim from #607 (`tarratsco/ztmf-ui:tarratsco/feature/system-delegates`), authorship preserved, atop current `main` (which has advanced past the fork's base — `tsc`/`lint` on the rehomed tree is being verified separately before this is marked ready).


---

## Reviewer changes applied on top of the original (cc @tarratsco)

Resolved in a follow-up commit; the original 5 commits are preserved beneath it:
- The add call opts out of the global auth interceptor (`skipAuthHandling`) and `classifyAddError` now keys on the `DELEGATE_NOT_ENABLED` code (paired backend change in the BE rehome) — so the capability-off case renders the intended in-dialog guard instead of the previously-unreachable branch behind the interceptor's generic toast. The test was updated to assert the coded rejection (it now reflects the real interceptor-bypass path).

## Deliberately out of scope for this ticket (follow-on)

Flagged so the boundary is explicit — not changed here:
- **Delegate add/renew on a decommissioned system** — not specially gated by this PR or the backend, and not a stated requirement. Open product question for the epic owner: should an ISSO be able to provision delegates on a decommissioned system?
- **Read-view Contacts reading-order** — moving Contacts into the left column changes DOM/reading order; worth an accessibility sign-off during review (not a regression; the existing read-view test still passes).
- **`addMonthsISO` month-overflow** — acceptable for an editable default expiry (per review); left as-is.
