### PR TITLE
Distinguish inferred passes from observed ones in the Insights panel

### DIFF
--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1296,10 +1296,50 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
       />
     )
     expand()
-    expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
+    // SecurityHub's feed is failure-only, so a "pass" is the absence of a
+    // finding, not an observed pass — the summary must not claim otherwise.
+    expect(
+      screen.getByText(/1 of 2 checks reported no findings/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/1 of 2 checks passed/)).not.toBeInTheDocument()
     // Feed chips are labeled by the SecurityHub finding code.
     expect(screen.getByText('IAM.1').textContent).toContain('✓')
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
+    // The chip still reads ✓, but neither its accessible name nor its hover may
+    // say "Passed".
+    expect(
+      screen.getByRole('img', { name: /^IAM\.1 — .* — No finding reported$/ })
+    ).toBeInTheDocument()
+  })
+
+  it('withholds an inferred SecurityHub pass from the control rollup', () => {
+    // A control whose only evidence is an inferred SecurityHub pass must not
+    // read as satisfied — that would assert the control is met on the strength
+    // of a check that may never have run on a partially scanned system.
+    const sechubOnly = rollupControls({
+      sechub_passing: [
+        { id: 'IAM.1', nist_controls: 'AC-3', description: 'x', level: 1 },
+      ],
+    })
+    expect(sechubOnly).toHaveLength(0)
+
+    // Kion and Hardenize report real passes, so theirs still count.
+    const kion = rollupControls({
+      kion_passing: [
+        { id: 'iam-user-inactive', nist_controls: 'AC-3', description: 'x' },
+      ],
+    })
+    expect(kion).toHaveLength(1)
+    expect(kion[0].state).toBe('satisfied')
+
+    // A SecurityHub *failure* is still real evidence and must survive.
+    const sechubFailing = rollupControls({
+      findings: {
+        sechub: [{ id: 'IAM.10', nist_controls: 'IA-2', description: 'y' }],
+      },
+    })
+    expect(sechubFailing).toHaveLength(1)
+    expect(sechubFailing[0].state).toBe('failing')
   })
 
   it('renders SecurityHub as a chip block even with only failing findings', () => {
@@ -1328,6 +1368,38 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
     // Title lives in the hover now, not as body text.
     expect(screen.queryByText('MFA should be enabled')).not.toBeInTheDocument()
+  })
+
+  it('words the collapse toggle as "no findings" for an inferred-pass source', () => {
+    // The summary and the chips avoid claiming a pass, but the collapse toggle is
+    // its own label — with 1,493 SecurityHub rows upstream, blocks routinely spill
+    // past the collapse threshold, so this is where the unsupported claim would
+    // survive.
+    const passing = Array.from({ length: 9 }, (_, i) => ({
+      id: `SEC.${i}`,
+      nist_controls: 'SC-7',
+      level: 1,
+    }))
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 2,
+            has_sechub_data: true,
+            sechub_passing: passing,
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(
+      screen.getByRole('button', {
+        name: /Show all 9 checks with no findings/i,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Show all 9 passing checks/i })
+    ).not.toBeInTheDocument()
   })
 
   it('collapses the passing bulk behind a toggle, keeps failing chips at the top, and expands on click', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -399,6 +399,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
       ...s,
       passing: asFindingArray(raw),
       hasPassing: Array.isArray(raw),
+      inferredPass: INFERRED_PASS_SOURCES.has(s.key),
     }
   })
   const anyFeedBlock = feedSources.some((s) => s.hasPassing)
@@ -610,6 +611,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
                   passing={s.passing}
                   failing={s.failing}
                   hasPassing={s.hasPassing}
+                  inferredPass={s.inferredPass}
                   resetKey={questionId}
                 />
               ) : null
