### PR TITLE
Name the check in plain language on Insights control chip hovers

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -927,6 +927,23 @@ describe('rollupControls (cross-source ARS control union)', () => {
     expect(evidenceFor('SC-8')?.description).toBe('HSTS not enabled')
   })
 
+  it('does not repeat a title-only finding as both the check and the sentence', () => {
+    // No id and no description, so both the check name and the sentence resolve
+    // to the same title — printing it twice in the hover (and announcing it twice
+    // to AT) reads as a bug.
+    const rolled = roll({
+      findings: {
+        sechub: [{ title: 'MFA should be enabled', nist_controls: 'IA-2' }],
+      },
+    })
+    expect(rolled[0].evidence[0]).toEqual({
+      source: 'SecurityHub',
+      check: 'MFA should be enabled',
+      state: 'failing',
+      description: undefined,
+    })
+  })
+
   it('leaves CFACTS control evidence without a sentence (it has no per-check text)', () => {
     const rolled = roll({ ars_satisfied_controls: ['IA-01'] })
     expect(rolled[0].evidence[0]).toEqual({

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -581,6 +581,42 @@ describe('InsightsPanel', () => {
     expect(tip).toHaveTextContent(/counted as failing/)
   })
 
+  it('names the check in plain language on a control chip hover, not just its slug', async () => {
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 1,
+            findings: {
+              kion: [
+                {
+                  id: 'iam-user-without-mfa-device-enabled',
+                  nist_controls: 'IA-2',
+                  description:
+                    'Identify IAM users without an MFA device enabled',
+                },
+              ],
+            },
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    const chip = screen.getByRole('img', { name: /^IA-2: failing/ })
+    // Sighted: the sentence renders under the slug line in the hover.
+    fireEvent.focus(chip)
+    const tip = await screen.findByRole('tooltip')
+    expect(tip).toHaveTextContent('iam-user-without-mfa-device-enabled')
+    expect(tip).toHaveTextContent(
+      'Identify IAM users without an MFA device enabled'
+    )
+    // AT: same sentence rides in the accessible name, which is the only thing a
+    // screen reader gets (the tooltip node content is never announced).
+    expect(chip).toHaveAccessibleName(
+      /Identify IAM users without an MFA device enabled/
+    )
+  })
+
   it('renders a minimal payload without a details toggle', () => {
     render(
       <InsightsPanel
@@ -840,6 +876,65 @@ describe('rollupControls (cross-source ARS control union)', () => {
     }).find((c) => c.id === 'SC-12')
     expect(sc12).toMatchObject({ state: 'failing', conflict: true })
     expect(sc12?.evidence).toHaveLength(2)
+  })
+
+  it("carries each check's sentence onto its evidence, for every finding source", () => {
+    // Kion puts the sentence in `description`, SecurityHub/Hardenize in `title`
+    // when they ship no description — the evidence has to read alike either way,
+    // since the control chip is labeled with the control id and the slug alone
+    // ("account-without-compliant-password-policy") makes the reader decode it.
+    const rolled = roll({
+      kion_passing: [
+        {
+          id: 'root-account-without-mfa-enabled',
+          nist_controls: 'AC-2',
+          description:
+            'Identify accounts without MFA enabled on root user account',
+        },
+      ],
+      findings: {
+        kion: [
+          {
+            id: 'account-without-compliant-password-policy',
+            nist_controls: 'IA-5',
+            description: 'Password Policy',
+          },
+        ],
+        sechub: [
+          {
+            id: 'IAM.10',
+            nist_controls: 'IA-2',
+            title: 'MFA should be enabled',
+          },
+        ],
+        hardenize: [
+          {
+            id: 'WWW_HSTS_MISSING',
+            nist_controls: 'SC-8',
+            description: 'HSTS not enabled',
+          },
+        ],
+      },
+    })
+    const evidenceFor = (id: string) =>
+      rolled.find((c) => c.id === id)?.evidence[0]
+    expect(evidenceFor('IA-5')?.description).toBe('Password Policy')
+    expect(evidenceFor('AC-2')?.description).toBe(
+      'Identify accounts without MFA enabled on root user account'
+    )
+    // SecurityHub ships no description, so the title stands in.
+    expect(evidenceFor('IA-2')?.description).toBe('MFA should be enabled')
+    expect(evidenceFor('SC-8')?.description).toBe('HSTS not enabled')
+  })
+
+  it('leaves CFACTS control evidence without a sentence (it has no per-check text)', () => {
+    const rolled = roll({ ars_satisfied_controls: ['IA-01'] })
+    expect(rolled[0].evidence[0]).toEqual({
+      source: 'CFACTS',
+      check: undefined,
+      state: 'satisfied',
+      description: undefined,
+    })
   })
 
   it('splits a multi-control mapping and skips malformed evidence without throwing', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -1283,7 +1283,15 @@ export function rollupControls(
       const id = part.trim()
       if (!id) continue
       const list = map.get(id) ?? []
-      list.push({ source, state, check, description })
+      list.push({
+        source,
+        state,
+        check,
+        // A title-only finding (no id, no description) resolves both the check
+        // and the sentence to that same title. Drop the duplicate rather than
+        // printing it twice in the hover and announcing it twice to AT.
+        description: description === check ? undefined : description,
+      })
       map.set(id, list)
     }
   }

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -1228,6 +1228,12 @@ export type ControlEvidence = {
   source: string
   check?: string
   state: ControlRollupState
+  // The check's human sentence, carried alongside the slug. A control chip is
+  // labeled with the control id, so without this its hover would name the check
+  // only by slug (`account-without-compliant-password-policy`) and the reader
+  // would have to decode it — the check chips have shown this sentence since
+  // they were introduced.
+  description?: string
 }
 
 // A control after the cross-source rollup: its net (weakest-link) state, whether
@@ -1267,7 +1273,8 @@ export function rollupControls(
     raw: unknown,
     source: string,
     state: ControlRollupState,
-    check?: string
+    check?: string,
+    description?: string
   ) => {
     const text = asText(raw)
     if (!text) return
@@ -1276,14 +1283,19 @@ export function rollupControls(
       const id = part.trim()
       if (!id) continue
       const list = map.get(id) ?? []
-      list.push({ source, state, check })
+      list.push({ source, state, check, description })
       map.set(id, list)
     }
   }
   const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
   const finding = (f: unknown) =>
     f && typeof f === 'object'
-      ? (f as { nist_controls?: unknown; id?: unknown; title?: unknown })
+      ? (f as {
+          nist_controls?: unknown
+          id?: unknown
+          title?: unknown
+          description?: unknown
+        })
       : null
   // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
   // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
@@ -1322,12 +1334,21 @@ export function rollupControls(
         o?.nist_controls,
         label,
         'satisfied',
-        asText(o?.id) ?? asText(o?.title)
+        asText(o?.id) ?? asText(o?.title),
+        // Kion puts the sentence in `description`, SecurityHub in `title` —
+        // same fallback CheckTooltip uses, so both hovers read alike.
+        asText(o?.description) ?? asText(o?.title)
       )
     })
     arr(findings[src]).forEach((f) => {
       const o = finding(f)
-      add(o?.nist_controls, label, 'failing', asText(o?.id) ?? asText(o?.title))
+      add(
+        o?.nist_controls,
+        label,
+        'failing',
+        asText(o?.id) ?? asText(o?.title),
+        asText(o?.description) ?? asText(o?.title)
+      )
     })
   }
   return [...map.entries()].map(([id, evidence]) => {
@@ -1357,6 +1378,12 @@ const CONTROL_EVIDENCE_WORD: Record<ControlRollupState, string> = {
 function controlEvidenceLine(e: ControlEvidence): string {
   return `${e.source}${e.check ? ` · ${e.check}` : ''} · ${CONTROL_EVIDENCE_WORD[e.state]}`
 }
+// Spoken form folds in the check's sentence. The hover renders that sentence on
+// its own line (below), but a screen reader gets one string per evidence entry,
+// so it has to ride along here or it would be sighted-only.
+function controlEvidenceSpoken(e: ControlEvidence): string {
+  return `${controlEvidenceLine(e)}${e.description ? ` — ${e.description}` : ''}`
+}
 // Accessible name folds the net state, the conflict note, and every source line
 // into one string — the ✓/○/✗/⚠ marker and colour are otherwise the only place the
 // state and its provenance live, and neither reaches a screen reader (508).
@@ -1364,7 +1391,7 @@ function controlAriaLabel(c: ControlRollup): string {
   const head = c.conflict
     ? `${c.id}: sources disagree, counted as ${CONTROL_STATE_WORD[c.state]}`
     : `${c.id}: ${CONTROL_STATE_WORD[c.state]}`
-  return `${head}. ${c.evidence.map(controlEvidenceLine).join('; ')}.`
+  return `${head}. ${c.evidence.map(controlEvidenceSpoken).join('; ')}.`
 }
 
 // Rich hover for an ARS control chip: the control id, a conflict note stating how a
@@ -1389,6 +1416,13 @@ function ControlTooltip({ control }: { control: ControlRollup }) {
             sx={{ fontSize: 10, lineHeight: 1.5, opacity: 0.9 }}
           >
             {controlEvidenceLine(e)}
+            {/* The sentence gets its own indented line rather than being tacked
+                onto the slug line — a control with several evidence entries would
+                otherwise wrap into an unreadable block, and the slug is what a
+                reviewer scans for first. */}
+            {e.description && (
+              <Box sx={{ pl: 1, opacity: 0.85 }}>{e.description}</Box>
+            )}
           </Box>
         ))}
       </Box>


### PR DESCRIPTION
An ARS control chip is labeled with the control id, so its hover is the only place that names the check behind it. It named it by slug alone:

```
IA-5
Kion · account-without-compliant-password-policy · failed
```

The payload carries a human sentence for that check (`"description": "Password Policy"`), and the check chips in the per-source blocks have shown it since they were introduced. The control chips never did, so the reader was left to decode the slug.

## What changed

- `ControlEvidence` gains an optional `description`, populated in `rollupControls` from the check's `description ?? title`. That is the same fallback `CheckTooltip` uses, so both hovers read alike: Kion puts its sentence in `description`, SecurityHub in `title`.
- The hover renders the sentence on its own indented line under the slug line. A control with several evidence entries stays scannable that way, and the slug is what a reviewer scans for first.
- A new `controlEvidenceSpoken` folds the sentence into the control chip's accessible name. Screen readers never receive tooltip node content, so without it the sentence would be sighted-only.
- Covers all three finding sources, passing and failing. CFACTS evidence is unchanged: it comes from the `ars_*` control arrays and has no per-check text to show.

The same chip now reads:

```
IA-5
Kion · account-without-compliant-password-policy · failed
    Password Policy
```

## On the regression

`ControlEvidence` was introduced in #612 with `source`, `check`, and `state`, so nothing was deleted from it. The behavior change is real all the same. Before that PR the check chips were labeled by NIST tag, so hovering a chip reading "IA-5" gave you the full sentence. After it, a chip labeled with a control id is the control chip, whose hover only had the slug. Same label, less information, as a side effect of the chip relabeling rather than a deliberate call.

## Tests

Four new cases: the sentence is carried for every finding source (Kion via `description`, SecurityHub via the `title` fallback, Hardenize), CFACTS evidence stays bare, a title-only finding does not repeat itself as both the check and the sentence, and a render test asserting the sentence appears in both the hover and the accessible name. Full suite passes at 615.

Worth flagging separately: `account-without-compliant-password-policy` maps to the sentence "Password Policy", which is a thin dictionary entry. This surfaces whatever the dictionary has. Improving the entries themselves is CMS-Enterprise/ztmf-insights#36, not this PR.