### PR TITLE
Label non-assignable OpDiv grants and stop revoking them

### DIFF
--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -54,6 +54,16 @@ const opdivOptions: OpDiv[] = [
   },
 ]
 
+// Full label source (incl. the non-assignable OpDiv 99, e.g. a parent/inactive
+// division), so the modal can label a grant to it even though it is absent from
+// opdivOptions. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
+// fallback.
+const opdivLabelMap: Record<number, { code: string; name: string }> = {
+  1: { code: 'AAA', name: 'Division A' },
+  2: { code: 'BBB', name: 'Division B' },
+  99: { code: 'ZZZ', name: 'Parent Division' },
+}
+
 function renderModal(
   overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
 ) {
@@ -64,6 +74,8 @@ function renderModal(
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
       onChanged={jest.fn()}
       {...overrides}
     />
@@ -75,9 +87,9 @@ beforeEach(() => {
   mockedNavigate.mockReset()
 })
 
-// The most important test: verifies the scopedIds filter strips out-of-scope
-// grants before the PUT so an OPDIV_ADMIN never triggers a backend 403.
-test('PUT body excludes grants the target user holds outside the caller scope', async () => {
+// Scoped caller (OPDIV_ADMIN, enforceCallerScope=true): the save strips
+// out-of-scope grants before the PUT so the backend scope gate never 403s.
+test('scoped caller: PUT body excludes grants the target holds outside caller scope', async () => {
   // Target user holds [1, 2, 99]. OpDiv 99 is absent from opdivOptions
   // (out of caller scope), so only [1, 2] must reach the batch endpoint.
   mock
@@ -85,7 +97,7 @@ test('PUT body excludes grants the target user holds outside the caller scope', 
     .reply(200, { data: [1, 2, 99] })
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
-  renderModal()
+  renderModal({ enforceCallerScope: true })
   await waitFor(() => expect(mock.history.get).toHaveLength(1))
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
@@ -95,6 +107,47 @@ test('PUT body excludes grants the target user holds outside the caller scope', 
   expect(body.opdiv_ids).toHaveLength(2)
   expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2]))
   expect(body.opdiv_ids).not.toContain(99)
+})
+
+// Unscoped caller (OWNER/HHS_ADMIN, enforceCallerScope=false): the save must
+// PRESERVE the target's non-assignable grants. Omitting 99 would read as a
+// revocation to the backend and silently drop the grant.
+test('unscoped caller: PUT body preserves grants outside the assignable set', async () => {
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(200, { data: [1, 2, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  renderModal({ enforceCallerScope: false })
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2, 99]))
+  expect(body.opdiv_ids).toHaveLength(3)
+})
+
+// A grant to a non-assignable OpDiv (99, absent from opdivOptions) still chips
+// with a readable label from opdivLabelMap - never a blank chip.
+test('labels a grant to a non-assignable OpDiv from the full label map', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal()
+
+  // The chip renders the label map entry, not a blank chip or a raw id.
+  expect(await screen.findByText('ZZZ - Parent Division')).toBeInTheDocument()
+})
+
+// A grant to an OpDiv missing from the label map falls back to "OpDiv #{id}"
+// rather than an empty chip.
+test('falls back to "OpDiv #{id}" for a grant missing from the label map', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [77] })
+
+  renderModal()
+
+  expect(await screen.findByText('OpDiv #77')).toBeInTheDocument()
 })
 
 test('success: modal closes and onChanged fires after save', async () => {
@@ -236,6 +289,8 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
       onChanged={jest.fn()}
     />
   )
@@ -246,6 +301,8 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
       onChanged={jest.fn()}
     />
   )
@@ -295,6 +352,8 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       userid={USER_ID_B}
       userName="Test User B"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
       onChanged={onChanged}
     />
   )

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -150,6 +150,58 @@ test('falls back to "OpDiv #{id}" for a grant missing from the label map', async
   expect(await screen.findByText('OpDiv #77')).toBeInTheDocument()
 })
 