@@ -925,9 +927,13 @@ function ControlChip({
 function CheckTooltip({
   finding,
   pass,
+  inferredPass = false,
 }: {
   finding: InsightFinding
   pass: boolean
+  // See INFERRED_PASS_SOURCES: this source reports only failures, so a "pass" is
+  // the absence of a finding and must not be worded as an observed pass.
+  inferredPass?: boolean
 }) {
   const slug = asText(finding?.id) ?? asText(finding?.title)
   // The chip label now carries the check name (its code/slug), so the hover leads
@@ -955,7 +961,7 @@ function CheckTooltip({
     nist ? `Control: ${nist}` : undefined,
     level != null ? `Level ${level}` : undefined,
     severity ? severity.toUpperCase() : undefined,
-    pass ? 'Passed' : 'Failed',
+    pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
   ]
     .filter(Boolean)
     .join(' · ')
@@ -1030,12 +1036,17 @@ function FeedCheckBlock({
   passing,
   failing,
   hasPassing,
+  inferredPass = false,
   resetKey,
 }: {
   label: string
   passing: InsightFinding[]
   failing: InsightFinding[]
   hasPassing: boolean
+  // See INFERRED_PASS_SOURCES: this source's passing entries mean "no finding
+  // reported", which the summary and each chip's hover must say rather than
+  // claiming the checks were observed to pass.
+  inferredPass?: boolean
   resetKey?: string | number
 }) {
   const [showAllPassing, setShowAllPassing] = React.useState(false)
@@ -1062,9 +1073,11 @@ function FeedCheckBlock({
   }
   const passed = passing.length
   const total = passing.length + failing.length
-  const summary = hasPassing
-    ? `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
-    : `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+  const summary = !hasPassing
+    ? `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+    : inferredPass
+      ? `${passed} of ${total} check${total === 1 ? '' : 's'} reported no findings`
+      : `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
   // Collapse the passing bulk once it spills past a couple of rows (mainly
   // Hardenize, which can carry 30+ passing checks). Failing chips (findings) are
   // always shown AND rendered first, so problems stay at the top and visible even
@@ -1090,7 +1103,7 @@ function FeedCheckBlock({
     const ariaLabel = [
       slug,
       desc,
-      pass ? 'Passed' : 'Failed',
+      pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
       remediation ? `How to fix: ${remediation}` : undefined,
     ]
       .filter(Boolean)
@@ -1100,7 +1113,9 @@ function FeedCheckBlock({
         key={key}
         id={slug ?? nist ?? '—'}
         variant={pass ? 'satisfied' : 'failing'}
-        tooltip={<CheckTooltip finding={f} pass={pass} />}
+        tooltip={
+          <CheckTooltip finding={f} pass={pass} inferredPass={inferredPass} />
+        }
         ariaLabel={ariaLabel || undefined}
       />
     )
@@ -1143,7 +1158,11 @@ function FeedCheckBlock({
         >
           {showAllPassing
             ? 'Show fewer'
-            : `Show all ${passing.length} passing checks`}
+            : // Matches the summary wording: for an inferred-pass source these
+              // are checks with no finding reported, not checks observed to pass.
+              `Show all ${passing.length} ${
+                inferredPass ? 'checks with no findings' : 'passing checks'
+              }`}
         </Link>
       )}
     </Box>
@@ -1265,6 +1284,20 @@ const CONTROL_RANK: Record<ControlRollupState, number> = {
 // appears here even though CFACTS never assessed it, and why a conflicted control
 // can net to failing. The payload is opaque, so every value is coerced and
 // guarded; a malformed element is skipped, never thrown.
+// Sources whose "passing" entries are inferred from the absence of a finding
+// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
+// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
+// as "mapped control with no active failure". That cannot distinguish "evaluated
+// and passed" from "never scanned", so on a partially scanned system it would
+// otherwise assert controls are met on the strength of checks that never ran.
+// Consequently these entries still render as ✓ chips (the check is not failing)
+// but are read as an absence of findings, and are withheld from the control
+// rollup rather than counted as affirmative `satisfied` evidence.
+//
+// Remove a source from this set once its feed emits real passes; nothing else
+// needs to change. Used by both the feed blocks and rollupControls below.
+const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
+
 export function rollupControls(
   payload: Partial<InsightPayload>
 ): ControlRollup[] {
@@ -1336,18 +1369,25 @@ export function rollupControls(
   }
   for (const src of ['kion', 'sechub', 'hardenize'] as const) {
     const label = SRC_LABEL[src]
-    arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach((f) => {
-      const o = finding(f)
-      add(
-        o?.nist_controls,
-        label,
-        'satisfied',
-        asText(o?.id) ?? asText(o?.title),
-        // Kion puts the sentence in `description`, SecurityHub in `title` —
-        // same fallback CheckTooltip uses, so both hovers read alike.
-        asText(o?.description) ?? asText(o?.title)
+    // An inferred pass is the absence of a finding, not evidence the control is
+    // met — counting it as `satisfied` would flip a control from "not assessed"
+    // to green on the strength of a check that may never have run.
+    if (!INFERRED_PASS_SOURCES.has(src)) {
+      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
+        (f) => {
+          const o = finding(f)
+          add(
+            o?.nist_controls,
+            label,
+            'satisfied',
+            asText(o?.id) ?? asText(o?.title),
+            // Kion puts the sentence in `description`, SecurityHub in `title` —
+            // same fallback CheckTooltip uses, so both hovers read alike.
+            asText(o?.description) ?? asText(o?.title)
+          )
+        }
       )
-    })
+    }
     arr(findings[src]).forEach((f) => {
       const o = finding(f)
       add(


### PR DESCRIPTION
SecurityHub's vendor feed carries only FAILED records and never emits a PASSED one, so `sechub_passing` is derived upstream as "mapped control with no active failure". That cannot tell "evaluated and passed" apart from "never scanned".

This matters more than the wording, because a passing entry is not display-only. `rollupControls` counts every `{source}_passing` entry as `satisfied` evidence in the cross-source ARS control union, so a control whose only evidence is an inferred pass flips from grey not-assessed to green satisfied. On a partially scanned system the panel would be asserting a control is met on the strength of a check that never ran. The ISSO disclaimer added in #630 says the findings are decision-support; it does not say green may mean unscanned.

Relevant now rather than hypothetical: the upstream view is about to start shipping `sechub_passing` on roughly 1,500 rows, and the panel switches rendering on the array's presence alone, with no code change.

## What changed

- `INFERRED_PASS_SOURCES` names the sources whose passing entries are inferred from the absence of a finding. SecurityHub is the only member today.
- Those entries are **withheld from the control rollup** rather than counted as affirmative `satisfied` evidence.
- Everywhere a pass would be claimed now says findings were not reported instead:
  - block summary: `N of M checks reported no findings`
  - chip hover and accessible name: `No finding reported` in place of `Passed`
  - collapse toggle: `Show all N checks with no findings`
- The chips still render green, since the check is genuinely not failing. Only the claim about why changes.

Removing a source from the set is all that is required once its feed emits real passes. Nothing else needs to change.

## Tests

Five cases covering the summary wording, the chip accessible name, the withheld rollup evidence, that a real-pass source such as Kion is unaffected, and the collapse toggle wording once a block spills past the collapse threshold. Each pairs a positive assertion with a negative one so the old "passed" phrasing cannot creep back. Full suite passes at 662.

## Note on layering

The cleanest home for this is the payload: a flag distinguishing an observed pass from "no finding reported" would let the UI stop hardcoding a per-source data-quality fact. That was raised upstream. This lands the correct behavior now, and collapses to a one-line deletion if the flag arrives later.

The same question applies to the archived Kion checks currently dropped from scoring. If those start counting as passes, they want this treatment rather than a silent flip.