### PR TITLE
fix(dashboard): scope average system score to the selected data call (#633)

### DIFF
--- a/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import StatisticsBlocks from './StatisticsBlocks'
+import type { FismaSystemType, SystemScoreEntry } from '@/types'
+
+// StatisticsBlocks reads the full active-system list from the outlet context and
+// the selection-scoped score map from props. The bug in ztmf-ui#633 was the
+// average dividing by the whole context list; these tests pin the denominator to
+// the systems that actually have a score.
+let mockFismaSystems: FismaSystemType[] = []
+jest.mock('../Title/Context', () => ({
+  __esModule: true,
+  useContextProp: () => ({ fismaSystems: mockFismaSystems }),
+}))
+
+const sys = (id: number, acronym: string): FismaSystemType =>
+  ({ fismasystemid: id, fismaacronym: acronym }) as FismaSystemType
+
+const score = (
+  n: number,
+  tier?: SystemScoreEntry['tier']
+): SystemScoreEntry => ({
+  score: n,
+  tier,
+})
+
+// Read the big numeral out of a tile located by its label. The high/low tiles
+// fold an acronym into the label element, so callers pass a regex for those.
+const tileValue = (label: string | RegExp): string => {
+  const tile = screen.getByText(label).closest('.MuiPaper-root')
+  const numeral = tile?.querySelector('h2')
+  return (numeral?.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
+  afterEach(() => {
+    mockFismaSystems = []
+  })
+
+  it('averages only over systems with a score, not the full active list', () => {
+    // Three active systems, only two answered the selected call. The average must
+    // be (2 + 5) / 2 = 3.5, NOT (2 + 5) / 3 = 2.33 (the old diluted denominator).
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2, 'Traditional'),
+      2: score(5, 'Optimal'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Average System Score')).toBe('3.5')
+  })
+
+  it('shows the Scored / Total ratio scoped to the selection', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2),
+      2: score(5),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('2 / 3')
+  })
+
+  it('keeps the average between the lowest and highest displayed scores', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(1.5, 'Traditional'),
+      2: score(3, 'Initial'),
+      3: score(4.82, 'Advanced'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    const avg = Number(tileValue('Average System Score'))
+    const low = Number(tileValue(/Lowest System Score/))
+    const high = Number(tileValue(/Highest System Score/))
+    expect(low).toBeLessThanOrEqual(avg)
+    expect(avg).toBeLessThanOrEqual(high)
+    expect(low).toBe(1.5)
+    expect(high).toBe(4.82)
+  })
+
+  it('handles a selection no system participated in without going below scale', () => {
+    // No scored systems: average is 0 (guarded), ratio is 0 / N, and the lowest
+    // tile falls back to 0.00 rather than rendering Infinity.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    render(<StatisticsBlocks scores={{}} />)
+
+    expect(tileValue('Average System Score')).toBe('0')
+    expect(tileValue('Scored / Total Systems')).toBe('0 / 2')
+    expect(tileValue('Lowest System Score:')).toBe('0.00')
+  })
+
+  it('formats large totals with thousands separators', () => {
+    mockFismaSystems = Array.from({ length: 1342 }, (_, i) =>
+      sys(i + 1, `S${i}`)
+    )
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(3.44),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('1 / 1,342')
+  })
+})

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -26,6 +26,7 @@ export default function StatisticsBlocks({
 }) {
   const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
+  const [answeredSystems, setAnsweredSystems] = useState<number>(0)
   const [avgSystemScore, setAvgSystemScore] = useState<number>(0)
   const [maxSystemAcronym, setMaxSystemAcronym] = useState<string>('')
   const [maxSystemScore, setMaxSystemScore] = useState<number>(0)
@@ -40,7 +41,12 @@ export default function StatisticsBlocks({
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    const totalCount = fismaSystems.length
+    // Count only the systems that actually contribute a score. The `scores` map
+    // is already scoped to the selected data call(s), so systems with no answers
+    // in the selection must not inflate the denominator (that dragged the average
+    // below the scale minimum — see ztmf-ui#633). Counted inside the loop so the
+    // numerator and denominator always cover the same systems.
+    let scoredCount: number = 0
     let maxScore: number = 0
     let maxScoreSystem: string = ''
     let maxScoreTier: ScoreTier | undefined
@@ -62,16 +68,18 @@ export default function StatisticsBlocks({
           minScoreTier = entry.tier
         }
         totalScores += entry.score
+        scoredCount += 1
       }
     }
-    if (totalCount === 0) {
+    if (scoredCount === 0) {
       setAvgSystemScore(0)
       setMinSystemScore(0)
     } else {
-      setAvgSystemScore(Number((totalScores / totalCount).toFixed(2)))
+      setAvgSystemScore(Number((totalScores / scoredCount).toFixed(2)))
       setMinSystemScore(minScore)
     }
-    setTotalSystems(totalCount)
+    setAnsweredSystems(scoredCount)
+    setTotalSystems(fismaSystems.length)
     setMaxSystemScore(maxScore)
     setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
@@ -99,14 +107,14 @@ export default function StatisticsBlocks({
       }}
     >
       <StatisticsPaper variant="outlined">
-        <Typography variant="h2" sx={{ color: '#004297', fontSize: '56px' }}>
-          {totalSystems}
+        <Typography variant="h2" sx={{ color: '#004297', fontSize: '44px' }}>
+          {answeredSystems.toLocaleString()} / {totalSystems.toLocaleString()}
         </Typography>
         <Typography
           variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
-          Total Systems
+          Scored / Total Systems
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">


### PR DESCRIPTION
## Summary
Closes #633

The dashboard's **Average System Score** tile read far below the scale minimum (e.g. `0.56`) when a single data call was selected — impossible given the 1.0–5.0 scale and the displayed lowest score of `1.00`.

Root cause: the average summed the per-system scores of only the systems that have answers in the selected data call, but divided by the count of **all active systems** (~1,342). Systems with no answers in the call contributed nothing to the numerator yet still inflated the denominator, dragging the mean far below the true value (~3.44 for FY2025 Q3).

This is a frontend-only fix. The backend `/scores/aggregate?datacallid=` endpoint already returns only systems with answers in the selected call, and `buildDashboardMaps` already builds a selection-scoped score map — the dilution was purely in the tile calculation.

## Changes

- **Average denominator** now counts only systems that actually contribute a score, computed in the same loop as the numerator so both always cover the same set. This guarantees the average falls between the displayed lowest and highest.
- **Total Systems tile** is now a **`Scored / Total Systems`** ratio (e.g. `238 / 1,342`), making the selection-scoped count explicit alongside the active-system total.
- Adds a `StatisticsBlocks` test suite (previously untested) covering subset participation, the average-between-bounds invariant, the empty-selection edge case, and thousands-separator formatting.

## Acceptance criteria

- [x] Average System Score is calculated over systems with answers in the selected data call
- [x] The average always falls between the displayed lowest and highest system scores
- [x] Total Systems reflects the current selection (shown as `Scored / Total`, clearly labelled)
- [x] Coverage for a data call in which only a subset of systems participated

## UI 
### BEFORE
<img width="1711" height="870" alt="image" src="https://github.com/user-attachments/assets/c4ab995b-1057-4538-ab49-87b8debbd3cf" />

### AFTER
<img width="1707" height="870" alt="image" src="https://github.com/user-attachments/assets/529872bc-e66d-42a1-9083-ca383b889a08" />


## Testing

- New `StatisticsBlocks.test.tsx` — 5 tests, all passing
- Full suite green (667 passed), lint + type-check clean
- Verify in UI, you see the scored / total systems tile.