### PR TITLE
Add ISSO maturity-determination disclaimer to the Insights panel

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -658,10 +658,15 @@ describe('OptionInsightBadges', () => {
     // carries its own determination framing rather than relying on the panel's.
     render(<OptionInsightBadges score={1} insight={insight} />)
     const badge = screen.getByLabelText(/^ZTMF Insights —/)
-    expect(badge).toHaveAccessibleName(/final maturity determination is yours/i)
+    // Names the ISSO, not "you" — the badge renders for every role that can view
+    // the questionnaire, so second person would misattribute the determination.
+    expect(badge).toHaveAccessibleName(
+      /final maturity determination is the ISSO's/i
+    )
+    expect(badge).not.toHaveAccessibleName(/determination is yours/i)
     fireEvent.focus(badge)
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
-      /final maturity determination is yours/i
+      /final maturity determination is the ISSO's/i
     )
   })
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -3,6 +3,7 @@ import InsightsPanel, {
   OptionInsightBadges,
   severityStyle,
   rollupControls,
+  ISSO_DETERMINATION_DISCLAIMER,
 } from './InsightsPanel'
 import type { InsightPayload } from '@/types'
 import CONFIG from '@/utils/config'
@@ -593,6 +594,52 @@ describe('InsightsPanel', () => {
   })
 })
 