+// A non-assignable grant (99) resolves as a chip but must NOT be offered in the
+// dropdown - filterOptions narrows the selectable set to the assignable OpDivs
+// so it can't be re-selected.
+test('dropdown excludes a non-assignable grant even though it chips', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal()
+  // The grant chips (so the fetch has resolved and options are settled).
+  await screen.findByText('ZZZ - Parent Division')
+
+  // Open the dropdown.
+  await userEvent.click(screen.getByRole('combobox'))
+
+  // Assignable OpDivs are offered...
+  expect(await screen.findByRole('option', { name: /AAA/ })).toBeInTheDocument()
+  // ...but the non-assignable grant is filtered out of the selectable options.
+  expect(screen.queryByRole('option', { name: /ZZZ/ })).not.toBeInTheDocument()
+})
+
+// A scoped caller's save strips out-of-scope ids regardless, so a delete would
+// be a silent no-op. The out-of-scope chip renders WITHOUT a delete affordance,
+// while an in-scope chip keeps it.
+test('scoped caller: an out-of-scope grant chip is not deletable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+
+  renderModal({ enforceCallerScope: true })
+
+  const inScope = (await screen.findByText('AAA - Division A')).closest(
+    '.MuiChip-root'
+  ) as HTMLElement
+  const outOfScope = screen
+    .getByText('ZZZ - Parent Division')
+    .closest('.MuiChip-root') as HTMLElement
+
+  expect(inScope.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
+  expect(outOfScope.querySelector('.MuiChip-deleteIcon')).toBeNull()
+})
+
+// An unscoped caller's removal really revokes, so their out-of-scope chip must
+// keep the delete affordance.
+test('unscoped caller: an out-of-scope grant chip stays deletable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal({ enforceCallerScope: false })
+
+  const outOfScope = (await screen.findByText('ZZZ - Parent Division')).closest(
+    '.MuiChip-root'
+  ) as HTMLElement
+
+  expect(outOfScope.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
+})
+
 test('success: modal closes and onChanged fires after save', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1] })
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -10,7 +10,7 @@ import { Button as CmsButton } from '@cmsgov/design-system'
 import { GridRowId } from '@mui/x-data-grid'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
