### PR TITLE
ZTMF Insights: finding-name chips, cross-source ARS control union, per-source sections

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -471,7 +471,7 @@ export type InsightPayload = {
   // or []. `ars_satisfied_controls` length == `ars_controls_satisfied`.
   ars_satisfied_controls?: string[] | null
   // Applicable-but-not-satisfied controls (applicable − satisfied). Informational,
-  // rendered greyed — distinct from `ars_failing_controls` (Archer-explicit fails).
+  // rendered greyed — distinct from `ars_failing_controls` (explicit fails).
   // satisfied + not_satisfied == ars_controls_total when the pipeline emits them.
   ars_not_satisfied_controls?: string[] | null
   ars_failing_controls?: string[] | null

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import InsightsPanel, {
   OptionInsightBadges,
   severityStyle,
+  rollupControls,
 } from './InsightsPanel'
 import type { InsightPayload } from '@/types'
 import CONFIG from '@/utils/config'
@@ -52,19 +53,16 @@ const fullPayload: InsightPayload = {
 }
 
 describe('InsightsPanel', () => {
-  it('renders the ZTMF Insights label and all five source chips', () => {
+  it('renders the ZTMF Insights label and the four source chips', () => {
     render(<InsightsPanel payload={fullPayload} />)
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
-    // Chips render the source name with a trailing colon (e.g. "Kion:").
-    for (const source of [
-      'Kion',
-      'SecurityHub',
-      'Hardenize',
-      'CFACTS',
-      'ARS',
-    ]) {
+    // Chips render the source name with a trailing colon (e.g. "Kion:"). ARS is
+    // the control catalog (the "ARS Controls" section), not an evidence source —
+    // its coverage rolls up under CFACTS, so there is no standalone ARS chip.
+    for (const source of ['Kion', 'SecurityHub', 'Hardenize', 'CFACTS']) {
       expect(screen.getByText(`${source}:`)).toBeInTheDocument()
     }
+    expect(screen.queryByText('ARS:')).not.toBeInTheDocument()
   })
 
   it('renders the suggested maturity pill when the suggestion differs from the prior score', () => {
@@ -152,17 +150,19 @@ describe('InsightsPanel', () => {
   })
 
   it('renders a finding uniformly: code, title, description, severity, How to fix', () => {
+    // Hardenize is the remaining FindingRow source (Kion/SecurityHub now render as
+    // the compact chip block), so the uniform card shape is asserted through it.
     render(
       <InsightsPanel
         payload={{
           suggested_score: 1,
           findings: {
-            sechub: [
+            hardenize: [
               {
-                id: 'IAM.10',
-                title: 'MFA should be enabled',
-                description: 'Enable MFA for all IAM users.',
-                remediation: 'Turn on MFA in the IAM console.',
+                id: 'WWW_HSTS_MISSING',
+                title: 'HSTS not enabled',
+                description: 'Enable HSTS on this host.',
+                remediation: 'Send a Strict-Transport-Security header.',
                 severity: 'MEDIUM',
               },
             ],
@@ -171,11 +171,11 @@ describe('InsightsPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    expect(screen.getByText('IAM.10')).toBeInTheDocument()
-    expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+    expect(screen.getByText('WWW_HSTS_MISSING')).toBeInTheDocument()
+    expect(screen.getByText('HSTS not enabled')).toBeInTheDocument()
     // Description surfaces in the severity badge hover, not the card body.
     expect(
-      screen.getByLabelText(/MEDIUM: Enable MFA for all IAM users\./)
+      screen.getByLabelText(/MEDIUM: Enable HSTS on this host\./)
     ).toBeInTheDocument()
     expect(screen.getByText('MEDIUM')).toBeInTheDocument()
     expect(screen.getByText(/How to fix/)).toBeInTheDocument()
@@ -190,11 +190,11 @@ describe('InsightsPanel', () => {
             suggested_score: 1,
             cfacts_reasoning: 'IDM-Okta detected. MFA required.',
             findings: {
-              sechub: [
+              hardenize: [
                 {
-                  id: 'IAM.10',
-                  title: 'MFA should be enabled',
-                  remediation: 'Turn on MFA in the IAM console.',
+                  id: 'WWW_HSTS_MISSING',
+                  title: 'HSTS not enabled',
+                  remediation: 'Send a Strict-Transport-Security header.',
                   severity: 'MEDIUM',
                 },
               ],
@@ -206,11 +206,11 @@ describe('InsightsPanel', () => {
       // Remediation gated off...
       expect(screen.queryByText(/How to fix/)).not.toBeInTheDocument()
       expect(
-        screen.queryByText(/Turn on MFA in the IAM console/)
+        screen.queryByText(/Strict-Transport-Security/)
       ).not.toBeInTheDocument()
       // ...but the finding itself and the CFACTS reasoning still render.
-      expect(screen.getByText('IAM.10')).toBeInTheDocument()
-      expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
+      expect(screen.getByText('WWW_HSTS_MISSING')).toBeInTheDocument()
+      expect(screen.getByText('HSTS not enabled')).toBeInTheDocument()
       expect(screen.getByText(/IDM-Okta detected/)).toBeInTheDocument()
     } finally {
       CONFIG.INSIGHTS_SUGGEST_FIX_ENABLED = true
@@ -221,14 +221,76 @@ describe('InsightsPanel', () => {
     render(<InsightsPanel payload={fullPayload} />)
     // Nothing in the drawer shows until expanded.
     expect(screen.queryByText(/IAM\.10/)).not.toBeInTheDocument()
-    expect(screen.queryByText('IA-02')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('iam-user-without-mfa-device-enabled')
+    ).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
 
     // Kion renders as its pass/fail chip block (failing chip labeled by the
-    // NIST tag, ✗); the sechub finding renders as a FindingRow (slug visible).
-    expect(screen.getByText('IA-02').textContent).toContain('✗')
+    // finding name, ✗ — the NIST control moved into the hover); the sechub
+    // finding renders as a FindingRow (slug visible).
+    expect(
+      screen.getByText('iam-user-without-mfa-device-enabled').textContent
+    ).toContain('✗')
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
+  })
+
+  it('labels each Kion check by its finding name (green pass / red fail) with the description + control + state in the hover', async () => {
+    render(
+      <InsightsPanel
+        payload={{
+          suggested_score: 1,
+          has_kion_data: true,
+          findings: {
+            kion: [
+              {
+                id: 'iam-user-without-mfa-device-enabled',
+                nist_controls: 'IA-02',
+                description: 'Identify IAM users without an MFA device enabled',
+              },
+            ],
+          },
+          kion_passing: [
+            {
+              id: 'iam-user-inactive',
+              nist_controls: 'AC-2',
+              description: 'Identify inactive IAM Users',
+              level: 1,
+            },
+          ],
+        }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+
+    // Chip label is the finding name itself, coloured by state: ✗ for a check
+    // that has a finding (failing), ✓ for one with no finding (passing).
+    const fail = screen.getByRole('img', {
+      name: /^iam-user-without-mfa-device-enabled — .* — Failed$/,
+    })
+    const pass = screen.getByRole('img', {
+      name: /^iam-user-inactive — .* — Passed$/,
+    })
+    expect(fail.textContent).toContain('✗')
+    expect(fail.textContent).toContain('iam-user-without-mfa-device-enabled')
+    expect(pass.textContent).toContain('✓')
+
+    // Per-check rollup: 1 passing + 1 failing reads "1 of 2 checks passed".
+    expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
+
+    // The control now lives in the hover, not on the chip label.
+    expect(fail.textContent).not.toContain('IA-02')
+
+    // Hover/focus reveals the description, the mapped control, and met/failed —
+    // the signal Mack asked to surface instead of a bare control tag.
+    fireEvent.focus(fail)
+    const tip = await screen.findByRole('tooltip')
+    expect(tip).toHaveTextContent(
+      'Identify IAM users without an MFA device enabled'
+    )
+    expect(tip).toHaveTextContent('Control: IA-02')
+    expect(tip).toHaveTextContent('Failed')
   })
 
   it('lists satisfied, non-satisfied, and failing ARS control IDs when the pipeline provides them', () => {
@@ -275,12 +337,12 @@ describe('InsightsPanel', () => {
     expect(ac17[0].textContent).not.toContain('○')
     // The genuinely-not-satisfied control still renders grey.
     expect(screen.getByText('IA-02(02)').textContent).toContain('○')
-    // Accessible name reflects failing, not not-satisfied.
+    // Accessible name reflects the failing net state, not merely not-satisfied.
     expect(
-      screen.getByRole('img', { name: /^AC-17: Other Than Satisfied/ })
+      screen.getByRole('img', { name: /^AC-17: failing/ })
     ).toBeInTheDocument()
     expect(
-      screen.queryByRole('img', { name: /^AC-17: Not satisfied/ })
+      screen.queryByRole('img', { name: /^AC-17: not satisfied/ })
     ).not.toBeInTheDocument()
   })
 
@@ -296,18 +358,17 @@ describe('InsightsPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    // The chip's accessible name is "<id>: <state reason>" — the same string the
-    // Tooltip surfaces on hover — so passed / not-satisfied / failed is exposed
-    // both visually (✓/○/✗ + colour) and to a screen reader, keyed off which
-    // array the control came from.
+    // The chip's accessible name is "<id>: <net state>. <source · check · verb>…"
+    // — the same evidence the Tooltip surfaces on hover — so the state and its
+    // provenance reach a screen reader, not just the ✓/○/✗ marker and colour.
     expect(
-      screen.getByRole('img', { name: /^IA-01: Satisfied/ })
+      screen.getByRole('img', { name: /^IA-01: satisfied/ })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('img', { name: /^IA-02\(02\): Not satisfied/ })
+      screen.getByRole('img', { name: /^IA-02\(02\): not satisfied/ })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('img', { name: /^AC-17: Other Than Satisfied/ })
+      screen.getByRole('img', { name: /^AC-17: failing/ })
     ).toBeInTheDocument()
   })
 
@@ -318,12 +379,12 @@ describe('InsightsPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    const chip = screen.getByRole('img', { name: /^IA-01: Satisfied/ })
+    const chip = screen.getByRole('img', { name: /^IA-01: satisfied/ })
     // Focusable, and the MUI Tooltip fires on focus (not just hover) so a
-    // keyboard-only sighted user can read the state reason.
+    // keyboard-only sighted user can read the per-source evidence.
     expect(chip).toHaveAttribute('tabindex', '0')
     fireEvent.focus(chip)
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(/Satisfied/)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(/CFACTS/)
   })
 
   it('renders non-satisfied ARS controls even when the satisfied array is absent', () => {
@@ -353,16 +414,80 @@ describe('InsightsPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    // The valid string still renders; the panel is not blanked.
+    // The valid string renders; the non-string elements are dropped (not coerced
+    // into junk "42" / "[object Object]" chips), and the panel is not blanked.
     expect(screen.getByText('IA-01')).toBeInTheDocument()
+    expect(screen.queryByText('42')).not.toBeInTheDocument()
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument()
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
   })
 
-  it('shows the ARS Controls count with no chips when the control arrays are absent', () => {
+  it('derives the ARS Controls total from the sources, not a standalone count', () => {
+    // fullPayload carries no ars_* arrays, but its Kion finding maps to IA-02 — the
+    // union surfaces that control (failing) and the header counts it. There is no
+    // longer a source-less count: the total IS the union of source controls.
     render(<InsightsPanel payload={fullPayload} />)
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    expect(screen.getByText(/4 of 4 satisfied/)).toBeInTheDocument()
+    expect(screen.getByText(/0 of 1 satisfied/)).toBeInTheDocument()
+    expect(screen.getByText('IA-02').textContent).toContain('✗')
+    // A control no source touched does not appear.
     expect(screen.queryByText('IA-01')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a control a Kion check passes in the ARS Controls union (SC-12)', () => {
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 1,
+            kion_passing: [
+              {
+                id: 'kms-key-with-rotation-disabled',
+                nist_controls: 'SC-12',
+                level: 2,
+              },
+            ],
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // SC-12 shows satisfied even though CFACTS never assessed it — the row is the
+    // cross-source total, and Kion passed the check that maps to SC-12.
+    expect(screen.getByText('SC-12').textContent).toContain('✓')
+  })
+
+  it('flags a control passed by one check and failed by another as an amber conflict, netting to failing, and names both sources on hover', async () => {
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 1,
+            kion_passing: [
+              { id: 'kms-key-with-rotation-disabled', nist_controls: 'SC-12' },
+            ],
+            findings: {
+              kion: [
+                {
+                  id: 'kms-key-with-cross-account-access',
+                  nist_controls: 'SC-12',
+                },
+              ],
+            },
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // Amber ⚠ conflict chip — not a plain ✓ or ✗ — so the disagreement is visible.
+    const chip = screen.getByRole('img', { name: /^SC-12: sources disagree/ })
+    expect(chip.textContent).toContain('⚠')
+    // Hover names each source + check and states how the score resolved it.
+    fireEvent.focus(chip)
+    const tip = await screen.findByRole('tooltip')
+    expect(tip).toHaveTextContent('kms-key-with-rotation-disabled')
+    expect(tip).toHaveTextContent('kms-key-with-cross-account-access')
+    expect(tip).toHaveTextContent(/counted as failing/)
   })
 
   it('renders a minimal payload without a details toggle', () => {
@@ -472,25 +597,27 @@ describe('InsightsPanel resilience (opaque payload)', () => {
       <InsightsPanel
         payload={{
           suggested_score: 2,
-          evidence_sources: 'ARS, CFACTS',
+          has_kion_data: true,
           findings: { kion: 'not-an-array' as unknown as [] },
         }}
       />
     )
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
-    // The malformed findings block is skipped, not thrown on.
+    // The malformed findings block is skipped, not thrown on. The panel still
+    // renders, and "Based on" is derived from the active source chips.
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
-    expect(screen.getByText(/ARS, CFACTS/)).toBeInTheDocument()
+    expect(screen.getByText(/Based on:/)).toBeInTheDocument()
   })
 
   it('degrades a malformed non-string text field instead of blanking the panel', () => {
-    // evidence_sources arriving as an object would throw "Objects are not valid
-    // as a React child"; asText coerces it so the panel stays intact.
+    // A field arriving as an object would throw "Objects are not valid as a React
+    // child"; asText coerces it so the panel stays intact.
     render(
       <InsightsPanel
         payload={{
           suggested_score: 2,
-          evidence_sources: { bad: true } as unknown as string,
+          has_kion_data: true,
+          cfacts_reasoning: { bad: true } as unknown as string,
         }}
       />
     )
@@ -513,6 +640,65 @@ describe('InsightsPanel resilience (opaque payload)', () => {
     fireEvent.click(screen.getByRole('button', { name: /details/i }))
     expect(screen.getByText(/IAM\.10/)).toBeInTheDocument()
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
+  })
+})
+
+describe('rollupControls (cross-source ARS control union)', () => {
+  const roll = (p: unknown) => rollupControls(p as InsightPayload)
+
+  it('unions a Kion passing check control into satisfied with no CFACTS arrays', () => {
+    expect(
+      roll({
+        kion_passing: [
+          { id: 'kms-rotation', nist_controls: 'SC-12', level: 2 },
+        ],
+      })
+    ).toEqual([
+      {
+        id: 'SC-12',
+        state: 'satisfied',
+        conflict: false,
+        evidence: [
+          { source: 'Kion', check: 'kms-rotation', state: 'satisfied' },
+        ],
+      },
+    ])
+  })
+
+  it('nets weakest-link across sources: a SecHub fail overrides a CFACTS satisfied (and flags conflict)', () => {
+    const rolled = roll({
+      ars_satisfied_controls: ['AC-2'],
+      ars_not_satisfied_controls: ['AC-3'],
+      findings: { sechub: [{ id: 'EC2.10', nist_controls: 'AC-2' }] },
+    })
+    const map = Object.fromEntries(rolled.map((c) => [c.id, c.state]))
+    expect(map['AC-2']).toBe('failing')
+    expect(map['AC-3']).toBe('unsatisfied')
+    // AC-2 is satisfied by CFACTS but failed by SecHub → conflict (amber ⚠), not a
+    // plain red fail.
+    expect(rolled.find((c) => c.id === 'AC-2')?.conflict).toBe(true)
+  })
+
+  it('flags pass+fail on the same control as a conflict that nets to failing', () => {
+    const sc12 = roll({
+      kion_passing: [{ id: 'rot', nist_controls: 'SC-12' }],
+      findings: { kion: [{ id: 'xacct', nist_controls: 'SC-12' }] },
+    }).find((c) => c.id === 'SC-12')
+    expect(sc12).toMatchObject({ state: 'failing', conflict: true })
+    expect(sc12?.evidence).toHaveLength(2)
+  })
+
+  it('splits a multi-control mapping and skips malformed evidence without throwing', () => {
+    const rolled = roll({
+      findings: {
+        kion: [
+          { id: 'x', nist_controls: 'AC-2, AC-3' },
+          null,
+          { id: 'no-control' },
+        ],
+      },
+    })
+    expect(rolled.map((c) => c.id).sort()).toEqual(['AC-2', 'AC-3'])
   })
 })
 
@@ -639,17 +825,28 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     render(<InsightsPanel payload={kionPassFail} />)
     expand()
     expect(screen.getByText(/3 of 4 checks passed/)).toBeInTheDocument()
-    // 3 passing (green ✓) + 1 failing (red ✗), labeled by NIST tag.
-    expect(screen.getByText('IA-5').textContent).toContain('✓')
-    expect(screen.getByText('IA-2').textContent).toContain('✗')
+    // 3 passing (green ✓) + 1 failing (red ✗), each labeled by its check name.
+    expect(
+      screen.getByText('account-without-compliant-password-policy').textContent
+    ).toContain('✓')
+    expect(
+      screen.getByText('iam-user-without-mfa-device-enabled').textContent
+    ).toContain('✗')
   })
 
-  it('renders a chip per check even when a NIST tag repeats (distinct checks)', () => {
+  it('renders a chip per check even when two checks map to the same control', () => {
     render(<InsightsPanel payload={kionPassFail} />)
     expand()
-    const ac2 = screen.getAllByText('AC-2')
-    expect(ac2).toHaveLength(2)
-    ac2.forEach((chip) => expect(chip.textContent).toContain('✓'))
+    // Two distinct checks share control AC-2; each still gets its own feed chip
+    // (labeled by check name)…
+    expect(
+      screen.getByText('root-account-without-mfa-enabled').textContent
+    ).toContain('✓')
+    expect(
+      screen.getByText('iam-user-with-password-and-no-mfa').textContent
+    ).toContain('✓')
+    // …while the ARS Controls union collapses AC-2 to a single control chip.
+    expect(screen.getAllByText('AC-2')).toHaveLength(1)
   })
 
   it('folds pass/fail status into each chip accessible name (role=img so AT exposes it)', () => {
@@ -710,15 +907,15 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
       />
     )
     expand()
-    // No fabricated pass count — labeled "N finding(s)" — but still the chip
-    // block (NIST tag + ✗), NOT the old verbose FindingRow (slug is not body
-    // text, only reachable via the chip's accessible name).
+    // No fabricated pass count — labeled "N finding(s)" — but still the chip block
+    // (finding name + ✗), NOT the old verbose FindingRow.
     expect(screen.getByText(/1 finding/)).toBeInTheDocument()
     expect(screen.queryByText(/checks? passed/)).not.toBeInTheDocument()
-    expect(screen.getByText('AC-6-10').textContent).toContain('✗')
     expect(
-      screen.queryByText('iam-role-missing-permissions-boundary')
-    ).not.toBeInTheDocument()
+      screen.getByText('iam-role-missing-permissions-boundary').textContent
+    ).toContain('✗')
+    // The control it maps to also surfaces in the ARS Controls union.
+    expect(screen.getByText('AC-6-10').textContent).toContain('✗')
   })
 
   it('renders SecurityHub as the block when its passing array ships', () => {
@@ -739,13 +936,12 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     )
     expand()
     expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
-    expect(screen.getByText('AC-3').textContent).toContain('✓')
-    expect(screen.getByText('IA-2').textContent).toContain('✗')
-    // As a block the finding slug is not rendered as body text.
-    expect(screen.queryByText('IAM.10')).not.toBeInTheDocument()
+    // Feed chips are labeled by the SecurityHub finding code.
+    expect(screen.getByText('IAM.1').textContent).toContain('✓')
+    expect(screen.getByText('IAM.10').textContent).toContain('✗')
   })
 
-  it('keeps SecurityHub on the FindingRow list until its passing array ships', () => {
+  it('renders SecurityHub as a chip block even with only failing findings', () => {
     render(
       <InsightsPanel
         payload={{
@@ -757,6 +953,7 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
                 title: 'MFA should be enabled',
                 description: 'Enable MFA',
                 severity: 'MEDIUM',
+                nist_controls: 'IA-2',
               },
             ],
           },
@@ -764,11 +961,58 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
       />
     )
     expand()
-    // No passing array → old FindingRow: slug + title visible as body text.
-    expect(screen.getByText('IAM.10')).toBeInTheDocument()
-    expect(screen.getByText('MFA should be enabled')).toBeInTheDocument()
-    // Not the block — no "N of M checks passed" header for SecurityHub.
-    expect(screen.queryByText(/checks? passed/)).not.toBeInTheDocument()
+    // One "SecurityHub:" header + a chip labeled by the finding code (✗) — the
+    // compact block, not the old per-finding FindingRow list.
+    expect(screen.getByText(/1 finding/)).toBeInTheDocument()
+    expect(screen.getByText('IAM.10').textContent).toContain('✗')
+    // Title lives in the hover now, not as body text.
+    expect(screen.queryByText('MFA should be enabled')).not.toBeInTheDocument()
+  })
+
+  it('renders Hardenize as chips when its passing array ships, keeping affected domains in the hover', async () => {
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 2,
+            has_hardenize_data: true,
+            hardenize_passing: [
+              {
+                id: 'DNS_DANGLING',
+                nist_controls: 'SC-7',
+                description: 'No dangling DNS records',
+                level: 1,
+              },
+            ],
+            findings: {
+              hardenize: [
+                {
+                  id: 'WWW_CERT_HOST_MISMATCH',
+                  title: "Certificate doesn't match hostname",
+                  severity: 'error',
+                  nist_controls: 'SC-8',
+                  instances: [
+                    { domain: 'idm.cms.gov', detail: 'cert CN mismatch' },
+                  ],
+                },
+              ],
+            },
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    // Passing array present → Hardenize flips to the same green/red chip block as
+    // Kion/SecurityHub (not the FindingRow list).
+    expect(screen.getByText('DNS_DANGLING').textContent).toContain('✓')
+    const fail = screen.getByRole('img', {
+      name: /^WWW_CERT_HOST_MISMATCH — .* — Failed$/,
+    })
+    expect(fail.textContent).toContain('✗')
+    // Affected domains ride along in the chip hover so nothing is lost vs FindingRow.
+    fireEvent.focus(fail)
+    const tip = await screen.findByRole('tooltip')
+    expect(tip).toHaveTextContent('idm.cms.gov')
   })
 
   it('degrades when a passing array arrives as a non-array', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -54,30 +54,25 @@ type SourceConfig = {
 // solid vs greyed chip; it is derived from the source's own availability flag /
 // key presence rather than assuming every source contributed.
 function buildSources(p: InsightPayload): SourceConfig[] {
+  // Chip order MUST match the drawer's section order (below). Kion sits last — it
+  // usually has the most checks — with SecurityHub second-to-last; CFACTS leads
+  // because its ARS-control coverage renders first in the drawer.
   return [
     {
-      // ARS leads — its control-coverage signal (satisfied + not-satisfied) is
-      // the richest, and the drawer renders the ARS Controls block first, so the
-      // chip order matches.
-      key: 'ars',
-      label: 'ARS',
-      color: '#7c5cbf',
-      score: p.ars_control_score,
-      active: p.ars_control_score != null || p.ars_controls_total != null,
-    },
-    {
-      key: 'kion',
-      label: 'Kion',
-      color: '#e86c25',
-      score: p.kion_suggested_score,
-      active: p.has_kion_data === true || p.kion_suggested_score != null,
-    },
-    {
-      key: 'sechub',
-      label: 'SecurityHub',
-      color: '#3a7ca5',
-      score: p.sechub_suggested_score,
-      active: p.has_sechub_data === true || p.sechub_suggested_score != null,
+      // CFACTS is the source that assesses the ARS-framework controls, so its chip
+      // subsumes the old standalone "ARS" chip: it's active and scored off EITHER
+      // the CFACTS reasoning fields OR the ARS control-coverage fields. ARS itself
+      // is the control catalog (the "ARS Controls" section), not a source chip.
+      key: 'cfacts',
+      label: 'CFACTS',
+      color: '#0071bc',
+      score: p.cfacts_suggested_score ?? p.ars_control_score,
+      active:
+        p.cfacts_suggested_score != null ||
+        p.cfacts_auth_methods != null ||
+        p.cfacts_reasoning != null ||
+        p.ars_control_score != null ||
+        p.ars_controls_total != null,
     },
     {
       key: 'hardenize',
@@ -88,11 +83,18 @@ function buildSources(p: InsightPayload): SourceConfig[] {
         p.has_hardenize_data === true || p.hardenize_suggested_score != null,
     },
     {
-      key: 'cfacts',
-      label: 'CFACTS',
-      color: '#0071bc',
-      score: p.cfacts_suggested_score,
-      active: p.cfacts_suggested_score != null || p.cfacts_auth_methods != null,
+      key: 'sechub',
+      label: 'SecurityHub',
+      color: '#3a7ca5',
+      score: p.sechub_suggested_score,
+      active: p.has_sechub_data === true || p.sechub_suggested_score != null,
+    },
+    {
+      key: 'kion',
+      label: 'Kion',
+      color: '#e86c25',
+      score: p.kion_suggested_score,
+      active: p.has_kion_data === true || p.kion_suggested_score != null,
     },
   ]
 }
@@ -302,6 +304,10 @@ function InsightsPanelInner({ payload }: Props) {
   if (!payload) return null
 
   const sources = buildSources(payload)
+  // "Based on" is derived from the active source chips, NOT the backend
+  // evidence_sources string — that string still lists "ARS", which is the control
+  // catalog, not a source. Deriving keeps the line consistent with the chip row.
+  const basedOnSources = sources.filter((s) => s.active).map((s) => s.label)
   const suggestedScore = payload.suggested_score
   const suggestedLabel =
     payload.suggested_label ?? maturityLabel(suggestedScore)
@@ -334,32 +340,16 @@ function InsightsPanelInner({ payload }: Props) {
     kionFindings.length > 0 ||
     sechubFindings.length > 0 ||
     hardenizeFindings.length > 0
-  // ARS control IDs behind the counts. Optional/additive — undefined, null, or
-  // [] until the pipeline emits them; render only when non-empty. The payload is
-  // opaque, so filter to strings: a non-string element would otherwise render as
-  // a React child and throw, blanking the whole panel via the boundary.
-  const toStringArray = (v: unknown): string[] =>
-    Array.isArray(v) ? v.filter((c): c is string => typeof c === 'string') : []
-  const arsSatisfied = toStringArray(payload.ars_satisfied_controls)
-  const arsNotSatisfied = toStringArray(payload.ars_not_satisfied_controls)
-  const arsFailing = toStringArray(payload.ars_failing_controls)
-
-  // The three ARS arrays are NOT mutually exclusive: the pipeline builds
-  // ars_not_satisfied_controls as (applicable AND NOT Satisfied), which is a
-  // SUPERSET of ars_failing_controls (Other Than Satisfied) — a failing control
-  // appears in BOTH. Rendering each array on its own would show that control
-  // twice, once grey ○ (not-satisfied) and once red ✗ (failing), or label a
-  // failing control as merely not-satisfied. Assign each control to exactly one
-  // bucket by precedence — failing > satisfied > not-satisfied remainder — so a
-  // flagged control always renders once, in its most-severe state. (Satisfied vs
-  // not-satisfied are already disjoint by the backend's definition; the subtract
-  // is defensive.)
-  const arsFailingSet = new Set(arsFailing)
-  const arsSatisfiedOnly = arsSatisfied.filter((id) => !arsFailingSet.has(id))
-  const arsSatisfiedOnlySet = new Set(arsSatisfiedOnly)
-  const arsNotSatisfiedOnly = arsNotSatisfied.filter(
-    (id) => !arsFailingSet.has(id) && !arsSatisfiedOnlySet.has(id)
-  )
+  // ARS Controls is the UNION of every control any source touches (CFACTS +
+  // per-check NIST mappings from Kion/SecurityHub/Hardenize), each rolled up to a
+  // single state by weakest-link. Split into the three render buckets, ordered
+  // satisfied → not-satisfied → failing so a flagged control renders once, in its
+  // most-severe state. Additive/opaque-safe: empty until sources emit controls.
+  const controls = rollupControls(payload)
+  const controlsSatisfied = controls.filter((c) => c.state === 'satisfied')
+  const controlsUnsatisfied = controls.filter((c) => c.state === 'unsatisfied')
+  const controlsFailing = controls.filter((c) => c.state === 'failing')
+  const controlsTotal = controls.length
 
   // Per-source pass/fail. A finding = a FAILED check (failing side, `findings`);
   // the PASSING side ships separately as `{source}_passing` (same InsightFinding
@@ -369,11 +359,13 @@ function InsightsPanelInner({ payload }: Props) {
   // — Kion is live, sechub/hardenize light up when their arrays land, no code
   // change. `hasPassing` keys on the array being PRESENT (even empty) so an
   // all-failing source with a shipped passing array still reads "0 of M".
+  // Feed section order matches the chip order: Hardenize, SecurityHub, Kion — Kion
+  // last because it usually has the most checks.
   const feedSources = (
     [
-      { key: 'kion', label: 'Kion', failing: kionFindings },
-      { key: 'sechub', label: 'SecurityHub', failing: sechubFindings },
       { key: 'hardenize', label: 'Hardenize', failing: hardenizeFindings },
+      { key: 'sechub', label: 'SecurityHub', failing: sechubFindings },
+      { key: 'kion', label: 'Kion', failing: kionFindings },
     ] as const
   ).map((s) => {
     const raw = payload[`${s.key}_passing`]
@@ -385,12 +377,36 @@ function InsightsPanelInner({ payload }: Props) {
   })
   const anyFeedBlock = feedSources.some((s) => s.hasPassing)
 
+  // Every source chip that carries data must have a matching section explaining its
+  // score — a scored chip with no section reads as "passed, but no reason why".
+  // Hardenize renders a section whenever it has data (even clean, where the reason
+  // IS the absence of failures); CFACTS renders its reasoning/auth (or, failing
+  // that, its score) whenever it has any of its own signal.
+  const hardenizeActive =
+    payload.has_hardenize_data === true ||
+    payload.hardenize_suggested_score != null
+  // The CFACTS chip scores off cfacts_suggested_score ?? ars_control_score, so the
+  // section falls back the same way — but only to ars_control_score when there's no
+  // ARS Controls section (controlsTotal === 0) to already serve as the reason.
+  // Otherwise a scored CFACTS chip could have no matching section at all.
+  const cfactsScore =
+    payload.cfacts_suggested_score ?? payload.ars_control_score
+  const cfactsText =
+    [asText(payload.cfacts_reasoning), asText(payload.cfacts_auth_methods)]
+      .filter(Boolean)
+      .join(' · ') ||
+    (payload.cfacts_suggested_score != null ||
+    (controlsTotal === 0 && cfactsScore != null)
+      ? `scored ${maturityLabel(cfactsScore) ?? `Score ${cfactsScore}`}`
+      : undefined)
+
   const hasDetail =
     hasFindings ||
     anyFeedBlock ||
-    !!payload.cfacts_reasoning ||
-    !!payload.ars_controls_total ||
-    !!payload.evidence_sources
+    hardenizeActive ||
+    !!cfactsText ||
+    controlsTotal > 0 ||
+    basedOnSources.length > 0
 
   return (
     <Box
@@ -531,82 +547,67 @@ function InsightsPanelInner({ payload }: Props) {
 
       <Collapse in={open} unmountOnExit>
         <Box sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid #e0e4f0' }}>
-          {/* ARS Controls first — richest signal (satisfied + not-satisfied
-              control coverage), so it leads the drawer ahead of the other
-              enrichment sources. */}
-          {payload.ars_controls_total != null && (
+          {/* ARS Controls — the cross-source control TOTAL: the union of every
+              control any evidence source touches (CFACTS coverage + the NIST
+              control each Kion / SecurityHub / Hardenize check maps to), each
+              rolled up weakest-link. Leads the drawer as the richest signal. A
+              control Kion passes (e.g. SC-12) shows satisfied here even if CFACTS
+              never assessed it — this row is the total, not CFACTS alone. */}
+          {controlsTotal > 0 && (
             <Box sx={{ mb: 0.75 }}>
               <Typography sx={{ fontSize: 12, color: '#555' }}>
                 <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
                   ARS Controls:
                 </Box>{' '}
-                {asText(payload.ars_controls_satisfied) ?? 0} of{' '}
-                {asText(payload.ars_controls_total)} satisfied
+                {controlsSatisfied.length} of {controlsTotal} satisfied
               </Typography>
-              {(arsSatisfiedOnly.length > 0 ||
-                arsNotSatisfiedOnly.length > 0 ||
-                arsFailing.length > 0) && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 0.5,
-                    mt: 0.5,
-                  }}
-                >
-                  {arsSatisfiedOnly.map((id, i) => (
-                    <ControlChip
-                      key={`sat-${id}-${i}`}
-                      id={id}
-                      variant="satisfied"
-                    />
-                  ))}
-                  {arsNotSatisfiedOnly.map((id, i) => (
-                    <ControlChip
-                      key={`unsat-${id}-${i}`}
-                      id={id}
-                      variant="unsatisfied"
-                    />
-                  ))}
-                  {arsFailing.map((id, i) => (
-                    <ControlChip
-                      key={`fail-${id}-${i}`}
-                      id={id}
-                      variant="failing"
-                    />
-                  ))}
-                </Box>
-              )}
+              <Box
+                sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}
+              >
+                {[
+                  ...controlsSatisfied,
+                  ...controlsUnsatisfied,
+                  ...controlsFailing,
+                ].map((c, i) => (
+                  <ControlChip
+                    key={`${c.state}-${c.id}-${i}`}
+                    id={c.id}
+                    variant={c.conflict ? 'conflict' : c.state}
+                    tooltip={<ControlTooltip control={c} />}
+                    ariaLabel={controlAriaLabel(c)}
+                  />
+                ))}
+              </Box>
             </Box>
           )}
 
-          {payload.evidence_sources && (
-            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
-              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
-                Based on:
-              </Box>{' '}
-              {asText(payload.evidence_sources)}
-            </Typography>
-          )}
-
-          {payload.cfacts_reasoning && (
+          {/* CFACTS — its own section, distinct from the ARS Controls total. Shown
+              whenever CFACTS has any of its own signal (reasoning, auth methods, or
+              a score) so a scored CFACTS chip always has a matching "why". */}
+          {cfactsText && (
             <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
               <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
                 CFACTS:
               </Box>{' '}
-              {asText(payload.cfacts_reasoning)}
+              {cfactsText}
+            </Typography>
+          )}
+
+          {basedOnSources.length > 0 && (
+            <Typography sx={{ fontSize: 12, color: '#555', mb: 0.75 }}>
+              <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                Based on:
+              </Box>{' '}
+              {basedOnSources.join(', ')}
             </Typography>
           )}
 
           {feedSources.map((s) => {
-            // Kion renders as the chip block on EVERY question (its passing array
-            // is rolling out and its FindingRow detail is low-value — no
-            // instances, unreliable remediation), so all Kion sections look
-            // uniform even before the passing array ships for a given question.
-            // SecHub/Hardenize keep the richer FindingRow (affected domains,
-            // severity) until their own passing arrays land, at which point
-            // `hasPassing` flips them to the same block automatically.
-            const asBlock = s.hasPassing || s.key === 'kion'
+            // Kion and SecurityHub render as the compact chip block (finding-name
+            // chips, ✓/✗). Hardenize keeps the richer FindingRow (affected domains)
+            // for its failing findings.
+            const asBlock =
+              s.hasPassing || s.key === 'kion' || s.key === 'sechub'
             if (asBlock) {
               return s.hasPassing || s.failing.length > 0 ? (
                 <FeedCheckBlock
@@ -618,13 +619,33 @@ function InsightsPanelInner({ payload }: Props) {
                 />
               ) : null
             }
-            return s.failing.map((f, i) => (
-              <FindingRow
-                key={`${s.key}-${f?.id ?? i}`}
-                source={s.label}
-                finding={f}
-              />
-            ))
+            // Hardenize (the only non-block source): a scored chip must have a
+            // section. Failing findings render as rows (with affected domains).
+            // When there are none but the source has data, still render the section
+            // and state WHY it passed — scanned clean — rather than showing nothing.
+            if (s.failing.length > 0) {
+              return s.failing.map((f, i) => (
+                <FindingRow
+                  key={`${s.key}-${f?.id ?? 'x'}-${i}`}
+                  source={s.label}
+                  finding={f}
+                />
+              ))
+            }
+            if (!hardenizeActive) return null
+            const hzLabel = maturityLabel(payload.hardenize_suggested_score)
+            return (
+              <Typography
+                key="feed-hardenize-clean"
+                sx={{ fontSize: 12, color: '#555', mb: 0.75 }}
+              >
+                <Box component="span" sx={{ fontWeight: 600, color: '#333' }}>
+                  {s.label}:
+                </Box>{' '}
+                no failing findings — scanned clean
+                {hzLabel ? `, scored ${hzLabel}` : ''}
+              </Typography>
+            )
           })}
         </Box>
       </Collapse>
@@ -660,8 +681,8 @@ export default function InsightsPanel(props: Props) {
 
 // A single ARS control ID pill. Three states: satisfied (green ✓), unsatisfied
 // (grey ○ — informational, applicable-but-not-satisfied, no alarm), failing
-// (red ✗ — Archer-explicit fails).
-type ControlChipVariant = 'satisfied' | 'unsatisfied' | 'failing'
+// (red ✗ — a source found the control failing).
+type ControlChipVariant = 'satisfied' | 'unsatisfied' | 'failing' | 'conflict'
 const CONTROL_CHIP_STYLE: Record<
   ControlChipVariant,
   { marker: string; bgcolor: string; color: string; border: string }
@@ -684,18 +705,30 @@ const CONTROL_CHIP_STYLE: Record<
     color: '#b02a37',
     border: '1px solid #f1b0b0',
   },
+  // Sources disagree (a pass AND a fail for the same control). Amber ⚠ so it reads
+  // as "needs a human" rather than a settled pass/fail; the hover names both sides
+  // and states how the score resolved it (weakest-link → failing).
+  conflict: {
+    marker: '⚠',
+    bgcolor: '#fff4e5',
+    color: '#a1560a',
+    border: '1px solid #f0c680',
+  },
 }
 
 // Plain-language reason behind each ARS chip's state, surfaced on hover and as the
-// chip's accessible name. The three arrays the pipeline emits ARE the reason: a
-// control lands in exactly one of satisfied / not-satisfied / failing, so the
-// variant fully determines why it's coloured the way it is — no per-control text
-// needed. Ordered passed / not-assessed / failed to match ✓ / ○ / ✗.
+// chip's accessible name. The rollup assigns a control exactly one of satisfied /
+// not-satisfied / failing (weakest-link across sources), so the variant fully
+// determines why it's coloured the way it is — no per-control text needed. Ordered
+// passed / not-assessed / failed to match ✓ / ○ / ✗.
 const CONTROL_CHIP_HELP: Record<ControlChipVariant, string> = {
-  satisfied: 'Satisfied — assessed and met (per CFACTS/Archer).',
+  satisfied:
+    'Satisfied — an evidence source passed this control and none failed it.',
   unsatisfied:
-    'Not satisfied — applies to this question but is not marked Satisfied (may be unassessed).',
-  failing: 'Other Than Satisfied — Archer flagged this control as failing.',
+    'Not satisfied — applies to this question (per CFACTS) but no source has confirmed it satisfied.',
+  failing: 'Failing — an evidence source found this control failing.',
+  conflict:
+    'Sources disagree — at least one passed this control and at least one failed it. Counted as failing (weakest-link); review the failing check.',
 }
 
 function ControlChip({
@@ -706,9 +739,10 @@ function ControlChip({
 }: {
   id: string
   variant: ControlChipVariant
-  // When set, the chip label (a short NIST tag) carries a hover with the fuller
-  // context — used by the feed pass/fail chips whose underlying check slug is
-  // too long to be the label itself. May be rich (multi-line) node.
+  // When set, the chip label carries a hover with the fuller context — used by
+  // the feed pass/fail chips, whose label is the check name and whose hover holds
+  // the description, mapped control, and met/failed state. May be a rich
+  // (multi-line) node.
   tooltip?: React.ReactNode
   // Plain-text equivalent of a rich tooltip, for the accessible name.
   ariaLabel?: string
@@ -784,27 +818,62 @@ function CheckTooltip({
   pass: boolean
 }) {
   const slug = asText(finding?.id) ?? asText(finding?.title)
-  const desc = asText(finding?.description)
+  // The chip label now carries the check name (its code/slug), so the hover leads
+  // with the human sentence, then the control it maps to, its severity, and the
+  // met/failed state — what a reviewer needs to judge the finding. Kion puts that
+  // sentence in `description`, SecurityHub in `title`; lead with whichever is
+  // present so both feeds read the same. The slug is only a last-resort title so
+  // the hover never names nothing.
+  const name = asText(finding?.description) ?? asText(finding?.title)
   const nist = asText(finding?.nist_controls)
+  const severity = asText(finding?.severity)
   const level = typeof finding?.level === 'number' ? finding.level : null
   const meta = [
-    nist,
+    nist ? `Control: ${nist}` : undefined,
     level != null ? `Level ${level}` : undefined,
+    severity ? severity.toUpperCase() : undefined,
     pass ? 'Passed' : 'Failed',
   ]
     .filter(Boolean)
     .join(' · ')
+  // Affected hosts (Hardenize-only). When Hardenize renders as chips, its findings'
+  // domains must live in the hover — chips have no room for the FindingRow's "N
+  // domains" affordance, so without this the affected hosts would be lost. Kion and
+  // SecurityHub carry no instances, so this is empty for them.
+  const domains = (Array.isArray(finding?.instances) ? finding.instances : [])
+    .map((inst) => ({
+      domain: asText(inst?.domain),
+      detail: formatHardenizeDetail(inst?.detail),
+    }))
+    .filter((d) => d.domain)
   return (
     <Box sx={{ py: 0.25 }}>
-      {slug && (
-        <Box sx={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700 }}>
-          {slug}
-        </Box>
-      )}
-      {desc && (
-        <Box sx={{ fontSize: 11, mt: 0.5, lineHeight: 1.5 }}>{desc}</Box>
+      {name ? (
+        <Box sx={{ fontSize: 11, lineHeight: 1.5 }}>{name}</Box>
+      ) : (
+        slug && (
+          <Box sx={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700 }}>
+            {slug}
+          </Box>
+        )
       )}
       {meta && <Box sx={{ fontSize: 10, mt: 0.5, opacity: 0.8 }}>{meta}</Box>}
+      {domains.length > 0 && (
+        <Box sx={{ mt: 0.5 }}>
+          <Box sx={{ fontSize: 10, fontWeight: 600, opacity: 0.9 }}>
+            Affected {domains.length === 1 ? 'domain' : 'domains'}:
+          </Box>
+          {domains.map((d, i) => (
+            <Box
+              key={`${d.domain}-${i}`}
+              sx={{ fontSize: 10, lineHeight: 1.5, opacity: 0.85 }}
+            >
+              {d.domain}
+              {d.detail ? ` — ${d.detail}` : ''}
+            </Box>
+          ))}
+        </Box>
+      )}
     </Box>
   )
 }
@@ -812,9 +881,12 @@ function CheckTooltip({
 // ARS-style pass/fail block for one finding-source — the SINGLE rendering path
 // for every finding-source, so all questions look uniform (no fallback to the
 // old verbose FindingRow list). One ✓/✗ chip per check: passing from
-// `{source}_passing` (green), failing from `findings.{source}` (red), labeled by
-// the short NIST tag with the slug + description in the hover. Rollup is
-// per-check — a control tag can repeat because each check is distinct.
+// `{source}_passing` (green — no finding), failing from `findings.{source}`
+// (red — has a finding), labeled by the check name (finding slug) with the
+// description + mapped control + met/failed state in the hover. Reviewers asked
+// to see the finding itself, not the control it rolls up to, so the name is on
+// the chip and the control moved into the tooltip. Rollup is per-check — the
+// same control can repeat because each check is distinct.
 //
 // Header adapts to what shipped: when the passing array is present we can state
 // the full "N of M checks passed"; when it's absent (source has only failing
@@ -855,7 +927,7 @@ function FeedCheckBlock({
           {chips.map(({ pass, f }, i) => {
             const nist = asText(f?.nist_controls)
             const slug = asText(f?.id) ?? asText(f?.title)
-            const desc = asText(f?.description)
+            const desc = asText(f?.description) ?? asText(f?.title)
             // Fold pass/fail into the accessible name — the ✓/✗ + color is the
             // only other place that distinction lives, and neither is exposed to
             // a screen reader (508).
@@ -865,7 +937,7 @@ function FeedCheckBlock({
             return (
               <ControlChip
                 key={`${pass ? 'p' : 'f'}-${slug ?? ''}-${i}`}
-                id={nist ?? slug ?? '—'}
+                id={slug ?? nist ?? '—'}
                 variant={pass ? 'satisfied' : 'failing'}
                 tooltip={<CheckTooltip finding={f} pass={pass} />}
                 ariaLabel={ariaLabel || undefined}
@@ -942,6 +1014,186 @@ const SEVERITY_HELP: Record<string, string> = {
 }
 function severityHelp(sev?: string): string | undefined {
   return SEVERITY_HELP[(sev ?? '').toLowerCase()]
+}
+
+// The state of one control in the ARS Controls rollup. `unsatisfied` = CFACTS says
+// the control applies here but nothing has confirmed it satisfied (may be
+// unassessed) — informational, not an alarm.
+export type ControlRollupState = 'satisfied' | 'unsatisfied' | 'failing'
+
+// One piece of evidence behind a control's state: which source spoke to it, the
+// specific check (when the evidence is a finding-source check rather than a CFACTS
+// coverage flag), and what that evidence said.
+export type ControlEvidence = {
+  source: string
+  check?: string
+  state: ControlRollupState
+}
+
+// A control after the cross-source rollup: its net (weakest-link) state, whether
+// its sources disagree, and the full evidence list so the UI can name every source
+// and show how a conflict resolved.
+export type ControlRollup = {
+  id: string
+  state: ControlRollupState
+  conflict: boolean
+  evidence: ControlEvidence[]
+}
+
+// Weakest-link precedence for a control's NET state: failing beats satisfied beats
+// unsatisfied. So a control is failing if ANY source fails it, else satisfied if
+// ANY source passes it, else unsatisfied. Matches the zero-trust scoring principle
+// (lowest signal wins).
+const CONTROL_RANK: Record<ControlRollupState, number> = {
+  failing: 3,
+  satisfied: 2,
+  unsatisfied: 1,
+}
+
+// The ARS Controls total is the UNION of every ARS control any evidence source
+// touches — CFACTS applicable/failing controls PLUS the NIST control each Kion,
+// SecurityHub, and Hardenize check maps to. Each control keeps its full evidence
+// list, nets to a weakest-link state, and is flagged `conflict` when at least one
+// source passes it AND at least one source fails it (e.g. SC-12: Kion passes
+// key-rotation but fails cross-account-access). This is why a control Kion passes
+// appears here even though CFACTS never assessed it, and why a conflicted control
+// can net to failing. The payload is opaque, so every value is coerced and
+// guarded; a malformed element is skipped, never thrown.
+export function rollupControls(
+  payload: Partial<InsightPayload>
+): ControlRollup[] {
+  const map = new Map<string, ControlEvidence[]>()
+  const add = (
+    raw: unknown,
+    source: string,
+    state: ControlRollupState,
+    check?: string
+  ) => {
+    const text = asText(raw)
+    if (!text) return
+    // One check can map to several controls, e.g. "AC-2, AC-3".
+    for (const part of text.split(',')) {
+      const id = part.trim()
+      if (!id) continue
+      const list = map.get(id) ?? []
+      list.push({ source, state, check })
+      map.set(id, list)
+    }
+  }
+  const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
+  const finding = (f: unknown) =>
+    f && typeof f === 'object'
+      ? (f as { nist_controls?: unknown; id?: unknown; title?: unknown })
+      : null
+  // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
+  // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
+  // control catalog, not a source — CFACTS is the source of this coverage. These
+  // arrays are plain control-id strings (unlike nist_controls, which may arrive as
+  // an array and needs asText coercion), so filter to strings: a non-string
+  // element would otherwise coerce to a junk chip ("42", "[object Object]").
+  const isStr = (v: unknown): v is string => typeof v === 'string'
+  // ars_not_satisfied is a SUPERSET of ars_failing — a failing control appears in
+  // both. Subtract the failing ids so the control isn't listed twice in the hover
+  // (once "not assessed", once "failed"); the net state is failing either way.
+  const arsFailingIds = new Set(arr(payload.ars_failing_controls).filter(isStr))
+  arr(payload.ars_satisfied_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'satisfied'))
+  arr(payload.ars_not_satisfied_controls)
+    .filter(isStr)
+    .filter((c) => !arsFailingIds.has(c))
+    .forEach((c) => add(c, 'CFACTS', 'unsatisfied'))
+  arr(payload.ars_failing_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'failing'))
+  // Finding-source checks: a passing check satisfies its control, a failing one (a
+  // finding) fails it. Carry the check id/title so the hover can name it.
+  const findings = (payload.findings ?? {}) as Record<string, unknown>
+  const SRC_LABEL: Record<string, string> = {
+    kion: 'Kion',
+    sechub: 'SecurityHub',
+    hardenize: 'Hardenize',
+  }
+  for (const src of ['kion', 'sechub', 'hardenize'] as const) {
+    const label = SRC_LABEL[src]
+    arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach((f) => {
+      const o = finding(f)
+      add(
+        o?.nist_controls,
+        label,
+        'satisfied',
+        asText(o?.id) ?? asText(o?.title)
+      )
+    })
+    arr(findings[src]).forEach((f) => {
+      const o = finding(f)
+      add(o?.nist_controls, label, 'failing', asText(o?.id) ?? asText(o?.title))
+    })
+  }
+  return [...map.entries()].map(([id, evidence]) => {
+    const state = evidence.reduce<ControlRollupState>(
+      (net, e) => (CONTROL_RANK[e.state] > CONTROL_RANK[net] ? e.state : net),
+      'unsatisfied'
+    )
+    const conflict =
+      evidence.some((e) => e.state === 'satisfied') &&
+      evidence.some((e) => e.state === 'failing')
+    return { id, state, conflict, evidence }
+  })
+}
+
+// Plain-text words for a control's net state and each evidence line — shared by the
+// hover and the accessible name so sighted and AT users read the same thing.
+const CONTROL_STATE_WORD: Record<ControlRollupState, string> = {
+  satisfied: 'satisfied',
+  failing: 'failing',
+  unsatisfied: 'not satisfied',
+}
+const CONTROL_EVIDENCE_WORD: Record<ControlRollupState, string> = {
+  satisfied: 'passed',
+  failing: 'failed',
+  unsatisfied: 'not assessed',
+}
+function controlEvidenceLine(e: ControlEvidence): string {
+  return `${e.source}${e.check ? ` · ${e.check}` : ''} · ${CONTROL_EVIDENCE_WORD[e.state]}`
+}
+// Accessible name folds the net state, the conflict note, and every source line
+// into one string — the ✓/○/✗/⚠ marker and colour are otherwise the only place the
+// state and its provenance live, and neither reaches a screen reader (508).
+function controlAriaLabel(c: ControlRollup): string {
+  const head = c.conflict
+    ? `${c.id}: sources disagree, counted as ${CONTROL_STATE_WORD[c.state]}`
+    : `${c.id}: ${CONTROL_STATE_WORD[c.state]}`
+  return `${head}. ${c.evidence.map(controlEvidenceLine).join('; ')}.`
+}
+
+// Rich hover for an ARS control chip: the control id, a conflict note stating how a
+// disagreement resolved, then one line per source/check so the user can see exactly
+// why the control is met or failed and address a conflict at its source.
+function ControlTooltip({ control }: { control: ControlRollup }) {
+  return (
+    <Box sx={{ py: 0.25 }}>
+      <Box sx={{ fontFamily: 'monospace', fontSize: 11, fontWeight: 700 }}>
+        {control.id}
+      </Box>
+      {control.conflict && (
+        <Box sx={{ fontSize: 10, mt: 0.5, color: '#ffd9a0', lineHeight: 1.5 }}>
+          ⚠ Sources disagree — counted as {CONTROL_STATE_WORD[control.state]}{' '}
+          (weakest-link). Review the failing check to resolve.
+        </Box>
+      )}
+      <Box sx={{ mt: 0.5 }}>
+        {control.evidence.map((e, i) => (
+          <Box
+            key={`${e.source}-${e.check ?? ''}-${i}`}
+            sx={{ fontSize: 10, lineHeight: 1.5, opacity: 0.9 }}
+          >
+            {controlEvidenceLine(e)}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
 }
 
 // One structured finding, uniform across sources. Card = id (code) + title +


### PR DESCRIPTION
## What

Reworks the ZTMF Insights drawer so every evidence source reads consistently and every scored source chip has a section that explains it.

### Findings as chips
- Kion and SecurityHub findings render as compact pass/fail chips labeled by the finding name. The hover carries the description, mapped control, severity, and met/failed state. SecurityHub collapses from several `SecurityHub:` rows into one block.
- Hardenize shows a section whenever it has data: failing findings as rows with their affected domains, a "scanned clean" line when there are none, or a pass/fail chip block once its passing array ships. Affected domains also show in the chip hover so nothing is lost when Hardenize renders as chips.

<img width="1265" height="389" alt="image" src="https://github.com/user-attachments/assets/67049947-d8b3-443d-93c2-8c33863d49a4" />


### ARS Controls as a cross-source union
- The ARS Controls section is now the union of every control any source touches: CFACTS coverage plus the control each Kion, SecurityHub, and Hardenize check maps to. Each control rolls up weakest-link, so a fail from any source outranks a pass. A control that one source passes and another fails is flagged as a conflict and rendered as an amber chip whose hover names each source and states how it resolved.

### Source model
- ARS is treated as the control catalog (the ARS Controls section), not an evidence source, so the standalone ARS chip is dropped. Its coverage rolls up under CFACTS, which is the source that assesses it.
- Chip order and drawer section order are aligned (CFACTS, Hardenize, SecurityHub, Kion), and "Based on" is derived from the active source chips.

## Backend data enablement (SDL enrichment view, v18)

The passing-check chips and the control union depend on data added to the Security Data Lake enrichment view (`VW_ZTMF_INSIGHTS`) this cycle:

- Added structured `hardenize_passing` and `sechub_passing` arrays (shape `{id, nist_controls, description, level}`, matching the existing `kion_passing`), so all three finding sources honor the same passing-checks contract. Previously the `hardenize_l*_passing` fields were hardcoded NULL, so Hardenize could only ever show a "scanned clean" line.
- View v18 was promoted to the CORE snapshot via CREATE OR REPLACE for the two new columns (service role re-granted, `SNAPSHOT_TS` preserved), then reloaded to local dev and impl (9,880 rows each). Prod carries over through the existing sync lambdas via `SELECT *`.
- Result: EPPEC q36, for example, now ships a 7-element `hardenize_passing` (the DNS checks) that renders as green chips instead of the text line.

Known data gaps, tracked separately and not blocking the frontend:
- `sechub_passing` is always empty in this pipeline (SecurityHub is failing-only, 0 of 11,856 rows).
- `hardenize_passing` currently carries only `id` + `level` (the Hardenize dictionary has 42 entries, 0 with NIST controls or descriptions). Chips render today; the hover text and the ARS-control-union fold light up automatically once the Hardenize dictionary is seeded with NIST + descriptions.

## Testing
- Full suite green (563 passing). Adds `rollupControls` unit tests and expands the panel tests to cover the chip flip, the control union, conflict handling, and the per-source sections.
- Verified against dev data on the network questions: EPPEC q31/q36 and MIDAS q31 (all four sources active, Hardenize pass/fail chips, SecurityHub block, control union with a conflict chip).

## Notes
- Hardenize passing chips render from the structured `hardenize_passing` array. Where the Hardenize dictionary still lacks NIST mappings and descriptions, chips render with id + level; the hover text and the control-union fold happen automatically once the dictionary is seeded.

Closes #613