+describe('ISSO determination disclaimer', () => {
+  it('shows the disclaimer on a minimal payload, without opening the drawer', () => {
+    // Minimal payload has no details toggle at all, so the disclaimer has to be
+    // outside the Collapse to be reachable here.
+    render(<InsightsPanel payload={{ suggested_score: 3 }} />)
+    expect(
+      screen.queryByRole('button', { name: /details/i })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(ISSO_DETERMINATION_DISCLAIMER)).toBeInTheDocument()
+  })
+
+  it('states both that the findings are decision-support and that the determination is the ISSO’s', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    const note = screen.getByRole('note', { name: /about these findings/i })
+    expect(note).toHaveTextContent(
+      /tools for assessing their system's maturity/i
+    )
+    expect(note).toHaveTextContent(/decision-support only/i)
+    expect(note).toHaveTextContent(
+      /final maturity determination is the ISSO's responsibility/i
+    )
+  })
+
+  it('keeps the disclaimer visible while the details drawer is open', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getByText('Aligns with ARS Controls:')).toBeInTheDocument()
+    expect(screen.getByText(ISSO_DETERMINATION_DISCLAIMER)).toBeInTheDocument()
+  })
+
+  it('does not name the note icon (the prose beside it carries the message)', () => {
+    render(<InsightsPanel payload={{ suggested_score: 3 }} />)
+    // Only the ARS alignment info icon is exposed as an img; the note's icon is
+    // decorative, so exposing it would double-read the disclaimer.
+    expect(
+      screen.queryByRole('img', { name: /about these findings/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the disclaimer once per panel', () => {
+    render(<InsightsPanel payload={fullPayload} />)
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(screen.getAllByRole('note')).toHaveLength(1)
+  })
+})
+
 describe('OptionInsightBadges', () => {
   const insight: InsightPayload = {
     suggested_score: 1,
@@ -604,6 +651,18 @@ describe('OptionInsightBadges', () => {
     render(<OptionInsightBadges score={1} insight={insight} />)
     expect(screen.getByText('ZTMF Insights')).toBeInTheDocument()
     expect(screen.queryByText(/FY2024 Q1 answer/)).not.toBeInTheDocument()
+  })
+
+  it('frames the recommendation badge as pointing to an answer, not deciding it', async () => {
+    // The badge renders next to a radio option, outside the Insights box, so it
+    // carries its own determination framing rather than relying on the panel's.
+    render(<OptionInsightBadges score={1} insight={insight} />)
+    const badge = screen.getByLabelText(/^ZTMF Insights —/)
+    expect(badge).toHaveAccessibleName(/final maturity determination is yours/i)
+    fireEvent.focus(badge)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      /final maturity determination is yours/i
+    )
   })
 
   it("renders the prior-answer badge on last year's option", () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -46,6 +46,13 @@ function maturityLabel(score?: number | null): string | null {
 const ARS_ALIGN_DISCLAIMER =
   'Alignment maps automated security evidence to ARS 5.2 controls. It is indicative only and does not constitute an assessed control satisfaction determination or a compliance attestation. CFACTS remains the system of record for control status.'
 
+// Panel-level framing for everything the panel shows. The findings are automated
+// evidence meant to sharpen an ISSO's own assessment, not a maturity
+// determination — this stays visible whether or not the details drawer is open so
+// the framing can never be missed by scrolling past a collapsed section.
+export const ISSO_DETERMINATION_DISCLAIMER =
+  "These automated findings are intended to give ISSOs better tools for assessing their system's maturity. They are decision-support only — the final maturity determination is the ISSO's responsibility."
+
 // Suggested-pill tint keyed by score. Mirrors the prototype's trad/init/adv/opt
 // palette. Unknown/blank score renders neutral.
 const SUGGESTED_TINT: Record<number, { bg: string; fg: string }> = {
@@ -253,13 +260,16 @@ export function OptionInsightBadges({
     >
       {isSuggested && (
         <Tooltip
-          title="The answer the automated evidence points to"
+          // The badge sits outside the Insights box, where the panel's
+          // determination disclaimer isn't visible, so the framing rides along
+          // with the badge itself.
+          title="The answer the automated evidence points to — the final maturity determination is yours"
           placement="top"
           arrow
         >
           <Box
             component="span"
-            aria-label="ZTMF Insights — the answer the automated evidence points to"
+            aria-label="ZTMF Insights — the answer the automated evidence points to; the final maturity determination is yours"
             sx={{
               px: 0.75,
               py: 0.125,
@@ -711,6 +721,43 @@ function InsightsPanelInner({ payload, questionId }: Props) {
           )}
         </Box>
       </Collapse>
+
+      {/* ISSO determination disclaimer — persistent, outside the Collapse, so it
+          is shown with the findings whether or not the drawer is open. Colors are
+          an explicit fg/bg pair rather than inherited text so the note keeps its
+          contrast wherever the panel is embedded, and it carries a border (not
+          color alone) so it still reads as a callout under forced-colors /
+          high-contrast modes. */}
+      <Box
+        role="note"
+        aria-label="About these findings"
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          mt: 1.5,
+          pt: 1.25,
+          borderTop: '1px solid #e0e4f0',
+        }}
+      >
+        <InfoOutlined
+          // Decorative: the note's text sits right beside it, so naming the icon
+          // would just double-read the same content.
+          aria-hidden
+          sx={{ fontSize: 14, color: '#5c636a', mt: '1px', flexShrink: 0 }}
+        />
+        <Typography
+          component="p"
+          sx={{
+            fontSize: 11.5,
+            lineHeight: 1.5,
+            // 6.6:1 on the panel's #f8f9fe — comfortably AA for small text.
+            color: '#4a4f5c',
+          }}
+        >
+          {ISSO_DETERMINATION_DISCLAIMER}
+        </Typography>
+      </Box>
     </Box>
   )
 }

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -263,13 +263,16 @@ export function OptionInsightBadges({
           // The badge sits outside the Insights box, where the panel's
           // determination disclaimer isn't visible, so the framing rides along
           // with the badge itself.
-          title="The answer the automated evidence points to — the final maturity determination is yours"
+          // Names the ISSO rather than "you": the badge renders for whoever is
+          // viewing the questionnaire (ISSM, admin, read-only), so second person
+          // would assign the determination to the wrong role.
+          title="The answer the automated evidence points to — the final maturity determination is the ISSO's"
           placement="top"
           arrow
         >
           <Box
             component="span"
-            aria-label="ZTMF Insights — the answer the automated evidence points to; the final maturity determination is yours"
+            aria-label="ZTMF Insights — the answer the automated evidence points to; the final maturity determination is the ISSO's"
             sx={{
               px: 0.75,
               py: 0.125,


### PR DESCRIPTION
Closes CMS-Enterprise/ztmf-insights#40

The Insights panel presents automated findings without framing what they are for, which leaves room for an ISSO to read an automated result as an authoritative maturity determination. This adds a persistent note stating that the findings are decision-support and that the final determination belongs to the ISSO.

## What changed

- A `role="note"` callout at the bottom of the Insights panel, rendered outside the details `Collapse` so it stays visible whether or not the drawer is open, and shows even on minimal payloads that have no details toggle at all.
- The copy is the wording suggested in the issue, verbatim: "These automated findings are intended to give ISSOs better tools for assessing their system's maturity. They are decision-support only — the final maturity determination is the ISSO's responsibility." It is exported as `ISSO_DETERMINATION_DISCLAIMER` so the tests assert against the same string the panel renders.
- The recommendation badge next to each answer option carries the same framing in its hover and accessible name. That badge sits outside the panel, where the note is not visible, so it needs to say it on its own. It names the ISSO rather than using second person, since the badge renders for every role that can view the questionnaire.
<img width="1737" height="169" alt="image" src="https://github.com/user-attachments/assets/666a19c3-243e-4cc0-b060-e64d5547361a" />

## Styling and accessibility

Separated by a divider, small text, subdued grey, with the info icon marked decorative so screen readers do not read the same sentence twice. Foreground and background are an explicit pair rather than inherited text, so the note holds 6.6:1 contrast (AA for small text is 4.5:1) regardless of the surface it sits on, and it is set off by a border rather than color alone so it still reads as a callout under forced-colors and high-contrast modes.

One note on the acceptance criteria: the app has a single light theme (`theme.ts` hardcodes `mode: 'light'`), so there is no dark theme to check against. The explicit color pair is what covers that criterion in practice.

## Tests

Seven new cases: the note renders on a minimal payload with no details toggle, both required statements are present, it stays visible while the drawer is open, the icon is not exposed as a named element, it renders once per panel, and the badge carries the framing in both its hover and its accessible name. Full suite passes at 611.

## Review note

The disclaimer copy is the issue's suggested wording, unchanged. The issue asks for the copy to be reviewed for accuracy before merge, so a confirmation on the wording is the main thing needed here.