### PR TITLE
feat(#609, #610): cross-navigation between System Info and the Questionnaire

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Cross-navigation coverage for ui#610: the questionnaire header needs a link
+// back to System Info and a Pillar Scores button, alongside the existing
+// Compare Datacalls button.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// notify() reaches notistack's standalone enqueueSnackbar, which needs a
+// mounted provider; keep isAuthHandled real so the error path is exercised as
+// written (same pattern as QuestionnairePage.test).
+const notifyMock = jest.fn()
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return {
+    ...actual,
+    notify: (...args: unknown[]) => notifyMock(...args),
+  }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const QUESTIONS = [
+  {
+    questionid: 900,
+    question: 'Question for Imperial Identity Verification',
+    notesprompt: 'Notes',
+    pillar: { pillar: 'Identity' },
+    function: {
+      functionid: 7006,
+      function: 'Imperial Identity Verification',
+      description: 'Imperial Identity Verification description',
+      datacenterenvironment: 'Imperial-Fleet',
+    },
+  },
+]
+
+const AGGREGATE = [
+  {
+    datacallid: 5,
+    fismasystemid: 1002,
+    systemscore: 3.75,
+    pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 3.5 }],
+  },
+]
+
+function makeCtx(role: userData['role'] | undefined) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = makeCtx('OWNER')
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/scores/aggregate'))
+      return Promise.resolve({ data: { data: AGGREGATE } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+// Data-router harness matching the app's createHashRouter, per the note in
+// QuestionnairePage.deeplink.test: a plain MemoryRouter hands the component the
+// unstable useNavigate and re-runs the fetch effect on the canonical redirect.
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> },
+      { path: '/systems/:fismasystemid', element: <div>system detail</div> },
+    ],
+    { initialEntries: ['/questionnaire/ssd-ex'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+const aggregateCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => typeof u === 'string' && u.includes('/scores/aggregate'))
+
+it('navigates to the system detail page keyed on fismasystemid', async () => {
+  const router = renderPage()
+  const button = await screen.findByRole('button', { name: 'System Info' })
+  await userEvent.click(button)
+  // The questionnaire route carries the acronym; the detail route is keyed on
+  // the id, so this proves the acronym was resolved to 1002 before linking.
+  expect(router.state.location.pathname).toBe('/systems/1002')
+})
+
+it('suppresses System Info when the role fails the system-access gate', async () => {
+  mockCtx = makeCtx(undefined)
+  renderPage()
+  // Compare Datacalls is ungated, so its presence proves the header rendered
+  // and only the gated button is missing.
+  await screen.findByRole('button', { name: 'Compare Datacalls' })
+  expect(
+    screen.queryByRole('button', { name: 'System Info' })
+  ).not.toBeInTheDocument()
+})
+
+it('fetches the pillar aggregate for this system and opens the modal', async () => {
+  renderPage()
+  const button = await screen.findByRole('button', { name: 'Pillar Scores' })
+  expect(aggregateCalls()).toHaveLength(0)
+  await userEvent.click(button)
+
+  await waitFor(() =>
+    expect(
+      aggregateCalls().some(
+        (u) =>
+          u.includes('fismasystemid=1002') && u.includes('include_pillars=true')
+      )
+    ).toBe(true)
+  )
+  // Acronym in the title comes from the resolved system, not the lowercased
+  // URL param, so it matches the dashboard's casing.
+  expect(
+    await screen.findByText(
+      /Super Star Destroyer Executor Command Systems \(SSD-EX\) - Pillar Scores/
+    )
+  ).toBeInTheDocument()
+})
+
+it('keeps the modal closed when the aggregate fetch fails', async () => {
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/scores/aggregate'))
+      return Promise.reject(new Error('boom'))
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  renderPage()
+  await userEvent.click(
+    await screen.findByRole('button', { name: 'Pillar Scores' })
+  )
+
+  await waitFor(() => expect(aggregateCalls()).not.toHaveLength(0))
+  // An empty modal would read as "this system has no scores"; nothing opens and
+  // the user is told instead.
+  await waitFor(() =>
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.stringContaining('error occurred'),
+      'error'
+    )
+  )
+  expect(screen.queryByText(/- Pillar Scores/)).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,6 +21,7 @@ import {
   QuestionScores,
   Insight,
   InsightPayload,
+  ScoreAggregate,
 } from '@/types'
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
@@ -44,9 +45,10 @@ import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
+import PillarScoresModal from '@/components/PillarScoresModal/PillarScoresModal'
 import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
-import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
+import { isAdmin, isReadOnlyAdmin, hasSystemAccess } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel from './InsightsPanel/InsightsPanel'
 import QuestionRadioGroup from './QuestionRadioGroup'
@@ -130,6 +132,12 @@ export default function QuestionnarePage() {
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const [diffModalOpen, setDiffModalOpen] = React.useState(false)
+  // PillarScoresModal takes its rows as a prop rather than fetching (unlike
+  // ScoreDiffModal), so the header button fetches before opening (ui#610).
+  const [pillarScores, setPillarScores] = React.useState<{
+    open: boolean
+    scores: ScoreAggregate[]
+  }>({ open: false, scores: [] })
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
@@ -443,6 +451,23 @@ export default function QuestionnarePage() {
       void clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
+  }
+
+  // Same aggregate call the dashboard's Pillar Scores action makes. Not cached:
+  // the dashboard memoizes across many rows, this page is one system and one
+  // click. On failure nothing opens and the user is told, rather than opening an
+  // empty modal that reads as "this system has no scores".
+  const handleOpenPillarScores = async () => {
+    try {
+      const res = await axiosInstance.get(
+        `/scores/aggregate?fismasystemid=${system}&include_pillars=true`
+      )
+      setPillarScores({ open: true, scores: res.data.data })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error('Error fetching pillar scores:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error')
+    }
   }
 
   // Keep insight, review, and card state scoped to one system x data call x
@@ -1193,6 +1218,14 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
+  // The data call both header modals present as "current". Prefer the call this
+  // questionnaire actually resolved (datacallID covers every entry path,
+  // including URL deep links where no route state exists); fall back to the
+  // route/selected/latest chain during the pre-fetch window.
+  const viewedDataCallId =
+    datacallID > 0
+      ? datacallID
+      : routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
   return (
     <>
       <Box
@@ -1203,14 +1236,40 @@ export default function QuestionnarePage() {
         }}
       >
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => setDiffModalOpen(true)}
-          sx={{ whiteSpace: 'nowrap' }}
-        >
-          Compare Datacalls
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {/* Cross-navigation back to this system's detail page (ui#610).
+              Gated on the same hasSystemAccess check the dashboard puts on its
+              own System Details action. Every current role passes it (delegates
+              included), so in practice this only suppresses the button while
+              userInfo is unloaded or carries an unrecognized role - but it is
+              the gate that moves if system-detail access ever narrows. */}
+          {hasSystemAccess(userInfo) && (
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate(`/systems/${system}`)}
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              System Info
+            </Button>
+          )}
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleOpenPillarScores}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Pillar Scores
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setDiffModalOpen(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Compare Datacalls
+          </Button>
+        </Box>
       </Box>
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1589,23 +1648,26 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
-      {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
-          questionnaire actually resolved (datacallID covers every entry path,
-          including URL deep links where no route state exists); fall back to
-          the route/selected/latest chain during the pre-fetch window. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
-        selectedDataCallId={
-          datacallID > 0
-            ? datacallID
-            : routeDatacallId ??
-              selectedDatacall?.datacallid ??
-              latestDataCallId
+        selectedDataCallId={viewedDataCallId}
+      />
+      {/* Same modal the dashboard's Pillar Scores action opens. The acronym
+          comes from the resolved system rather than the lowercased URL param so
+          the title matches the dashboard's casing. */}
+      <PillarScoresModal
+        open={pillarScores.open}
+        onClose={() => setPillarScores((prev) => ({ ...prev, open: false }))}
+        systemName={systemName}
+        systemAcronym={
+          systemInfo?.fismaacronym ?? fismaacronym?.toUpperCase() ?? ''
         }
+        scores={pillarScores.scores}
+        selectedDataCallId={viewedDataCallId}
       />
     </>
   )

--- a/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import SystemDetailHeader from './SystemDetailHeader'
+
+// Cross-navigation coverage for ui#609: System Info needs a link to the
+// system's questionnaire. The questionnaire route is keyed on :fismaacronym
+// while this page is routed by :fismasystemid, so the acronym is passed in.
+
+const BASE_PROPS = {
+  systemName: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  canEdit: false,
+  isEditing: false,
+  isSaving: false,
+  isFormValid: true,
+  onEdit: jest.fn(),
+  onSave: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+// Data-router harness so the component gets the same useNavigate the app does,
+// and so the resulting pathname is assertable off router.state.
+function renderHeader(props: Partial<typeof BASE_PROPS> = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/systems/:fismasystemid',
+        element: <SystemDetailHeader {...BASE_PROPS} {...props} />,
+      },
+      {
+        path: '/questionnaire/:fismaacronym',
+        element: <div>questionnaire</div>,
+      },
+      { path: '/', element: <div>dashboard</div> },
+    ],
+    { initialEntries: ['/systems/1002'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+it('renders a Questionnaire button', () => {
+  renderHeader()
+  expect(
+    screen.getByRole('button', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+})
+
+it('navigates to the questionnaire keyed on the lowercased acronym', async () => {
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  // Lowercased to match the URL shape the dashboard's own questionnaire action
+  // builds (FismaTable openQuestionnaire), so both entry points share one link.
+  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
+})
+
+it('carries no route state, so the questionnaire falls back to the selected/latest call', async () => {
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  // Absent location.state.datacallid is what makes QuestionnairePage resolve
+  // the cycle itself; sending a call id from here would pin the wrong one.
+  expect(router.state.location.state).toBeNull()
+})
+
+it('still links a decommissioned system, leaving the explanation to the questionnaire', async () => {
+  // The header takes no decommissioned flag on purpose: rather than hiding the
+  // button, the questionnaire's own "no questionnaire is available" alert
+  // explains the outcome (ui#609 review).
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
+})
+
+it('shows Questionnaire alongside Edit for an editor', () => {
+  renderHeader({ canEdit: true })
+  expect(
+    screen.getByRole('button', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+})
+
+it('hides Questionnaire while editing so a dirty form keeps Save/Cancel only', () => {
+  renderHeader({ canEdit: true, isEditing: true })
+  expect(
+    screen.queryByRole('button', { name: 'Questionnaire' })
+  ).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -5,6 +5,9 @@ import { useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
+  /** Drives the Questionnaire link; the questionnaire route is keyed on the
+   * acronym, not the fismasystemid this page is routed by (ui#609). */
+  fismaacronym: string
   /** Admins edit the whole form; an assigned ISSO gets the same Edit button
    * but only the target-maturity card unlocks for them (ztmf#398). */
   canEdit: boolean
@@ -18,6 +21,7 @@ interface SystemDetailHeaderProps {
 
 export default function SystemDetailHeader({
   systemName,
+  fismaacronym,
   canEdit,
   isEditing,
   isSaving,
@@ -61,11 +65,28 @@ export default function SystemDetailHeader({
             </CmsButton>
           </>
         ) : (
-          canEdit && (
-            <CmsButton variation="solid" onClick={onEdit}>
-              Edit
+          <>
+            {/* Cross-navigation to this system's questionnaire (ui#609). No
+                route state: QuestionnairePage falls back to the selected/latest
+                data call when location.state carries no datacallid, which is
+                the right default arriving from here, and it keeps the target a
+                plain shareable URL. Rendered only outside edit mode so a dirty
+                form keeps Save/Cancel as its only actions. A decommissioned
+                system links too and the questionnaire's own
+                "no questionnaire is available" alert explains the outcome. */}
+            <CmsButton
+              onClick={() =>
+                navigate(`/questionnaire/${fismaacronym.toLowerCase()}`)
+              }
+            >
+              Questionnaire
             </CmsButton>
-          )
+            {canEdit && (
+              <CmsButton variation="solid" onClick={onEdit}>
+                Edit
+              </CmsButton>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -612,6 +612,7 @@ export default function SystemDetailPage() {
 
       <SystemDetailHeader
         systemName={system.fismaname}
+        fismaacronym={system.fismaacronym}
         canEdit={isAdmin}
         isEditing={isEditing}
         isSaving={isSaving}


### PR DESCRIPTION
Closes #609
Closes #610

Both tickets are the same complaint from opposite directions: the System Info page and the Questionnaire were only reachable from the dashboard, so moving between a system's detail page and its questionnaire meant going back and finding the system again.

The routes are keyed on different identifiers, questionnaire on `:fismaacronym` and detail on `:fismasystemid`, and each page already holds both, so neither direction needs a new lookup to build its link.

## #609, System Info to Questionnaire

<img width="1440" height="900" alt="01-system-info-questionnaire-button" src="https://github.com/user-attachments/assets/10882c48-26d1-420b-a158-0fcda53357e6" />

`SystemDetailHeader` takes the acronym as a prop and renders a Questionnaire button to the left of Edit, targeting `/questionnaire/<acronym-lowercased>`, the same URL shape the dashboard's own questionnaire action builds in `FismaTable`.

It deliberately carries no route state. An absent `location.state.datacallid` is what lets `QuestionnairePage` resolve the cycle itself, which is the right default arriving from System Info with no per-row call context, and it keeps the target a plain shareable URL.

A decommissioned system links too rather than hiding the button, leaving the questionnaire's existing "no questionnaire is available for this system" alert to explain the outcome. The button is suppressed while the page is in edit mode, so a dirty form keeps Save and Cancel as its only actions, matching how that button group already behaves.

## #610, Questionnaire to System Info, plus Pillar Scores

<img width="2055" height="1094" alt="Screenshot 2026-07-29 at 10 36 22 AM" src="https://github.com/user-attachments/assets/e17e6e68-2eb6-48da-a88d-cb8a31890a31" />

The questionnaire header row already held Compare Datacalls next to the breadcrumbs, so System Info and Pillar Scores join it there.

System Info navigates to `/systems/<fismasystemid>`, resolved from the acronym the route carries. It sits behind the same `hasSystemAccess` check the dashboard puts on its own System Details action. Worth being precise about what that gate does today: every role in the union passes it, delegates included, so in practice it only suppresses the button while `userInfo` is unloaded or carries an unrecognized role. I kept it so the two move together if system-detail access ever narrows.

Pillar Scores reuses `PillarScoresModal`. Unlike `ScoreDiffModal` it takes its rows as a prop rather than fetching, so the handler makes the same `GET /scores/aggregate?fismasystemid=…&include_pillars=true` call the dashboard action makes and opens on success. A failure notifies rather than opening an empty modal, which would read as "this system has no scores". I did not port the dashboard's module-level `pillarScoresCache`: that memoizes across many rows, this is one system and one click.

The modal title takes its acronym from the resolved system rather than the lowercased URL param, so the casing matches the dashboard.

Small cleanup while I was in there: the selected-data-call fallback chain is now a single `viewedDataCallId` const, since both header modals need the same value.

## No unsaved-work guard, on purpose

Leaving the questionnaire for System Info does not prompt. In-progress answers are persisted through `saveDraft` / `loadDraft` keyed on user, system, question and data call, so navigating away and back restores the draft, and the existing Compare Datacalls button sets no guard either.

## Testing

Ten new tests, six in `SystemDetailHeader.test.tsx` (a new file, that component had no coverage) and four in `QuestionnairePage.crossnav.test.tsx`. Both use the `createMemoryRouter` data-router harness the deep-link suite documents, so the components get the same stable `useNavigate` the app does and the resulting pathname is assertable.

Coverage is the lowercased acronym target, the deliberately null route state, the decommissioned case still linking, edit-mode suppression, the acronym resolving to the right `fismasystemid`, the access gate, the aggregate call firing with the right params before the modal opens, and the failure path leaving the modal closed.

Full frontend gate green locally: `npx tsc --noEmit` clean, `eslint src` zero errors, and the whole jest suite at 52 suites and 677 tests passing. No backend change, so nothing for the Go or emberfall suites.

Snyk and the other secret-dependent checks will show red on this fork PR as usual.
