### PR TITLE
Correct the legacy field label to "Legacy System" (#634)

### DIFF
--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -145,9 +145,9 @@ describe('booleanOptions', () => {
   })
 
   it('overrides the true/false labels but keeps values and Unknown', () => {
-    expect(booleanOptions({ true: 'Not funded', false: 'Funded' })).toEqual([
-      { value: 'true', label: 'Not funded' },
-      { value: 'false', label: 'Funded' },
+    expect(booleanOptions({ true: 'Active', false: 'Inactive' })).toEqual([
+      { value: 'true', label: 'Active' },
+      { value: 'false', label: 'Inactive' },
       { value: '', label: 'Unknown' },
     ])
   })
@@ -162,9 +162,9 @@ describe('display formatting', () => {
   })
 
   it('applies custom true/false labels, leaving Unknown', () => {
-    const labels = { true: 'Not funded', false: 'Funded' }
-    expect(formatBool(true, labels)).toBe('Not funded')
-    expect(formatBool(false, labels)).toBe('Funded')
+    const labels = { true: 'Active', false: 'Inactive' }
+    expect(formatBool(true, labels)).toBe('Active')
+    expect(formatBool(false, labels)).toBe('Inactive')
     expect(formatBool(null, labels)).toBe('Unknown')
   })
 

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -80,8 +80,7 @@ export function optionsForField(
 
 // Custom labels for the true/false ends of a tri-state boolean. For fields
 // whose Yes/No reads ambiguously against the label (e.g. a negatively-phrased
-// "Not Funded for Remediation", where "No" would mean "it is funded"). Unknown
-// is always Unknown.
+// label where "No" would be a double negative). Unknown is always Unknown.
 export type BooleanLabels = { true: string; false: string }
 
 /**

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -83,14 +83,12 @@ describe('extended metadata formatting', () => {
     expect(screen.getByText('IaaS, PaaS')).toBeInTheDocument()
   })
 
-  test('applies the legacy field custom boolean labels', () => {
-    // legacy is a funding disposition; its label is "Not Funded for
-    // Remediation", so true reads "Not funded" rather than a double-negative
-    // "Yes".
+  test('renders the legacy field with default Yes/No labels', () => {
+    // legacy is a plain legacy-system flag labeled "Legacy System", so true
+    // reads as the default "Yes".
     renderWithExtended({ legacy: true })
-    expect(screen.getByText('Not Funded for Remediation')).toBeInTheDocument()
-    expect(screen.getByText('Not funded')).toBeInTheDocument()
-    expect(screen.queryByText('Yes')).not.toBeInTheDocument()
+    expect(screen.getByText('Legacy System')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
   })
 
   test('hides the extended card when only an empty array is present', () => {

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -18,8 +18,9 @@ export interface FieldConfig {
   // there is no backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
-  // its read-view text). For a negatively-phrased label where Yes/No would read
-  // as a double negative. Unknown stays Unknown.
+  // its read-view text). For a field whose label reads ambiguously against a
+  // plain Yes/No (e.g. a negatively-phrased label where "No" is a double
+  // negative). Unknown stays Unknown.
   booleanLabels?: { true: string; false: string }
 }
 
@@ -191,15 +192,10 @@ export const fieldConfigs: FieldConfig[] = [
   },
   {
     key: 'legacy',
-    label: 'Not Funded for Remediation',
+    label: 'Legacy System',
     section: 'extended',
     required: false,
     type: 'boolean',
-    booleanLabels: { true: 'Not funded', false: 'Funded' },
-    helpText:
-      'HHS has not committed funding to remediate known gaps on this system. ' +
-      "This is a funding disposition, not a judgement about the system's age " +
-      'or technology.',
   },
 ]
 


### PR DESCRIPTION
## Summary
PR #628 shipped the `legacy` field labeled **"Not Funded for Remediation"** with options **"Not funded / Funded / Unknown"**, framing a legacy-system flag as a funding disposition. This restores its correct name and a plain **Yes/No/Unknown** interface, and drops the funding-disposition help text.

Closes #634.

## Changes
- **`fieldConfig.ts`** (only production change): the `legacy` entry
  - `label`: `"Not Funded for Remediation"` → `"Legacy System"`
  - Removed the `booleanLabels: { true: 'Not funded', false: 'Funded' }` override → falls back to default **Yes / No / Unknown**
  - Removed the funding-disposition `helpText` value (the `helpText?` / `booleanLabels?` properties remain on the `FieldConfig` interface)
- Reworded two doc comments that used the old label as their example (`fieldConfig.ts`, `systemMetadataVocab.ts`)
- **Tests:** rewrote the read-view assertion for the new copy; de-referenced the retired copy from the vocab-util fixtures (`Not funded/Funded` → neutral `Active/Inactive`)

All rendering (edit modal, detail edit view, detail read view) reads `label` / `booleanLabels` / `helpText` generically from the field config, so the config entry is the only production change; everything else adapts.

## Acceptance criteria
- [x] Modal and detail views display "Legacy System" with Yes/No/Unknown options
- [x] Read views render appropriately
- [x] Help text removed while retaining the `helpText` property on the interface
- [x] Wire values unchanged; tri-state (true/false/null) preserved
- [x] Affected tests updated
- [x] No backend modifications

## UI
### BEFORE
<img width="1514" height="551" alt="image" src="https://github.com/user-attachments/assets/2628dc96-981d-4c5e-8b2e-bc947bb266b4" />

<img width="1547" height="637" alt="image" src="https://github.com/user-attachments/assets/38887236-c864-428c-95d8-9436386b275c" />

### AFTER
<img width="1523" height="546" alt="image" src="https://github.com/user-attachments/assets/2531bd40-36cf-4575-96a2-0573f8145026" />

<img width="1629" height="608" alt="image" src="https://github.com/user-attachments/assets/0f66c44d-7913-4a2f-9d64-e418f9a91071" />


## Verification
- `jest` on all 4 affected suites: 48/48 pass
- ESLint clean on edited files; no new `tsc` errors introduced
- No remaining references to the old copy anywhere in `src/`
- On ZTMF, go to a system's details page. Click edit. Scroll down to the extended metadata section and view the Legacy System field. Verify the three options are Yes, No, Unknown.