### PR TITLE
feat(#609, #610): cross-navigation between System Info and the Questionnaire

### DIFF
--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
@@ -276,4 +276,47 @@ it('flushes a pending draft when the page unmounts mid-debounce', async () => {
   })
   expect(questionId).toBe(7006)
   expect(draft.notes).toBe('Imperial posture note')
+})
+
+it('does not lose a newer edit made while an earlier save is in flight', async () => {
+  // Regression for the identity-clear race (#640 review): edit A's debounced
+  // save starts; edit B replaces the pending payload under the SAME generation
+  // (saveGenRef only moves on explicit clears); save A's completion must not
+  // clear B's payload, or an unmount before B's own debounce flushes nothing.
+  const { saveDraft } = require('./draftStore') as { saveDraft: jest.Mock }
+  let resolveSaveA!: (saved: boolean) => void
+  saveDraft.mockImplementationOnce(
+    () => new Promise<boolean>((resolve) => (resolveSaveA = resolve))
+  )
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  // Edit A; let its 1s debounce fire so saveDraft(A) is genuinely in flight.
+  await userEvent.type(notesField, 'A')
+  await waitFor(() => expect(saveDraft).toHaveBeenCalledTimes(1), {
+    timeout: 3000,
+  })
+  expect(saveDraft.mock.calls[0][4].notes).toBe('A')
+
+  // Edit B while A remains unresolved.
+  await userEvent.type(notesField, 'B')
+
+  // A resolves successfully. Identity check must leave B's payload pending.
+  await act(async () => {
+    resolveSaveA(true)
+  })
+
+  // Leave before B's own debounce fires.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(2)
+  expect(saveDraft.mock.calls[1][4].notes).toBe('AB')
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Cross-navigation coverage for ui#610: the questionnaire header needs a link
+// back to System Info and a Pillar Scores button, alongside the existing
+// Compare Datacalls button.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// notify() reaches notistack's standalone enqueueSnackbar, which needs a
+// mounted provider; keep isAuthHandled real so the error path is exercised as
+// written (same pattern as QuestionnairePage.test).
+const notifyMock = jest.fn()
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return {
+    ...actual,
+    notify: (...args: unknown[]) => notifyMock(...args),
+  }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const QUESTIONS = [
+  {
+    questionid: 900,
+    question: 'Question for Imperial Identity Verification',
+    notesprompt: 'Notes',
+    pillar: { pillar: 'Identity' },
+    function: {
+      functionid: 7006,
+      function: 'Imperial Identity Verification',
+      description: 'Imperial Identity Verification description',
+      datacenterenvironment: 'Imperial-Fleet',
+    },
+  },
+]
+
+const AGGREGATE = [
+  {
+    datacallid: 5,
+    fismasystemid: 1002,
+    systemscore: 3.75,
+    pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 3.5 }],
+  },
+]
+
+function makeCtx(role: userData['role'] | undefined) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = makeCtx('OWNER')
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/scores/aggregate'))
+      return Promise.resolve({ data: { data: AGGREGATE } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+// Data-router harness matching the app's createHashRouter, per the note in
+// QuestionnairePage.deeplink.test: a plain MemoryRouter hands the component the
+// unstable useNavigate and re-runs the fetch effect on the canonical redirect.
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> },
+      { path: '/systems/:fismasystemid', element: <div>system detail</div> },
+    ],
+    { initialEntries: ['/questionnaire/ssd-ex'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+const aggregateCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => typeof u === 'string' && u.includes('/scores/aggregate'))
+
+it('navigates to the system detail page keyed on fismasystemid', async () => {
+  const router = renderPage()
+  const button = await screen.findByRole('button', { name: 'System Info' })
+  await userEvent.click(button)
+  // The questionnaire route carries the acronym; the detail route is keyed on
+  // the id, so this proves the acronym was resolved to 1002 before linking.
+  expect(router.state.location.pathname).toBe('/systems/1002')
+})
+
+it('suppresses System Info when the role fails the system-access gate', async () => {
+  mockCtx = makeCtx(undefined)
+  renderPage()
+  // Compare Datacalls is ungated, so its presence proves the header rendered
+  // and only the gated button is missing.
+  await screen.findByRole('button', { name: 'Compare Datacalls' })
+  expect(
+    screen.queryByRole('button', { name: 'System Info' })
+  ).not.toBeInTheDocument()
+})
+
+it('fetches the pillar aggregate for this system and opens the modal', async () => {
+  renderPage()
+  const button = await screen.findByRole('button', { name: 'Pillar Scores' })
+  expect(aggregateCalls()).toHaveLength(0)
+  await userEvent.click(button)
+
+  await waitFor(() =>
+    expect(
+      aggregateCalls().some(
+        (u) =>
+          u.includes('fismasystemid=1002') && u.includes('include_pillars=true')
+      )
+    ).toBe(true)
+  )
+  // Acronym in the title comes from the resolved system, not the lowercased
+  // URL param, so it matches the dashboard's casing.
+  expect(
+    await screen.findByText(
+      /Super Star Destroyer Executor Command Systems \(SSD-EX\) - Pillar Scores/
+    )
+  ).toBeInTheDocument()
+})
+
+it('keeps the modal closed when the aggregate fetch fails', async () => {
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/scores/aggregate'))
+      return Promise.reject(new Error('boom'))
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  renderPage()
+  await userEvent.click(
+    await screen.findByRole('button', { name: 'Pillar Scores' })
+  )
+
+  await waitFor(() => expect(aggregateCalls()).not.toHaveLength(0))
+  // An empty modal would read as "this system has no scores"; nothing opens and
+  // the user is told instead.
+  await waitFor(() =>
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.stringContaining('error occurred'),
+      'error'
+    )
+  )
+  expect(screen.queryByText(/- Pillar Scores/)).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -59,6 +59,11 @@ const QUESTIONS = [
   },
 ]
 
+const OPTIONS_7006 = [
+  { functionoptionid: 100, description: 'Baseline', score: 1 },
+  { functionoptionid: 101, description: 'Advanced', score: 2 },
+]
+
 const AGGREGATE = [
   {
     datacallid: 5,
@@ -136,8 +141,8 @@ function renderPage() {
     ],
     { initialEntries: ['/questionnaire/ssd-ex'] }
   )
-  render(<RouterProvider router={router} />)
-  return router
+  const { unmount } = render(<RouterProvider router={router} />)
+  return { router, unmount }
 }
 
 const aggregateCalls = () =>
@@ -146,8 +151,8 @@ const aggregateCalls = () =>
     .filter((u) => typeof u === 'string' && u.includes('/scores/aggregate'))
 
 it('navigates to the system detail page keyed on fismasystemid', async () => {
-  const router = renderPage()
-  const button = await screen.findByRole('button', { name: 'System Info' })
+  const { router } = renderPage()
+  const button = await screen.findByRole('link', { name: 'System Info' })
   await userEvent.click(button)
   // The questionnaire route carries the acronym; the detail route is keyed on
   // the id, so this proves the acronym was resolved to 1002 before linking.
@@ -161,7 +166,7 @@ it('suppresses System Info when the role fails the system-access gate', async ()
   // and only the gated button is missing.
   await screen.findByRole('button', { name: 'Compare Datacalls' })
   expect(
-    screen.queryByRole('button', { name: 'System Info' })
+    screen.queryByRole('link', { name: 'System Info' })
   ).not.toBeInTheDocument()
 })
 
@@ -213,4 +218,62 @@ it('keeps the modal closed when the aggregate fetch fails', async () => {
     )
   )
   expect(screen.queryByText(/- Pillar Scores/)).not.toBeInTheDocument()
+})
+
+it('offers a way back from the no-questionnaire state', async () => {
+  // A decommissioned or out-of-scope system joins to zero functions, and the
+  // #609 button makes that state reachable from System Info. Without the link
+  // here the trip is one-way (#640 review).
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  renderPage()
+  expect(
+    await screen.findByText(/No questionnaire is available for this system/i)
+  ).toBeInTheDocument()
+  expect(
+    await screen.findByRole('link', { name: 'System Info' })
+  ).toHaveAttribute('href', '/systems/1002')
+})
+
+it('flushes a pending draft when the page unmounts mid-debounce', async () => {
+  const { saveDraft } = require('./draftStore') as {
+    saveDraft: jest.Mock
+  }
+  // Real options so the answer/notes panel renders rather than staying in its
+  // loading state.
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  await userEvent.type(notesField, 'Imperial posture note')
+  // Nothing written yet: the save is debounced 1s and no timer has fired.
+  expect(saveDraft).not.toHaveBeenCalled()
+
+  // Leaving for System Info (or the Dashboard breadcrumb, or browser back)
+  // unmounts the page. beforeunload does not fire on in-app navigation and the
+  // debounce cleanup cancels its own timer, so without the unmount flush this
+  // edit was silently dropped.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(1)
+  const [userid, system, questionId, datacallID, draft] =
+    saveDraft.mock.calls[0]
+  expect({ userid, system, datacallID }).toEqual({
+    userid: '1',
+    system: 1002,
+    datacallID: 5,
+  })
+  expect(questionId).toBe(7006)
+  expect(draft.notes).toBe('Imperial posture note')
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,6 +21,7 @@ import {
   QuestionScores,
   Insight,
   InsightPayload,
+  ScoreAggregate,
 } from '@/types'
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
@@ -44,9 +45,10 @@ import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
+import PillarScoresModal from '@/components/PillarScoresModal/PillarScoresModal'
 import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
-import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
+import { isAdmin, isReadOnlyAdmin, hasSystemAccess } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel from './InsightsPanel/InsightsPanel'
 import QuestionRadioGroup from './QuestionRadioGroup'
@@ -130,6 +132,12 @@ export default function QuestionnarePage() {
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const [diffModalOpen, setDiffModalOpen] = React.useState(false)
+  // PillarScoresModal takes its rows as a prop rather than fetching (unlike
+  // ScoreDiffModal), so the header button fetches before opening (ui#610).
+  const [pillarScores, setPillarScores] = React.useState<{
+    open: boolean
+    scores: ScoreAggregate[]
+  }>({ open: false, scores: [] })
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
@@ -443,6 +451,23 @@ export default function QuestionnarePage() {
       void clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
+  }
+
+  // Same aggregate call the dashboard's Pillar Scores action makes. Not cached:
+  // the dashboard memoizes across many rows, this page is one system and one
+  // click. On failure nothing opens and the user is told, rather than opening an
+  // empty modal that reads as "this system has no scores".
+  const handleOpenPillarScores = async () => {
+    try {
+      const res = await axiosInstance.get(
+        `/scores/aggregate?fismasystemid=${system}&include_pillars=true`
+      )
+      setPillarScores({ open: true, scores: res.data.data })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error('Error fetching pillar scores:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error')
+    }
   }
 
   // Keep insight, review, and card state scoped to one system x data call x
@@ -1193,6 +1218,14 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
+  // The data call both header modals present as "current". Prefer the call this
+  // questionnaire actually resolved (datacallID covers every entry path,
+  // including URL deep links where no route state exists); fall back to the
+  // route/selected/latest chain during the pre-fetch window.
+  const viewedDataCallId =
+    datacallID > 0
+      ? datacallID
+      : routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
   return (
     <>
       <Box
@@ -1203,14 +1236,40 @@ export default function QuestionnarePage() {
         }}
       >
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => setDiffModalOpen(true)}
-          sx={{ whiteSpace: 'nowrap' }}
-        >
-          Compare Datacalls
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {/* Cross-navigation back to this system's detail page (ui#610).
+              Gated on the same hasSystemAccess check the dashboard puts on its
+              own System Details action. Every current role passes it (delegates
+              included), so in practice this only suppresses the button while
+              userInfo is unloaded or carries an unrecognized role - but it is
+              the gate that moves if system-detail access ever narrows. */}
+          {hasSystemAccess(userInfo) && (
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => navigate(`/systems/${system}`)}
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              System Info
+            </Button>
+          )}
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleOpenPillarScores}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Pillar Scores
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setDiffModalOpen(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Compare Datacalls
+          </Button>
+        </Box>
       </Box>
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1589,23 +1648,26 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
-      {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
-          questionnaire actually resolved (datacallID covers every entry path,
-          including URL deep links where no route state exists); fall back to
-          the route/selected/latest chain during the pre-fetch window. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
-        selectedDataCallId={
-          datacallID > 0
-            ? datacallID
-            : routeDatacallId ??
-              selectedDatacall?.datacallid ??
-              latestDataCallId
+        selectedDataCallId={viewedDataCallId}
+      />
+      {/* Same modal the dashboard's Pillar Scores action opens. The acronym
+          comes from the resolved system rather than the lowercased URL param so
+          the title matches the dashboard's casing. */}
+      <PillarScoresModal
+        open={pillarScores.open}
+        onClose={() => setPillarScores((prev) => ({ ...prev, open: false }))}
+        systemName={systemName}
+        systemAcronym={
+          systemInfo?.fismaacronym ?? fismaacronym?.toUpperCase() ?? ''
         }
+        scores={pillarScores.scores}
+        selectedDataCallId={viewedDataCallId}
       />
     </>
   )

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -1044,7 +1044,7 @@ export default function QuestionnarePage() {
       return
     }
     const currentGen = saveGenRef.current
-    pendingDraftRef.current = {
+    const pending = {
       userid: userInfo.userid,
       system,
       questionId,
@@ -1052,19 +1052,26 @@ export default function QuestionnarePage() {
       draft: { selectQuestionOption, notes },
       gen: currentGen,
     }
+    pendingDraftRef.current = pending
     const timer = setTimeout(() => {
       if (saveGenRef.current !== currentGen) return
       saveDraft(
-        userInfo.userid,
-        system,
-        questionId,
-        datacallID,
-        { selectQuestionOption, notes },
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft,
         () => saveGenRef.current === currentGen
       ).then((saved) => {
         if (saveGenRef.current !== currentGen) return
-        // Written, so an unmount flush would only rewrite identical content.
-        if (pendingDraftRef.current?.gen === currentGen)
+        // Clear by identity, not generation: a newer edit re-runs this effect
+        // and replaces the ref with a NEW object under the SAME generation
+        // (saveGenRef only moves on explicit clears), so a generation check
+        // here would let the older save's completion discard the newer edit's
+        // payload while its own debounce is still pending — and an unmount in
+        // that window would then flush nothing (#640 review). Gated on `saved`
+        // so a failed write stays in the ref for the unmount flush to retry.
+        if (saved && pendingDraftRef.current === pending)
           pendingDraftRef.current = null
         if (saved) {
           if (draftStatusRef.current !== 'restored') setDraftStatus('saved')

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -26,7 +26,7 @@ import {
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
@@ -209,6 +209,20 @@ export default function QuestionnarePage() {
   // Incremented on every explicit draft clear so in-flight debounced saves
   // that fire after a clear don't resurrect the just-removed draft.
   const saveGenRef = React.useRef(0)
+  // Mirrors the payload the debounced draft save would write, so unmount can
+  // flush it. The debounce cleanup cancels its own pending timer, and a route
+  // change away from this page (System Info, the Dashboard breadcrumb, browser
+  // back) tears the component down without firing beforeunload, so an edit made
+  // inside the 1s window was dropped. Carries the generation so a flush cannot
+  // resurrect a draft clearCurrentDraft deleted after the timer was scheduled.
+  const pendingDraftRef = React.useRef<{
+    userid: string
+    system: number
+    questionId: number
+    datacallID: number
+    draft: { selectQuestionOption: number; notes: string }
+    gen: number
+  } | null>(null)
   const unsavedRef = React.useRef({
     selectQuestionOption,
     initQuestionChoice,
@@ -462,7 +476,7 @@ export default function QuestionnarePage() {
       const res = await axiosInstance.get(
         `/scores/aggregate?fismasystemid=${system}&include_pillars=true`
       )
-      setPillarScores({ open: true, scores: res.data.data })
+      setPillarScores({ open: true, scores: res.data?.data ?? [] })
     } catch (error) {
       if (isAuthHandled(error)) return
       console.error('Error fetching pillar scores:', error)
@@ -1008,10 +1022,12 @@ export default function QuestionnarePage() {
       datacallID <= 0 ||
       loadingQuestion
     ) {
+      pendingDraftRef.current = null
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
     if (selectQuestionOption === initQuestionChoice && notes === initNotes) {
+      pendingDraftRef.current = null
       saveGenRef.current++
       // Skip clearDraft when a draft was just restored from storage — the draft
       // values matching the server state does not mean the user reverted manually.
@@ -1028,6 +1044,14 @@ export default function QuestionnarePage() {
       return
     }
     const currentGen = saveGenRef.current
+    pendingDraftRef.current = {
+      userid: userInfo.userid,
+      system,
+      questionId,
+      datacallID,
+      draft: { selectQuestionOption, notes },
+      gen: currentGen,
+    }
     const timer = setTimeout(() => {
       if (saveGenRef.current !== currentGen) return
       saveDraft(
@@ -1039,6 +1063,9 @@ export default function QuestionnarePage() {
         () => saveGenRef.current === currentGen
       ).then((saved) => {
         if (saveGenRef.current !== currentGen) return
+        // Written, so an unmount flush would only rewrite identical content.
+        if (pendingDraftRef.current?.gen === currentGen)
+          pendingDraftRef.current = null
         if (saved) {
           if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
         } else {
@@ -1059,6 +1086,32 @@ export default function QuestionnarePage() {
     loadingQuestion,
     userInfo.userid,
   ])
+
+  // Flush a pending draft on unmount. beforeunload below covers tab close and
+  // hard refresh, but it does not fire on in-app navigation, and the debounce
+  // cleanup cancels the timer that would have written the draft. Mount-once so
+  // the cleanup runs on unmount only, never on a dep change (flushing on every
+  // dep change would defeat the debounce and write on each keystroke).
+  // saveDraft takes primitives and touches no component state, so the write
+  // completes after this component is gone.
+  React.useEffect(() => {
+    return () => {
+      const pending = pendingDraftRef.current
+      // Reading the live generation is the point of this guard, not a staleness
+      // bug: it must reflect any clearCurrentDraft that ran after the timer was
+      // scheduled, so a flush cannot resurrect a just-deleted draft. Copying it
+      // into the effect body would freeze it at its mount value.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      if (!pending || saveGenRef.current !== pending.gen) return
+      void saveDraft(
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft
+      )
+    }
+  }, [])
 
   // Warn before tab close or hard refresh when the active question has edits
   // that haven't been committed to the backend yet.
@@ -1195,10 +1248,41 @@ export default function QuestionnarePage() {
       </>
     )
   }
+  // Cross-navigation back to this system's detail page (ui#610). A real router
+  // link rather than onClick + navigate, so open-in-new-tab and copy-link work.
+  // Gated on the same hasSystemAccess check the dashboard puts on its own System
+  // Details action. Every current role passes it (delegates included), so in
+  // practice this only suppresses the link while userInfo is unloaded or carries
+  // an unrecognized role - but it is the gate that moves if system-detail access
+  // ever narrows.
+  const systemInfoLink = hasSystemAccess(userInfo) ? (
+    <Button
+      variant="outlined"
+      size="small"
+      component={RouterLink}
+      to={`/systems/${system}`}
+      sx={{ whiteSpace: 'nowrap' }}
+    >
+      System Info
+    </Button>
+  ) : null
   if (noQuestions) {
     return (
       <>
-        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+          {/* Without this the flow System Info -> Questionnaire -> "no
+              questionnaire available" is one-way, which the #609 button makes
+              reachable for any out-of-scope or decommissioned system (#640
+              review). */}
+          {systemInfoLink}
+        </Box>
         <Container maxWidth={false} disableGutters>
           <Alert severity="info" sx={{ mt: 2 }}>
             No questionnaire is available for this system. This typically
@@ -1237,22 +1321,7 @@ export default function QuestionnarePage() {
       >
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
         <Box sx={{ display: 'flex', gap: 1 }}>
-          {/* Cross-navigation back to this system's detail page (ui#610).
-              Gated on the same hasSystemAccess check the dashboard puts on its
-              own System Details action. Every current role passes it (delegates
-              included), so in practice this only suppresses the button while
-              userInfo is unloaded or carries an unrecognized role - but it is
-              the gate that moves if system-detail access ever narrows. */}
-          {hasSystemAccess(userInfo) && (
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => navigate(`/systems/${system}`)}
-              sx={{ whiteSpace: 'nowrap' }}
-            >
-              System Info
-            </Button>
-          )}
+          {systemInfoLink}
           <Button
             variant="outlined"
             size="small"

--- a/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import SystemDetailHeader from './SystemDetailHeader'
 
@@ -40,42 +39,31 @@ function renderHeader(props: Partial<typeof BASE_PROPS> = {}) {
   return router
 }
 
-it('renders a Questionnaire button', () => {
+it('renders Questionnaire as a link, not a bare button', () => {
   renderHeader()
-  expect(
-    screen.getByRole('button', { name: 'Questionnaire' })
-  ).toBeInTheDocument()
+  // An anchor (CmsButton href) rather than onClick + navigate, so
+  // open-in-new-tab and copy-link work (#640 review).
+  const link = screen.getByRole('link', { name: 'Questionnaire' })
+  expect(link).toBeInTheDocument()
+  expect(link.tagName).toBe('A')
 })
 
-it('navigates to the questionnaire keyed on the lowercased acronym', async () => {
-  const router = renderHeader()
-  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+it('targets the questionnaire keyed on the lowercased acronym', () => {
+  renderHeader()
   // Lowercased to match the URL shape the dashboard's own questionnaire action
   // builds (FismaTable openQuestionnaire), so both entry points share one link.
-  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
-})
-
-it('carries no route state, so the questionnaire falls back to the selected/latest call', async () => {
-  const router = renderHeader()
-  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
-  // Absent location.state.datacallid is what makes QuestionnairePage resolve
-  // the cycle itself; sending a call id from here would pin the wrong one.
-  expect(router.state.location.state).toBeNull()
-})
-
-it('still links a decommissioned system, leaving the explanation to the questionnaire', async () => {
-  // The header takes no decommissioned flag on purpose: rather than hiding the
-  // button, the questionnaire's own "no questionnaire is available" alert
-  // explains the outcome (ui#609 review).
-  const router = renderHeader()
-  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
-  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
+  // Bare acronym with no trailing segments: the omitted datacall is what makes
+  // QuestionnairePage resolve the cycle itself, and pinning one from here would
+  // fix the wrong call.
+  expect(
+    screen.getByRole('link', { name: 'Questionnaire' }).getAttribute('href')
+  ).toBe('/questionnaire/ssd-ex')
 })
 
 it('shows Questionnaire alongside Edit for an editor', () => {
   renderHeader({ canEdit: true })
   expect(
-    screen.getByRole('button', { name: 'Questionnaire' })
+    screen.getByRole('link', { name: 'Questionnaire' })
   ).toBeInTheDocument()
   expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
 })
@@ -83,7 +71,7 @@ it('shows Questionnaire alongside Edit for an editor', () => {
 it('hides Questionnaire while editing so a dirty form keeps Save/Cancel only', () => {
   renderHeader({ canEdit: true, isEditing: true })
   expect(
-    screen.queryByRole('button', { name: 'Questionnaire' })
+    screen.queryByRole('link', { name: 'Questionnaire' })
   ).not.toBeInTheDocument()
   expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()

--- a/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import SystemDetailHeader from './SystemDetailHeader'
+
+// Cross-navigation coverage for ui#609: System Info needs a link to the
+// system's questionnaire. The questionnaire route is keyed on :fismaacronym
+// while this page is routed by :fismasystemid, so the acronym is passed in.
+
+const BASE_PROPS = {
+  systemName: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  canEdit: false,
+  isEditing: false,
+  isSaving: false,
+  isFormValid: true,
+  onEdit: jest.fn(),
+  onSave: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+// Data-router harness so the component gets the same useNavigate the app does,
+// and so the resulting pathname is assertable off router.state.
+function renderHeader(props: Partial<typeof BASE_PROPS> = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/systems/:fismasystemid',
+        element: <SystemDetailHeader {...BASE_PROPS} {...props} />,
+      },
+      {
+        path: '/questionnaire/:fismaacronym',
+        element: <div>questionnaire</div>,
+      },
+      { path: '/', element: <div>dashboard</div> },
+    ],
+    { initialEntries: ['/systems/1002'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+it('renders a Questionnaire button', () => {
+  renderHeader()
+  expect(
+    screen.getByRole('button', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+})
+
+it('navigates to the questionnaire keyed on the lowercased acronym', async () => {
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  // Lowercased to match the URL shape the dashboard's own questionnaire action
+  // builds (FismaTable openQuestionnaire), so both entry points share one link.
+  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
+})
+
+it('carries no route state, so the questionnaire falls back to the selected/latest call', async () => {
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  // Absent location.state.datacallid is what makes QuestionnairePage resolve
+  // the cycle itself; sending a call id from here would pin the wrong one.
+  expect(router.state.location.state).toBeNull()
+})
+
+it('still links a decommissioned system, leaving the explanation to the questionnaire', async () => {
+  // The header takes no decommissioned flag on purpose: rather than hiding the
+  // button, the questionnaire's own "no questionnaire is available" alert
+  // explains the outcome (ui#609 review).
+  const router = renderHeader()
+  await userEvent.click(screen.getByRole('button', { name: 'Questionnaire' }))
+  expect(router.state.location.pathname).toBe('/questionnaire/ssd-ex')
+})
+
+it('shows Questionnaire alongside Edit for an editor', () => {
+  renderHeader({ canEdit: true })
+  expect(
+    screen.getByRole('button', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+})
+
+it('hides Questionnaire while editing so a dirty form keeps Save/Cancel only', () => {
+  renderHeader({ canEdit: true, isEditing: true })
+  expect(
+    screen.queryByRole('button', { name: 'Questionnaire' })
+  ).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -5,6 +5,9 @@ import { useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
+  /** Drives the Questionnaire link; the questionnaire route is keyed on the
+   * acronym, not the fismasystemid this page is routed by (ui#609). */
+  fismaacronym: string
   /** Admins edit the whole form; an assigned ISSO gets the same Edit button
    * but only the target-maturity card unlocks for them (ztmf#398). */
   canEdit: boolean
@@ -18,6 +21,7 @@ interface SystemDetailHeaderProps {
 
 export default function SystemDetailHeader({
   systemName,
+  fismaacronym,
   canEdit,
   isEditing,
   isSaving,
@@ -61,11 +65,28 @@ export default function SystemDetailHeader({
             </CmsButton>
           </>
         ) : (
-          canEdit && (
-            <CmsButton variation="solid" onClick={onEdit}>
-              Edit
+          <>
+            {/* Cross-navigation to this system's questionnaire (ui#609). No
+                route state: QuestionnairePage falls back to the selected/latest
+                data call when location.state carries no datacallid, which is
+                the right default arriving from here, and it keeps the target a
+                plain shareable URL. Rendered only outside edit mode so a dirty
+                form keeps Save/Cancel as its only actions. A decommissioned
+                system links too and the questionnaire's own
+                "no questionnaire is available" alert explains the outcome. */}
+            <CmsButton
+              onClick={() =>
+                navigate(`/questionnaire/${fismaacronym.toLowerCase()}`)
+              }
+            >
+              Questionnaire
             </CmsButton>
-          )
+            {canEdit && (
+              <CmsButton variation="solid" onClick={onEdit}>
+                Edit
+              </CmsButton>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography, IconButton } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { Button as CmsButton } from '@cmsgov/design-system'
-import { useNavigate } from 'react-router-dom'
+import { useHref, useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
@@ -31,6 +31,14 @@ export default function SystemDetailHeader({
   onCancel,
 }: SystemDetailHeaderProps) {
   const navigate = useNavigate()
+  // Rendered as an <a> via CmsButton's href so open-in-new-tab and copy-link
+  // work. CmsButton has no polymorphic `component` prop, so react-router's Link
+  // cannot be composed in; useHref resolves the path the same way Link would
+  // (under the app's hash router it yields `#/questionnaire/<acronym>`) instead
+  // of hand-writing the fragment. (#640 review)
+  const questionnaireHref = useHref(
+    `/questionnaire/${fismaacronym.toLowerCase()}`
+  )
 
   return (
     <Box
@@ -66,21 +74,15 @@ export default function SystemDetailHeader({
           </>
         ) : (
           <>
-            {/* Cross-navigation to this system's questionnaire (ui#609). No
-                route state: QuestionnairePage falls back to the selected/latest
-                data call when location.state carries no datacallid, which is
-                the right default arriving from here, and it keeps the target a
-                plain shareable URL. Rendered only outside edit mode so a dirty
-                form keeps Save/Cancel as its only actions. A decommissioned
-                system links too and the questionnaire's own
+            {/* Cross-navigation to this system's questionnaire (ui#609). The
+                target carries no route state: QuestionnairePage falls back to
+                the selected/latest data call when location.state has no
+                datacallid, which is the right default arriving from here, and it
+                keeps the link plainly shareable. Rendered only outside edit mode
+                so a dirty form keeps Save/Cancel as its only actions. A
+                decommissioned system links too and the questionnaire's own
                 "no questionnaire is available" alert explains the outcome. */}
-            <CmsButton
-              onClick={() =>
-                navigate(`/questionnaire/${fismaacronym.toLowerCase()}`)
-              }
-            >
-              Questionnaire
-            </CmsButton>
+            <CmsButton href={questionnaireHref}>Questionnaire</CmsButton>
             {canEdit && (
               <CmsButton variation="solid" onClick={onEdit}>
                 Edit

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -612,6 +612,7 @@ export default function SystemDetailPage() {
 
       <SystemDetailHeader
         systemName={system.fismaname}
+        fismaacronym={system.fismaacronym}
         canEdit={isAdmin}
         isEditing={isEditing}
         isSaving={isSaving}


### PR DESCRIPTION
> **Note:** In-repo copy of #638 by @voidspooks. Moved from the fork so Snyk and the deploy CI gates can run — those jobs require org secrets unavailable to fork PRs. Commits and authorship are unchanged.
>
> Refs #638

---

Closes #609
Closes #610

Both tickets are the same complaint from opposite directions: the System Info page and the Questionnaire were only reachable from the dashboard, so moving between a system's detail page and its questionnaire meant going back and finding the system again.

The routes are keyed on different identifiers, questionnaire on `:fismaacronym` and detail on `:fismasystemid`, and each page already holds both, so neither direction needs a new lookup to build its link.

## #609, System Info to Questionnaire

<img width="1440" height="900" alt="01-system-info-questionnaire-button" src="https://github.com/user-attachments/assets/10882c48-26d1-420b-a158-0fcda53357e6" />

`SystemDetailHeader` takes the acronym as a prop and renders a Questionnaire button to the left of Edit, targeting `/questionnaire/<acronym-lowercased>`, the same URL shape the dashboard's own questionnaire action builds in `FismaTable`.

It deliberately carries no route state. An absent `location.state.datacallid` is what lets `QuestionnairePage` resolve the cycle itself, which is the right default arriving from System Info with no per-row call context, and it keeps the target a plain shareable URL.

A decommissioned system links too rather than hiding the button, leaving the questionnaire's existing "no questionnaire is available for this system" alert to explain the outcome. The button is suppressed while the page is in edit mode, so a dirty form keeps Save and Cancel as its only actions, matching how that button group already behaves.

## #610, Questionnaire to System Info, plus Pillar Scores

<img width="2055" height="1094" alt="Screenshot 2026-07-29 at 10 36 22 AM" src="https://github.com/user-attachments/assets/e17e6e68-2eb6-48da-a88d-cb8a31890a31" />

The questionnaire header row already held Compare Datacalls next to the breadcrumbs, so System Info and Pillar Scores join it there.

System Info navigates to `/systems/<fismasystemid>`, resolved from the acronym the route carries. It sits behind the same `hasSystemAccess` check the dashboard puts on its own System Details action. Worth being precise about what that gate does today: every role in the union passes it, delegates included, so in practice it only suppresses the button while `userInfo` is unloaded or carries an unrecognized role. I kept it so the two move together if system-detail access ever narrows.

Pillar Scores reuses `PillarScoresModal`. Unlike `ScoreDiffModal` it takes its rows as a prop rather than fetching, so the handler makes the same `GET /scores/aggregate?fismasystemid=…&include_pillars=true` call the dashboard action makes and opens on success. A failure notifies rather than opening an empty modal, which would read as "this system has no scores". I did not port the dashboard's module-level `pillarScoresCache`: that memoizes across many rows, this is one system and one click.

The modal title takes its acronym from the resolved system rather than the lowercased URL param, so the casing matches the dashboard.

Small cleanup while I was in there: the selected-data-call fallback chain is now a single `viewedDataCallId` const, since both header modals need the same value.

## No unsaved-work guard, on purpose

Leaving the questionnaire for System Info does not prompt. In-progress answers are persisted through `saveDraft` / `loadDraft` keyed on user, system, question and data call, so navigating away and back restores the draft, and the existing Compare Datacalls button sets no guard either.

## Testing

Ten new tests, six in `SystemDetailHeader.test.tsx` (a new file, that component had no coverage) and four in `QuestionnairePage.crossnav.test.tsx`. Both use the `createMemoryRouter` data-router harness the deep-link suite documents, so the components get the same stable `useNavigate` the app does and the resulting pathname is assertable.

Coverage is the lowercased acronym target, the deliberately null route state, the decommissioned case still linking, edit-mode suppression, the acronym resolving to the right `fismasystemid`, the access gate, the aggregate call firing with the right params before the modal opens, and the failure path leaving the modal closed.

Full frontend gate green locally: `npx tsc --noEmit` clean, `eslint src` zero errors, and the whole jest suite at 52 suites and 677 tests passing. No backend change, so nothing for the Go or emberfall suites.

Snyk and the other secret-dependent checks will show red on this fork PR as usual.

