### PR TITLE
Nightly sync: main -> impl (2026-07-30)

### DIFF
--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -145,9 +145,9 @@ describe('booleanOptions', () => {
   })
 
   it('overrides the true/false labels but keeps values and Unknown', () => {
-    expect(booleanOptions({ true: 'Not funded', false: 'Funded' })).toEqual([
-      { value: 'true', label: 'Not funded' },
-      { value: 'false', label: 'Funded' },
+    expect(booleanOptions({ true: 'Active', false: 'Inactive' })).toEqual([
+      { value: 'true', label: 'Active' },
+      { value: 'false', label: 'Inactive' },
       { value: '', label: 'Unknown' },
     ])
   })
@@ -162,9 +162,9 @@ describe('display formatting', () => {
   })
 
   it('applies custom true/false labels, leaving Unknown', () => {
-    const labels = { true: 'Not funded', false: 'Funded' }
-    expect(formatBool(true, labels)).toBe('Not funded')
-    expect(formatBool(false, labels)).toBe('Funded')
+    const labels = { true: 'Active', false: 'Inactive' }
+    expect(formatBool(true, labels)).toBe('Active')
+    expect(formatBool(false, labels)).toBe('Inactive')
     expect(formatBool(null, labels)).toBe('Unknown')
   })
 

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -80,8 +80,7 @@ export function optionsForField(
 
 // Custom labels for the true/false ends of a tri-state boolean. For fields
 // whose Yes/No reads ambiguously against the label (e.g. a negatively-phrased
-// "Not Funded for Remediation", where "No" would mean "it is funded"). Unknown
-// is always Unknown.
+// label where "No" would be a double negative). Unknown is always Unknown.
 export type BooleanLabels = { true: string; false: string }
 
 /**

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1296,10 +1296,50 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
       />
     )
     expand()
-    expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
+    // SecurityHub's feed is failure-only, so a "pass" is the absence of a
+    // finding, not an observed pass — the summary must not claim otherwise.
+    expect(
+      screen.getByText(/1 of 2 checks reported no findings/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/1 of 2 checks passed/)).not.toBeInTheDocument()
     // Feed chips are labeled by the SecurityHub finding code.
     expect(screen.getByText('IAM.1').textContent).toContain('✓')
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
+    // The chip still reads ✓, but neither its accessible name nor its hover may
+    // say "Passed".
+    expect(
+      screen.getByRole('img', { name: /^IAM\.1 — .* — No finding reported$/ })
+    ).toBeInTheDocument()
+  })
+
+  it('withholds an inferred SecurityHub pass from the control rollup', () => {
+    // A control whose only evidence is an inferred SecurityHub pass must not
+    // read as satisfied — that would assert the control is met on the strength
+    // of a check that may never have run on a partially scanned system.
+    const sechubOnly = rollupControls({
+      sechub_passing: [
+        { id: 'IAM.1', nist_controls: 'AC-3', description: 'x', level: 1 },
+      ],
+    })
+    expect(sechubOnly).toHaveLength(0)
+
+    // Kion and Hardenize report real passes, so theirs still count.
+    const kion = rollupControls({
+      kion_passing: [
+        { id: 'iam-user-inactive', nist_controls: 'AC-3', description: 'x' },
+      ],
+    })
+    expect(kion).toHaveLength(1)
+    expect(kion[0].state).toBe('satisfied')
+
+    // A SecurityHub *failure* is still real evidence and must survive.
+    const sechubFailing = rollupControls({
+      findings: {
+        sechub: [{ id: 'IAM.10', nist_controls: 'IA-2', description: 'y' }],
+      },
+    })
+    expect(sechubFailing).toHaveLength(1)
+    expect(sechubFailing[0].state).toBe('failing')
   })
 
   it('renders SecurityHub as a chip block even with only failing findings', () => {
@@ -1328,6 +1368,38 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
     // Title lives in the hover now, not as body text.
     expect(screen.queryByText('MFA should be enabled')).not.toBeInTheDocument()
+  })
+
+  it('words the collapse toggle as "no findings" for an inferred-pass source', () => {
+    // The summary and the chips avoid claiming a pass, but the collapse toggle is
+    // its own label — with 1,493 SecurityHub rows upstream, blocks routinely spill
+    // past the collapse threshold, so this is where the unsupported claim would
+    // survive.
+    const passing = Array.from({ length: 9 }, (_, i) => ({
+      id: `SEC.${i}`,
+      nist_controls: 'SC-7',
+      level: 1,
+    }))
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 2,
+            has_sechub_data: true,
+            sechub_passing: passing,
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(
+      screen.getByRole('button', {
+        name: /Show all 9 checks with no findings/i,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Show all 9 passing checks/i })
+    ).not.toBeInTheDocument()
   })
 
   it('collapses the passing bulk behind a toggle, keeps failing chips at the top, and expands on click', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -399,6 +399,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
       ...s,
       passing: asFindingArray(raw),
       hasPassing: Array.isArray(raw),
+      inferredPass: INFERRED_PASS_SOURCES.has(s.key),
     }
   })
   const anyFeedBlock = feedSources.some((s) => s.hasPassing)
@@ -610,6 +611,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
                   passing={s.passing}
                   failing={s.failing}
                   hasPassing={s.hasPassing}
+                  inferredPass={s.inferredPass}
                   resetKey={questionId}
                 />
               ) : null
@@ -925,9 +927,13 @@ function ControlChip({
 function CheckTooltip({
   finding,
   pass,
+  inferredPass = false,
 }: {
   finding: InsightFinding
   pass: boolean
+  // See INFERRED_PASS_SOURCES: this source reports only failures, so a "pass" is
+  // the absence of a finding and must not be worded as an observed pass.
+  inferredPass?: boolean
 }) {
   const slug = asText(finding?.id) ?? asText(finding?.title)
   // The chip label now carries the check name (its code/slug), so the hover leads
@@ -955,7 +961,7 @@ function CheckTooltip({
     nist ? `Control: ${nist}` : undefined,
     level != null ? `Level ${level}` : undefined,
     severity ? severity.toUpperCase() : undefined,
-    pass ? 'Passed' : 'Failed',
+    pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
   ]
     .filter(Boolean)
     .join(' · ')
@@ -1030,12 +1036,17 @@ function FeedCheckBlock({
   passing,
   failing,
   hasPassing,
+  inferredPass = false,
   resetKey,
 }: {
   label: string
   passing: InsightFinding[]
   failing: InsightFinding[]
   hasPassing: boolean
+  // See INFERRED_PASS_SOURCES: this source's passing entries mean "no finding
+  // reported", which the summary and each chip's hover must say rather than
+  // claiming the checks were observed to pass.
+  inferredPass?: boolean
   resetKey?: string | number
 }) {
   const [showAllPassing, setShowAllPassing] = React.useState(false)
@@ -1062,9 +1073,11 @@ function FeedCheckBlock({
   }
   const passed = passing.length
   const total = passing.length + failing.length
-  const summary = hasPassing
-    ? `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
-    : `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+  const summary = !hasPassing
+    ? `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+    : inferredPass
+      ? `${passed} of ${total} check${total === 1 ? '' : 's'} reported no findings`
+      : `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
   // Collapse the passing bulk once it spills past a couple of rows (mainly
   // Hardenize, which can carry 30+ passing checks). Failing chips (findings) are
   // always shown AND rendered first, so problems stay at the top and visible even
@@ -1090,7 +1103,7 @@ function FeedCheckBlock({
     const ariaLabel = [
       slug,
       desc,
-      pass ? 'Passed' : 'Failed',
+      pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
       remediation ? `How to fix: ${remediation}` : undefined,
     ]
       .filter(Boolean)
@@ -1100,7 +1113,9 @@ function FeedCheckBlock({
         key={key}
         id={slug ?? nist ?? '—'}
         variant={pass ? 'satisfied' : 'failing'}
-        tooltip={<CheckTooltip finding={f} pass={pass} />}
+        tooltip={
+          <CheckTooltip finding={f} pass={pass} inferredPass={inferredPass} />
+        }
         ariaLabel={ariaLabel || undefined}
       />
     )
@@ -1143,7 +1158,11 @@ function FeedCheckBlock({
         >
           {showAllPassing
             ? 'Show fewer'
-            : `Show all ${passing.length} passing checks`}
+            : // Matches the summary wording: for an inferred-pass source these
+              // are checks with no finding reported, not checks observed to pass.
+              `Show all ${passing.length} ${
+                inferredPass ? 'checks with no findings' : 'passing checks'
+              }`}
         </Link>
       )}
     </Box>
@@ -1265,6 +1284,20 @@ const CONTROL_RANK: Record<ControlRollupState, number> = {
 // appears here even though CFACTS never assessed it, and why a conflicted control
 // can net to failing. The payload is opaque, so every value is coerced and
 // guarded; a malformed element is skipped, never thrown.
+// Sources whose "passing" entries are inferred from the absence of a finding
+// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
+// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
+// as "mapped control with no active failure". That cannot distinguish "evaluated
+// and passed" from "never scanned", so on a partially scanned system it would
+// otherwise assert controls are met on the strength of checks that never ran.
+// Consequently these entries still render as ✓ chips (the check is not failing)
+// but are read as an absence of findings, and are withheld from the control
+// rollup rather than counted as affirmative `satisfied` evidence.
+//
+// Remove a source from this set once its feed emits real passes; nothing else
+// needs to change. Used by both the feed blocks and rollupControls below.
+const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
+
 export function rollupControls(
   payload: Partial<InsightPayload>
 ): ControlRollup[] {
@@ -1336,18 +1369,25 @@ export function rollupControls(
   }
   for (const src of ['kion', 'sechub', 'hardenize'] as const) {
     const label = SRC_LABEL[src]
-    arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach((f) => {
-      const o = finding(f)
-      add(
-        o?.nist_controls,
-        label,
-        'satisfied',
-        asText(o?.id) ?? asText(o?.title),
-        // Kion puts the sentence in `description`, SecurityHub in `title` —
-        // same fallback CheckTooltip uses, so both hovers read alike.
-        asText(o?.description) ?? asText(o?.title)
+    // An inferred pass is the absence of a finding, not evidence the control is
+    // met — counting it as `satisfied` would flip a control from "not assessed"
+    // to green on the strength of a check that may never have run.
+    if (!INFERRED_PASS_SOURCES.has(src)) {
+      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
+        (f) => {
+          const o = finding(f)
+          add(
+            o?.nist_controls,
+            label,
+            'satisfied',
+            asText(o?.id) ?? asText(o?.title),
+            // Kion puts the sentence in `description`, SecurityHub in `title` —
+            // same fallback CheckTooltip uses, so both hovers read alike.
+            asText(o?.description) ?? asText(o?.title)
+          )
+        }
       )
-    })
+    }
     arr(findings[src]).forEach((f) => {
       const o = finding(f)
       add(

--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -1,0 +1,322 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Cross-navigation coverage for ui#610: the questionnaire header needs a link
+// back to System Info and a Pillar Scores button, alongside the existing
+// Compare Datacalls button.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// notify() reaches notistack's standalone enqueueSnackbar, which needs a
+// mounted provider; keep isAuthHandled real so the error path is exercised as
+// written (same pattern as QuestionnairePage.test).
+const notifyMock = jest.fn()
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return {
+    ...actual,
+    notify: (...args: unknown[]) => notifyMock(...args),
+  }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const QUESTIONS = [
+  {
+    questionid: 900,
+    question: 'Question for Imperial Identity Verification',
+    notesprompt: 'Notes',
+    pillar: { pillar: 'Identity' },
+    function: {
+      functionid: 7006,
+      function: 'Imperial Identity Verification',
+      description: 'Imperial Identity Verification description',
+      datacenterenvironment: 'Imperial-Fleet',
+    },
+  },
+]
+
+const OPTIONS_7006 = [
+  { functionoptionid: 100, description: 'Baseline', score: 1 },
+  { functionoptionid: 101, description: 'Advanced', score: 2 },
+]
+
+const AGGREGATE = [
+  {
+    datacallid: 5,
+    fismasystemid: 1002,
+    systemscore: 3.75,
+    pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 3.5 }],
+  },
+]
+
+function makeCtx(role: userData['role'] | undefined) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = makeCtx('OWNER')
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/scores/aggregate'))
+      return Promise.resolve({ data: { data: AGGREGATE } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+// Data-router harness matching the app's createHashRouter, per the note in
+// QuestionnairePage.deeplink.test: a plain MemoryRouter hands the component the
+// unstable useNavigate and re-runs the fetch effect on the canonical redirect.
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> },
+      { path: '/systems/:fismasystemid', element: <div>system detail</div> },
+    ],
+    { initialEntries: ['/questionnaire/ssd-ex'] }
+  )
+  const { unmount } = render(<RouterProvider router={router} />)
+  return { router, unmount }
+}
+
+const aggregateCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => typeof u === 'string' && u.includes('/scores/aggregate'))
+
+it('navigates to the system detail page keyed on fismasystemid', async () => {
+  const { router } = renderPage()
+  const button = await screen.findByRole('link', { name: 'System Info' })
+  await userEvent.click(button)
+  // The questionnaire route carries the acronym; the detail route is keyed on
+  // the id, so this proves the acronym was resolved to 1002 before linking.
+  expect(router.state.location.pathname).toBe('/systems/1002')
+})
+
+it('suppresses System Info when the role fails the system-access gate', async () => {
+  mockCtx = makeCtx(undefined)
+  renderPage()
+  // Compare Datacalls is ungated, so its presence proves the header rendered
+  // and only the gated button is missing.
+  await screen.findByRole('button', { name: 'Compare Datacalls' })
+  expect(
+    screen.queryByRole('link', { name: 'System Info' })
+  ).not.toBeInTheDocument()
+})
+
+it('fetches the pillar aggregate for this system and opens the modal', async () => {
+  renderPage()
+  const button = await screen.findByRole('button', { name: 'Pillar Scores' })
+  expect(aggregateCalls()).toHaveLength(0)
+  await userEvent.click(button)
+
+  await waitFor(() =>
+    expect(
+      aggregateCalls().some(
+        (u) =>
+          u.includes('fismasystemid=1002') && u.includes('include_pillars=true')
+      )
+    ).toBe(true)
+  )
+  // Acronym in the title comes from the resolved system, not the lowercased
+  // URL param, so it matches the dashboard's casing.
+  expect(
+    await screen.findByText(
+      /Super Star Destroyer Executor Command Systems \(SSD-EX\) - Pillar Scores/
+    )
+  ).toBeInTheDocument()
+})
+
+it('keeps the modal closed when the aggregate fetch fails', async () => {
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/scores/aggregate'))
+      return Promise.reject(new Error('boom'))
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  renderPage()
+  await userEvent.click(
+    await screen.findByRole('button', { name: 'Pillar Scores' })
+  )
+
+  await waitFor(() => expect(aggregateCalls()).not.toHaveLength(0))
+  // An empty modal would read as "this system has no scores"; nothing opens and
+  // the user is told instead.
+  await waitFor(() =>
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.stringContaining('error occurred'),
+      'error'
+    )
+  )
+  expect(screen.queryByText(/- Pillar Scores/)).not.toBeInTheDocument()
+})
+
+it('offers a way back from the no-questionnaire state', async () => {
+  // A decommissioned or out-of-scope system joins to zero functions, and the
+  // #609 button makes that state reachable from System Info. Without the link
+  // here the trip is one-way (#640 review).
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  renderPage()
+  expect(
+    await screen.findByText(/No questionnaire is available for this system/i)
+  ).toBeInTheDocument()
+  expect(
+    await screen.findByRole('link', { name: 'System Info' })
+  ).toHaveAttribute('href', '/systems/1002')
+})
+
+it('flushes a pending draft when the page unmounts mid-debounce', async () => {
+  const { saveDraft } = require('./draftStore') as {
+    saveDraft: jest.Mock
+  }
+  // Real options so the answer/notes panel renders rather than staying in its
+  // loading state.
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  await userEvent.type(notesField, 'Imperial posture note')
+  // Nothing written yet: the save is debounced 1s and no timer has fired.
+  expect(saveDraft).not.toHaveBeenCalled()
+
+  // Leaving for System Info (or the Dashboard breadcrumb, or browser back)
+  // unmounts the page. beforeunload does not fire on in-app navigation and the
+  // debounce cleanup cancels its own timer, so without the unmount flush this
+  // edit was silently dropped.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(1)
+  const [userid, system, questionId, datacallID, draft] =
+    saveDraft.mock.calls[0]
+  expect({ userid, system, datacallID }).toEqual({
+    userid: '1',
+    system: 1002,
+    datacallID: 5,
+  })
+  expect(questionId).toBe(7006)
+  expect(draft.notes).toBe('Imperial posture note')
+})
+
+it('does not lose a newer edit made while an earlier save is in flight', async () => {
+  // Regression for the identity-clear race (#640 review): edit A's debounced
+  // save starts; edit B replaces the pending payload under the SAME generation
+  // (saveGenRef only moves on explicit clears); save A's completion must not
+  // clear B's payload, or an unmount before B's own debounce flushes nothing.
+  const { saveDraft } = require('./draftStore') as { saveDraft: jest.Mock }
+  let resolveSaveA!: (saved: boolean) => void
+  saveDraft.mockImplementationOnce(
+    () => new Promise<boolean>((resolve) => (resolveSaveA = resolve))
+  )
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  // Edit A; let its 1s debounce fire so saveDraft(A) is genuinely in flight.
+  await userEvent.type(notesField, 'A')
+  await waitFor(() => expect(saveDraft).toHaveBeenCalledTimes(1), {
+    timeout: 3000,
+  })
+  expect(saveDraft.mock.calls[0][4].notes).toBe('A')
+
+  // Edit B while A remains unresolved.
+  await userEvent.type(notesField, 'B')
+
+  // A resolves successfully. Identity check must leave B's payload pending.
+  await act(async () => {
+    resolveSaveA(true)
+  })
+
+  // Leave before B's own debounce fires.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(2)
+  expect(saveDraft.mock.calls[1][4].notes).toBe('AB')
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,11 +21,12 @@ import {
   QuestionScores,
   Insight,
   InsightPayload,
+  ScoreAggregate,
 } from '@/types'
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
@@ -44,9 +45,10 @@ import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
+import PillarScoresModal from '@/components/PillarScoresModal/PillarScoresModal'
 import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
-import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
+import { isAdmin, isReadOnlyAdmin, hasSystemAccess } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel from './InsightsPanel/InsightsPanel'
 import QuestionRadioGroup from './QuestionRadioGroup'
@@ -130,6 +132,12 @@ export default function QuestionnarePage() {
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const [diffModalOpen, setDiffModalOpen] = React.useState(false)
+  // PillarScoresModal takes its rows as a prop rather than fetching (unlike
+  // ScoreDiffModal), so the header button fetches before opening (ui#610).
+  const [pillarScores, setPillarScores] = React.useState<{
+    open: boolean
+    scores: ScoreAggregate[]
+  }>({ open: false, scores: [] })
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
@@ -201,6 +209,20 @@ export default function QuestionnarePage() {
   // Incremented on every explicit draft clear so in-flight debounced saves
   // that fire after a clear don't resurrect the just-removed draft.
   const saveGenRef = React.useRef(0)
+  // Mirrors the payload the debounced draft save would write, so unmount can
+  // flush it. The debounce cleanup cancels its own pending timer, and a route
+  // change away from this page (System Info, the Dashboard breadcrumb, browser
+  // back) tears the component down without firing beforeunload, so an edit made
+  // inside the 1s window was dropped. Carries the generation so a flush cannot
+  // resurrect a draft clearCurrentDraft deleted after the timer was scheduled.
+  const pendingDraftRef = React.useRef<{
+    userid: string
+    system: number
+    questionId: number
+    datacallID: number
+    draft: { selectQuestionOption: number; notes: string }
+    gen: number
+  } | null>(null)
   const unsavedRef = React.useRef({
     selectQuestionOption,
     initQuestionChoice,
@@ -443,6 +465,23 @@ export default function QuestionnarePage() {
       void clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
+  }
+
+  // Same aggregate call the dashboard's Pillar Scores action makes. Not cached:
+  // the dashboard memoizes across many rows, this page is one system and one
+  // click. On failure nothing opens and the user is told, rather than opening an
+  // empty modal that reads as "this system has no scores".
+  const handleOpenPillarScores = async () => {
+    try {
+      const res = await axiosInstance.get(
+        `/scores/aggregate?fismasystemid=${system}&include_pillars=true`
+      )
+      setPillarScores({ open: true, scores: res.data?.data ?? [] })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error('Error fetching pillar scores:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error')
+    }
   }
 
   // Keep insight, review, and card state scoped to one system x data call x
@@ -983,10 +1022,12 @@ export default function QuestionnarePage() {
       datacallID <= 0 ||
       loadingQuestion
     ) {
+      pendingDraftRef.current = null
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
     if (selectQuestionOption === initQuestionChoice && notes === initNotes) {
+      pendingDraftRef.current = null
       saveGenRef.current++
       // Skip clearDraft when a draft was just restored from storage — the draft
       // values matching the server state does not mean the user reverted manually.
@@ -1003,17 +1044,35 @@ export default function QuestionnarePage() {
       return
     }
     const currentGen = saveGenRef.current
+    const pending = {
+      userid: userInfo.userid,
+      system,
+      questionId,
+      datacallID,
+      draft: { selectQuestionOption, notes },
+      gen: currentGen,
+    }
+    pendingDraftRef.current = pending
     const timer = setTimeout(() => {
       if (saveGenRef.current !== currentGen) return
       saveDraft(
-        userInfo.userid,
-        system,
-        questionId,
-        datacallID,
-        { selectQuestionOption, notes },
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft,
         () => saveGenRef.current === currentGen
       ).then((saved) => {
         if (saveGenRef.current !== currentGen) return
+        // Clear by identity, not generation: a newer edit re-runs this effect
+        // and replaces the ref with a NEW object under the SAME generation
+        // (saveGenRef only moves on explicit clears), so a generation check
+        // here would let the older save's completion discard the newer edit's
+        // payload while its own debounce is still pending — and an unmount in
+        // that window would then flush nothing (#640 review). Gated on `saved`
+        // so a failed write stays in the ref for the unmount flush to retry.
+        if (saved && pendingDraftRef.current === pending)
+          pendingDraftRef.current = null
         if (saved) {
           if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
         } else {
@@ -1034,6 +1093,32 @@ export default function QuestionnarePage() {
     loadingQuestion,
     userInfo.userid,
   ])
+
+  // Flush a pending draft on unmount. beforeunload below covers tab close and
+  // hard refresh, but it does not fire on in-app navigation, and the debounce
+  // cleanup cancels the timer that would have written the draft. Mount-once so
+  // the cleanup runs on unmount only, never on a dep change (flushing on every
+  // dep change would defeat the debounce and write on each keystroke).
+  // saveDraft takes primitives and touches no component state, so the write
+  // completes after this component is gone.
+  React.useEffect(() => {
+    return () => {
+      const pending = pendingDraftRef.current
+      // Reading the live generation is the point of this guard, not a staleness
+      // bug: it must reflect any clearCurrentDraft that ran after the timer was
+      // scheduled, so a flush cannot resurrect a just-deleted draft. Copying it
+      // into the effect body would freeze it at its mount value.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      if (!pending || saveGenRef.current !== pending.gen) return
+      void saveDraft(
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft
+      )
+    }
+  }, [])
 
   // Warn before tab close or hard refresh when the active question has edits
   // that haven't been committed to the backend yet.
@@ -1170,10 +1255,41 @@ export default function QuestionnarePage() {
       </>
     )
   }
+  // Cross-navigation back to this system's detail page (ui#610). A real router
+  // link rather than onClick + navigate, so open-in-new-tab and copy-link work.
+  // Gated on the same hasSystemAccess check the dashboard puts on its own System
+  // Details action. Every current role passes it (delegates included), so in
+  // practice this only suppresses the link while userInfo is unloaded or carries
+  // an unrecognized role - but it is the gate that moves if system-detail access
+  // ever narrows.
+  const systemInfoLink = hasSystemAccess(userInfo) ? (
+    <Button
+      variant="outlined"
+      size="small"
+      component={RouterLink}
+      to={`/systems/${system}`}
+      sx={{ whiteSpace: 'nowrap' }}
+    >
+      System Info
+    </Button>
+  ) : null
   if (noQuestions) {
     return (
       <>
-        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+          {/* Without this the flow System Info -> Questionnaire -> "no
+              questionnaire available" is one-way, which the #609 button makes
+              reachable for any out-of-scope or decommissioned system (#640
+              review). */}
+          {systemInfoLink}
+        </Box>
         <Container maxWidth={false} disableGutters>
           <Alert severity="info" sx={{ mt: 2 }}>
             No questionnaire is available for this system. This typically
@@ -1193,6 +1309,14 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
+  // The data call both header modals present as "current". Prefer the call this
+  // questionnaire actually resolved (datacallID covers every entry path,
+  // including URL deep links where no route state exists); fall back to the
+  // route/selected/latest chain during the pre-fetch window.
+  const viewedDataCallId =
+    datacallID > 0
+      ? datacallID
+      : routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
   return (
     <>
       <Box
@@ -1203,14 +1327,25 @@ export default function QuestionnarePage() {
         }}
       >
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => setDiffModalOpen(true)}
-          sx={{ whiteSpace: 'nowrap' }}
-        >
-          Compare Datacalls
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {systemInfoLink}
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleOpenPillarScores}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Pillar Scores
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setDiffModalOpen(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Compare Datacalls
+          </Button>
+        </Box>
       </Box>
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1589,23 +1724,26 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
-      {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
-          questionnaire actually resolved (datacallID covers every entry path,
-          including URL deep links where no route state exists); fall back to
-          the route/selected/latest chain during the pre-fetch window. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
-        selectedDataCallId={
-          datacallID > 0
-            ? datacallID
-            : routeDatacallId ??
-              selectedDatacall?.datacallid ??
-              latestDataCallId
+        selectedDataCallId={viewedDataCallId}
+      />
+      {/* Same modal the dashboard's Pillar Scores action opens. The acronym
+          comes from the resolved system rather than the lowercased URL param so
+          the title matches the dashboard's casing. */}
+      <PillarScoresModal
+        open={pillarScores.open}
+        onClose={() => setPillarScores((prev) => ({ ...prev, open: false }))}
+        systemName={systemName}
+        systemAcronym={
+          systemInfo?.fismaacronym ?? fismaacronym?.toUpperCase() ?? ''
         }
+        scores={pillarScores.scores}
+        selectedDataCallId={viewedDataCallId}
       />
     </>
   )

--- a/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import StatisticsBlocks from './StatisticsBlocks'
+import type { FismaSystemType, SystemScoreEntry } from '@/types'
+
+// StatisticsBlocks reads the full active-system list from the outlet context and
+// the selection-scoped score map from props. The bug in ztmf-ui#633 was the
+// average dividing by the whole context list; these tests pin the denominator to
+// the systems that actually have a score.
+let mockFismaSystems: FismaSystemType[] = []
+jest.mock('../Title/Context', () => ({
+  __esModule: true,
+  useContextProp: () => ({ fismaSystems: mockFismaSystems }),
+}))
+
+const sys = (id: number, acronym: string): FismaSystemType =>
+  ({ fismasystemid: id, fismaacronym: acronym }) as FismaSystemType
+
+const score = (
+  n: number,
+  tier?: SystemScoreEntry['tier']
+): SystemScoreEntry => ({
+  score: n,
+  tier,
+})
+
+// Read the big numeral out of a tile located by its label. The high/low tiles
+// fold an acronym into the label element, so callers pass a regex for those.
+const tileValue = (label: string | RegExp): string => {
+  const tile = screen.getByText(label).closest('.MuiPaper-root')
+  const numeral = tile?.querySelector('h2')
+  return (numeral?.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
+  afterEach(() => {
+    mockFismaSystems = []
+  })
+
+  it('averages only over systems with a score, not the full active list', () => {
+    // Three active systems, only two answered the selected call. The average must
+    // be (2 + 5) / 2 = 3.5, NOT (2 + 5) / 3 = 2.33 (the old diluted denominator).
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2, 'Traditional'),
+      2: score(5, 'Optimal'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Average System Score')).toBe('3.5')
+  })
+
+  it('shows the Scored / Total ratio scoped to the selection', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2),
+      2: score(5),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('2 / 3')
+  })
+
+  it('keeps the average between the lowest and highest displayed scores', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(1.5, 'Traditional'),
+      2: score(3, 'Initial'),
+      3: score(4.82, 'Advanced'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    const avg = Number(tileValue('Average System Score'))
+    const low = Number(tileValue(/Lowest System Score/))
+    const high = Number(tileValue(/Highest System Score/))
+    expect(low).toBeLessThanOrEqual(avg)
+    expect(avg).toBeLessThanOrEqual(high)
+    expect(low).toBe(1.5)
+    expect(high).toBe(4.82)
+  })
+
+  it('handles a selection no system participated in without going below scale', () => {
+    // No scored systems: average is 0 (guarded), ratio is 0 / N, and the lowest
+    // tile falls back to 0.00 rather than rendering Infinity.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    render(<StatisticsBlocks scores={{}} />)
+
+    expect(tileValue('Average System Score')).toBe('0')
+    expect(tileValue('Scored / Total Systems')).toBe('0 / 2')
+    expect(tileValue('Lowest System Score:')).toBe('0.00')
+  })
+
+  it('formats large totals with thousands separators', () => {
+    mockFismaSystems = Array.from({ length: 1342 }, (_, i) =>
+      sys(i + 1, `S${i}`)
+    )
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(3.44),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('1 / 1,342')
+  })
+})

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -26,6 +26,7 @@ export default function StatisticsBlocks({
 }) {
   const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
+  const [answeredSystems, setAnsweredSystems] = useState<number>(0)
   const [avgSystemScore, setAvgSystemScore] = useState<number>(0)
   const [maxSystemAcronym, setMaxSystemAcronym] = useState<string>('')
   const [maxSystemScore, setMaxSystemScore] = useState<number>(0)
@@ -40,7 +41,12 @@ export default function StatisticsBlocks({
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    const totalCount = fismaSystems.length
+    // Count only the systems that actually contribute a score. The `scores` map
+    // is already scoped to the selected data call(s), so systems with no answers
+    // in the selection must not inflate the denominator (that dragged the average
+    // below the scale minimum — see ztmf-ui#633). Counted inside the loop so the
+    // numerator and denominator always cover the same systems.
+    let scoredCount: number = 0
     let maxScore: number = 0
     let maxScoreSystem: string = ''
     let maxScoreTier: ScoreTier | undefined
@@ -62,16 +68,18 @@ export default function StatisticsBlocks({
           minScoreTier = entry.tier
         }
         totalScores += entry.score
+        scoredCount += 1
       }
     }
-    if (totalCount === 0) {
+    if (scoredCount === 0) {
       setAvgSystemScore(0)
       setMinSystemScore(0)
     } else {
-      setAvgSystemScore(Number((totalScores / totalCount).toFixed(2)))
+      setAvgSystemScore(Number((totalScores / scoredCount).toFixed(2)))
       setMinSystemScore(minScore)
     }
-    setTotalSystems(totalCount)
+    setAnsweredSystems(scoredCount)
+    setTotalSystems(fismaSystems.length)
     setMaxSystemScore(maxScore)
     setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
@@ -99,14 +107,14 @@ export default function StatisticsBlocks({
       }}
     >
       <StatisticsPaper variant="outlined">
-        <Typography variant="h2" sx={{ color: '#004297', fontSize: '56px' }}>
-          {totalSystems}
+        <Typography variant="h2" sx={{ color: '#004297', fontSize: '44px' }}>
+          {answeredSystems.toLocaleString()} / {totalSystems.toLocaleString()}
         </Typography>
         <Typography
           variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
-          Total Systems
+          Scored / Total Systems
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">

--- a/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import SystemDetailHeader from './SystemDetailHeader'
+
+// Cross-navigation coverage for ui#609: System Info needs a link to the
+// system's questionnaire. The questionnaire route is keyed on :fismaacronym
+// while this page is routed by :fismasystemid, so the acronym is passed in.
+
+const BASE_PROPS = {
+  systemName: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  canEdit: false,
+  isEditing: false,
+  isSaving: false,
+  isFormValid: true,
+  onEdit: jest.fn(),
+  onSave: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+// Data-router harness so the component gets the same useNavigate the app does,
+// and so the resulting pathname is assertable off router.state.
+function renderHeader(props: Partial<typeof BASE_PROPS> = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/systems/:fismasystemid',
+        element: <SystemDetailHeader {...BASE_PROPS} {...props} />,
+      },
+      {
+        path: '/questionnaire/:fismaacronym',
+        element: <div>questionnaire</div>,
+      },
+      { path: '/', element: <div>dashboard</div> },
+    ],
+    { initialEntries: ['/systems/1002'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+it('renders Questionnaire as a link, not a bare button', () => {
+  renderHeader()
+  // An anchor (CmsButton href) rather than onClick + navigate, so
+  // open-in-new-tab and copy-link work (#640 review).
+  const link = screen.getByRole('link', { name: 'Questionnaire' })
+  expect(link).toBeInTheDocument()
+  expect(link.tagName).toBe('A')
+})
+
+it('targets the questionnaire keyed on the lowercased acronym', () => {
+  renderHeader()
+  // Lowercased to match the URL shape the dashboard's own questionnaire action
+  // builds (FismaTable openQuestionnaire), so both entry points share one link.
+  // Bare acronym with no trailing segments: the omitted datacall is what makes
+  // QuestionnairePage resolve the cycle itself, and pinning one from here would
+  // fix the wrong call.
+  expect(
+    screen.getByRole('link', { name: 'Questionnaire' }).getAttribute('href')
+  ).toBe('/questionnaire/ssd-ex')
+})
+
+it('shows Questionnaire alongside Edit for an editor', () => {
+  renderHeader({ canEdit: true })
+  expect(
+    screen.getByRole('link', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+})
+
+it('hides Questionnaire while editing so a dirty form keeps Save/Cancel only', () => {
+  renderHeader({ canEdit: true, isEditing: true })
+  expect(
+    screen.queryByRole('link', { name: 'Questionnaire' })
+  ).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -1,10 +1,13 @@
 import { Box, Typography, IconButton } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { Button as CmsButton } from '@cmsgov/design-system'
-import { useNavigate } from 'react-router-dom'
+import { useHref, useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
+  /** Drives the Questionnaire link; the questionnaire route is keyed on the
+   * acronym, not the fismasystemid this page is routed by (ui#609). */
+  fismaacronym: string
   /** Admins edit the whole form; an assigned ISSO gets the same Edit button
    * but only the target-maturity card unlocks for them (ztmf#398). */
   canEdit: boolean
@@ -18,6 +21,7 @@ interface SystemDetailHeaderProps {
 
 export default function SystemDetailHeader({
   systemName,
+  fismaacronym,
   canEdit,
   isEditing,
   isSaving,
@@ -27,6 +31,14 @@ export default function SystemDetailHeader({
   onCancel,
 }: SystemDetailHeaderProps) {
   const navigate = useNavigate()
+  // Rendered as an <a> via CmsButton's href so open-in-new-tab and copy-link
+  // work. CmsButton has no polymorphic `component` prop, so react-router's Link
+  // cannot be composed in; useHref resolves the path the same way Link would
+  // (under the app's hash router it yields `#/questionnaire/<acronym>`) instead
+  // of hand-writing the fragment. (#640 review)
+  const questionnaireHref = useHref(
+    `/questionnaire/${fismaacronym.toLowerCase()}`
+  )
 
   return (
     <Box
@@ -61,11 +73,22 @@ export default function SystemDetailHeader({
             </CmsButton>
           </>
         ) : (
-          canEdit && (
-            <CmsButton variation="solid" onClick={onEdit}>
-              Edit
-            </CmsButton>
-          )
+          <>
+            {/* Cross-navigation to this system's questionnaire (ui#609). The
+                target carries no route state: QuestionnairePage falls back to
+                the selected/latest data call when location.state has no
+                datacallid, which is the right default arriving from here, and it
+                keeps the link plainly shareable. Rendered only outside edit mode
+                so a dirty form keeps Save/Cancel as its only actions. A
+                decommissioned system links too and the questionnaire's own
+                "no questionnaire is available" alert explains the outcome. */}
+            <CmsButton href={questionnaireHref}>Questionnaire</CmsButton>
+            {canEdit && (
+              <CmsButton variation="solid" onClick={onEdit}>
+                Edit
+              </CmsButton>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -612,6 +612,7 @@ export default function SystemDetailPage() {
 
       <SystemDetailHeader
         systemName={system.fismaname}
+        fismaacronym={system.fismaacronym}
         canEdit={isAdmin}
         isEditing={isEditing}
         isSaving={isSaving}

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -83,14 +83,12 @@ describe('extended metadata formatting', () => {
     expect(screen.getByText('IaaS, PaaS')).toBeInTheDocument()
   })
 
-  test('applies the legacy field custom boolean labels', () => {
-    // legacy is a funding disposition; its label is "Not Funded for
-    // Remediation", so true reads "Not funded" rather than a double-negative
-    // "Yes".
+  test('renders the legacy field with default Yes/No labels', () => {
+    // legacy is a plain legacy-system flag labeled "Legacy System", so true
+    // reads as the default "Yes".
     renderWithExtended({ legacy: true })
-    expect(screen.getByText('Not Funded for Remediation')).toBeInTheDocument()
-    expect(screen.getByText('Not funded')).toBeInTheDocument()
-    expect(screen.queryByText('Yes')).not.toBeInTheDocument()
+    expect(screen.getByText('Legacy System')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
   })
 
   test('hides the extended card when only an empty array is present', () => {

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -18,8 +18,9 @@ export interface FieldConfig {
   // there is no backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
-  // its read-view text). For a negatively-phrased label where Yes/No would read
-  // as a double negative. Unknown stays Unknown.
+  // its read-view text). For a field whose label reads ambiguously against a
+  // plain Yes/No (e.g. a negatively-phrased label where "No" is a double
+  // negative). Unknown stays Unknown.
   booleanLabels?: { true: string; false: string }
 }
 
@@ -191,15 +192,10 @@ export const fieldConfigs: FieldConfig[] = [
   },
   {
     key: 'legacy',
-    label: 'Not Funded for Remediation',
+    label: 'Legacy System',
     section: 'extended',
     required: false,
     type: 'boolean',
-    booleanLabels: { true: 'Not funded', false: 'Funded' },
-    helpText:
-      'HHS has not committed funding to remediate known gaps on this system. ' +
-      "This is a funding disposition, not a judgement about the system's age " +
-      'or technology.',
   },
 ]
 


### PR DESCRIPTION
Automated nightly sync of `main` into `impl` — **main wins every overlap**.

This branch is `impl` with `main` merged in using `-X theirs`, so the result is deterministic: main's version wins any conflict, and impl-only files that don't conflict are preserved. There should be nothing to hand-resolve.

⚠️ **Merge this with a MERGE COMMIT, not squash.** `main` and `impl` share no squash ancestry; squashing here would leave them diverged and every future nightly sync would re-conflict. A merge commit re-establishes shared ancestry and closes the gap.

- Review the net change, then merge (merge commit). Merging pushes to `impl` and triggers the impl deploy (orchestration-impl).
- To smoke-test the merged result in the impl environment first, run **Manual Deploy to IMPL** with `--ref automation/sync-main-to-impl`.

_Opened by the nightly-impl-sync workflow._
