### PR TITLE
Render extended metadata fields as validated selects

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,19 @@ export type DataCenterEnvironment = {
   ordr: number
 }
 
+// One allowed value for an extended-metadata field, from
+// GET /api/v1/systemattributes. `field` is the column ("fips", "system_type",
+// "cloud_service_model", ...); `value` is a canonical option or the label for
+// a boolean field. `selectable` false hides a row from the dropdown (e.g. the
+// help row carrying only a `description`). Rows arrive ordered by `ordr`.
+export type SystemAttribute = {
+  field: string
+  value: string
+  description: string | null
+  selectable: boolean
+  ordr: number
+}
+
 export type userData = {
   userid: string
   email: string
@@ -132,19 +145,21 @@ export type FismaSystemType = {
   reactivated_date: string | null
   reactivation_notes: string | null
   opdiv_id?: number | null
-  // Extended metadata fields (migration 0044+)
+  // Extended metadata fields, typed and canonicalized by the backend.
+  // Enum strings carry a canonical value or null; the tri-state booleans are
+  // true / false / null = Unknown; cloud_service_model is a decomposed list.
   isso_name?: string | null
-  hva?: string | null
+  hva?: boolean | null
   fips?: string | null
   system_type?: string | null
-  cloud_system?: string | null
-  cloud_service_model?: string | null
+  cloud_system?: boolean | null
+  cloud_service_model?: string[] | null
   cloud_vendor?: string | null
   system_operator?: string | null
   goco_coco_gogo?: string | null
   system_owner?: string | null
   system_owner_email?: string | null
-  legacy?: string | null
+  legacy?: boolean | null
   // Risk-based target maturity (ztmf#398). null = no target asserted yet;
   // the UI presents the Advanced default.
   target_maturity_tier?: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,13 +96,12 @@ export type DataCenterEnvironment = {
 
 // One allowed value for an extended-metadata field, from
 // GET /api/v1/systemattributes. `field` is the column ("fips", "system_type",
-// "cloud_service_model", ...); `value` is a canonical option or the label for
-// a boolean field. `selectable` false hides a row from the dropdown (e.g. the
-// help row carrying only a `description`). Rows arrive ordered by `ordr`.
+// "cloud_service_model", ...); `value` is a canonical option. `selectable` false
+// hides a row from the dropdown. Rows arrive ordered by `ordr`. The endpoint is
+// a plain allowed-values list; field help copy lives in the UI, not here.
 export type SystemAttribute = {
   field: string
   value: string
-  description: string | null
   selectable: boolean
   ordr: number
 }

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -1,0 +1,102 @@
+import {
+  fetchSystemMetadataVocab,
+  SYSTEM_METADATA_VOCAB,
+  toSelectOptionsWithCurrent,
+  parseCombo,
+  serializeCombo,
+  multiSelectOptionsWithCurrent,
+} from './systemMetadataVocab'
+
+describe('fetchSystemMetadataVocab', () => {
+  test('resolves the canonical vocabulary (stopgap until the endpoint)', async () => {
+    const vocab = await fetchSystemMetadataVocab()
+    expect(vocab).toBe(SYSTEM_METADATA_VOCAB)
+    expect(vocab.fips).toEqual(['High', 'Moderate', 'Low'])
+    expect(vocab.goco_coco_gogo).toEqual(['GOCO', 'COCO', 'GOGO'])
+    expect(vocab.cloud_service_model).toEqual(['IaaS', 'PaaS', 'SaaS', 'Other'])
+  })
+})
+
+describe('toSelectOptionsWithCurrent', () => {
+  const allowed = ['High', 'Moderate', 'Low']
+
+  test('maps allowed values to value/label options', () => {
+    expect(toSelectOptionsWithCurrent(allowed, null)).toEqual([
+      { value: 'High', label: 'High' },
+      { value: 'Moderate', label: 'Moderate' },
+      { value: 'Low', label: 'Low' },
+    ])
+  })
+
+  test('appends a legacy value not in the set as a disabled option', () => {
+    const opts = toSelectOptionsWithCurrent(allowed, 'Undefined')
+    expect(opts).toHaveLength(4)
+    expect(opts[3]).toEqual({
+      value: 'Undefined',
+      label: 'Undefined',
+      disabled: true,
+    })
+  })
+
+  test('does not duplicate a current value already in the set', () => {
+    expect(toSelectOptionsWithCurrent(allowed, 'Low')).toHaveLength(3)
+  })
+
+  test('adds nothing for a null/empty current value', () => {
+    expect(toSelectOptionsWithCurrent(allowed, null)).toHaveLength(3)
+    expect(toSelectOptionsWithCurrent(allowed, '')).toHaveLength(3)
+    expect(toSelectOptionsWithCurrent(allowed, undefined)).toHaveLength(3)
+  })
+})
+
+describe('parseCombo', () => {
+  test('splits a slash combo into trimmed parts', () => {
+    expect(parseCombo('IaaS/PaaS')).toEqual(['IaaS', 'PaaS'])
+  })
+
+  test('tolerates legacy comma/semicolon delimiters and whitespace', () => {
+    expect(parseCombo('IaaS, PaaS')).toEqual(['IaaS', 'PaaS'])
+    expect(parseCombo('IaaS;PaaS ; SaaS')).toEqual(['IaaS', 'PaaS', 'SaaS'])
+  })
+
+  test('returns an empty array for null/empty', () => {
+    expect(parseCombo(null)).toEqual([])
+    expect(parseCombo('')).toEqual([])
+    expect(parseCombo(undefined)).toEqual([])
+  })
+})
+
+describe('serializeCombo', () => {
+  test('sorts and slash-joins for a stable stored string', () => {
+    expect(serializeCombo(['PaaS', 'IaaS'])).toBe('IaaS/PaaS')
+    expect(serializeCombo(['SaaS', 'IaaS', 'PaaS'])).toBe('IaaS/PaaS/SaaS')
+  })
+
+  test('de-duplicates and trims', () => {
+    expect(serializeCombo(['IaaS', 'IaaS ', ' PaaS'])).toBe('IaaS/PaaS')
+  })
+
+  test('empty selection serializes to null (unset stays unset)', () => {
+    expect(serializeCombo([])).toBeNull()
+    expect(serializeCombo(['', '  '])).toBeNull()
+  })
+
+  test('round-trips with parseCombo', () => {
+    expect(serializeCombo(parseCombo('SaaS/IaaS'))).toBe('IaaS/SaaS')
+  })
+})
+
+describe('multiSelectOptionsWithCurrent', () => {
+  const allowed = ['IaaS', 'PaaS', 'SaaS', 'Other']
+
+  test('returns the canonical parts when the current parts are all canonical', () => {
+    expect(multiSelectOptionsWithCurrent(allowed, ['IaaS'])).toEqual(allowed)
+  })
+
+  test('appends a legacy part not in the canon so it is not dropped', () => {
+    expect(multiSelectOptionsWithCurrent(allowed, ['IaaS', 'FaaS'])).toEqual([
+      ...allowed,
+      'FaaS',
+    ])
+  })
+})

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -1,102 +1,291 @@
-import {
-  fetchSystemMetadataVocab,
-  SYSTEM_METADATA_VOCAB,
-  toSelectOptionsWithCurrent,
-  parseCombo,
-  serializeCombo,
-  multiSelectOptionsWithCurrent,
-} from './systemMetadataVocab'
+import MockAdapter from 'axios-mock-adapter'
 
-describe('fetchSystemMetadataVocab', () => {
-  test('resolves the canonical vocabulary (stopgap until the endpoint)', async () => {
-    const vocab = await fetchSystemMetadataVocab()
-    expect(vocab).toBe(SYSTEM_METADATA_VOCAB)
-    expect(vocab.fips).toEqual(['High', 'Moderate', 'Low'])
-    expect(vocab.goco_coco_gogo).toEqual(['GOCO', 'COCO', 'GOGO'])
-    expect(vocab.cloud_service_model).toEqual(['IaaS', 'PaaS', 'SaaS', 'Other'])
+// Replace the app's axios instance with a bare one. The production module
+// reads import.meta.env at load time, which throws under @swc/jest.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+
+import axiosInstance from '@/axiosConfig'
+import {
+  fetchSystemAttributes,
+  optionsForField,
+  boolToSelectValue,
+  selectValueToBool,
+  formatBool,
+  formatList,
+  extendedFieldEqual,
+  buildExtendedDiff,
+  crossFieldClears,
+  isCrossFieldHidden,
+} from './systemMetadataVocab'
+import type { SystemAttribute, FismaSystemType } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+afterEach(() => mock.reset())
+
+const ROWS: SystemAttribute[] = [
+  {
+    field: 'fips',
+    value: 'High',
+    description: null,
+    selectable: true,
+    ordr: 30,
+  },
+  {
+    field: 'fips',
+    value: 'Low',
+    description: null,
+    selectable: true,
+    ordr: 10,
+  },
+  {
+    field: 'fips',
+    value: 'Moderate',
+    description: null,
+    selectable: true,
+    ordr: 20,
+  },
+  {
+    // help row: carries a description only, never offered as an option.
+    field: 'fips',
+    value: '',
+    description: 'Federal Information Processing Standard impact level.',
+    selectable: false,
+    ordr: 0,
+  },
+  {
+    field: 'cloud_service_model',
+    value: 'IaaS',
+    description: null,
+    selectable: true,
+    ordr: 10,
+  },
+]
+
+describe('fetchSystemAttributes', () => {
+  it('unwraps the { data: [...] } envelope', async () => {
+    mock.onGet('/systemattributes').reply(200, { data: ROWS })
+    await expect(fetchSystemAttributes()).resolves.toEqual(ROWS)
+  })
+
+  it('returns an empty array when data is null', async () => {
+    mock.onGet('/systemattributes').reply(200, { data: null })
+    await expect(fetchSystemAttributes()).resolves.toEqual([])
+  })
+
+  it('requests selectable_only by default and can opt out', async () => {
+    mock.onGet('/systemattributes').reply((config) => {
+      return [200, { data: [], params: config.params }]
+    })
+
+    await fetchSystemAttributes()
+    expect(mock.history.get[0].params).toEqual({ selectable_only: true })
+
+    await fetchSystemAttributes(undefined, false)
+    expect(mock.history.get[1].params).toBeUndefined()
+  })
+
+  it('rejects on a server error', async () => {
+    mock.onGet('/systemattributes').reply(500)
+    await expect(fetchSystemAttributes()).rejects.toBeDefined()
   })
 })
 
-describe('toSelectOptionsWithCurrent', () => {
-  const allowed = ['High', 'Moderate', 'Low']
-
-  test('maps allowed values to value/label options', () => {
-    expect(toSelectOptionsWithCurrent(allowed, null)).toEqual([
-      { value: 'High', label: 'High' },
-      { value: 'Moderate', label: 'Moderate' },
+describe('optionsForField', () => {
+  it('keeps a fields selectable rows, ordered by ordr', () => {
+    expect(optionsForField(ROWS, 'fips')).toEqual([
       { value: 'Low', label: 'Low' },
+      { value: 'Moderate', label: 'Moderate' },
+      { value: 'High', label: 'High' },
     ])
   })
 
-  test('appends a legacy value not in the set as a disabled option', () => {
-    const opts = toSelectOptionsWithCurrent(allowed, 'Undefined')
-    expect(opts).toHaveLength(4)
-    expect(opts[3]).toEqual({
-      value: 'Undefined',
-      label: 'Undefined',
-      disabled: true,
+  it('excludes non-selectable help rows', () => {
+    const values = optionsForField(ROWS, 'fips').map((o) => o.value)
+    expect(values).not.toContain('')
+  })
+
+  it('narrows to the requested field only', () => {
+    expect(optionsForField(ROWS, 'cloud_service_model')).toEqual([
+      { value: 'IaaS', label: 'IaaS' },
+    ])
+  })
+
+  it('returns an empty array for an unknown field', () => {
+    expect(optionsForField(ROWS, 'nope')).toEqual([])
+  })
+})
+
+describe('tri-state boolean conversions', () => {
+  it('maps a boolean|null to its select value', () => {
+    expect(boolToSelectValue(true)).toBe('true')
+    expect(boolToSelectValue(false)).toBe('false')
+    expect(boolToSelectValue(null)).toBe('')
+    expect(boolToSelectValue(undefined)).toBe('')
+  })
+
+  it('maps a select value back to the wire boolean|null', () => {
+    expect(selectValueToBool('true')).toBe(true)
+    expect(selectValueToBool('false')).toBe(false)
+    expect(selectValueToBool('')).toBeNull()
+  })
+
+  it('round-trips through both directions', () => {
+    for (const v of [true, false, null] as const) {
+      expect(selectValueToBool(boolToSelectValue(v))).toBe(v)
+    }
+  })
+})
+
+describe('display formatting', () => {
+  it('formats a tri-state boolean as Yes/No/Unknown', () => {
+    expect(formatBool(true)).toBe('Yes')
+    expect(formatBool(false)).toBe('No')
+    expect(formatBool(null)).toBe('Unknown')
+    expect(formatBool(undefined)).toBe('Unknown')
+  })
+
+  it('joins a decomposed list, with a placeholder when empty', () => {
+    expect(formatList(['IaaS', 'PaaS'])).toBe('IaaS, PaaS')
+    expect(formatList([])).toBe('—')
+    expect(formatList(null)).toBe('—')
+    expect(formatList(undefined)).toBe('—')
+  })
+})
+
+describe('extendedFieldEqual', () => {
+  it('treats null and undefined as the same unset', () => {
+    expect(extendedFieldEqual(null, undefined)).toBe(true)
+    expect(extendedFieldEqual(undefined, null)).toBe(true)
+  })
+
+  it('compares scalars by value', () => {
+    expect(extendedFieldEqual('High', 'High')).toBe(true)
+    expect(extendedFieldEqual('High', 'Low')).toBe(false)
+    expect(extendedFieldEqual(true, false)).toBe(false)
+  })
+
+  it('compares arrays order-insensitively', () => {
+    expect(extendedFieldEqual(['IaaS', 'PaaS'], ['PaaS', 'IaaS'])).toBe(true)
+    expect(extendedFieldEqual(['IaaS'], ['IaaS', 'PaaS'])).toBe(false)
+  })
+
+  it('treats an empty array and unset as the same stored state', () => {
+    // Both mean "no values", so a diff against an unset baseline skips the
+    // redundant clear rather than sending an empty array the backend already
+    // reflects.
+    expect(extendedFieldEqual([], null)).toBe(true)
+    expect(extendedFieldEqual([], undefined)).toBe(true)
+  })
+})
+
+describe('buildExtendedDiff', () => {
+  const KEYS = [
+    'hva',
+    'fips',
+    'cloud_system',
+    'cloud_service_model',
+    'cloud_vendor',
+  ] as (keyof FismaSystemType)[]
+
+  const base = {
+    hva: true,
+    fips: 'Low',
+    cloud_system: true,
+    cloud_service_model: ['IaaS'],
+    cloud_vendor: 'AWS',
+  } as unknown as FismaSystemType
+
+  it('omits unchanged fields', () => {
+    expect(buildExtendedDiff(base, base, KEYS)).toEqual({})
+  })
+
+  it('includes only changed fields, at their typed value', () => {
+    const edited = { ...base, fips: 'High', hva: false } as FismaSystemType
+    expect(buildExtendedDiff(edited, base, KEYS)).toEqual({
+      fips: 'High',
+      hva: false,
     })
   })
 
-  test('does not duplicate a current value already in the set', () => {
-    expect(toSelectOptionsWithCurrent(allowed, 'Low')).toHaveLength(3)
+  it('sends each per-type clear signal for a cleared field', () => {
+    const edited = {
+      ...base,
+      fips: '',
+      cloud_system: null,
+      cloud_service_model: [],
+    } as unknown as FismaSystemType
+    expect(buildExtendedDiff(edited, base, KEYS)).toEqual({
+      fips: '',
+      cloud_system: null,
+      cloud_service_model: [],
+    })
   })
 
-  test('adds nothing for a null/empty current value', () => {
-    expect(toSelectOptionsWithCurrent(allowed, null)).toHaveLength(3)
-    expect(toSelectOptionsWithCurrent(allowed, '')).toHaveLength(3)
-    expect(toSelectOptionsWithCurrent(allowed, undefined)).toHaveLength(3)
-  })
-})
-
-describe('parseCombo', () => {
-  test('splits a slash combo into trimmed parts', () => {
-    expect(parseCombo('IaaS/PaaS')).toEqual(['IaaS', 'PaaS'])
+  it('normalizes an unset changed field to null', () => {
+    const edited = { ...base, cloud_vendor: undefined } as FismaSystemType
+    expect(buildExtendedDiff(edited, base, KEYS)).toEqual({
+      cloud_vendor: null,
+    })
   })
 
-  test('tolerates legacy comma/semicolon delimiters and whitespace', () => {
-    expect(parseCombo('IaaS, PaaS')).toEqual(['IaaS', 'PaaS'])
-    expect(parseCombo('IaaS;PaaS ; SaaS')).toEqual(['IaaS', 'PaaS', 'SaaS'])
-  })
-
-  test('returns an empty array for null/empty', () => {
-    expect(parseCombo(null)).toEqual([])
-    expect(parseCombo('')).toEqual([])
-    expect(parseCombo(undefined)).toEqual([])
-  })
-})
-
-describe('serializeCombo', () => {
-  test('sorts and slash-joins for a stable stored string', () => {
-    expect(serializeCombo(['PaaS', 'IaaS'])).toBe('IaaS/PaaS')
-    expect(serializeCombo(['SaaS', 'IaaS', 'PaaS'])).toBe('IaaS/PaaS/SaaS')
-  })
-
-  test('de-duplicates and trims', () => {
-    expect(serializeCombo(['IaaS', 'IaaS ', ' PaaS'])).toBe('IaaS/PaaS')
-  })
-
-  test('empty selection serializes to null (unset stays unset)', () => {
-    expect(serializeCombo([])).toBeNull()
-    expect(serializeCombo(['', '  '])).toBeNull()
-  })
-
-  test('round-trips with parseCombo', () => {
-    expect(serializeCombo(parseCombo('SaaS/IaaS'))).toBe('IaaS/SaaS')
+  it('treats a missing baseline as every field unset (create path)', () => {
+    const edited = {
+      hva: false,
+      fips: 'Low',
+      cloud_system: null,
+      cloud_service_model: [],
+      cloud_vendor: null,
+    } as unknown as FismaSystemType
+    // Only the fields that differ from unset are sent: the booleans/arrays that
+    // are already at their clear signal are omitted.
+    expect(buildExtendedDiff(edited, null, KEYS)).toEqual({
+      hva: false,
+      fips: 'Low',
+    })
   })
 })
 
-describe('multiSelectOptionsWithCurrent', () => {
-  const allowed = ['IaaS', 'PaaS', 'SaaS', 'Other']
-
-  test('returns the canonical parts when the current parts are all canonical', () => {
-    expect(multiSelectOptionsWithCurrent(allowed, ['IaaS'])).toEqual(allowed)
+describe('crossFieldClears', () => {
+  it('clears cloud model and vendor when cloud_system is set to No', () => {
+    expect(crossFieldClears('cloud_system', false)).toEqual({
+      cloud_service_model: [],
+      cloud_vendor: '',
+    })
   })
 
-  test('appends a legacy part not in the canon so it is not dropped', () => {
-    expect(multiSelectOptionsWithCurrent(allowed, ['IaaS', 'FaaS'])).toEqual([
-      ...allowed,
-      'FaaS',
-    ])
+  it('does not cascade when cloud_system is Yes or Unknown', () => {
+    expect(crossFieldClears('cloud_system', true)).toEqual({})
+    expect(crossFieldClears('cloud_system', null)).toEqual({})
+  })
+
+  it('does not cascade for other fields', () => {
+    expect(crossFieldClears('fips', 'Low')).toEqual({})
+  })
+})
+
+describe('isCrossFieldHidden', () => {
+  it('hides cloud model and vendor while cloud_system is No', () => {
+    expect(
+      isCrossFieldHidden('cloud_service_model', { cloud_system: false })
+    ).toBe(true)
+    expect(isCrossFieldHidden('cloud_vendor', { cloud_system: false })).toBe(
+      true
+    )
+  })
+
+  it('shows them when cloud_system is Yes or Unknown', () => {
+    expect(
+      isCrossFieldHidden('cloud_service_model', { cloud_system: true })
+    ).toBe(false)
+    expect(
+      isCrossFieldHidden('cloud_service_model', { cloud_system: null })
+    ).toBe(false)
+  })
+
+  it('never hides unrelated fields', () => {
+    expect(isCrossFieldHidden('fips', { cloud_system: false })).toBe(false)
   })
 })

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -11,6 +11,7 @@ import axiosInstance from '@/axiosConfig'
 import {
   fetchSystemAttributes,
   optionsForField,
+  booleanOptions,
   boolToSelectValue,
   selectValueToBool,
   formatBool,
@@ -29,36 +30,31 @@ const ROWS: SystemAttribute[] = [
   {
     field: 'fips',
     value: 'High',
-    description: null,
     selectable: true,
     ordr: 30,
   },
   {
     field: 'fips',
     value: 'Low',
-    description: null,
     selectable: true,
     ordr: 10,
   },
   {
     field: 'fips',
     value: 'Moderate',
-    description: null,
     selectable: true,
     ordr: 20,
   },
   {
-    // help row: carries a description only, never offered as an option.
+    // non-selectable row: never offered as an option.
     field: 'fips',
     value: '',
-    description: 'Federal Information Processing Standard impact level.',
     selectable: false,
     ordr: 0,
   },
   {
     field: 'cloud_service_model',
     value: 'IaaS',
-    description: null,
     selectable: true,
     ordr: 10,
   },
@@ -139,12 +135,37 @@ describe('tri-state boolean conversions', () => {
   })
 })
 
+describe('booleanOptions', () => {
+  it('defaults to Yes/No/Unknown', () => {
+    expect(booleanOptions()).toEqual([
+      { value: 'true', label: 'Yes' },
+      { value: 'false', label: 'No' },
+      { value: '', label: 'Unknown' },
+    ])
+  })
+
+  it('overrides the true/false labels but keeps values and Unknown', () => {
+    expect(booleanOptions({ true: 'Not funded', false: 'Funded' })).toEqual([
+      { value: 'true', label: 'Not funded' },
+      { value: 'false', label: 'Funded' },
+      { value: '', label: 'Unknown' },
+    ])
+  })
+})
+
 describe('display formatting', () => {
   it('formats a tri-state boolean as Yes/No/Unknown', () => {
     expect(formatBool(true)).toBe('Yes')
     expect(formatBool(false)).toBe('No')
     expect(formatBool(null)).toBe('Unknown')
     expect(formatBool(undefined)).toBe('Unknown')
+  })
+
+  it('applies custom true/false labels, leaving Unknown', () => {
+    const labels = { true: 'Not funded', false: 'Funded' }
+    expect(formatBool(true, labels)).toBe('Not funded')
+    expect(formatBool(false, labels)).toBe('Funded')
+    expect(formatBool(null, labels)).toBe('Unknown')
   })
 
   it('joins a decomposed list, with a placeholder when empty', () => {

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -20,7 +20,7 @@ import type { SystemAttribute, FismaSystemType } from '@/types'
  *
  * @param signal - Optional AbortSignal to cancel the request.
  * @param selectableOnly - When true, asks the backend for dropdown options
- *   only (hides help rows carrying just a description).
+ *   only (hides any non-selectable rows).
  * @returns Every attribute row (empty array when none).
  */
 export async function fetchSystemAttributes(
@@ -78,14 +78,30 @@ export function optionsForField(
     .map((r) => ({ value: r.value, label: r.value }))
 }
 
-// Tri-state boolean control. The select values are strings ('' for Unknown)
-// because a MUI Select value must be a string; boolToSelectValue /
-// selectValueToBool convert to and from the wire boolean|null.
-export const BOOLEAN_OPTIONS: SelectOption[] = [
-  { value: 'true', label: 'Yes' },
-  { value: 'false', label: 'No' },
-  { value: '', label: 'Unknown' },
-]
+// Custom labels for the true/false ends of a tri-state boolean. For fields
+// whose Yes/No reads ambiguously against the label (e.g. a negatively-phrased
+// "Not Funded for Remediation", where "No" would mean "it is funded"). Unknown
+// is always Unknown.
+export type BooleanLabels = { true: string; false: string }
+
+/**
+ * Options for a tri-state boolean control. The select values are strings ('' for
+ * Unknown) because a MUI Select value must be a string; boolToSelectValue /
+ * selectValueToBool convert to and from the wire boolean|null.
+ *
+ * @param labels - Optional overrides for the true/false labels (Yes/No default).
+ * @returns The three options in Yes/No/Unknown order.
+ */
+export function booleanOptions(labels?: BooleanLabels): SelectOption[] {
+  return [
+    { value: 'true', label: labels?.true ?? 'Yes' },
+    { value: 'false', label: labels?.false ?? 'No' },
+    { value: '', label: 'Unknown' },
+  ]
+}
+
+// The default Yes/No/Unknown option set, for fields without custom labels.
+export const BOOLEAN_OPTIONS: SelectOption[] = booleanOptions()
 
 /**
  * Maps a tri-state boolean to its select value ('' = Unknown).
@@ -107,10 +123,18 @@ export function selectValueToBool(v: string): boolean | null {
 
 /**
  * Display label for a tri-state boolean (read view / table).
+ *
+ * @param v - The value to format.
+ * @param labels - Optional overrides for the true/false labels (Yes/No default),
+ *   matching the field's edit-control options.
+ * @returns The display label; Unknown when unset.
  */
-export function formatBool(v: boolean | null | undefined): string {
-  if (v === true) return 'Yes'
-  if (v === false) return 'No'
+export function formatBool(
+  v: boolean | null | undefined,
+  labels?: BooleanLabels
+): string {
+  if (v === true) return labels?.true ?? 'Yes'
+  if (v === false) return labels?.false ?? 'No'
   return 'Unknown'
 }
 

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Canonical allowed values for the extended system-metadata fields
+ * (ztmf-ui#460, frontend slice of ztmf#395).
+ *
+ * SWAP POINT: these values are hardcoded from the canonical set agreed on
+ * ztmf#395 (2026-07-08) as a stopgap. The backend vocabulary endpoint that
+ * serves them is ztmf#433 and is not built yet. When it ships, change ONLY
+ * `fetchSystemMetadataVocab` below to read from it (mirroring
+ * `fetchDataCenterEnvironments`) - the field configs, the edit views, and the
+ * option helpers all consume the fetched result, so nothing else changes.
+ *
+ * `cloud_vendor` is deliberately absent: it is free text (out of scope on
+ * ztmf#395). NULL/unset is always valid ("not yet captured") and is handled by
+ * the option helpers, not by listing an empty value here.
+ */
+
+// The metadata fields that render as a single-value select.
+export type MetadataSelectField =
+  | 'fips'
+  | 'system_type'
+  | 'hva'
+  | 'cloud_system'
+  | 'goco_coco_gogo'
+  | 'system_operator'
+  | 'legacy'
+
+// The one multi-select field. Stored as a sorted, slash-joined combo of the
+// parts below (e.g. "IaaS/PaaS"); the helpers convert between the string and
+// the parts array.
+export type MetadataMultiSelectField = 'cloud_service_model'
+
+export type SystemMetadataVocab = Record<
+  MetadataSelectField | MetadataMultiSelectField,
+  string[]
+>
+
+// Canonical set from ztmf#395. Order is the display order in the dropdown.
+export const SYSTEM_METADATA_VOCAB: SystemMetadataVocab = {
+  fips: ['High', 'Moderate', 'Low'],
+  system_type: [
+    'Major Application',
+    'Minor Standalone',
+    'Minor Application',
+    'General Support System',
+    'Enterprise',
+    'Local',
+    'Other',
+  ],
+  hva: ['Yes', 'No'],
+  cloud_system: ['Yes', 'No'],
+  goco_coco_gogo: ['GOCO', 'COCO', 'GOGO'],
+  system_operator: ['Agency', 'Contractor'],
+  legacy: ['Yes', 'No'],
+  cloud_service_model: ['IaaS', 'PaaS', 'SaaS', 'Other'],
+}
+
+/**
+ * Returns the metadata vocabulary. Currently resolves the hardcoded canonical
+ * set; becomes a `GET` to the ztmf#433 endpoint when that lands (see SWAP
+ * POINT above). Async so callers already await it and the swap is invisible.
+ *
+ * @param _signal - Reserved for the real fetch's AbortSignal; unused today.
+ * @returns The allowed values per field.
+ */
+export async function fetchSystemMetadataVocab(
+  _signal?: AbortSignal
+): Promise<SystemMetadataVocab> {
+  return SYSTEM_METADATA_VOCAB
+}
+
+/**
+ * Reads the metadata vocabulary for a component. Seeded with the local
+ * canonical set so selects render correctly on first paint, then refreshed
+ * from `fetchSystemMetadataVocab` (a no-op today, a network read once ztmf#433
+ * ships). Kept as a hook so every consumer gets the swap for free.
+ *
+ * @returns The current vocabulary.
+ */
+export function useSystemMetadataVocab(): SystemMetadataVocab {
+  const [vocab, setVocab] = useState<SystemMetadataVocab>(SYSTEM_METADATA_VOCAB)
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchSystemMetadataVocab(controller.signal)
+      .then((v) => {
+        if (!controller.signal.aborted) setVocab(v)
+      })
+      .catch(() => {
+        // Non-fatal: fall back to the seeded canonical set.
+      })
+    return () => controller.abort()
+  }, [])
+  return vocab
+}
+
+export type SelectOption = {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+/**
+ * Single-select options for a field, preserving the system's current value
+ * when it is not in the served set (a legacy/unmapped value). Without this,
+ * editing such a system would show a blank select and drop the value on save.
+ * The current value is appended as a disabled option so it renders and stays
+ * valid but cannot be re-picked - the same pattern as
+ * `toDropdownOptionsWithCurrent` for datacenter environments.
+ *
+ * @param allowed - Canonical values for the field.
+ * @param current - The system's stored value (may be null/unset/legacy).
+ * @returns Options in display order, with a trailing disabled legacy option
+ *   when needed.
+ */
+export function toSelectOptionsWithCurrent(
+  allowed: string[],
+  current: string | null | undefined
+): SelectOption[] {
+  const options: SelectOption[] = allowed.map((v) => ({ value: v, label: v }))
+  if (current && !allowed.includes(current)) {
+    options.push({ value: current, label: current, disabled: true })
+  }
+  return options
+}
+
+/**
+ * Splits a stored `cloud_service_model` combo into its parts. Tolerates the
+ * legacy delimiters seen in the raw data (slash, comma, semicolon) so an
+ * un-canonicalized value still populates the multi-select.
+ *
+ * @param value - The stored combo (e.g. "IaaS/PaaS"), possibly null.
+ * @returns The parts, or an empty array when unset.
+ */
+export function parseCombo(value: string | null | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(/[/,;]/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Joins multi-select parts back into the stored combo: de-duplicated and
+ * sorted so the same selection always serializes to the same string (the
+ * canonical storage shape on ztmf#395). Empty selection serializes to null so
+ * an unset value stays unset rather than becoming "".
+ *
+ * @param parts - The selected parts.
+ * @returns The sorted slash-joined combo, or null when empty.
+ */
+export function serializeCombo(parts: string[]): string | null {
+  const unique = Array.from(new Set(parts.map((p) => p.trim()).filter(Boolean)))
+  if (unique.length === 0) return null
+  return unique.sort().join('/')
+}
+
+/**
+ * Multi-select options for `cloud_service_model`: the canonical parts plus any
+ * current part not in the canon (so a legacy combo's odd part still shows and
+ * is not silently dropped on save).
+ *
+ * @param allowed - Canonical parts.
+ * @param currentParts - Parts parsed from the stored value.
+ * @returns The union, canonical parts first.
+ */
+export function multiSelectOptionsWithCurrent(
+  allowed: string[],
+  currentParts: string[]
+): string[] {
+  const extras = currentParts.filter((p) => !allowed.includes(p))
+  return [...allowed, ...extras]
+}

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -1,173 +1,213 @@
 import { useEffect, useState } from 'react'
+import axiosInstance from '@/axiosConfig'
+import type { SystemAttribute, FismaSystemType } from '@/types'
 
 /**
- * Canonical allowed values for the extended system-metadata fields
- * (ztmf-ui#460, frontend slice of ztmf#395).
+ * Backend-driven vocabulary for the extended system-metadata fields, from
+ * GET /api/v1/systemattributes. Mirrors dataCenterEnvironments.ts: fetch the
+ * rows, then derive per-field dropdown options client-side, so the server
+ * stays the single source of truth for the allowed values.
  *
- * SWAP POINT: these values are hardcoded from the canonical set agreed on
- * ztmf#395 (2026-07-08) as a stopgap. The backend vocabulary endpoint that
- * serves them is ztmf#433 and is not built yet. When it ships, change ONLY
- * `fetchSystemMetadataVocab` below to read from it (mirroring
- * `fetchDataCenterEnvironments`) - the field configs, the edit views, and the
- * option helpers all consume the fetched result, so nothing else changes.
- *
- * `cloud_vendor` is deliberately absent: it is free text (out of scope on
- * ztmf#395). NULL/unset is always valid ("not yet captured") and is handled by
- * the option helpers, not by listing an empty value here.
+ * The endpoint returns one row per allowed value across every field; callers
+ * narrow to a field with optionsForField. Enum fields (fips, system_type,
+ * system_operator, goco_coco_gogo) and the cloud_service_model parts come from
+ * here. The tri-state booleans (hva, cloud_system, legacy) are structural
+ * Yes/No/Unknown, not a served list - see BOOLEAN_OPTIONS.
  */
 
-// The metadata fields that render as a single-value select.
-export type MetadataSelectField =
-  | 'fips'
-  | 'system_type'
-  | 'hva'
-  | 'cloud_system'
-  | 'goco_coco_gogo'
-  | 'system_operator'
-  | 'legacy'
-
-// The one multi-select field. Stored as a sorted, slash-joined combo of the
-// parts below (e.g. "IaaS/PaaS"); the helpers convert between the string and
-// the parts array.
-export type MetadataMultiSelectField = 'cloud_service_model'
-
-export type SystemMetadataVocab = Record<
-  MetadataSelectField | MetadataMultiSelectField,
-  string[]
->
-
-// Canonical set from ztmf#395. Order is the display order in the dropdown.
-export const SYSTEM_METADATA_VOCAB: SystemMetadataVocab = {
-  fips: ['High', 'Moderate', 'Low'],
-  system_type: [
-    'Major Application',
-    'Minor Standalone',
-    'Minor Application',
-    'General Support System',
-    'Enterprise',
-    'Local',
-    'Other',
-  ],
-  hva: ['Yes', 'No'],
-  cloud_system: ['Yes', 'No'],
-  goco_coco_gogo: ['GOCO', 'COCO', 'GOGO'],
-  system_operator: ['Agency', 'Contractor'],
-  legacy: ['Yes', 'No'],
-  cloud_service_model: ['IaaS', 'PaaS', 'SaaS', 'Other'],
+/**
+ * Fetches the full system-attribute vocabulary.
+ *
+ * @param signal - Optional AbortSignal to cancel the request.
+ * @param selectableOnly - When true, asks the backend for dropdown options
+ *   only (hides help rows carrying just a description).
+ * @returns Every attribute row (empty array when none).
+ */
+export async function fetchSystemAttributes(
+  signal?: AbortSignal,
+  selectableOnly = true
+): Promise<SystemAttribute[]> {
+  const res = await axiosInstance.get<{ data: SystemAttribute[] | null }>(
+    '/systemattributes',
+    { params: selectableOnly ? { selectable_only: true } : undefined, signal }
+  )
+  return res.data.data ?? []
 }
 
 /**
- * Returns the metadata vocabulary. Currently resolves the hardcoded canonical
- * set; becomes a `GET` to the ztmf#433 endpoint when that lands (see SWAP
- * POINT above). Async so callers already await it and the swap is invisible.
+ * Reads the system-attribute vocabulary for a component: empty until the
+ * fetch resolves (selects render their current value in the meantime), then
+ * the served rows. Kept as a hook so each consumer gets it without threading.
  *
- * @param _signal - Reserved for the real fetch's AbortSignal; unused today.
- * @returns The allowed values per field.
+ * @returns The current attribute rows.
  */
-export async function fetchSystemMetadataVocab(
-  _signal?: AbortSignal
-): Promise<SystemMetadataVocab> {
-  return SYSTEM_METADATA_VOCAB
-}
-
-/**
- * Reads the metadata vocabulary for a component. Seeded with the local
- * canonical set so selects render correctly on first paint, then refreshed
- * from `fetchSystemMetadataVocab` (a no-op today, a network read once ztmf#433
- * ships). Kept as a hook so every consumer gets the swap for free.
- *
- * @returns The current vocabulary.
- */
-export function useSystemMetadataVocab(): SystemMetadataVocab {
-  const [vocab, setVocab] = useState<SystemMetadataVocab>(SYSTEM_METADATA_VOCAB)
+export function useSystemAttributes(): SystemAttribute[] {
+  const [rows, setRows] = useState<SystemAttribute[]>([])
   useEffect(() => {
     const controller = new AbortController()
-    fetchSystemMetadataVocab(controller.signal)
-      .then((v) => {
-        if (!controller.signal.aborted) setVocab(v)
+    fetchSystemAttributes(controller.signal)
+      .then((r) => {
+        if (!controller.signal.aborted) setRows(r)
       })
       .catch(() => {
-        // Non-fatal: fall back to the seeded canonical set.
+        // Non-fatal: an empty vocab just means no dropdown options yet.
       })
     return () => controller.abort()
   }, [])
-  return vocab
+  return rows
 }
 
-export type SelectOption = {
-  value: string
-  label: string
-  disabled?: boolean
-}
+export type SelectOption = { value: string; label: string }
 
 /**
- * Single-select options for a field, preserving the system's current value
- * when it is not in the served set (a legacy/unmapped value). Without this,
- * editing such a system would show a blank select and drop the value on save.
- * The current value is appended as a disabled option so it renders and stays
- * valid but cannot be re-picked - the same pattern as
- * `toDropdownOptionsWithCurrent` for datacenter environments.
+ * Dropdown options for a single field: its selectable rows in display order.
+ * Off-canon values can no longer be stored (the backend CHECK-constrains these
+ * columns), so there is no legacy-value preservation to do.
  *
- * @param allowed - Canonical values for the field.
- * @param current - The system's stored value (may be null/unset/legacy).
- * @returns Options in display order, with a trailing disabled legacy option
- *   when needed.
+ * @param rows - All attribute rows from the endpoint.
+ * @param field - The field key ("fips", "system_type", "cloud_service_model", ...).
+ * @returns The field's options, ordered by `ordr`.
  */
-export function toSelectOptionsWithCurrent(
-  allowed: string[],
-  current: string | null | undefined
+export function optionsForField(
+  rows: SystemAttribute[],
+  field: string
 ): SelectOption[] {
-  const options: SelectOption[] = allowed.map((v) => ({ value: v, label: v }))
-  if (current && !allowed.includes(current)) {
-    options.push({ value: current, label: current, disabled: true })
+  return rows
+    .filter((r) => r.field === field && r.selectable)
+    .sort((a, b) => a.ordr - b.ordr)
+    .map((r) => ({ value: r.value, label: r.value }))
+}
+
+// Tri-state boolean control. The select values are strings ('' for Unknown)
+// because a MUI Select value must be a string; boolToSelectValue /
+// selectValueToBool convert to and from the wire boolean|null.
+export const BOOLEAN_OPTIONS: SelectOption[] = [
+  { value: 'true', label: 'Yes' },
+  { value: 'false', label: 'No' },
+  { value: '', label: 'Unknown' },
+]
+
+/**
+ * Maps a tri-state boolean to its select value ('' = Unknown).
+ */
+export function boolToSelectValue(v: boolean | null | undefined): string {
+  if (v === true) return 'true'
+  if (v === false) return 'false'
+  return ''
+}
+
+/**
+ * Maps a boolean select value back to the wire boolean|null (Unknown -> null).
+ */
+export function selectValueToBool(v: string): boolean | null {
+  if (v === 'true') return true
+  if (v === 'false') return false
+  return null
+}
+
+/**
+ * Display label for a tri-state boolean (read view / table).
+ */
+export function formatBool(v: boolean | null | undefined): string {
+  if (v === true) return 'Yes'
+  if (v === false) return 'No'
+  return 'Unknown'
+}
+
+/**
+ * Display label for a decomposed multi-select value.
+ *
+ * @param v - The stored parts, or null.
+ * @returns The parts joined for display, or an em-dash when empty.
+ */
+export function formatList(v: string[] | null | undefined): string {
+  return v && v.length > 0 ? v.join(', ') : '—'
+}
+
+/**
+ * Whether two extended-field values are equal, for building a dirty-diff PUT.
+ * Arrays compare order-insensitively (selection order is not meaningful);
+ * null and undefined are treated as the same "unset". Used to send only the
+ * fields the user actually changed - the backend reads an omitted field as
+ * "leave unchanged" and the per-type clear signal (enum '', boolean null,
+ * array []) as "clear".
+ *
+ * @param a - One value.
+ * @param b - The other value.
+ * @returns True when they represent the same stored value.
+ */
+/**
+ * Builds the dirty-diff of extended-metadata fields for a write payload: every
+ * field whose edited value differs from the baseline, at its typed value (an
+ * unset value normalizes to null). Unchanged fields are omitted so the backend
+ * leaves them untouched, while a per-type clear signal (enum '', boolean null,
+ * array []) passes through as the user's clear. On create, pass an empty
+ * baseline so only the fields the user set are sent.
+ *
+ * @param edited - The edited system.
+ * @param baseline - The system to diff against (the loaded system, or an empty
+ *   one when creating); a missing baseline treats every field as unset.
+ * @param keys - The extended-metadata field keys to consider.
+ * @returns A partial payload containing only the changed fields.
+ */
+export function buildExtendedDiff(
+  edited: FismaSystemType,
+  baseline: Partial<FismaSystemType> | null | undefined,
+  keys: (keyof FismaSystemType)[]
+): Partial<FismaSystemType> {
+  const diff: Partial<FismaSystemType> = {}
+  for (const key of keys) {
+    if (!extendedFieldEqual(edited[key], baseline?.[key])) {
+      ;(diff as Record<string, unknown>)[key] = edited[key] ?? null
+    }
   }
-  return options
+  return diff
 }
 
 /**
- * Splits a stored `cloud_service_model` combo into its parts. Tolerates the
- * legacy delimiters seen in the raw data (slash, comma, semicolon) so an
- * un-canonicalized value still populates the multi-select.
+ * Extra field clears that an extended-field edit forces on its dependents.
+ * A system that is not a cloud system has no service model or vendor, so
+ * setting cloud_system to No clears both to their per-type signal (array []
+ * and enum ''). Merge the result into the edited system alongside the edit.
  *
- * @param value - The stored combo (e.g. "IaaS/PaaS"), possibly null.
- * @returns The parts, or an empty array when unset.
+ * @param key - The field being changed.
+ * @param value - Its new value.
+ * @returns The dependent fields to clear (empty when no cascade applies).
  */
-export function parseCombo(value: string | null | undefined): string[] {
-  if (!value) return []
-  return value
-    .split(/[/,;]/)
-    .map((p) => p.trim())
-    .filter(Boolean)
+export function crossFieldClears(
+  key: string,
+  value: unknown
+): Partial<FismaSystemType> {
+  if (key === 'cloud_system' && value === false) {
+    return { cloud_service_model: [], cloud_vendor: '' }
+  }
+  return {}
 }
 
 /**
- * Joins multi-select parts back into the stored combo: de-duplicated and
- * sorted so the same selection always serializes to the same string (the
- * canonical storage shape on ztmf#395). Empty selection serializes to null so
- * an unset value stays unset rather than becoming "".
+ * Whether a field is hidden by a cross-field rule given the current system
+ * state. cloud_service_model and cloud_vendor only apply to cloud systems, so
+ * they are hidden (and cleared by crossFieldClears) while cloud_system is No.
  *
- * @param parts - The selected parts.
- * @returns The sorted slash-joined combo, or null when empty.
+ * @param key - The field to test.
+ * @param system - The current edited system.
+ * @returns True when the field should not be rendered.
  */
-export function serializeCombo(parts: string[]): string | null {
-  const unique = Array.from(new Set(parts.map((p) => p.trim()).filter(Boolean)))
-  if (unique.length === 0) return null
-  return unique.sort().join('/')
+export function isCrossFieldHidden(
+  key: string,
+  system: Pick<FismaSystemType, 'cloud_system'>
+): boolean {
+  return (
+    (key === 'cloud_service_model' || key === 'cloud_vendor') &&
+    system.cloud_system === false
+  )
 }
 
-/**
- * Multi-select options for `cloud_service_model`: the canonical parts plus any
- * current part not in the canon (so a legacy combo's odd part still shows and
- * is not silently dropped on save).
- *
- * @param allowed - Canonical parts.
- * @param currentParts - Parts parsed from the stored value.
- * @returns The union, canonical parts first.
- */
-export function multiSelectOptionsWithCurrent(
-  allowed: string[],
-  currentParts: string[]
-): string[] {
-  const extras = currentParts.filter((p) => !allowed.includes(p))
-  return [...allowed, ...extras]
+export function extendedFieldEqual(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) || Array.isArray(b)) {
+    const aa = Array.isArray(a) ? [...a].sort() : []
+    const bb = Array.isArray(b) ? [...b].sort() : []
+    return aa.length === bb.length && aa.every((v, i) => v === bb[i])
+  }
+  return (a ?? null) === (b ?? null)
 }

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -1,0 +1,144 @@
+// Coverage for the Add/Edit modal's extended-metadata clearing. The key
+// regression: picking "None" on an enum select must persist as an empty string
+// (the backend's blankToNil clears on '' and treats null as "leave unchanged"),
+// and the save must send a dirty-diff of only the changed field.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MockAdapter from 'axios-mock-adapter'
+import EditSystemModal from './EditSystemModal'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+afterEach(() => mock.reset())
+// The modal fetches the OpDiv reference list on open; a bare response keeps the
+// form out of its loading state.
+beforeEach(() =>
+  mock.onGet('/opdivs').reply(200, { data: [{ opdiv_id: 1, name: 'CMS' }] })
+)
+
+const SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Executor',
+  fismaacronym: 'EXEC',
+  fismauid: 'UID-42',
+  component: 'CMS',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: 'admiral.piett@executor.empire',
+  datacallcontact: 'captain.needa@executor.empire',
+  opdiv_id: 1,
+  sdl_sync_enabled: false,
+  fips: 'Low',
+  hva: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+test('clearing an enum select to None saves an empty string, not null', async () => {
+  mock.onGet('/systemattributes').reply(200, {
+    data: [
+      {
+        field: 'fips',
+        value: 'Low',
+        description: null,
+        selectable: true,
+        ordr: 10,
+      },
+      {
+        field: 'fips',
+        value: 'High',
+        description: null,
+        selectable: true,
+        ordr: 20,
+      },
+    ],
+  })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={SYSTEM}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  // Clear FIPS: open the select and choose the None option.
+  await user.click(
+    await screen.findByRole('combobox', { name: 'FIPS Impact Level' })
+  )
+  await user.click(await screen.findByRole('option', { name: /None/ }))
+
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // Empty string is the clear signal; null would read as "leave unchanged".
+  expect(putBody).toHaveProperty('fips', '')
+})
+
+test('an untouched extended field is omitted from the save (dirty-diff)', async () => {
+  mock.onGet('/systemattributes').reply(200, {
+    data: [
+      {
+        field: 'fips',
+        value: 'Low',
+        description: null,
+        selectable: true,
+        ordr: 10,
+      },
+    ],
+  })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={SYSTEM}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  await screen.findByRole('combobox', { name: 'FIPS Impact Level' })
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // Nothing was changed, so no extended field should be in the payload.
+  expect(putBody).not.toHaveProperty('fips')
+  expect(putBody).not.toHaveProperty('hva')
+  expect(putBody).not.toHaveProperty('cloud_service_model')
+})

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -139,3 +139,34 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
   expect(putBody).not.toHaveProperty('hva')
   expect(putBody).not.toHaveProperty('cloud_service_model')
 })
+
+test('clearing a free-text field saves an empty string, not null', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, cloud_vendor: 'AWS' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  // Cloud Vendor is free text (no email/select branch); clear it and save.
+  const input = await screen.findByRole('textbox', { name: 'Cloud Vendor' })
+  await user.clear(input)
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // '' clears via blankToNil; null would read as "leave unchanged" and the
+  // clear would silently no-op.
+  expect(putBody).toHaveProperty('cloud_vendor', '')
+})

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -59,14 +59,12 @@ test('clearing an enum select to None saves an empty string, not null', async ()
       {
         field: 'fips',
         value: 'Low',
-        description: null,
         selectable: true,
         ordr: 10,
       },
       {
         field: 'fips',
         value: 'High',
-        description: null,
         selectable: true,
         ordr: 20,
       },
@@ -109,7 +107,6 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
       {
         field: 'fips',
         value: 'Low',
-        description: null,
         selectable: true,
         ordr: 10,
       },

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -49,7 +49,7 @@ import {
 import {
   useSystemAttributes,
   optionsForField,
-  BOOLEAN_OPTIONS,
+  booleanOptions,
   boolToSelectValue,
   selectValueToBool,
   buildExtendedDiff,
@@ -195,6 +195,7 @@ export default function EditSystemModal({
           fullWidth
           disabled={disabled}
           value={current || ''}
+          helperText={field.helpText}
           InputLabelProps={{ sx: { marginTop: 0 } }}
           onChange={(e) => setField(field.key, e.target.value)}
         >
@@ -220,12 +221,13 @@ export default function EditSystemModal({
           value={boolToSelectValue(
             editedFismaSystem[field.key] as boolean | null | undefined
           )}
+          helperText={field.helpText}
           InputLabelProps={{ sx: { marginTop: 0 } }}
           onChange={(e) =>
             setField(field.key, selectValueToBool(e.target.value))
           }
         >
-          {BOOLEAN_OPTIONS.map((o) => (
+          {booleanOptions(field.booleanLabels).map((o) => (
             <MenuItem key={o.label} value={o.value}>
               {o.label}
             </MenuItem>
@@ -250,6 +252,7 @@ export default function EditSystemModal({
             multiple: true,
             renderValue: (selected) => (selected as string[]).join(', '),
           }}
+          helperText={field.helpText}
           InputLabelProps={{ sx: { marginTop: 0 } }}
           onChange={(e) =>
             setField(field.key, e.target.value as unknown as string[])
@@ -274,6 +277,7 @@ export default function EditSystemModal({
         value={
           (editedFismaSystem[field.key] as string | null | undefined) ?? ''
         }
+        helperText={field.helpText}
         InputLabelProps={{ sx: { marginTop: 0 } }}
         onChange={(e) => setField(field.key, e.target.value || null)}
       />

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -279,7 +279,10 @@ export default function EditSystemModal({
         }
         helperText={field.helpText}
         InputLabelProps={{ sx: { marginTop: 0 } }}
-        onChange={(e) => setField(field.key, e.target.value || null)}
+        // Send the raw value, so clearing sends '' (the blankToNil clear
+        // signal) rather than null, which the backend reads as "leave
+        // unchanged". Matches the detail edit view's text branch.
+        onChange={(e) => setField(field.key, e.target.value)}
       />
     )
   }

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -47,11 +47,14 @@ import {
   type FieldConfig,
 } from '@/views/SystemDetailPage/fieldConfig'
 import {
-  useSystemMetadataVocab,
-  toSelectOptionsWithCurrent,
-  parseCombo,
-  serializeCombo,
-  multiSelectOptionsWithCurrent,
+  useSystemAttributes,
+  optionsForField,
+  BOOLEAN_OPTIONS,
+  boolToSelectValue,
+  selectValueToBool,
+  buildExtendedDiff,
+  crossFieldClears,
+  isCrossFieldHidden,
 } from '@/utils/systemMetadataVocab'
 
 /**
@@ -73,7 +76,6 @@ export default function EditSystemModal({
     system?.datacenterenvironment
   )
   const extendedFields = getFieldsBySection('extended')
-  const vocab = useSystemMetadataVocab()
 
   const [formValid, setFormValid] = React.useState<FormValidType>({
     issoemail: false,
@@ -165,17 +167,24 @@ export default function EditSystemModal({
   }
   const [editedFismaSystem, setEditedFismaSystem] =
     React.useState<FismaSystemType>(EMPTY_SYSTEM)
+  const attributes = useSystemAttributes()
+
+  const setField = (key: string, value: string | boolean | string[] | null) =>
+    setEditedFismaSystem((prev) => ({
+      ...prev,
+      [key]: value,
+      ...crossFieldClears(key, value),
+    }))
 
   // Renders an extended-metadata field per its configured type: canonical
-  // single-select, cloud_service_model multi-select, or free text. Selects
-  // preserve a legacy/unmapped current value and offer a blank to clear.
+  // enum select, tri-state boolean (Yes/No/Unknown), decomposed multi-select,
+  // or free text. Each control stores the field's typed clear signal when
+  // emptied: enum '', boolean null, array [].
   const renderExtendedControl = (field: FieldConfig) => {
-    const current = editedFismaSystem[field.key] as string | null | undefined
+    // isso_name is backend-resolved, so its control is read-only.
+    const disabled = field.readOnly
     if (field.type === 'select') {
-      const options = toSelectOptionsWithCurrent(
-        (vocab as Record<string, string[]>)[field.key] ?? [],
-        current
-      )
+      const current = editedFismaSystem[field.key] as string | null | undefined
       return (
         <TextField
           id={`${mode}-${field.key}`}
@@ -184,18 +193,40 @@ export default function EditSystemModal({
           variant="standard"
           margin="normal"
           fullWidth
+          disabled={disabled}
           value={current || ''}
           InputLabelProps={{ sx: { marginTop: 0 } }}
-          onChange={(e) =>
-            setEditedFismaSystem((prev) => ({
-              ...prev,
-              [field.key]: e.target.value || null,
-            }))
-          }
+          onChange={(e) => setField(field.key, e.target.value)}
         >
           <MenuItem value="">&mdash; None &mdash;</MenuItem>
-          {options.map((o) => (
-            <MenuItem key={o.value} value={o.value} disabled={o.disabled}>
+          {optionsForField(attributes, field.key).map((o) => (
+            <MenuItem key={o.value} value={o.value}>
+              {o.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      )
+    }
+    if (field.type === 'boolean') {
+      return (
+        <TextField
+          id={`${mode}-${field.key}`}
+          select
+          label={field.label}
+          variant="standard"
+          margin="normal"
+          fullWidth
+          disabled={disabled}
+          value={boolToSelectValue(
+            editedFismaSystem[field.key] as boolean | null | undefined
+          )}
+          InputLabelProps={{ sx: { marginTop: 0 } }}
+          onChange={(e) =>
+            setField(field.key, selectValueToBool(e.target.value))
+          }
+        >
+          {BOOLEAN_OPTIONS.map((o) => (
+            <MenuItem key={o.label} value={o.value}>
               {o.label}
             </MenuItem>
           ))}
@@ -203,11 +234,8 @@ export default function EditSystemModal({
       )
     }
     if (field.type === 'multiselect') {
-      const currentParts = parseCombo(current)
-      const options = multiSelectOptionsWithCurrent(
-        (vocab as Record<string, string[]>)[field.key] ?? [],
-        currentParts
-      )
+      const current =
+        (editedFismaSystem[field.key] as string[] | null | undefined) ?? []
       return (
         <TextField
           id={`${mode}-${field.key}`}
@@ -216,23 +244,20 @@ export default function EditSystemModal({
           variant="standard"
           margin="normal"
           fullWidth
-          value={currentParts}
+          disabled={disabled}
+          value={current}
           SelectProps={{
             multiple: true,
             renderValue: (selected) => (selected as string[]).join(', '),
           }}
           InputLabelProps={{ sx: { marginTop: 0 } }}
-          onChange={(e) => {
-            const parts = e.target.value as unknown as string[]
-            setEditedFismaSystem((prev) => ({
-              ...prev,
-              [field.key]: serializeCombo(parts),
-            }))
-          }}
+          onChange={(e) =>
+            setField(field.key, e.target.value as unknown as string[])
+          }
         >
-          {options.map((opt) => (
-            <MenuItem key={opt} value={opt}>
-              {opt}
+          {optionsForField(attributes, field.key).map((o) => (
+            <MenuItem key={o.value} value={o.value}>
+              {o.label}
             </MenuItem>
           ))}
         </TextField>
@@ -245,15 +270,12 @@ export default function EditSystemModal({
         variant="standard"
         margin="normal"
         fullWidth
-        disabled={field.readOnly}
-        value={current ?? ''}
-        InputLabelProps={{ sx: { marginTop: 0 } }}
-        onChange={(e) =>
-          setEditedFismaSystem((prev) => ({
-            ...prev,
-            [field.key]: e.target.value || null,
-          }))
+        disabled={disabled}
+        value={
+          (editedFismaSystem[field.key] as string | null | undefined) ?? ''
         }
+        InputLabelProps={{ sx: { marginTop: 0 } }}
+        onChange={(e) => setField(field.key, e.target.value || null)}
       />
     )
   }
@@ -379,12 +401,13 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
           opdiv_id: editedFismaSystem.opdiv_id,
         }
-        // Extended metadata fields are editable across all OpDivs; send each,
-        // using null to leave a value unchanged (the backend writes only
-        // non-null fields, so imported data isn't clobbered).
-        for (const key of EXTENDED_METADATA_KEYS) {
-          editBody[key] = editedFismaSystem[key] ?? null
-        }
+        // Extended metadata: dirty-diff. Omitted = leave unchanged; a field's
+        // per-type clear signal (enum '', boolean null, array []) = clear. Send
+        // only the fields the user changed from the loaded system.
+        Object.assign(
+          editBody,
+          buildExtendedDiff(editedFismaSystem, system, EXTENDED_METADATA_KEYS)
+        )
         await axiosInstance.put(
           `fismasystems/${editedFismaSystem.fismasystemid}`,
           editBody
@@ -427,9 +450,16 @@ export default function EditSystemModal({
           sdl_sync_enabled: editedFismaSystem.sdl_sync_enabled ?? false,
           opdiv_id: editedFismaSystem.opdiv_id,
         }
-        for (const key of EXTENDED_METADATA_KEYS) {
-          body[key] = editedFismaSystem[key] ?? null
-        }
+        // Create: no prior system, so send only the extended fields the user
+        // actually set (diff against the empty baseline).
+        Object.assign(
+          body,
+          buildExtendedDiff(
+            editedFismaSystem,
+            EMPTY_SYSTEM as FismaSystemType,
+            EXTENDED_METADATA_KEYS
+          )
+        )
         await axiosInstance.post(`fismasystems`, body)
         notify(STATUS_MESSAGES.created, 'success', { autoHideDuration: 1500 })
         onClose(editedFismaSystem)
@@ -1318,11 +1348,16 @@ export default function EditSystemModal({
                         : EXTENDED_METADATA_EDIT_HINT}
                     </Typography>
                     <Grid container spacing={2}>
-                      {extendedFields.map((field) => (
-                        <Grid item xs={12} sm={6} md={4} key={field.key}>
-                          {renderExtendedControl(field)}
-                        </Grid>
-                      ))}
+                      {extendedFields
+                        .filter(
+                          (field) =>
+                            !isCrossFieldHidden(field.key, editedFismaSystem)
+                        )
+                        .map((field) => (
+                          <Grid item xs={12} sm={6} md={4} key={field.key}>
+                            {renderExtendedControl(field)}
+                          </Grid>
+                        ))}
                     </Grid>
                   </Box>
                 </Grid>

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -44,7 +44,15 @@ import type { OpDiv } from '@/types'
 import {
   getFieldsBySection,
   EXTENDED_METADATA_KEYS,
+  type FieldConfig,
 } from '@/views/SystemDetailPage/fieldConfig'
+import {
+  useSystemMetadataVocab,
+  toSelectOptionsWithCurrent,
+  parseCombo,
+  serializeCombo,
+  multiSelectOptionsWithCurrent,
+} from '@/utils/systemMetadataVocab'
 
 /**
  * Component that renders a modal to edit fisma systems.
@@ -65,6 +73,7 @@ export default function EditSystemModal({
     system?.datacenterenvironment
   )
   const extendedFields = getFieldsBySection('extended')
+  const vocab = useSystemMetadataVocab()
 
   const [formValid, setFormValid] = React.useState<FormValidType>({
     issoemail: false,
@@ -156,6 +165,99 @@ export default function EditSystemModal({
   }
   const [editedFismaSystem, setEditedFismaSystem] =
     React.useState<FismaSystemType>(EMPTY_SYSTEM)
+
+  // Renders an extended-metadata field per its configured type: canonical
+  // single-select, cloud_service_model multi-select, or free text. Selects
+  // preserve a legacy/unmapped current value and offer a blank to clear.
+  const renderExtendedControl = (field: FieldConfig) => {
+    const current = editedFismaSystem[field.key] as string | null | undefined
+    if (field.type === 'select') {
+      const options = toSelectOptionsWithCurrent(
+        (vocab as Record<string, string[]>)[field.key] ?? [],
+        current
+      )
+      return (
+        <TextField
+          id={`${mode}-${field.key}`}
+          select
+          label={field.label}
+          variant="standard"
+          margin="normal"
+          fullWidth
+          value={current || ''}
+          InputLabelProps={{ sx: { marginTop: 0 } }}
+          onChange={(e) =>
+            setEditedFismaSystem((prev) => ({
+              ...prev,
+              [field.key]: e.target.value || null,
+            }))
+          }
+        >
+          <MenuItem value="">&mdash; None &mdash;</MenuItem>
+          {options.map((o) => (
+            <MenuItem key={o.value} value={o.value} disabled={o.disabled}>
+              {o.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      )
+    }
+    if (field.type === 'multiselect') {
+      const currentParts = parseCombo(current)
+      const options = multiSelectOptionsWithCurrent(
+        (vocab as Record<string, string[]>)[field.key] ?? [],
+        currentParts
+      )
+      return (
+        <TextField
+          id={`${mode}-${field.key}`}
+          select
+          label={field.label}
+          variant="standard"
+          margin="normal"
+          fullWidth
+          value={currentParts}
+          SelectProps={{
+            multiple: true,
+            renderValue: (selected) => (selected as string[]).join(', '),
+          }}
+          InputLabelProps={{ sx: { marginTop: 0 } }}
+          onChange={(e) => {
+            const parts = e.target.value as unknown as string[]
+            setEditedFismaSystem((prev) => ({
+              ...prev,
+              [field.key]: serializeCombo(parts),
+            }))
+          }}
+        >
+          {options.map((opt) => (
+            <MenuItem key={opt} value={opt}>
+              {opt}
+            </MenuItem>
+          ))}
+        </TextField>
+      )
+    }
+    return (
+      <TextField
+        id={`${mode}-${field.key}`}
+        label={field.label}
+        variant="standard"
+        margin="normal"
+        fullWidth
+        disabled={field.readOnly}
+        value={current ?? ''}
+        InputLabelProps={{ sx: { marginTop: 0 } }}
+        onChange={(e) =>
+          setEditedFismaSystem((prev) => ({
+            ...prev,
+            [field.key]: e.target.value || null,
+          }))
+        }
+      />
+    )
+  }
+
   React.useEffect(() => {
     if (system && open) {
       setFormValid((prevState) => ({
@@ -1218,27 +1320,7 @@ export default function EditSystemModal({
                     <Grid container spacing={2}>
                       {extendedFields.map((field) => (
                         <Grid item xs={12} sm={6} md={4} key={field.key}>
-                          <TextField
-                            id={`${mode}-${field.key}`}
-                            label={field.label}
-                            variant="standard"
-                            margin="normal"
-                            fullWidth
-                            disabled={field.readOnly}
-                            value={
-                              (editedFismaSystem[field.key] as
-                                | string
-                                | null
-                                | undefined) ?? ''
-                            }
-                            InputLabelProps={{ sx: { marginTop: 0 } }}
-                            onChange={(e) => {
-                              setEditedFismaSystem((prevState) => ({
-                                ...prevState,
-                                [field.key]: e.target.value || null,
-                              }))
-                            }}
-                          />
+                          {renderExtendedControl(field)}
                         </Grid>
                       ))}
                     </Grid>

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -93,7 +93,6 @@ test('optional selects do not render in an error state on a valid form', async (
       {
         field: 'system_type',
         value: 'Major Application',
-        description: null,
         selectable: true,
         ordr: 10,
       },

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -1,54 +1,57 @@
-// Coverage for the extended-metadata selects on the system detail edit view
-// (ztmf-ui#460). The canonical vocab is served locally by
-// useSystemMetadataVocab (stopgap until ztmf#433), so only axios needs a stub.
+// Behavioral coverage for the extended-metadata edit controls: the tri-state
+// boolean select emits a typed boolean|null, and the cloud dependents lock
+// when cloud_system is No. The pure conversion/gating helpers are unit-tested
+// in utils/systemMetadataVocab.test.ts; this pins the JSX wiring.
 
-// The view imports dataCenterEnvironments -> axiosConfig, whose import.meta
-// line jest can't parse; stub it (no requests are made in these tests).
-jest.mock('@/axiosConfig', () => ({
-  __esModule: true,
-  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
-}))
+// useSystemAttributes -> axiosConfig reads import.meta.env at load and throws
+// under @swc/jest. Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
 
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import MockAdapter from 'axios-mock-adapter'
 import SystemDetailEditView from './SystemDetailEditView'
+import axiosInstance from '@/axiosConfig'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
-import type {
-  FismaSystemType,
-  FormValidType,
-  FormValidHelperText,
-} from '@/types'
+import type { FismaSystemType } from '@/types'
 
-// Any field reads valid so the test focuses on select behavior, not error UI.
-const allValid = new Proxy({}, { get: () => true }) as unknown as FormValidType
-const noErrors = new Proxy(
-  {},
-  { get: () => '' }
-) as unknown as FormValidHelperText
+const mock = new MockAdapter(axiosInstance)
+afterEach(() => mock.reset())
 
-function renderEdit(overrides: Partial<FismaSystemType> = {}) {
-  const edited = {
-    fismasystemid: 1,
-    fismaname: 'Test System',
-    fismaacronym: 'TS',
-    fismauid: 'uid',
-    component: 'C',
-    datacenterenvironment: 'AWS',
-    decommissioned: false,
-    sdl_sync_enabled: null,
-    system_type: 'Enterprise',
-    cloud_service_model: 'IaaS/PaaS',
-    legacy: 'Maybe', // deliberately non-canonical (legacy value)
-    ...overrides,
-  } as unknown as FismaSystemType
+const BASE_SYSTEM = {
+  fismasystemid: 1,
+  fismaname: 'Test System',
+  fismaacronym: 'TS',
+  fismauid: 'UID-1',
+  component: 'CMS',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: 'isso@example.gov',
+  datacallcontact: 'dcc@example.gov',
+  decommissioned: false,
+  sdl_sync_enabled: null,
+  hva: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  legacy: null,
+} as unknown as FismaSystemType
 
+/**
+ * Renders the edit view with no-op handlers, overriding just the pieces a test
+ * cares about. Returns the onFieldChange spy for asserting emitted values.
+ */
+function renderEditView(editedOverrides: Partial<FismaSystemType> = {}) {
   const onFieldChange = jest.fn()
+  const editedSystem = { ...BASE_SYSTEM, ...editedOverrides } as FismaSystemType
   renderWithProviders(
     <SystemDetailEditView
-      system={edited}
-      editedSystem={edited}
-      formValid={allValid}
-      formValidErrorText={noErrors}
+      system={BASE_SYSTEM}
+      editedSystem={editedSystem}
+      formValid={{}}
+      formValidErrorText={{}}
       decommissionDate=""
       decommissionDateError=""
       decommissionNotes=""
@@ -76,35 +79,44 @@ function renderEdit(overrides: Partial<FismaSystemType> = {}) {
   return { onFieldChange }
 }
 
-test('a canonical field renders as a select showing its current value', () => {
-  renderEdit()
-  const systemType = screen.getByRole('combobox', { name: /system type/i })
-  expect(systemType).toHaveTextContent('Enterprise')
-})
-
-test('a legacy value not in the canon is preserved in the select', () => {
-  renderEdit()
-  // "Maybe" is not a canonical legacy value but must still display.
-  expect(screen.getByRole('combobox', { name: /^legacy/i })).toHaveTextContent(
-    'Maybe'
-  )
-})
-
-test('cloud_service_model renders as a multi-select showing its parts', () => {
-  renderEdit()
-  const model = screen.getByRole('combobox', {
-    name: /cloud service model/i,
-  })
-  expect(model).toHaveTextContent(/IaaS/)
-  expect(model).toHaveTextContent(/PaaS/)
-})
-
-test('picking a canonical option fires onFieldChange with the value', async () => {
+test('tri-state boolean select emits a typed boolean, not a string', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
   const user = userEvent.setup()
-  const { onFieldChange } = renderEdit()
+  const { onFieldChange } = renderEditView({ hva: null })
 
-  await user.click(screen.getByRole('combobox', { name: /system type/i }))
-  await user.click(await screen.findByRole('option', { name: 'Local' }))
+  await user.click(screen.getByRole('combobox', { name: 'HVA' }))
+  await user.click(screen.getByRole('option', { name: 'No' }))
 
-  expect(onFieldChange).toHaveBeenCalledWith('system_type', 'Local')
+  expect(onFieldChange).toHaveBeenCalledWith('hva', false)
+})
+
+test('setting the boolean to Unknown emits null (the clear signal)', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  const user = userEvent.setup()
+  const { onFieldChange } = renderEditView({ hva: true })
+
+  await user.click(screen.getByRole('combobox', { name: 'HVA' }))
+  await user.click(screen.getByRole('option', { name: 'Unknown' }))
+
+  expect(onFieldChange).toHaveBeenCalledWith('hva', null)
+})
+
+test('cloud dependents are hidden while cloud_system is No', () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  renderEditView({ cloud_system: false })
+
+  expect(screen.queryByLabelText('Cloud Vendor')).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole('combobox', { name: 'Cloud Service Model' })
+  ).not.toBeInTheDocument()
+})
+
+test('cloud dependents are shown while cloud_system is Yes', () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  renderEditView({ cloud_system: true })
+
+  expect(screen.getByLabelText('Cloud Vendor')).toBeInTheDocument()
+  expect(
+    screen.getByRole('combobox', { name: 'Cloud Service Model' })
+  ).toBeInTheDocument()
 })

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -1,0 +1,110 @@
+// Coverage for the extended-metadata selects on the system detail edit view
+// (ztmf-ui#460). The canonical vocab is served locally by
+// useSystemMetadataVocab (stopgap until ztmf#433), so only axios needs a stub.
+
+// The view imports dataCenterEnvironments -> axiosConfig, whose import.meta
+// line jest can't parse; stub it (no requests are made in these tests).
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SystemDetailEditView from './SystemDetailEditView'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type {
+  FismaSystemType,
+  FormValidType,
+  FormValidHelperText,
+} from '@/types'
+
+// Any field reads valid so the test focuses on select behavior, not error UI.
+const allValid = new Proxy({}, { get: () => true }) as unknown as FormValidType
+const noErrors = new Proxy(
+  {},
+  { get: () => '' }
+) as unknown as FormValidHelperText
+
+function renderEdit(overrides: Partial<FismaSystemType> = {}) {
+  const edited = {
+    fismasystemid: 1,
+    fismaname: 'Test System',
+    fismaacronym: 'TS',
+    fismauid: 'uid',
+    component: 'C',
+    datacenterenvironment: 'AWS',
+    decommissioned: false,
+    sdl_sync_enabled: null,
+    system_type: 'Enterprise',
+    cloud_service_model: 'IaaS/PaaS',
+    legacy: 'Maybe', // deliberately non-canonical (legacy value)
+    ...overrides,
+  } as unknown as FismaSystemType
+
+  const onFieldChange = jest.fn()
+  renderWithProviders(
+    <SystemDetailEditView
+      system={edited}
+      editedSystem={edited}
+      formValid={allValid}
+      formValidErrorText={noErrors}
+      decommissionDate=""
+      decommissionDateError=""
+      decommissionNotes=""
+      showDecommissionForm={false}
+      decommissionedByName=""
+      reactivationNotes=""
+      showReactivateForm={false}
+      reactivatedByName=""
+      onInputChange={jest.fn()}
+      onFieldChange={onFieldChange}
+      onValidatedFieldChange={jest.fn()}
+      onDecommissionDateChange={jest.fn()}
+      onDecommissionNotesChange={jest.fn()}
+      onShowDecommissionForm={jest.fn()}
+      onDecommissionRequest={jest.fn()}
+      onReactivationNotesChange={jest.fn()}
+      onShowReactivateForm={jest.fn()}
+      onReactivateRequest={jest.fn()}
+      validateDecommissionDate={jest.fn()}
+      onSdlSyncToggle={jest.fn()}
+      datacenterEnvironments={[]}
+      opdivName="CMS"
+    />
+  )
+  return { onFieldChange }
+}
+
+test('a canonical field renders as a select showing its current value', () => {
+  renderEdit()
+  const systemType = screen.getByRole('combobox', { name: /system type/i })
+  expect(systemType).toHaveTextContent('Enterprise')
+})
+
+test('a legacy value not in the canon is preserved in the select', () => {
+  renderEdit()
+  // "Maybe" is not a canonical legacy value but must still display.
+  expect(screen.getByRole('combobox', { name: /^legacy/i })).toHaveTextContent(
+    'Maybe'
+  )
+})
+
+test('cloud_service_model renders as a multi-select showing its parts', () => {
+  renderEdit()
+  const model = screen.getByRole('combobox', {
+    name: /cloud service model/i,
+  })
+  expect(model).toHaveTextContent(/IaaS/)
+  expect(model).toHaveTextContent(/PaaS/)
+})
+
+test('picking a canonical option fires onFieldChange with the value', async () => {
+  const user = userEvent.setup()
+  const { onFieldChange } = renderEdit()
+
+  await user.click(screen.getByRole('combobox', { name: /system type/i }))
+  await user.click(await screen.findByRole('option', { name: 'Local' }))
+
+  expect(onFieldChange).toHaveBeenCalledWith('system_type', 'Local')
+})

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -43,14 +43,17 @@ const BASE_SYSTEM = {
  * Renders the edit view with no-op handlers, overriding just the pieces a test
  * cares about. Returns the onFieldChange spy for asserting emitted values.
  */
-function renderEditView(editedOverrides: Partial<FismaSystemType> = {}) {
+function renderEditView(
+  editedOverrides: Partial<FismaSystemType> = {},
+  formValid: Record<string, boolean> = {}
+) {
   const onFieldChange = jest.fn()
   const editedSystem = { ...BASE_SYSTEM, ...editedOverrides } as FismaSystemType
   renderWithProviders(
     <SystemDetailEditView
       system={BASE_SYSTEM}
       editedSystem={editedSystem}
-      formValid={{}}
+      formValid={formValid}
       formValidErrorText={{}}
       decommissionDate=""
       decommissionDateError=""
@@ -78,6 +81,40 @@ function renderEditView(editedOverrides: Partial<FismaSystemType> = {}) {
   )
   return { onFieldChange }
 }
+
+test('optional selects do not render in an error state on a valid form', async () => {
+  // A realistic formValid: every required field is valid and the optional
+  // extended fields simply have no entry. Optional fields never get a formValid
+  // key, so without the `field.required` guard the error check reads
+  // !undefined === true and paints them all invalid. An all-valid stand-in
+  // would hide exactly that regression.
+  mock.onGet('/systemattributes').reply(200, {
+    data: [
+      {
+        field: 'system_type',
+        value: 'Major Application',
+        description: null,
+        selectable: true,
+        ordr: 10,
+      },
+    ],
+  })
+  const requiredValid = {
+    fismaname: true,
+    fismaacronym: true,
+    fismauid: true,
+    component: true,
+    datacenterenvironment: true,
+    issoemail: true,
+    datacallcontact: true,
+  }
+  renderEditView({ system_type: 'Major Application' }, requiredValid)
+
+  // Wait for the vocabulary fetch so the select renders its chosen value.
+  await screen.findByRole('combobox', { name: 'System Type' })
+  // No field on a valid form should carry MUI's error styling.
+  expect(document.querySelectorAll('.Mui-error')).toHaveLength(0)
+})
 
 test('tri-state boolean select emits a typed boolean, not a string', async () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -28,7 +28,7 @@ import { toDropdownOptionsWithCurrent } from '@/utils/dataCenterEnvironments'
 import {
   useSystemAttributes,
   optionsForField,
-  BOOLEAN_OPTIONS,
+  booleanOptions,
   boolToSelectValue,
   selectValueToBool,
   isCrossFieldHidden,
@@ -142,7 +142,7 @@ function renderEditField(
         helperText={
           field.required && !formValid[field.key]
             ? formValidErrorText[field.key]
-            : ''
+            : field.helpText ?? ''
         }
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
@@ -180,6 +180,7 @@ function renderEditField(
         )}
         fullWidth
         disabled={disabled}
+        helperText={field.helpText ?? ''}
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
         // Unknown ('') maps to null - the boolean clear signal.
@@ -187,7 +188,7 @@ function renderEditField(
           onFieldChange(field.key, selectValueToBool(e.target.value))
         }
       >
-        {BOOLEAN_OPTIONS.map((o) => (
+        {booleanOptions(field.booleanLabels).map((o) => (
           <MenuItem key={o.label} value={o.value}>
             {o.label}
           </MenuItem>
@@ -214,6 +215,7 @@ function renderEditField(
           multiple: true,
           renderValue: (selected) => (selected as string[]).join(', '),
         }}
+        helperText={field.helpText ?? ''}
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
         // Deselecting all yields [] - the array clear signal.
@@ -246,7 +248,7 @@ function renderEditField(
       helperText={
         field.required && !formValid[field.key]
           ? formValidErrorText[field.key]
-          : ''
+          : field.helpText ?? ''
       }
       InputLabelProps={{ sx: { marginTop: 0 } }}
       onChange={(e) => {

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -26,13 +26,14 @@ import {
 } from '@/views/EditSystemModal/validators'
 import { toDropdownOptionsWithCurrent } from '@/utils/dataCenterEnvironments'
 import {
-  useSystemMetadataVocab,
-  toSelectOptionsWithCurrent,
-  parseCombo,
-  serializeCombo,
-  multiSelectOptionsWithCurrent,
-  type SystemMetadataVocab,
+  useSystemAttributes,
+  optionsForField,
+  BOOLEAN_OPTIONS,
+  boolToSelectValue,
+  selectValueToBool,
+  isCrossFieldHidden,
 } from '@/utils/systemMetadataVocab'
+import type { SystemAttribute } from '@/types'
 import { getTodayISO, MAX_NOTES_LENGTH } from '@/utils/decommission'
 import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 import {
@@ -57,7 +58,12 @@ interface SystemDetailEditViewProps {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     key: string
   ) => void
-  onFieldChange: (key: string, value: string) => void
+  // Sets an extended field to its typed value: a string for enums/text, a
+  // boolean|null for the tri-state booleans, or a string[] for the multi-select.
+  onFieldChange: (
+    key: string,
+    value: string | boolean | string[] | null
+  ) => void
   onValidatedFieldChange: (key: string, isValid: boolean, value: string) => void
   onDecommissionDateChange: (value: string) => void
   onDecommissionNotesChange: (value: string) => void
@@ -80,7 +86,7 @@ interface SystemDetailEditViewProps {
 function renderEditField(
   field: FieldConfig,
   props: SystemDetailEditViewProps,
-  vocab: SystemMetadataVocab,
+  attributes: SystemAttribute[],
   disabled = false
 ) {
   const {
@@ -112,16 +118,13 @@ function renderEditField(
 
   if (field.type === 'select') {
     const current = editedSystem[field.key] as string | null | undefined
-    // datacenterenvironment draws from its own reference vocab; the extended
-    // metadata fields draw from the canonical vocab. Both preserve the current
-    // value as a disabled option when it is not in the served set.
+    // datacenterenvironment draws from its own reference vocab (and preserves a
+    // legacy value); the canonical enum fields draw from systemattributes,
+    // where off-canon values cannot occur so no preservation is needed.
     const isDataCenter = field.key === 'datacenterenvironment'
     const options = isDataCenter
       ? toDropdownOptionsWithCurrent(datacenterEnvironments, current)
-      : toSelectOptionsWithCurrent(
-          (vocab as Record<string, string[]>)[field.key] ?? [],
-          current
-        )
+      : optionsForField(attributes, field.key)
     return (
       <TextField
         key={field.key}
@@ -133,23 +136,29 @@ function renderEditField(
         value={current || ''}
         fullWidth
         disabled={disabled}
-        error={!formValid[field.key]}
-        helperText={!formValid[field.key] ? formValidErrorText[field.key] : ''}
+        // Optional fields have no formValid entry; gate the error on required
+        // so they do not render permanently invalid.
+        error={field.required && !formValid[field.key]}
+        helperText={
+          field.required && !formValid[field.key]
+            ? formValidErrorText[field.key]
+            : ''
+        }
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
         onChange={(e) =>
           field.required
             ? onInputChange(e, field.key)
-            : onFieldChange(field.key, e.target.value)
+            : // enum clear signal is '' so the backend's blankToNil nulls it.
+              onFieldChange(field.key, e.target.value)
         }
       >
-        {/* Optional fields offer a blank option so a value can be cleared. */}
         {!field.required && <MenuItem value="">&mdash; None &mdash;</MenuItem>}
         {options.map((option) => (
           <MenuItem
             key={option.value}
             value={option.value}
-            disabled={option.disabled}
+            disabled={(option as { disabled?: boolean }).disabled}
           >
             {option.label}
           </MenuItem>
@@ -158,12 +167,7 @@ function renderEditField(
     )
   }
 
-  if (field.type === 'multiselect') {
-    const currentParts = parseCombo(editedSystem[field.key] as string | null)
-    const options = multiSelectOptionsWithCurrent(
-      (vocab as Record<string, string[]>)[field.key] ?? [],
-      currentParts
-    )
+  if (field.type === 'boolean') {
     return (
       <TextField
         key={field.key}
@@ -171,7 +175,39 @@ function renderEditField(
         select
         label={field.label}
         variant="standard"
-        value={currentParts}
+        value={boolToSelectValue(
+          editedSystem[field.key] as boolean | null | undefined
+        )}
+        fullWidth
+        disabled={disabled}
+        InputLabelProps={{ sx: { marginTop: 0 } }}
+        sx={{ mt: 2 }}
+        // Unknown ('') maps to null - the boolean clear signal.
+        onChange={(e) =>
+          onFieldChange(field.key, selectValueToBool(e.target.value))
+        }
+      >
+        {BOOLEAN_OPTIONS.map((o) => (
+          <MenuItem key={o.label} value={o.value}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    )
+  }
+
+  if (field.type === 'multiselect') {
+    const current =
+      (editedSystem[field.key] as string[] | null | undefined) ?? []
+    const options = optionsForField(attributes, field.key)
+    return (
+      <TextField
+        key={field.key}
+        id={`edit-${field.key}`}
+        select
+        label={field.label}
+        variant="standard"
+        value={current}
         fullWidth
         disabled={disabled}
         SelectProps={{
@@ -180,14 +216,14 @@ function renderEditField(
         }}
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
-        onChange={(e) => {
-          const parts = e.target.value as unknown as string[]
-          onFieldChange(field.key, serializeCombo(parts) ?? '')
-        }}
+        // Deselecting all yields [] - the array clear signal.
+        onChange={(e) =>
+          onFieldChange(field.key, e.target.value as unknown as string[])
+        }
       >
-        {options.map((opt) => (
-          <MenuItem key={opt} value={opt}>
-            {opt}
+        {options.map((o) => (
+          <MenuItem key={o.value} value={o.value}>
+            {o.label}
           </MenuItem>
         ))}
       </TextField>
@@ -350,10 +386,10 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
     onSdlSyncToggle,
     targetMaturitySlot,
   } = props
-  const vocab = useSystemMetadataVocab()
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
   const contactFields = getFieldsBySection('contacts')
+  const attributes = useSystemAttributes()
   const extendedFields = getFieldsBySection('extended')
 
   return (
@@ -375,7 +411,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
           />
           <CardContent>
             {identityFields.map((field) =>
-              renderEditField(field, props, vocab)
+              renderEditField(field, props, attributes)
             )}
           </CardContent>
         </Card>
@@ -593,7 +629,9 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
               InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
               value={props.opdivName ?? ''}
             />
-            {orgFields.map((field) => renderEditField(field, props, vocab))}
+            {orgFields.map((field) =>
+              renderEditField(field, props, attributes)
+            )}
           </CardContent>
         </Card>
       </Grid>
@@ -610,7 +648,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             <Grid container spacing={3}>
               {contactFields.map((field) => (
                 <Grid item xs={12} sm={6} key={field.key}>
-                  {renderEditField(field, props, vocab)}
+                  {renderEditField(field, props, attributes)}
                 </Grid>
               ))}
             </Grid>
@@ -632,11 +670,13 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
           />
           <CardContent>
             <Grid container spacing={3}>
-              {extendedFields.map((field) => (
-                <Grid item xs={12} sm={6} md={4} key={field.key}>
-                  {renderEditField(field, props, vocab, field.readOnly)}
-                </Grid>
-              ))}
+              {extendedFields
+                .filter((field) => !isCrossFieldHidden(field.key, editedSystem))
+                .map((field) => (
+                  <Grid item xs={12} sm={6} md={4} key={field.key}>
+                    {renderEditField(field, props, attributes, field.readOnly)}
+                  </Grid>
+                ))}
             </Grid>
           </CardContent>
         </Card>

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -25,6 +25,14 @@ import {
   optionalEmailValidator,
 } from '@/views/EditSystemModal/validators'
 import { toDropdownOptionsWithCurrent } from '@/utils/dataCenterEnvironments'
+import {
+  useSystemMetadataVocab,
+  toSelectOptionsWithCurrent,
+  parseCombo,
+  serializeCombo,
+  multiSelectOptionsWithCurrent,
+  type SystemMetadataVocab,
+} from '@/utils/systemMetadataVocab'
 import { getTodayISO, MAX_NOTES_LENGTH } from '@/utils/decommission'
 import SdlSyncToggle from '@/components/SdlSyncToggle/SdlSyncToggle'
 import {
@@ -72,6 +80,7 @@ interface SystemDetailEditViewProps {
 function renderEditField(
   field: FieldConfig,
   props: SystemDetailEditViewProps,
+  vocab: SystemMetadataVocab,
   disabled = false
 ) {
   const {
@@ -79,6 +88,7 @@ function renderEditField(
     formValid,
     formValidErrorText,
     onInputChange,
+    onFieldChange,
     onValidatedFieldChange,
     datacenterEnvironments,
   } = props
@@ -101,6 +111,17 @@ function renderEditField(
   }
 
   if (field.type === 'select') {
+    const current = editedSystem[field.key] as string | null | undefined
+    // datacenterenvironment draws from its own reference vocab; the extended
+    // metadata fields draw from the canonical vocab. Both preserve the current
+    // value as a disabled option when it is not in the served set.
+    const isDataCenter = field.key === 'datacenterenvironment'
+    const options = isDataCenter
+      ? toDropdownOptionsWithCurrent(datacenterEnvironments, current)
+      : toSelectOptionsWithCurrent(
+          (vocab as Record<string, string[]>)[field.key] ?? [],
+          current
+        )
     return (
       <TextField
         key={field.key}
@@ -109,25 +130,64 @@ function renderEditField(
         required={field.required}
         label={field.label}
         variant="standard"
-        value={editedSystem[field.key] || ''}
+        value={current || ''}
         fullWidth
         disabled={disabled}
         error={!formValid[field.key]}
         helperText={!formValid[field.key] ? formValidErrorText[field.key] : ''}
         InputLabelProps={{ sx: { marginTop: 0 } }}
         sx={{ mt: 2 }}
-        onChange={(e) => onInputChange(e, field.key)}
+        onChange={(e) =>
+          field.required
+            ? onInputChange(e, field.key)
+            : onFieldChange(field.key, e.target.value)
+        }
       >
-        {toDropdownOptionsWithCurrent(
-          datacenterEnvironments,
-          editedSystem[field.key] as string | null | undefined
-        ).map((option) => (
+        {/* Optional fields offer a blank option so a value can be cleared. */}
+        {!field.required && <MenuItem value="">&mdash; None &mdash;</MenuItem>}
+        {options.map((option) => (
           <MenuItem
             key={option.value}
             value={option.value}
             disabled={option.disabled}
           >
             {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    )
+  }
+
+  if (field.type === 'multiselect') {
+    const currentParts = parseCombo(editedSystem[field.key] as string | null)
+    const options = multiSelectOptionsWithCurrent(
+      (vocab as Record<string, string[]>)[field.key] ?? [],
+      currentParts
+    )
+    return (
+      <TextField
+        key={field.key}
+        id={`edit-${field.key}`}
+        select
+        label={field.label}
+        variant="standard"
+        value={currentParts}
+        fullWidth
+        disabled={disabled}
+        SelectProps={{
+          multiple: true,
+          renderValue: (selected) => (selected as string[]).join(', '),
+        }}
+        InputLabelProps={{ sx: { marginTop: 0 } }}
+        sx={{ mt: 2 }}
+        onChange={(e) => {
+          const parts = e.target.value as unknown as string[]
+          onFieldChange(field.key, serializeCombo(parts) ?? '')
+        }}
+      >
+        {options.map((opt) => (
+          <MenuItem key={opt} value={opt}>
+            {opt}
           </MenuItem>
         ))}
       </TextField>
@@ -290,6 +350,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
     onSdlSyncToggle,
     targetMaturitySlot,
   } = props
+  const vocab = useSystemMetadataVocab()
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
   const contactFields = getFieldsBySection('contacts')
@@ -313,7 +374,9 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             sx={{ pb: 0 }}
           />
           <CardContent>
-            {identityFields.map((field) => renderEditField(field, props))}
+            {identityFields.map((field) =>
+              renderEditField(field, props, vocab)
+            )}
           </CardContent>
         </Card>
       </Grid>
@@ -530,7 +593,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
               InputLabelProps={{ shrink: true, sx: { marginTop: 0 } }}
               value={props.opdivName ?? ''}
             />
-            {orgFields.map((field) => renderEditField(field, props))}
+            {orgFields.map((field) => renderEditField(field, props, vocab))}
           </CardContent>
         </Card>
       </Grid>
@@ -547,7 +610,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             <Grid container spacing={3}>
               {contactFields.map((field) => (
                 <Grid item xs={12} sm={6} key={field.key}>
-                  {renderEditField(field, props)}
+                  {renderEditField(field, props, vocab)}
                 </Grid>
               ))}
             </Grid>
@@ -571,7 +634,7 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             <Grid container spacing={3}>
               {extendedFields.map((field) => (
                 <Grid item xs={12} sm={6} md={4} key={field.key}>
-                  {renderEditField(field, props, field.readOnly)}
+                  {renderEditField(field, props, vocab, field.readOnly)}
                 </Grid>
               ))}
             </Grid>

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -394,9 +394,16 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
 
   return (
     <Grid container spacing={3}>
-      {/* System Identity */}
-      <Grid item xs={12} md={7}>
-        <Card variant="outlined">
+      {/* Left column: System Identity, then Contacts. Contacts fills the
+          vertical space the taller right column would otherwise leave blank,
+          matching the read view. */}
+      <Grid
+        item
+        xs={12}
+        md={7}
+        sx={{ display: 'flex', flexDirection: 'column' }}
+      >
+        <Card variant="outlined" sx={{ mb: 3 }}>
           <CardHeader
             title="System Identity"
             titleTypographyProps={{ variant: 'h6' }}
@@ -413,6 +420,22 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             {identityFields.map((field) =>
               renderEditField(field, props, attributes)
             )}
+          </CardContent>
+        </Card>
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardHeader
+            title="Contacts"
+            titleTypographyProps={{ variant: 'h6' }}
+            sx={{ pb: 0 }}
+          />
+          <CardContent>
+            <Grid container spacing={3}>
+              {contactFields.map((field) => (
+                <Grid item xs={12} key={field.key}>
+                  {renderEditField(field, props, attributes)}
+                </Grid>
+              ))}
+            </Grid>
           </CardContent>
         </Card>
       </Grid>
@@ -632,26 +655,6 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
             {orgFields.map((field) =>
               renderEditField(field, props, attributes)
             )}
-          </CardContent>
-        </Card>
-      </Grid>
-
-      {/* Contacts — full width, fields horizontal */}
-      <Grid item xs={12}>
-        <Card variant="outlined">
-          <CardHeader
-            title="Contacts"
-            titleTypographyProps={{ variant: 'h6' }}
-            sx={{ pb: 0 }}
-          />
-          <CardContent>
-            <Grid container spacing={3}>
-              {contactFields.map((field) => (
-                <Grid item xs={12} sm={6} key={field.key}>
-                  {renderEditField(field, props, attributes)}
-                </Grid>
-              ))}
-            </Grid>
           </CardContent>
         </Card>
       </Grid>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -36,6 +36,10 @@ import SystemDetailReadView from './SystemDetailReadView'
 import SystemDetailEditView from './SystemDetailEditView'
 import TargetMaturityCard from './TargetMaturityCard'
 import { EXTENDED_METADATA_KEYS } from './fieldConfig'
+import {
+  buildExtendedDiff,
+  crossFieldClears,
+} from '@/utils/systemMetadataVocab'
 import SystemEnrichmentCard from './SystemEnrichmentCard'
 import SystemDelegatesSection from './SystemDelegatesSection'
 
@@ -286,8 +290,13 @@ export default function SystemDetailPage() {
     }
   }
 
-  const handleFieldChange = (key: string, value: string) => {
-    setEditedSystem((prev) => (prev ? { ...prev, [key]: value } : prev))
+  const handleFieldChange = (
+    key: string,
+    value: string | boolean | string[] | null
+  ) => {
+    setEditedSystem((prev) =>
+      prev ? { ...prev, [key]: value, ...crossFieldClears(key, value) } : prev
+    )
   }
 
   const handleValidatedFieldChange = (
@@ -340,12 +349,13 @@ export default function SystemDetailPage() {
         issoemail: editedSystem.issoemail,
         sdl_sync_enabled: editedSystem.sdl_sync_enabled,
       }
-      // Extended metadata fields are editable across all OpDivs; send each,
-      // using null to leave a value unchanged (the backend writes only
-      // non-null fields, so imported data isn't clobbered).
-      for (const key of EXTENDED_METADATA_KEYS) {
-        putBody[key] = editedSystem[key] ?? null
-      }
+      // Extended metadata: send only the fields the user changed. The backend
+      // reads an omitted field as "leave unchanged" and a per-type clear signal
+      // (enum '', boolean null, array []) as "clear".
+      Object.assign(
+        putBody,
+        buildExtendedDiff(editedSystem, system, EXTENDED_METADATA_KEYS)
+      )
       await axiosInstance.put(
         `fismasystems/${editedSystem.fismasystemid}`,
         putBody

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -92,4 +92,17 @@ describe('extended metadata formatting', () => {
     renderWithExtended({ cloud_system: false })
     expect(screen.getByText('Cloud System')).toBeInTheDocument()
   })
+
+  test('hides the cloud dependents when cloud_system is No', () => {
+    // Cloud service model and vendor do not apply to a non-cloud system, so the
+    // read view omits them just as the edit view does.
+    renderWithExtended({
+      cloud_system: false,
+      cloud_vendor: 'AWS',
+      cloud_service_model: ['IaaS'],
+    })
+    expect(screen.getByText('Cloud System')).toBeInTheDocument()
+    expect(screen.queryByText('Cloud Vendor')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cloud Service Model')).not.toBeInTheDocument()
+  })
 })

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -1,3 +1,11 @@
+// systemMetadataVocab (imported transitively for formatBool/formatList) loads
+// axiosConfig, which reads import.meta.env at module load and throws under
+// @swc/jest. Swap in a bare axios instance.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+
 import { screen } from '@testing-library/react'
 import SystemDetailReadView from './SystemDetailReadView'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
@@ -46,4 +54,42 @@ test('OpDiv label appears before Group Acronym in the Organization card', () => 
     opdivLabel.compareDocumentPosition(groupLabel) &
       Node.DOCUMENT_POSITION_FOLLOWING
   ).toBeTruthy()
+})
+
+function renderWithExtended(extra: Partial<FismaSystemType>) {
+  return renderWithProviders(
+    <SystemDetailReadView
+      system={{ ...BASE_SYSTEM, ...extra } as FismaSystemType}
+      decommissionedByName=""
+      opdivName="CMS"
+    />
+  )
+}
+
+describe('extended metadata formatting', () => {
+  test('renders tri-state booleans as Yes/No/Unknown, not raw values', () => {
+    renderWithExtended({ hva: true, cloud_system: false, legacy: null })
+    expect(screen.getByText('HVA')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
+    // The raw boolean shape must never reach the page.
+    expect(screen.queryByText('true')).not.toBeInTheDocument()
+    expect(screen.queryByText('false')).not.toBeInTheDocument()
+  })
+
+  test('renders a decomposed multi-select as a comma list', () => {
+    renderWithExtended({ cloud_service_model: ['IaaS', 'PaaS'] })
+    expect(screen.getByText('Cloud Service Model')).toBeInTheDocument()
+    expect(screen.getByText('IaaS, PaaS')).toBeInTheDocument()
+  })
+
+  test('hides the extended card when only an empty array is present', () => {
+    renderWithExtended({ cloud_service_model: [] })
+    expect(screen.queryByText('Cloud Service Model')).not.toBeInTheDocument()
+  })
+
+  test('shows the extended card when a boolean is explicitly No', () => {
+    renderWithExtended({ cloud_system: false })
+    expect(screen.getByText('Cloud System')).toBeInTheDocument()
+  })
 })

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -83,6 +83,16 @@ describe('extended metadata formatting', () => {
     expect(screen.getByText('IaaS, PaaS')).toBeInTheDocument()
   })
 
+  test('applies the legacy field custom boolean labels', () => {
+    // legacy is a funding disposition; its label is "Not Funded for
+    // Remediation", so true reads "Not funded" rather than a double-negative
+    // "Yes".
+    renderWithExtended({ legacy: true })
+    expect(screen.getByText('Not Funded for Remediation')).toBeInTheDocument()
+    expect(screen.getByText('Not funded')).toBeInTheDocument()
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument()
+  })
+
   test('hides the extended card when only an empty array is present', () => {
     renderWithExtended({ cloud_service_model: [] })
     expect(screen.queryByText('Cloud Service Model')).not.toBeInTheDocument()

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -16,6 +16,7 @@ import {
   EXTENDED_METADATA_SUBHEADER,
 } from '@/constants'
 import { getFieldsBySection, FieldConfig } from './fieldConfig'
+import { formatBool, formatList } from '@/utils/systemMetadataVocab'
 
 interface SystemDetailReadViewProps {
   system: FismaSystemType
@@ -43,12 +44,29 @@ function FieldDisplay({
   )
 }
 
+/**
+ * Read-view display string for a field, keyed off its configured type:
+ * tri-state booleans read as Yes/No/Unknown and decomposed multi-selects as a
+ * comma list, so the raw "true"/array shapes never leak to the page. Text,
+ * email, and single selects fall through to their stored string.
+ *
+ * @param field - The field being rendered.
+ * @param system - The system whose value to format.
+ * @returns The display string (empty string when unset; FieldDisplay shows the placeholder).
+ */
+function formatFieldValue(field: FieldConfig, system: FismaSystemType): string {
+  const raw = system[field.key]
+  if (field.type === 'boolean') return formatBool(raw as boolean | null)
+  if (field.type === 'multiselect') return formatList(raw as string[] | null)
+  return String(raw ?? '')
+}
+
 function renderFields(fields: FieldConfig[], system: FismaSystemType) {
   return fields.map((field) => (
     <FieldDisplay
       key={field.key}
       label={field.label}
-      value={String(system[field.key] ?? '')}
+      value={formatFieldValue(field, system)}
     />
   ))
 }
@@ -67,9 +85,12 @@ export default function SystemDetailReadView({
   // Systems without extended metadata have every field null and would otherwise
   // render an empty card. (Read view is not role-gated; the values are the
   // system's own metadata, visible to anyone who can view the system.)
-  const hasAnyExtendedData = extendedFields.some(
-    (field) => system[field.key] != null && system[field.key] !== ''
-  )
+  const hasAnyExtendedData = extendedFields.some((field) => {
+    const raw = system[field.key]
+    if (raw == null || raw === '') return false
+    if (Array.isArray(raw)) return raw.length > 0
+    return true
+  })
 
   return (
     <Grid container spacing={3}>
@@ -245,7 +266,7 @@ export default function SystemDetailReadView({
                   <Grid item xs={12} sm={6} md={4} key={field.key}>
                     <FieldDisplay
                       label={field.label}
-                      value={String(system[field.key] ?? '')}
+                      value={formatFieldValue(field, system)}
                     />
                   </Grid>
                 ))}

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -16,7 +16,11 @@ import {
   EXTENDED_METADATA_SUBHEADER,
 } from '@/constants'
 import { getFieldsBySection, FieldConfig } from './fieldConfig'
-import { formatBool, formatList } from '@/utils/systemMetadataVocab'
+import {
+  formatBool,
+  formatList,
+  isCrossFieldHidden,
+} from '@/utils/systemMetadataVocab'
 
 interface SystemDetailReadViewProps {
   system: FismaSystemType
@@ -80,7 +84,12 @@ export default function SystemDetailReadView({
   const identityFields = getFieldsBySection('identity')
   const orgFields = getFieldsBySection('organization')
   const contactFields = getFieldsBySection('contacts')
-  const extendedFields = getFieldsBySection('extended')
+  // cloud_service_model and cloud_vendor do not apply to a non-cloud system, so
+  // they are hidden here just as the edit view hides them when cloud_system is
+  // No (they are empty in that case anyway).
+  const extendedFields = getFieldsBySection('extended').filter(
+    (field) => !isCrossFieldHidden(field.key, system)
+  )
   // Only show the Extended Metadata card when at least one field is populated.
   // Systems without extended metadata have every field null and would otherwise
   // render an empty card. (Read view is not role-gated; the values are the

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -135,7 +135,7 @@ export default function SystemDetailReadView({
           <CardContent>
             <Grid container spacing={3}>
               {contactFields.map((field) => (
-                <Grid item xs={12} sm={6} key={field.key}>
+                <Grid item xs={12} key={field.key}>
                   <FieldDisplay
                     label={field.label}
                     value={String(system[field.key] ?? '')}

--- a/src/views/SystemDetailPage/SystemDetailReadView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.tsx
@@ -60,7 +60,8 @@ function FieldDisplay({
  */
 function formatFieldValue(field: FieldConfig, system: FismaSystemType): string {
   const raw = system[field.key]
-  if (field.type === 'boolean') return formatBool(raw as boolean | null)
+  if (field.type === 'boolean')
+    return formatBool(raw as boolean | null, field.booleanLabels)
   if (field.type === 'multiselect') return formatList(raw as string[] | null)
   return String(raw ?? '')
 }

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -2,7 +2,7 @@ import { FismaSystemType } from '@/types'
 
 export type FieldSection = 'identity' | 'organization' | 'contacts' | 'extended'
 
-export type FieldType = 'text' | 'email' | 'select' | 'multiselect'
+export type FieldType = 'text' | 'email' | 'select' | 'multiselect' | 'boolean'
 
 export interface FieldConfig {
   key: keyof FismaSystemType
@@ -116,7 +116,7 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'HVA',
     section: 'extended',
     required: false,
-    type: 'select',
+    type: 'boolean',
   },
   {
     key: 'fips',
@@ -137,7 +137,7 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'Cloud System',
     section: 'extended',
     required: false,
-    type: 'select',
+    type: 'boolean',
   },
   {
     key: 'cloud_service_model',
@@ -186,7 +186,7 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'Legacy',
     section: 'extended',
     required: false,
-    type: 'select',
+    type: 'boolean',
   },
 ]
 

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -13,6 +13,14 @@ export interface FieldConfig {
   // Display-only: rendered but never editable and excluded from the write
   // payload. Used for values the backend resolves/owns (e.g. isso_name).
   readOnly?: boolean
+  // Short guidance shown under the control while editing. For terms of art
+  // whose label alone is ambiguous or easily misread. Rendered only when set;
+  // there is no backend dependency, the copy lives here.
+  helpText?: string
+  // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
+  // its read-view text). For a negatively-phrased label where Yes/No would read
+  // as a double negative. Unknown stays Unknown.
+  booleanLabels?: { true: string; false: string }
 }
 
 export const fieldConfigs: FieldConfig[] = [
@@ -183,10 +191,15 @@ export const fieldConfigs: FieldConfig[] = [
   },
   {
     key: 'legacy',
-    label: 'Legacy',
+    label: 'Not Funded for Remediation',
     section: 'extended',
     required: false,
     type: 'boolean',
+    booleanLabels: { true: 'Not funded', false: 'Funded' },
+    helpText:
+      'HHS has not committed funding to remediate known gaps on this system. ' +
+      "This is a funding disposition, not a judgement about the system's age " +
+      'or technology.',
   },
 ]
 

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -2,7 +2,7 @@ import { FismaSystemType } from '@/types'
 
 export type FieldSection = 'identity' | 'organization' | 'contacts' | 'extended'
 
-export type FieldType = 'text' | 'email' | 'select'
+export type FieldType = 'text' | 'email' | 'select' | 'multiselect'
 
 export interface FieldConfig {
   key: keyof FismaSystemType
@@ -116,35 +116,35 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'HVA',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'fips',
     label: 'FIPS Impact Level',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'system_type',
     label: 'System Type',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'cloud_system',
     label: 'Cloud System',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'cloud_service_model',
     label: 'Cloud Service Model',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'multiselect',
   },
   {
     key: 'cloud_vendor',
@@ -158,14 +158,14 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'System Operator',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'goco_coco_gogo',
     label: 'GOCO/COCO/GOGO',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
   {
     key: 'system_owner',
@@ -186,7 +186,7 @@ export const fieldConfigs: FieldConfig[] = [
     label: 'Legacy',
     section: 'extended',
     required: false,
-    type: 'text',
+    type: 'select',
   },
 ]
 


### PR DESCRIPTION
## Summary

Part of the metadata-standardization effort (frontend of `ztmf#395`; real backend dependency is `ztmf#433`). The extended system-metadata fields (`fips`, `system_type`, `hva`, `cloud_system`, `cloud_service_model`, `goco_coco_gogo`, `system_operator`, `legacy`) render as free-text inputs, which lets dirty values back in (`Saas` vs `SaaS`, `GOVO`, `Minor Stand-alone`) — the exact data-quality problem canonicalization is fixing. This PR renders them as validated selects driven by the canonical vocabulary, in both the Add/Edit modal and the system detail edit view.

The vocabulary endpoint (`[ztmf#433](https://github.com/CMS-Enterprise/ztmf/issues/433)`) is not built yet, so the canonical set (agreed on `ztmf#395`) is served locally as a stopgap, isolated behind one module so the switch to the endpoint is a one-file change. `cloud_vendor` stays free text (out of scope on #395).

NOTE: First draft until ztmf#433 code comes in.

## Fix

### `src/utils/systemMetadataVocab.ts` (new) — the swap point

* `SYSTEM_METADATA_VOCAB`: the canonical allowed values per field, hardcoded from the #395 agreed set.
* `fetchSystemMetadataVocab` / `useSystemMetadataVocab`: mirror `fetchDataCenterEnvironments`. When #433 ships, only `fetchSystemMetadataVocab` changes to a GET; every consumer is unchanged.
* `toSelectOptionsWithCurrent`: options for a single-select, appending the system's current value as a disabled option when it is not in the served set (legacy value stays visible and valid on an untouched save — same pattern as the `datacenterenvironment` dropdown).
* `parseCombo` / `serializeCombo`: convert `cloud_service_model` between its stored sorted slash-joined combo (e.g. `IaaS/PaaS`) and the multi-select parts; empty selection serializes to null.
* `multiSelectOptionsWithCurrent`: canonical parts plus any legacy part not in the canon, so an odd stored part is not dropped.

### `src/views/SystemDetailPage/fieldConfig.ts`

* Adds a `multiselect` field type. The seven canonical fields become `select`; `cloud_service_model` becomes `multiselect`. `cloud_vendor` and the owner/name fields stay free text.

### `src/views/SystemDetailPage/SystemDetailEditView.tsx` and `src/views/EditSystemModal/EditSystemModal.tsx`

* Render the extended fields per their configuration as single-select, `cloud_service_model` multi-select, or free text. `datacenterenvironment` still draws from its own reference vocab; the extended selects draw from the metadata vocab.
* Optional selects include a blank "None" option so a value can be cleared.

## Behavioral notes

* A legacy/unmapped stored value (e.g. `Minor Stand-alone`) renders as a disabled, non-re-selectable option and is re-sent unchanged on an untouched save — not lost or blanked.
* All extended fields are optional; null/unset is handled and there is no required-field lockout. Selecting "None" clears an optional field.
* `cloud_service_model` is stored as a sorted, slash-joined combo; the multi-select round-trips through `parseCombo`/`serializeCombo`, and an empty selection serializes to null.
* Read view and table columns are untouched — they render the raw stored value, so display is unchanged.
* The `cloud_system = No => cloud_service_model = null` cross-field rule (from #431) is NOT enforced here; it is write validation owned by #433.

## Testing

* `src/utils/systemMetadataVocab.test.ts` (14 tests): `fetchSystemMetadataVocab` resolves the canonical set; `toSelectOptionsWithCurrent` maps values, appends legacy values as disabled, and does not duplicate/append for in-set or null values; `parseCombo` splits slash/comma/semicolon and trims; `serializeCombo` sorts, de-dupes, and returns null when empty, and round-trips with `multiSelectOptionsWithCurrent` appending legacy parts.
* `src/views/SystemDetailPage/SystemDetailEditView.test.tsx`: each canonical field renders as a select showing its current value; a legacy value is preserved in the select; `cloud_service_model` renders as a multi-select showing its parts; picking an option fires onChange with the updated value.
* New assertions were litmus-verified (break test, assertion flips red, restore). `tsc --noEmit` and lint clean; full suite green (612 passing).

## Manual verification

Open the Add/Edit System modal and the system detail edit view:

1. Each extended field (except `cloud_vendor`) is a dropdown, not a text box; `cloud_service_model` allows multiple selections.
2. Yes/No fields (`hva`, `cloud_system`, `legacy`) offer Yes / No.
3. Edit a system whose `system_type` holds a legacy value (e.g. `Minor Stand-alone`): it still displays, is not re-selectable, and saving without touching it keeps the value.
4. Pick a canonical value, save, reopen — value persists. Select "None" on an optional field, save — it clears.
5. `cloud_service_model`: select IaaS + PaaS, save, reopen — both stay selected and the stored value reads `IaaS/PaaS`.
6. Table columns still show the values.

---

### Notes for reviewers

* https://github.com/CMS-Enterprise/ztmf/issues/433 Needs to go in first.