-import Autocomplete from '@mui/material/Autocomplete'
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
@@ -24,9 +24,24 @@ type Props = {
   /**
    * Assignable OpDivs, already scoped by the caller (children only, active,
    * and - for an OPDIV_ADMIN actor - limited to their own OpDivs). The modal
-   * does not re-scope; it renders exactly what it is given.
+   * does not re-scope; it renders exactly what it is given. Drives the dropdown.
    */
   opdivOptions: OpDiv[]
+  /**
+   * Full label source (all OpDivs, incl. parent/inactive), keyed by opdiv_id.
+   * Separate from opdivOptions so a grant to a non-assignable OpDiv still
+   * resolves to a readable chip instead of a blank one. Ids missing here fall
+   * back to "OpDiv #{id}".
+   */
+  opdivLabelMap: Record<number, { code: string; name: string }>
+  /**
+   * True when the caller is scope-limited (an OPDIV_ADMIN): the save must drop
+   * grants outside the assignable set, since the backend rejects a desired set
+   * containing an ID the caller doesn't hold. False for unscoped admins
+   * (OWNER/HHS_ADMIN), whose save must PRESERVE the target's out-of-scope
+   * grants - omitting them reads as a revocation.
+   */
+  enforceCallerScope: boolean
   /**
    * Fired after a successful save so the caller can refresh the user's row
    * (grants + derived identity_provider) against post-mutation server state.
@@ -40,6 +55,8 @@ export default function OpDivGrantModal({
   userid,
   userName,
   opdivOptions,
+  opdivLabelMap,
+  enforceCallerScope,
   onChanged,
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
@@ -47,23 +64,35 @@ export default function OpDivGrantModal({
   const [loading, setLoading] = React.useState(false)
   const [fetchFailed, setFetchFailed] = React.useState(false)
 
-  const opdivMap = React.useMemo(() => {
-    const map: Record<number, { code: string; name: string }> = {}
-    for (const od of opdivOptions) {
-      map[od.opdiv_id] = { code: od.code, name: od.name }
-    }
-    return map
-  }, [opdivOptions])
-
-  const sortedOptionIds = React.useMemo(
-    () =>
-      opdivOptions
-        .map((od) => od.opdiv_id)
-        .sort((a, b) =>
-          (opdivMap[a]?.code || '').localeCompare(opdivMap[b]?.code || '')
-        ),
-    [opdivOptions, opdivMap]
+  // The assignable set drives the dropdown and gates a scoped caller's save.
+  const assignableIds = React.useMemo(
+    () => new Set(opdivOptions.map((od) => od.opdiv_id)),
+    [opdivOptions]
   )
+
+  // Label from the full map (assignable or not), with an identifiable fallback
+  // so a grant to an OpDiv missing from the map never chips blank.
+  const optionLabel = React.useCallback(
+    (opdivId: number) => {
+      const od = opdivLabelMap[opdivId]
+      return od ? `${od.code} - ${od.name}` : `OpDiv #${opdivId}`
+    },
+    [opdivLabelMap]
+  )
+
+  // Options = assignable + currently-granted, so a chip for a grant to a
+  // non-assignable OpDiv still resolves against the options (no MUI "value not
+  // in options" warning, no blank chip). filterOptions below narrows the
+  // DROPDOWN back to the assignable set so those grants are not re-selectable.
+  const sortedOptionIds = React.useMemo(() => {
+    const ids = new Set<number>(assignableIds)
+    for (const id of localOpDivs) ids.add(id)
+    return Array.from(ids).sort((a, b) =>
+      optionLabel(a).localeCompare(optionLabel(b))
+    )
+  }, [assignableIds, localOpDivs, optionLabel])
+
+  const baseFilter = React.useMemo(() => createFilterOptions<number>(), [])
 
   const handleError = React.useCallback((error: unknown) => {
     if (isAuthHandled(error)) return
@@ -100,20 +129,18 @@ export default function OpDivGrantModal({
     }
   }, [open, userid, handleError])
 
-  const optionLabel = (opdivId: number) => {
-    const od = opdivMap[opdivId]
-    return od ? `${od.code} - ${od.name}` : ''
-  }
-
   const handleSave = () => {
     setSaving(true)
-    // An OPDIV_ADMIN's scope is already encoded in sortedOptionIds (only their
-    // own OpDivs appear as options). Filter localOpDivs to that set so the
-    // batch request never includes out-of-scope IDs the target user holds from
-    // another admin — the backend scope gate rejects any desired set that
-    // contains an ID the caller doesn't hold, even if they didn't add it.
-    const scopedIds = localOpDivs.filter((id) => sortedOptionIds.includes(id))
-    setUserOpDivs(String(userid), scopedIds)
+    // Scoped caller (OPDIV_ADMIN): drop grants outside the assignable set so the
+    // batch request never includes out-of-scope IDs the target holds from
+    // another admin - the backend rejects any desired set containing an ID the
+    // caller doesn't hold. Unscoped caller (OWNER/HHS_ADMIN): send every grant
+    // as-is, since omitting the target's non-assignable grants would revoke
+    // them.
+    const idsToSave = enforceCallerScope
+      ? localOpDivs.filter((id) => assignableIds.has(id))
+      : localOpDivs
+    setUserOpDivs(String(userid), idsToSave)
       .then(() => {
         notify('Saved', 'success')
         onChanged?.(String(userid))
@@ -145,6 +172,11 @@ export default function OpDivGrantModal({
           disabled={loading || fetchFailed}
           disableClearable
           getOptionLabel={optionLabel}
+          // Keep the dropdown scoped to the assignable set even though options
+          // also carries current non-assignable grants (for chip resolution).
+          filterOptions={(options, params) =>
+            baseFilter(options, params).filter((o) => assignableIds.has(o))
+          }
           renderOption={(props, option, { selected }) => (
             <li {...props} key={option}>
               <Checkbox style={{ marginRight: 8 }} checked={selected} />

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Chip,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -167,7 +168,6 @@ export default function OpDivGrantModal({
         <Autocomplete
           multiple
           disableCloseOnSelect
-          limitTags={3}
           options={sortedOptionIds}
           disabled={loading || fetchFailed}
           disableClearable
@@ -176,6 +176,25 @@ export default function OpDivGrantModal({
           // also carries current non-assignable grants (for chip resolution).
           filterOptions={(options, params) =>
             baseFilter(options, params).filter((o) => assignableIds.has(o))
+          }
+          // Render chips so a scoped caller's out-of-scope grants show WITHOUT a
+          // delete button: their save strips those ids regardless, so a delete
+          // would be a silent no-op. An unscoped caller keeps delete (their
+          // removal really revokes). No limitTags collapse - surfacing every
+          // grant, including the non-assignable ones, is the point of this fix.
+          renderTags={(value, getTagProps) =>
+            value.map((option, index) => {
+              const { key, onDelete, ...tagProps } = getTagProps({ index })
+              const locked = enforceCallerScope && !assignableIds.has(option)
+              return (
+                <Chip
+                  {...tagProps}
+                  key={key}
+                  label={optionLabel(option)}
+                  onDelete={locked ? undefined : onDelete}
+                />
+              )
+            })
           }
           renderOption={(props, option, { selected }) => (
             <li {...props} key={option}>

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -181,6 +181,12 @@ export default function UserTable() {
   const [opdivOptions, setOpDivOptions] = useState<OpDiv[]>([])
   // opdiv_id -> code, for rendering the OpDivs membership column.
   const [opdivCodeMap, setOpDivCodeMap] = useState<Record<number, string>>({})
+  // opdiv_id -> { code, name }, a full label source (incl. parent/inactive) so
+  // the grant modal can label grants to non-assignable OpDivs, which are absent
+  // from its scoped options list.
+  const [opdivLabelMap, setOpDivLabelMap] = useState<
+    Record<number, { code: string; name: string }>
+  >({})
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older
@@ -570,10 +576,13 @@ export default function UserTable() {
       try {
         const all = await fetchOpDivs(true)
         const codeMap: Record<number, string> = {}
+        const labelMap: Record<number, { code: string; name: string }> = {}
         all.forEach((od) => {
           codeMap[od.opdiv_id] = od.code
+          labelMap[od.opdiv_id] = { code: od.code, name: od.name }
         })
         setOpDivCodeMap(codeMap)
+        setOpDivLabelMap(labelMap)
 
         let assignable = all.filter((od) => !od.is_parent && od.active)
         if (isOpDivTier(userInfo)) {
@@ -585,6 +594,7 @@ export default function UserTable() {
         // Non-fatal: the grant modal simply shows no options if this fails.
         setOpDivOptions([])
         setOpDivCodeMap({})
+        setOpDivLabelMap({})
       }
     }
     loadOpDivs()
@@ -924,6 +934,11 @@ export default function UserTable() {
         userid={opdivModalUserId}
         userName={opdivModalUserName}
         opdivOptions={opdivOptions}
+        opdivLabelMap={opdivLabelMap}
+        // Only OpDiv-tier admins are scoped; their save must drop out-of-scope
+        // grants. Unscoped admins (OWNER/HHS_ADMIN) must preserve them. Same
+        // predicate that narrowed opdivOptions above, so options and save agree.
+        enforceCallerScope={isOpDivTier(userInfo)}
         onChanged={refreshUserRow}
       />
       <ConfirmDialog


### PR DESCRIPTION
## Summary

Closes #600

The Assign OpDivs modal rendered a user's existing grants to non-assignable OpDivs (a parent or inactive division) as blank chips with only a delete icon, and silently revoked them when an unscoped admin saved without making changes.

Root cause: the modal used a single scoped list (`opdivOptions`) for two jobs: populating the dropdown and resolving labels for existing grants. When a granted OpDiv fell outside that list, it had no label (blank chip), and the save filtered it out of the payload. The backend's removal logic only protects scoped admins, so for an unscoped admin (OWNER/HHS_ADMIN) an omitted grant read as a revocation and the grant was dropped.

This is a frontend-only fix that mirrors the existing `AssignSystemModal` pattern in the same table, which already separates a full label source from the scoped options.

## Changes

* **Full label source.** `UserTable` already fetches all OpDivs (incl. parent/inactive); it now builds a full `opdivLabelMap` from that same response and passes it to the modal, separate from the scoped options. The modal labels grants from it, with an `OpDiv #{id}` fallback so a chip is never blank.
* **Options vs. dropdown.** The Autocomplete options are now the union of assignable + current grants, so an out-of-scope chip resolves (no MUI "value not in options" warning); `filterOptions` narrows the dropdown back to the assignable set so those grants stay non-selectable.
* **Scope-gated save.** The save-time filter is gated on a new `enforceCallerScope` prop, computed as `isOpDivTier(userInfo)` (the same predicate that narrows the options). Scoped callers drop out-of-scope IDs; unscoped callers send every grant as-is, preserving non-assignable grants.

## Acceptance criteria

* [x] Non-assignable grants display readable labels.
* [x] No blank chips; fallback to `OpDiv #{id}`.
* [x] Unscoped admin saves preserve non-assignable grants.
* [x] Assignable OpDiv add/remove unchanged.
* [x] Scoped admins cannot submit out-of-scope grants.
* [x] Dropdown excludes parent/inactive OpDivs.
* [x] Coverage for labeled rendering and preservation.

## UI

BEFORE


https://github.com/user-attachments/assets/96d62e4e-2d11-4bfe-93ae-06f32f7e761e



AFTER


https://github.com/user-attachments/assets/7defa265-ad0e-4d72-8efe-f9beda60ab42



## Testing

* Reframed the existing scope test as the scoped-admin path; added scoped-preservation, labeled-rendering, and `OpDiv#{id}`-fallback tests. Each new test is litmus-verified, failing against the pre-fix code.
* `yarn jest`: full suite green (670 passed); `tsc --noEmit` clean (pre-existing unrelated warnings only).