### PR TITLE
fix(auth): sync logout across tabs and stop the sign-in redirect loop (#606)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,9 +10,14 @@ import router from '@/router/router'
 import { SIGN_IN_GREETING } from '@/locales/en'
 import '@/sass/style.scss'
 import onPerfEntry from './utils/onPerfEntry'
+import { initLogoutListener } from '@/utils/sessionSync'
 import { SnackbarProvider } from 'notistack'
 // IIFE that initializes the root node and renders the application.
 ;(async function () {
+  // Cross-tab logout sync (#606): register once for this tab's lifetime so a
+  // logout in any other tab drops this one cleanly onto the sign-in page.
+  initLogoutListener()
+
   // create the root element in the DOM
   const rootElement = document.getElementById('root') as HTMLElement
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,8 +14,7 @@ import { initLogoutListener } from '@/utils/sessionSync'
 import { SnackbarProvider } from 'notistack'
 // IIFE that initializes the root node and renders the application.
 ;(async function () {
-  // Cross-tab logout sync (#606): register once for this tab's lifetime so a
-  // logout in any other tab drops this one cleanly onto the sign-in page.
+  // Once per tab lifetime, outside React so StrictMode cannot double-invoke it.
   initLogoutListener()
 
   // create the root element in the DOM

--- a/src/utils/authInterceptor.integration.test.ts
+++ b/src/utils/authInterceptor.integration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The #606 loop fix against a REAL router. authInterceptor.test.ts mocks the
+ * router, so it can pin that revalidate() runs before navigate() but not that
+ * the loop stops. That matters because the fix relies on react-router keeping
+ * its internal isRevalidationRequired flag across the interrupting navigation -
+ * public behavior of a private detail, so a version bump could regress #606
+ * with every mocked test still green. These assert the outcome instead: the
+ * /signin navigation commits with FRESH loader data.
+ */
+import type { AxiosError } from 'axios'
+import { createMemoryRouter } from 'react-router-dom'
+import { AuthCodes, SignInReasons } from '@/utils/authCodes'
+import { Routes, RouteIds } from '@/router/constants'
+
+// The interceptor imports the router singleton; point that import at whichever
+// memory router the current test built. Getters resolve lazily, so it stays live.
+const mockRouterRef: { current: ReturnType<typeof createMemoryRouter> | null } =
+  { current: null }
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: {
+    get state() {
+      return mockRouterRef.current?.state
+    },
+    navigate: (...args: unknown[]) =>
+      (
+        mockRouterRef.current?.navigate as unknown as (
+          ...a: unknown[]
+        ) => Promise<void>
+      )(...args),
+    revalidate: () => mockRouterRef.current?.revalidate(),
+  },
+}))
+
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  markAuthHandled: (e: object) => Object.assign(e, { __authHandled: true }),
+}))
+
+import { handleAuthError } from './authInterceptor'
+
+// Mirrors authLoader's discriminated return.
+let sessionAlive = true
+let rootLoaderRuns = 0
+
+function rootLoader() {
+  rootLoaderRuns++
+  return sessionAlive
+    ? { status: 200, response: { userid: 'u1' } }
+    : { ok: false, reason: SignInReasons.EXPIRED, response: {} }
+}
+
+async function buildSignedInRouter() {
+  sessionAlive = true
+  rootLoaderRuns = 0
+  const router = createMemoryRouter(
+    [
+      {
+        id: RouteIds.ROOT,
+        path: Routes.ROOT,
+        loader: rootLoader,
+        children: [
+          { index: true, id: 'home' },
+          { path: RouteIds.SIGNIN, id: RouteIds.SIGNIN },
+        ],
+      },
+    ],
+    { initialEntries: [Routes.ROOT] }
+  )
+  mockRouterRef.current = router
+  router.initialize()
+  await waitForIdle(router)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({ status: 200 })
+  return router
+}
+
+/**
+ * Settle the router. It yields before checking, so `expectWorkStarted` asserts
+ * something was actually in flight - otherwise an interceptor that ever awaited
+ * before navigating would make the loader-count assertions vacuously pass.
+ */
+async function waitForIdle(
+  router: ReturnType<typeof createMemoryRouter>,
+  expectWorkStarted = false
+): Promise<void> {
+  if (expectWorkStarted) {
+    const busy =
+      router.state.navigation.state !== 'idle' ||
+      router.state.revalidation !== 'idle'
+    if (!busy) {
+      throw new Error(
+        'expected a navigation or revalidation to be in flight, but the router was idle'
+      )
+    }
+  }
+  for (let i = 0; i < 50; i++) {
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    if (
+      router.state.initialized &&
+      router.state.navigation.state === 'idle' &&
+      router.state.revalidation === 'idle'
+    ) {
+      return
+    }
+  }
+  throw new Error('router did not settle')
+}
+
+function authError(
+  status: number,
+  code: string
+): AxiosError<{ error?: string; code?: string }> {
+  return {
+    config: {},
+    response: {
+      status,
+      data: { code },
+      statusText: '',
+      headers: {},
+      config: {},
+    },
+    isAxiosError: true,
+    toJSON: () => ({}),
+    name: 'AxiosError',
+    message: 'mock',
+  } as unknown as AxiosError<{ error?: string; code?: string }>
+}
+
+afterEach(() => {
+  // Optional across versions, hence the guard.
+  mockRouterRef.current?.dispose?.()
+  mockRouterRef.current = null
+})
+
+test('a 401 against a signed-in dashboard lands on sign-in with FRESH loader data (#606)', async () => {
+  const router = await buildSignedInRouter()
+
+  // Session dies out from under the tab.
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await expect(
+    handleAuthError(authError(401, AuthCodes.UNAUTHORIZED))
+  ).rejects.toMatchObject({ __authHandled: true })
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  // The load-bearing assertion: without revalidate() this still reads 200.
+  expect(rootLoaderRuns).toBeGreaterThan(runsBefore)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({
+    ok: false,
+    reason: SignInReasons.EXPIRED,
+  })
+  expect(router.state.loaderData[RouteIds.ROOT]).not.toMatchObject({
+    status: 200,
+  })
+})
+
+test('the sign-in navigation carries the expired reason for LoginPage', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+
+  await expect(
+    handleAuthError(authError(401, AuthCodes.UNAUTHORIZED))
+  ).rejects.toMatchObject({ __authHandled: true })
+  await waitForIdle(router, true)
+
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.EXPIRED,
+  })
+})
+
+test('a burst of 401s settles on sign-in once, without a redirect storm (#606)', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  // What a dashboard mount does: several requests rejecting together.
+  await Promise.all(
+    Array.from({ length: 4 }, () =>
+      handleAuthError(authError(401, AuthCodes.UNAUTHORIZED)).catch(() => {})
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({ ok: false })
+  // Empirical bound for a homogeneous burst: lands on exactly 2, and goes to
+  // 5 without the guards. A mixed burst reaches 3 - separate test below.
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(2)
+})
+
+test('a 403 ACCOUNT_NOT_PROVISIONED burst settles on the NO_ACCOUNT terminal state', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await Promise.all(
+    Array.from({ length: 4 }, () =>
+      handleAuthError(authError(403, AuthCodes.ACCOUNT_NOT_PROVISIONED)).catch(
+        () => {}
+      )
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(2)
+})
+
+test('a mixed 401/403 burst settles on NO_ACCOUNT with a bounded number of loader runs', async () => {
+  // Interleaved: NO_ACCOUNT must win regardless of order, and runs stay
+  // bounded. Costs one more run than a homogeneous burst, since the first 403
+  // is allowed through to override the 401's EXPIRED redirect.
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await Promise.all(
+    [401, 403, 401, 403, 401, 403].map((s) =>
+      handleAuthError(
+        authError(
+          s,
+          s === 401 ? AuthCodes.UNAUTHORIZED : AuthCodes.ACCOUNT_NOT_PROVISIONED
+        )
+      ).catch(() => {})
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(3)
+})
+
+test('NO_ACCOUNT still overrides an EXPIRED redirect already committed', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+
+  await handleAuthError(authError(401, AuthCodes.UNAUTHORIZED)).catch(() => {})
+  await waitForIdle(router)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.EXPIRED,
+  })
+
+  // The more specific diagnosis arrives second and must win.
+  await handleAuthError(
+    authError(403, AuthCodes.ACCOUNT_NOT_PROVISIONED)
+  ).catch(() => {})
+  await waitForIdle(router)
+
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+})

--- a/src/utils/authInterceptor.integration.test.ts
+++ b/src/utils/authInterceptor.integration.test.ts
@@ -246,7 +246,7 @@ test('NO_ACCOUNT still overrides an EXPIRED redirect already committed', async (
   sessionAlive = false
 
   await handleAuthError(authError(401, AuthCodes.UNAUTHORIZED)).catch(() => {})
-  await waitForIdle(router)
+  await waitForIdle(router, true)
   expect(router.state.location.state).toMatchObject({
     reason: SignInReasons.EXPIRED,
   })
@@ -255,7 +255,7 @@ test('NO_ACCOUNT still overrides an EXPIRED redirect already committed', async (
   await handleAuthError(
     authError(403, AuthCodes.ACCOUNT_NOT_PROVISIONED)
   ).catch(() => {})
-  await waitForIdle(router)
+  await waitForIdle(router, true)
 
   expect(router.state.location.state).toMatchObject({
     reason: SignInReasons.NO_ACCOUNT,

--- a/src/utils/authInterceptor.test.ts
+++ b/src/utils/authInterceptor.test.ts
@@ -13,7 +13,7 @@ jest.mock('@/router/router', () => ({
       navigation: { location: undefined },
       revalidation: 'idle',
       // Keyed by route id; 'root' is RouteIds.ROOT (factory can't reference
-      // the enum). status 200 = the stale-active-session shape #606 fixes.
+      // the enum). status 200 = the stale-active-session shape the fix targets.
       loaderData: { root: { status: 200 } },
     },
   },
@@ -35,8 +35,16 @@ const mockedRevalidate = (router as unknown as { revalidate: jest.Mock })
 const mockedNotify = notify as jest.Mock
 const mockedRouter = router as unknown as {
   state: {
-    location: { pathname: string }
-    navigation: { location?: { pathname: string } }
+    location: {
+      pathname: string
+      state?: { reason?: string; message?: string }
+    }
+    navigation: {
+      location?: {
+        pathname: string
+        state?: { reason?: string; message?: string }
+      }
+    }
     revalidation: 'idle' | 'loading'
     loaderData: Record<string, { status?: number; ok?: boolean }>
   }
@@ -46,8 +54,19 @@ function setCurrentPath(pathname: string): void {
   mockedRouter.state.location.pathname = pathname
 }
 
-function setPendingPath(pathname: string | undefined): void {
-  mockedRouter.state.navigation.location = pathname ? { pathname } : undefined
+function setPendingPath(
+  pathname: string | undefined,
+  state?: { reason?: string; message?: string }
+): void {
+  mockedRouter.state.navigation.location = pathname
+    ? { pathname, state }
+    : undefined
+}
+
+function setCurrentState(
+  state: { reason?: string; message?: string } | undefined
+): void {
+  mockedRouter.state.location.state = state
 }
 
 function setRootLoaderStatus(status: number | undefined): void {
@@ -80,6 +99,7 @@ beforeEach(() => {
   // flight, and loader data still claiming an active session (the stale
   // shape a surprise 401 arrives against).
   setCurrentPath('/')
+  setCurrentState(undefined)
   setPendingPath(undefined)
   setRootLoaderStatus(200)
   mockedRouter.state.revalidation = 'idle'
@@ -200,7 +220,7 @@ test('network errors with no response pass through untouched', async () => {
   expect(mockedNotify).not.toHaveBeenCalled()
 })
 
-test('401 does not re-navigate when already on the sign-in route (#606 loop-guard)', async () => {
+test('401 does not re-navigate when already on the sign-in route (loop-guard)', async () => {
   setCurrentPath(Routes.SIGNIN)
   const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
 
@@ -222,11 +242,9 @@ test('the sign-in route guard tolerates a trailing slash and casing', async () =
   expect(mockedNavigate).not.toHaveBeenCalled()
 })
 
-test('403 ACCOUNT_NOT_PROVISIONED still navigates when already on sign-in so the terminal state wins', async () => {
-  // A NO_ACCOUNT diagnosis must not be swallowed just because an EXPIRED
-  // redirect from the same burst got there first: the terminal "contact your
-  // administrator" copy (no retry CTA) is the correct surface.
+test('403 ACCOUNT_NOT_PROVISIONED still navigates over a committed EXPIRED redirect so the terminal state wins', async () => {
   setCurrentPath(Routes.SIGNIN)
+  setCurrentState({ reason: SignInReasons.EXPIRED })
   const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
 
   await expect(handleAuthError(error)).rejects.toMatchObject({
@@ -241,11 +259,125 @@ test('403 ACCOUNT_NOT_PROVISIONED still navigates when already on sign-in so the
   })
 })
 
-test('401 does not re-navigate while a navigation to sign-in is already pending (#606 burst)', async () => {
-  // A burst of concurrent 401s: the first already started the /signin
-  // navigation, whose loader has not committed yet, so state.location still
-  // shows the old route. The rest of the burst must not interrupt and
-  // restart it.
+test('403 ACCOUNT_NOT_PROVISIONED overrides a PENDING EXPIRED redirect too (either arrival order)', async () => {
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN, { reason: SignInReasons.EXPIRED })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(
+    Routes.SIGNIN,
+    expect.objectContaining({
+      state: expect.objectContaining({ reason: SignInReasons.NO_ACCOUNT }),
+    })
+  )
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED does not re-navigate over an already-showing NO_ACCOUNT state', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  // Same message the body-less 403 resolves to, so this is a true duplicate.
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED does not re-navigate while a NO_ACCOUNT navigation is pending', async () => {
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN, {
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED suppressed by its own guard still revalidates stale loader data', async () => {
+  // revalidate() must sit OUTSIDE the navigate guard: a suppressed redirect
+  // still needs fresh loaderData, or the tab keeps bouncing.
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  setRootLoaderStatus(200)
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with a different message navigates so the terminal copy corrects itself', async () => {
+  // A body-less first 403 falls back to generic copy; a later one carrying the
+  // real text must not be deduped away.
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, {
+    code: AuthCodes.ACCOUNT_NOT_PROVISIONED,
+    error: 'Your ZTMF account is not set up.',
+  })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: 'Your ZTMF account is not set up.',
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with the SAME message is still deduped', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: 'Your ZTMF account is not set up.',
+  })
+  const error = makeError(403, {
+    code: AuthCodes.ACCOUNT_NOT_PROVISIONED,
+    error: 'Your ZTMF account is not set up.',
+  })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('a 401 does not clobber an already-showing NO_ACCOUNT terminal state', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({ reason: SignInReasons.NO_ACCOUNT })
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('401 does not re-navigate while a navigation to sign-in is already pending (burst)', async () => {
+  // The first 401 started the /signin navigation but it has not committed, so
+  // location still shows the old route. Stragglers must not restart it.
   setCurrentPath('/')
   setPendingPath(Routes.SIGNIN)
   const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
@@ -273,10 +405,8 @@ test('a pending navigation to a non-sign-in route does not suppress the redirect
   })
 })
 
-test('401 with stale active-session loader data revalidates the root loader before navigating (#606)', async () => {
-  // The actual loop-breaker: navigate('/signin') alone does not re-run the
-  // still-matched root authLoader, so LoginPage would see stale status===200
-  // and bounce back to the dashboard forever.
+test('401 with stale active-session loader data revalidates the root loader before navigating', async () => {
+  // The loop-breaker: navigate() alone leaves the root loader un-run.
   const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
 
   await expect(handleAuthError(error)).rejects.toMatchObject({
@@ -300,8 +430,7 @@ test('401 while loader data already reports no session does not fire a redundant
 })
 
 test('401 suppressed by the sign-in guard still revalidates stale loader data', async () => {
-  // Being on /signin with loader data claiming an active session is exactly
-  // the mid-bounce state - skipping the redirect must not skip the fix.
+  // The mid-bounce state: skipping the redirect must not skip the fix.
   setCurrentPath(Routes.SIGNIN)
   const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
 
@@ -322,10 +451,8 @@ test('403 ACCOUNT_NOT_PROVISIONED with stale loader data also revalidates', asyn
 })
 
 test('401 while a revalidation is already in flight does not re-fire revalidate', async () => {
-  // Stragglers in a 401 burst arrive while the first rejection's forced
-  // loader re-run is still pending (loaderData is stale until it lands);
-  // re-firing revalidate() would restart the /signin navigation's loader
-  // run for no benefit.
+  // loaderData is stale until the re-run lands; re-firing revalidate() would
+  // restart the pending navigation for no benefit.
   mockedRouter.state.revalidation = 'loading'
   const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
 

--- a/src/utils/authInterceptor.test.ts
+++ b/src/utils/authInterceptor.test.ts
@@ -5,7 +5,18 @@ import { AuthCodes, SignInReasons } from '@/utils/authCodes'
 
 jest.mock('@/router/router', () => ({
   __esModule: true,
-  default: { navigate: jest.fn() },
+  default: {
+    navigate: jest.fn(),
+    revalidate: jest.fn(),
+    state: {
+      location: { pathname: '/' },
+      navigation: { location: undefined },
+      revalidation: 'idle',
+      // Keyed by route id; 'root' is RouteIds.ROOT (factory can't reference
+      // the enum). status 200 = the stale-active-session shape #606 fixes.
+      loaderData: { root: { status: 200 } },
+    },
+  },
 }))
 
 jest.mock('@/utils/notify', () => ({
@@ -19,7 +30,29 @@ import { notify } from '@/utils/notify'
 import { handleAuthError } from './authInterceptor'
 
 const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
+const mockedRevalidate = (router as unknown as { revalidate: jest.Mock })
+  .revalidate
 const mockedNotify = notify as jest.Mock
+const mockedRouter = router as unknown as {
+  state: {
+    location: { pathname: string }
+    navigation: { location?: { pathname: string } }
+    revalidation: 'idle' | 'loading'
+    loaderData: Record<string, { status?: number; ok?: boolean }>
+  }
+}
+
+function setCurrentPath(pathname: string): void {
+  mockedRouter.state.location.pathname = pathname
+}
+
+function setPendingPath(pathname: string | undefined): void {
+  mockedRouter.state.navigation.location = pathname ? { pathname } : undefined
+}
+
+function setRootLoaderStatus(status: number | undefined): void {
+  mockedRouter.state.loaderData.root = status ? { status } : { ok: false }
+}
 
 function makeError(
   status: number | undefined,
@@ -41,7 +74,15 @@ function makeError(
 
 beforeEach(() => {
   mockedNavigate.mockReset()
+  mockedRevalidate.mockReset()
   mockedNotify.mockReset()
+  // Default: dashboard state - not on the sign-in route, no navigation in
+  // flight, and loader data still claiming an active session (the stale
+  // shape a surprise 401 arrives against).
+  setCurrentPath('/')
+  setPendingPath(undefined)
+  setRootLoaderStatus(200)
+  mockedRouter.state.revalidation = 'idle'
 })
 
 test('401 redirects to sign-in with the expired-session message and reason', async () => {
@@ -157,4 +198,139 @@ test('network errors with no response pass through untouched', async () => {
   await expect(handleAuthError(error)).rejects.toBe(error)
   expect(mockedNavigate).not.toHaveBeenCalled()
   expect(mockedNotify).not.toHaveBeenCalled()
+})
+
+test('401 does not re-navigate when already on the sign-in route (#606 loop-guard)', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  // Redundant redirect suppressed. (Dedupe only - the loop itself is broken
+  // by the revalidate() call, pinned further down.)
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('the sign-in route guard tolerates a trailing slash and casing', async () => {
+  setCurrentPath('/SignIn/')
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED still navigates when already on sign-in so the terminal state wins', async () => {
+  // A NO_ACCOUNT diagnosis must not be swallowed just because an EXPIRED
+  // redirect from the same burst got there first: the terminal "contact your
+  // administrator" copy (no retry CTA) is the correct surface.
+  setCurrentPath(Routes.SIGNIN)
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: ERROR_MESSAGES.permission,
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+})
+
+test('401 does not re-navigate while a navigation to sign-in is already pending (#606 burst)', async () => {
+  // A burst of concurrent 401s: the first already started the /signin
+  // navigation, whose loader has not committed yet, so state.location still
+  // shows the old route. The rest of the burst must not interrupt and
+  // restart it.
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('a pending navigation to a non-sign-in route does not suppress the redirect', async () => {
+  setCurrentPath('/')
+  setPendingPath('/users')
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: ERROR_MESSAGES.expired,
+      reason: SignInReasons.EXPIRED,
+    },
+  })
+})
+
+test('401 with stale active-session loader data revalidates the root loader before navigating (#606)', async () => {
+  // The actual loop-breaker: navigate('/signin') alone does not re-run the
+  // still-matched root authLoader, so LoginPage would see stale status===200
+  // and bounce back to the dashboard forever.
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).toHaveBeenCalled()
+  // Revalidate first so the /signin navigation commits with fresh loader data.
+  expect(mockedRevalidate.mock.invocationCallOrder[0]).toBeLessThan(
+    mockedNavigate.mock.invocationCallOrder[0]
+  )
+})
+
+test('401 while loader data already reports no session does not fire a redundant revalidation', async () => {
+  setRootLoaderStatus(undefined)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).not.toHaveBeenCalled()
+})
+
+test('401 suppressed by the sign-in guard still revalidates stale loader data', async () => {
+  // Being on /signin with loader data claiming an active session is exactly
+  // the mid-bounce state - skipping the redirect must not skip the fix.
+  setCurrentPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with stale loader data also revalidates', async () => {
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('401 while a revalidation is already in flight does not re-fire revalidate', async () => {
+  // Stragglers in a 401 burst arrive while the first rejection's forced
+  // loader re-run is still pending (loaderData is stale until it lands);
+  // re-firing revalidate() would restart the /signin navigation's loader
+  // run for no benefit.
+  mockedRouter.state.revalidation = 'loading'
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).not.toHaveBeenCalled()
 })

--- a/src/utils/authInterceptor.ts
+++ b/src/utils/authInterceptor.ts
@@ -4,7 +4,7 @@
 // node throws "Cannot use 'import.meta' outside a module" at load time).
 import type { AxiosError } from 'axios'
 import router from '@/router/router'
-import { Routes } from '@/router/constants'
+import { RouteIds, Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
 import { markAuthHandled, notify } from '@/utils/notify'
 import { AuthCodes, SignInReasons } from '@/utils/authCodes'
@@ -47,18 +47,62 @@ export async function handleAuthError(
   const code = error.response?.data?.code
   const backendMessage = error.response?.data?.error
 
+  // #606: an auth failure here usually means the session died out from under
+  // a still-rendered dashboard (logout in another tab, cookie expiry). Two
+  // pieces of router state need correcting, and a plain navigate('/signin')
+  // fixes only one of them:
+  //
+  // 1. The root authLoader's data. The root route stays matched on a child
+  //    navigation, so react-router does NOT re-run its loader and loaderData
+  //    keeps claiming status===200. LoginPage trusts that and <Navigate>s
+  //    straight back to the dashboard, whose mount fetches 401 again - the
+  //    reported "stuttering loop." router.revalidate() forces the authLoader
+  //    to re-run; once it reports no session the bounce stops. Called before
+  //    navigate() so the /signin navigation picks the revalidation up and
+  //    commits with fresh loader data, and only when the data is actually
+  //    stale so 401s while already signed out don't fire a redundant probe.
+  //
+  // 2. The location. Redirect to /signin carrying the reason so LoginPage
+  //    renders the right copy. For a 401 this is skipped when the tab is
+  //    already on (or already navigating to) the sign-in route - one redirect
+  //    per burst of concurrent rejections is enough, and a late 401 must not
+  //    clobber a NO_ACCOUNT terminal state already showing. NO_ACCOUNT itself
+  //    always navigates: it is the more specific diagnosis and must win over
+  //    a plain EXPIRED redirect from the same burst.
+  //
+  // Path normalization mirrors Title.tsx (lowercase + strip trailing slash).
+  const normalizePath = (pathname: string | undefined) =>
+    (pathname ?? '').toLowerCase().replace(/\/$/, '')
+  const signInPath = Routes.SIGNIN.toLowerCase()
+  const alreadyOnSignIn =
+    normalizePath(router.state?.location?.pathname) === signInPath ||
+    normalizePath(router.state?.navigation?.location?.pathname) === signInPath
+  const rootLoaderData = router.state?.loaderData?.[RouteIds.ROOT] as
+    | { status?: number }
+    | undefined
+  // Skip when a revalidation is already in flight: loaderData stays stale
+  // until it completes, so each straggler in a 401 burst would otherwise
+  // re-fire revalidate() and restart the pending /signin navigation's
+  // loader run. One forced re-run is enough.
+  const needsRevalidation =
+    rootLoaderData?.status === 200 && router.state?.revalidation !== 'loading'
+
   if (status === 401) {
-    router.navigate(Routes.SIGNIN, {
-      replace: true,
-      state: {
-        message: ERROR_MESSAGES.expired,
-        reason: SignInReasons.EXPIRED,
-      },
-    })
+    if (needsRevalidation) void router.revalidate()
+    if (!alreadyOnSignIn) {
+      router.navigate(Routes.SIGNIN, {
+        replace: true,
+        state: {
+          message: ERROR_MESSAGES.expired,
+          reason: SignInReasons.EXPIRED,
+        },
+      })
+    }
     throw markAuthHandled(error)
   }
   if (status === 403) {
     if (code === AuthCodes.ACCOUNT_NOT_PROVISIONED) {
+      if (needsRevalidation) void router.revalidate()
       router.navigate(Routes.SIGNIN, {
         replace: true,
         state: {

--- a/src/utils/authInterceptor.ts
+++ b/src/utils/authInterceptor.ts
@@ -47,43 +47,49 @@ export async function handleAuthError(
   const code = error.response?.data?.code
   const backendMessage = error.response?.data?.error
 
-  // #606: an auth failure here usually means the session died out from under
-  // a still-rendered dashboard (logout in another tab, cookie expiry). Two
-  // pieces of router state need correcting, and a plain navigate('/signin')
-  // fixes only one of them:
-  //
-  // 1. The root authLoader's data. The root route stays matched on a child
-  //    navigation, so react-router does NOT re-run its loader and loaderData
-  //    keeps claiming status===200. LoginPage trusts that and <Navigate>s
-  //    straight back to the dashboard, whose mount fetches 401 again - the
-  //    reported "stuttering loop." router.revalidate() forces the authLoader
-  //    to re-run; once it reports no session the bounce stops. Called before
-  //    navigate() so the /signin navigation picks the revalidation up and
-  //    commits with fresh loader data, and only when the data is actually
-  //    stale so 401s while already signed out don't fire a redundant probe.
-  //
-  // 2. The location. Redirect to /signin carrying the reason so LoginPage
-  //    renders the right copy. For a 401 this is skipped when the tab is
-  //    already on (or already navigating to) the sign-in route - one redirect
-  //    per burst of concurrent rejections is enough, and a late 401 must not
-  //    clobber a NO_ACCOUNT terminal state already showing. NO_ACCOUNT itself
-  //    always navigates: it is the more specific diagnosis and must win over
-  //    a plain EXPIRED redirect from the same burst.
-  //
-  // Path normalization mirrors Title.tsx (lowercase + strip trailing slash).
+  // Navigating to /signin leaves the root route matched, so react-router does
+  // not re-run its loader: loaderData keeps reporting status 200, LoginPage
+  // trusts it and <Navigate>s back to the dashboard, whose mount 401s again
+  // (#606). revalidate() is what breaks that cycle, so it must stay OUTSIDE
+  // the redirect guards below - a suppressed redirect still needs fresh data.
+  // Path normalization mirrors Title.tsx.
   const normalizePath = (pathname: string | undefined) =>
     (pathname ?? '').toLowerCase().replace(/\/$/, '')
   const signInPath = Routes.SIGNIN.toLowerCase()
+  const onSignIn = (loc?: { pathname?: string }) =>
+    normalizePath(loc?.pathname) === signInPath
   const alreadyOnSignIn =
-    normalizePath(router.state?.location?.pathname) === signInPath ||
-    normalizePath(router.state?.navigation?.location?.pathname) === signInPath
+    onSignIn(router.state?.location) ||
+    onSignIn(router.state?.navigation?.location)
+  const backendMessageOrPermission =
+    typeof backendMessage === 'string' && backendMessage.length > 0
+      ? backendMessage
+      : ERROR_MESSAGES.permission
+  // NO_ACCOUNT cannot reuse alreadyOnSignIn: an EXPIRED redirect landing first
+  // in a burst would suppress the more specific diagnosis. Keying on reason
+  // dedupes it against itself instead. The message is part of the key because
+  // LoginPage prefers location.state.message, so a body-less 403 that fell back
+  // to generic copy would otherwise freeze out a later one carrying the real
+  // text.
+  const showingNoAccount = (loc?: { pathname?: string; state?: unknown }) => {
+    if (!onSignIn(loc)) return false
+    const locState = loc?.state as
+      | { reason?: string; message?: string }
+      | null
+      | undefined
+    return (
+      locState?.reason === SignInReasons.NO_ACCOUNT &&
+      locState?.message === backendMessageOrPermission
+    )
+  }
+  const alreadyShowingNoAccount =
+    showingNoAccount(router.state?.location) ||
+    showingNoAccount(router.state?.navigation?.location)
   const rootLoaderData = router.state?.loaderData?.[RouteIds.ROOT] as
     | { status?: number }
     | undefined
-  // Skip when a revalidation is already in flight: loaderData stays stale
-  // until it completes, so each straggler in a 401 burst would otherwise
-  // re-fire revalidate() and restart the pending /signin navigation's
-  // loader run. One forced re-run is enough.
+  // loaderData stays stale until a revalidation lands, so without the in-flight
+  // check every straggler in a burst would restart the pending navigation.
   const needsRevalidation =
     rootLoaderData?.status === 200 && router.state?.revalidation !== 'loading'
 
@@ -103,16 +109,15 @@ export async function handleAuthError(
   if (status === 403) {
     if (code === AuthCodes.ACCOUNT_NOT_PROVISIONED) {
       if (needsRevalidation) void router.revalidate()
-      router.navigate(Routes.SIGNIN, {
-        replace: true,
-        state: {
-          message:
-            typeof backendMessage === 'string' && backendMessage.length > 0
-              ? backendMessage
-              : ERROR_MESSAGES.permission,
-          reason: SignInReasons.NO_ACCOUNT,
-        },
-      })
+      if (!alreadyShowingNoAccount) {
+        router.navigate(Routes.SIGNIN, {
+          replace: true,
+          state: {
+            message: backendMessageOrPermission,
+            reason: SignInReasons.NO_ACCOUNT,
+          },
+        })
+      }
       throw markAuthHandled(error)
     }
     if (code === AuthCodes.FORBIDDEN_ORIGIN) {
@@ -120,12 +125,7 @@ export async function handleAuthError(
       notify(ERROR_MESSAGES.permission, 'error')
       throw markAuthHandled(error)
     }
-    notify(
-      typeof backendMessage === 'string' && backendMessage.length > 0
-        ? backendMessage
-        : ERROR_MESSAGES.permission,
-      'error'
-    )
+    notify(backendMessageOrPermission, 'error')
     throw markAuthHandled(error)
   }
   throw error

--- a/src/utils/sessionSync.test.ts
+++ b/src/utils/sessionSync.test.ts
@@ -20,10 +20,6 @@ class FakeBroadcastChannel {
   addEventListener(type: string, fn: (e: MessageEvent) => void): void {
     if (type === 'message') this.listeners.push(fn)
   }
-  removeEventListener(type: string, fn: (e: MessageEvent) => void): void {
-    if (type === 'message')
-      this.listeners = this.listeners.filter((l) => l !== fn)
-  }
   /** Deliver a message the way the browser would: onmessage AND every listener. */
   dispatch(data: unknown): void {
     const event = { data } as MessageEvent

--- a/src/utils/sessionSync.test.ts
+++ b/src/utils/sessionSync.test.ts
@@ -1,12 +1,14 @@
 import { Routes } from '@/router/constants'
 
-// Minimal stand-in for the BroadcastChannel the module constructs at load time.
-// Captures posted messages and the registered onmessage so tests can drive both
-// the send and receive sides without a real channel.
+// Stand-in for the channel the module builds at load time. `dispatch` delivers
+// to onmessage AND addEventListener handlers like a browser does, so the
+// idempotency test can observe stacked handlers - driving onmessage directly
+// never could, since the property holds one function.
 class FakeBroadcastChannel {
   static last: FakeBroadcastChannel | null = null
   name: string
   onmessage: ((e: MessageEvent) => void) | null = null
+  listeners: ((e: MessageEvent) => void)[] = []
   posted: unknown[] = []
   constructor(name: string) {
     this.name = name
@@ -14,6 +16,19 @@ class FakeBroadcastChannel {
   }
   postMessage(data: unknown): void {
     this.posted.push(data)
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.push(fn)
+  }
+  removeEventListener(type: string, fn: (e: MessageEvent) => void): void {
+    if (type === 'message')
+      this.listeners = this.listeners.filter((l) => l !== fn)
+  }
+  /** Deliver a message the way the browser would: onmessage AND every listener. */
+  dispatch(data: unknown): void {
+    const event = { data } as MessageEvent
+    this.onmessage?.(event)
+    this.listeners.forEach((fn) => fn(event))
   }
   close(): void {}
 }
@@ -63,14 +78,13 @@ describe('with BroadcastChannel available', () => {
   })
 
   it('a received logout reloads the tab without touching the hash', () => {
-    // The reload re-runs the root authLoader, which renders LoginPage on any
-    // route - and leaving the hash alone means a user who vetoes the reload
-    // via the questionnaire's beforeunload guard loses nothing.
+    // Leaving the hash alone means a user who vetoes the reload via the
+    // questionnaire's beforeunload guard loses nothing.
     window.location.hash = '#/users'
     const { initLogoutListener } = loadModule()
     initLogoutListener()
 
-    FakeBroadcastChannel.last?.onmessage?.({ data: 'logout' } as MessageEvent)
+    FakeBroadcastChannel.last?.dispatch('logout')
 
     expect(window.location.reload as jest.Mock).toHaveBeenCalled()
     expect(window.location.hash).toBe('#/users')
@@ -80,21 +94,45 @@ describe('with BroadcastChannel available', () => {
     const { initLogoutListener } = loadModule()
     initLogoutListener()
 
-    FakeBroadcastChannel.last?.onmessage?.({ data: 'other' } as MessageEvent)
+    FakeBroadcastChannel.last?.dispatch('other')
 
     expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
   })
 
+  it('is idempotent across repeat initLogoutListener calls', () => {
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.dispatch('logout')
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows a postMessage failure so the logging-out tab still finishes', () => {
+    // handleLogout calls this before its own reload with the session already
+    // dead, so an escaping throw would strand the user mid-logout.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const { broadcastLogout } = loadModule()
+    const channel = FakeBroadcastChannel.last!
+    channel.postMessage = () => {
+      throw new Error('InvalidStateError')
+    }
+
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(errSpy).toHaveBeenCalled()
+
+    errSpy.mockRestore()
+  })
+
   it('reloads even when the tab is already on the sign-in route', () => {
-    // No "already on /signin" suppression: a tab can sit on /signin with
-    // stale in-memory loader data still claiming an active session, and
-    // skipping the reload would leave it wedged. Reloading a genuinely
-    // signed-out /signin tab is cheap and idempotent.
+    // A tab can sit on /signin with stale loader data still claiming a
+    // session; skipping the reload would wedge it.
     window.location.hash = `#${Routes.SIGNIN}`
     const { initLogoutListener } = loadModule()
     initLogoutListener()
 
-    FakeBroadcastChannel.last?.onmessage?.({ data: 'logout' } as MessageEvent)
+    FakeBroadcastChannel.last?.dispatch('logout')
 
     expect(window.location.reload as jest.Mock).toHaveBeenCalled()
   })
@@ -115,5 +153,33 @@ describe('without BroadcastChannel (unsupported browser)', () => {
     expect(() => broadcastLogout()).not.toThrow()
     expect(() => initLogoutListener()).not.toThrow()
     expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when constructing the channel throws', () => {
+  // Import-time throw would white-screen the app; degrade to the no-op path.
+  function loadModule() {
+    ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+      function ThrowingChannel() {
+        throw new Error('blocked by policy')
+      } as unknown
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('does not throw at import and leaves both functions as no-ops', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => loadModule()).not.toThrow()
+    const { broadcastLogout, initLogoutListener } = loadModule()
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(() => initLogoutListener()).not.toThrow()
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+    expect(errSpy).toHaveBeenCalled()
+
+    errSpy.mockRestore()
   })
 })

--- a/src/utils/sessionSync.test.ts
+++ b/src/utils/sessionSync.test.ts
@@ -1,0 +1,119 @@
+import { Routes } from '@/router/constants'
+
+// Minimal stand-in for the BroadcastChannel the module constructs at load time.
+// Captures posted messages and the registered onmessage so tests can drive both
+// the send and receive sides without a real channel.
+class FakeBroadcastChannel {
+  static last: FakeBroadcastChannel | null = null
+  name: string
+  onmessage: ((e: MessageEvent) => void) | null = null
+  posted: unknown[] = []
+  constructor(name: string) {
+    this.name = name
+    FakeBroadcastChannel.last = this
+  }
+  postMessage(data: unknown): void {
+    this.posted.push(data)
+  }
+  close(): void {}
+}
+
+const originalLocation = window.location
+const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown })
+  .BroadcastChannel
+
+beforeEach(() => {
+  jest.resetModules()
+  FakeBroadcastChannel.last = null
+  // jsdom forbids assigning hash / calling reload on the real location; swap in
+  // a writable stub so the redirect is observable.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { hash: '', reload: jest.fn() },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+  ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+    originalBroadcastChannel
+})
+
+describe('with BroadcastChannel available', () => {
+  function loadModule() {
+    ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+      FakeBroadcastChannel as unknown
+    // Fresh import so the module-level channel is built against the fake.
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('broadcastLogout posts a logout message on the channel', () => {
+    const { broadcastLogout } = loadModule()
+    broadcastLogout()
+    expect(FakeBroadcastChannel.last?.posted).toEqual(['logout'])
+  })
+
+  it('a received logout reloads the tab without touching the hash', () => {
+    // The reload re-runs the root authLoader, which renders LoginPage on any
+    // route - and leaving the hash alone means a user who vetoes the reload
+    // via the questionnaire's beforeunload guard loses nothing.
+    window.location.hash = '#/users'
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.onmessage?.({ data: 'logout' } as MessageEvent)
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+    expect(window.location.hash).toBe('#/users')
+  })
+
+  it('ignores non-logout messages', () => {
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.onmessage?.({ data: 'other' } as MessageEvent)
+
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('reloads even when the tab is already on the sign-in route', () => {
+    // No "already on /signin" suppression: a tab can sit on /signin with
+    // stale in-memory loader data still claiming an active session, and
+    // skipping the reload would leave it wedged. Reloading a genuinely
+    // signed-out /signin tab is cheap and idempotent.
+    window.location.hash = `#${Routes.SIGNIN}`
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.onmessage?.({ data: 'logout' } as MessageEvent)
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+  })
+})
+
+describe('without BroadcastChannel (unsupported browser)', () => {
+  function loadModule() {
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('broadcastLogout and initLogoutListener are safe no-ops', () => {
+    const { broadcastLogout, initLogoutListener } = loadModule()
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(() => initLogoutListener()).not.toThrow()
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/sessionSync.ts
+++ b/src/utils/sessionSync.ts
@@ -1,49 +1,51 @@
-// Cross-tab logout synchronization (#606).
-//
-// Auth is server-controlled via HTTP-only cookies, so logging out in one tab
-// clears the cookie browser-wide - but other open tabs still hold root loader
-// data claiming an active session and keep rendering the dashboard until
-// something re-runs the authLoader. This module lets the logging-out tab
-// notify every other tab immediately so they tear down cleanly.
-//
-// Mechanism: BroadcastChannel. It delivers only to OTHER tabs (never the
-// sender), needs no persisted key to clean up, and is the purpose-built API
-// for this. It is feature-guarded so browsers without it (Safari < 15.4,
-// some locked-down enterprise builds) simply don't get the proactive teardown
-// and fall back to the interceptor's 401 handling on their next request.
-//
-// The reaction is a plain reload, nothing more:
-// - Reloading re-runs the root authLoader against the now-cleared cookie, and
-//   Title renders LoginPage whenever the loader reports no session - on any
-//   route. So there is no need to move the tab to /signin first, and no
-//   "already on /signin" suppression that could race a tab whose loader data
-//   is still stale.
-// - The hash is deliberately NOT touched. The reload can be vetoed: the
-//   questionnaire registers a beforeunload guard for uncommitted edits, and a
-//   hash write before reload() would client-side-navigate the tab even when
-//   the user cancels that dialog to rescue their work. Leaving the hash alone
-//   means Cancel truly cancels; the axios interceptor then signs the tab out
-//   cleanly on its next request instead.
-const channel =
-  typeof window !== 'undefined' && 'BroadcastChannel' in window
-    ? new BroadcastChannel('ztmf-auth')
-    : null
+// Cross-tab logout (#606). Logging out clears the HTTP-only session cookie
+// browser-wide, but other tabs keep rendering off stale root loader data until
+// something re-runs the authLoader. The logging-out tab signals here.
+
+// Guarded because this runs at import time via main.tsx: a throw would
+// white-screen the app before it renders. Feature detection proves the
+// interface exists, not that constructing it succeeds.
+let channel: BroadcastChannel | null = null
+try {
+  if (typeof window !== 'undefined' && 'BroadcastChannel' in window) {
+    channel = new BroadcastChannel('ztmf-auth')
+  }
+} catch (error) {
+  console.error(
+    'BroadcastChannel unavailable; cross-tab logout disabled',
+    error
+  )
+}
 
 const LOGOUT = 'logout'
 
 /**
- * Called by handleLogout so every other tab tears down too. Best-effort - if
- * BroadcastChannel is unavailable this is a no-op and the logging-out tab still
- * reloads itself as before.
+ * Signal every other tab. No-op without a channel; callers reload themselves
+ * regardless.
+ *
+ * postMessage is spec'd to throw (InvalidStateError, DataCloneError). Neither
+ * should be reachable, but handleLogout calls this after the session is already
+ * dead and before its own reload, so an escaping throw would strand the user
+ * mid-logout.
  */
 export function broadcastLogout(): void {
-  channel?.postMessage(LOGOUT)
+  try {
+    channel?.postMessage(LOGOUT)
+  } catch (error) {
+    console.error('Cross-tab logout signal failed', error)
+  }
 }
 
 /**
- * Registered once at app startup (main.tsx). Reacts to a logout from another
- * tab by reloading, which re-runs the root authLoader against the cleared
- * cookie and lands the tab on LoginPage.
+ * Registered once at startup. Reloading is the whole reaction: it re-runs the
+ * authLoader, and Title renders LoginPage on any route once that reports no
+ * session.
+ *
+ * Do not add a hash write or an "already on /signin" skip. The questionnaire's
+ * beforeunload guard can veto this reload, and a hash write would move the tab
+ * anyway when a user cancels it to save their work; the skip would wedge a tab
+ * sitting on /signin whose loader data still claims a session. `onmessage`
+ * rather than addEventListener keeps repeat registration idempotent.
  */
 export function initLogoutListener(): void {
   if (!channel) return

--- a/src/utils/sessionSync.ts
+++ b/src/utils/sessionSync.ts
@@ -1,0 +1,54 @@
+// Cross-tab logout synchronization (#606).
+//
+// Auth is server-controlled via HTTP-only cookies, so logging out in one tab
+// clears the cookie browser-wide - but other open tabs still hold root loader
+// data claiming an active session and keep rendering the dashboard until
+// something re-runs the authLoader. This module lets the logging-out tab
+// notify every other tab immediately so they tear down cleanly.
+//
+// Mechanism: BroadcastChannel. It delivers only to OTHER tabs (never the
+// sender), needs no persisted key to clean up, and is the purpose-built API
+// for this. It is feature-guarded so browsers without it (Safari < 15.4,
+// some locked-down enterprise builds) simply don't get the proactive teardown
+// and fall back to the interceptor's 401 handling on their next request.
+//
+// The reaction is a plain reload, nothing more:
+// - Reloading re-runs the root authLoader against the now-cleared cookie, and
+//   Title renders LoginPage whenever the loader reports no session - on any
+//   route. So there is no need to move the tab to /signin first, and no
+//   "already on /signin" suppression that could race a tab whose loader data
+//   is still stale.
+// - The hash is deliberately NOT touched. The reload can be vetoed: the
+//   questionnaire registers a beforeunload guard for uncommitted edits, and a
+//   hash write before reload() would client-side-navigate the tab even when
+//   the user cancels that dialog to rescue their work. Leaving the hash alone
+//   means Cancel truly cancels; the axios interceptor then signs the tab out
+//   cleanly on its next request instead.
+const channel =
+  typeof window !== 'undefined' && 'BroadcastChannel' in window
+    ? new BroadcastChannel('ztmf-auth')
+    : null
+
+const LOGOUT = 'logout'
+
+/**
+ * Called by handleLogout so every other tab tears down too. Best-effort - if
+ * BroadcastChannel is unavailable this is a no-op and the logging-out tab still
+ * reloads itself as before.
+ */
+export function broadcastLogout(): void {
+  channel?.postMessage(LOGOUT)
+}
+
+/**
+ * Registered once at app startup (main.tsx). Reacts to a logout from another
+ * tab by reloading, which re-runs the root authLoader against the cleared
+ * cookie and lands the tab on LoginPage.
+ */
+export function initLogoutListener(): void {
+  if (!channel) return
+  channel.onmessage = (e: MessageEvent) => {
+    if (e.data !== LOGOUT) return
+    window.location.reload()
+  }
+}

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -43,6 +43,13 @@ jest.mock('@/utils/notify', () => ({
   isAuthHandled: jest.fn(),
 }))
 
+// Cross-tab logout signal (#606); mock so the test can assert it fires on
+// sign-out without constructing a real BroadcastChannel.
+jest.mock('@/utils/sessionSync', () => ({
+  __esModule: true,
+  broadcastLogout: jest.fn(),
+}))
+
 // Heavy children the logout affordance does not depend on. Stubbing them keeps
 // the test focused on the header menu and avoids their own asset/network deps.
 jest.mock('@/components/EmailModal/EmailModal', () => ({
@@ -86,6 +93,7 @@ import axiosInstance from '@/axiosConfig'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
 import { notify } from '@/utils/notify'
+import { broadcastLogout } from '@/utils/sessionSync'
 import Title from './Title'
 
 const mockedUseLoaderData = useLoaderData as jest.Mock
@@ -95,6 +103,7 @@ const mockedPost = axiosInstance.post as jest.Mock
 const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
 const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
 const mockedNotify = notify as jest.Mock
+const mockedBroadcastLogout = broadcastLogout as jest.Mock
 
 function makeUser(role: UserRole): userData {
   return {
@@ -200,6 +209,8 @@ describe('Title logout affordance', () => {
     // Toast fires immediately (before the await), covering the click-to-
     // reload gap with visible feedback.
     expect(mockedNotify).toHaveBeenCalledWith('Signing out...', 'info')
+    // Every other open tab is signalled to tear down too (#606).
+    expect(mockedBroadcastLogout).toHaveBeenCalled()
   })
 
   it('still redirects to sign-in when the logout request fails', async () => {
@@ -218,6 +229,8 @@ describe('Title logout affordance', () => {
       expect(window.location.reload as jest.Mock).toHaveBeenCalled()
     )
     expect(window.location.hash).toBe(Routes.SIGNIN)
+    // Broadcast is independent of the POST result (best-effort).
+    expect(mockedBroadcastLogout).toHaveBeenCalled()
     errSpy.mockRestore()
   })
 })

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -209,7 +209,7 @@ describe('Title logout affordance', () => {
     // Toast fires immediately (before the await), covering the click-to-
     // reload gap with visible feedback.
     expect(mockedNotify).toHaveBeenCalledWith('Signing out...', 'info')
-    // Every other open tab is signalled to tear down too (#606).
+    // Every other open tab is signalled to tear down too.
     expect(mockedBroadcastLogout).toHaveBeenCalled()
   })
 

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -275,9 +275,8 @@ export default function Title() {
     } catch (error) {
       console.error('Error logging out:', error)
     }
-    // Notify every other open tab so they tear down too (#606). Best-effort
-    // and independent of the POST result, matching the "even if the request
-    // fails we still drop to sign-in" contract above.
+    // Best-effort and independent of the POST result, matching the "even if
+    // the request fails we still drop to sign-in" contract above.
     broadcastLogout()
     window.location.hash = Routes.SIGNIN
     window.location.reload()

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -34,6 +34,7 @@ import type { AuthLoaderData } from '@/router/authLoader'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
 import { notify } from '@/utils/notify'
+import { broadcastLogout } from '@/utils/sessionSync'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import LoginPage from '../LoginPage/LoginPage'
@@ -274,6 +275,10 @@ export default function Title() {
     } catch (error) {
       console.error('Error logging out:', error)
     }
+    // Notify every other open tab so they tear down too (#606). Best-effort
+    // and independent of the POST result, matching the "even if the request
+    // fails we still drop to sign-in" contract above.
+    broadcastLogout()
     window.location.hash = Routes.SIGNIN
     window.location.reload()
   }


### PR DESCRIPTION
## Summary

Closes #606

With multiple tabs open, logging out in one tab left the others stuttering between the dashboard and the sign-in page instead of signing out.

Two independent causes. First, nothing told the other tabs: auth lives in HTTP-only cookies, so `POST /auth/logout` clears them browser-wide, but `handleLogout` only reloaded its own tab. Every other tab kept rendering the dashboard off in-memory loader data.

Second, the stutter itself was stale root loader data, and the obvious fix feeds it. Navigating to `/signin` leaves the root route matched, and react-router does not re-run a still-matched route's loader — so `loaderData` kept reporting `status === 200`, `LoginPage` trusted it and `<Navigate>`d back to the dashboard, whose mount fetches 401'd again. The interceptor's existing `router.navigate(SIGNIN)` could never break that cycle.

Frontend-only fix. The cross-tab signal is new; the loop fix corrects how the existing auth interceptor recovers stale loader state.

## Changes

* **Cross-tab logout signal.** New `src/utils/sessionSync.ts` owns a `BroadcastChannel('ztmf-auth')`. `handleLogout` calls `broadcastLogout()`; each tab registers `initLogoutListener()` once in `main.tsx`. Best-effort and fired regardless of the logout POST's result, matching the existing "even if the request fails we still drop to sign-in" contract.
* **Receiver reloads only.** It does not rewrite the hash and has no "already on `/signin`" skip. `Title` renders `LoginPage` on any route once the loader reports no session, so a hash write buys nothing — and since the questionnaire's `beforeunload` guard can veto the reload, writing the hash first would navigate the tab away even when a user cancels to rescue unsaved edits. The skip was also a race: a tab can sit on `/signin` mid-bounce with stale loader data and would stay wedged.
* **Loop fix: revalidate stale loader data.** `handleAuthError` now calls `router.revalidate()` when root `loaderData` still claims an active session, before navigating. The `isRevalidationRequired` flag survives the interrupting navigation, so the `/signin` navigation re-runs the authLoader and commits against fresh data (verified against the react-router 7.18.0 source — the version `package.json` and `yarn.lock` pin — and pinned by the integration test below rather than left as an assumption). Browser-independent, so it also covers plain session expiry and keeps browsers without `BroadcastChannel` from stuttering.
* **Redirect dedupe.** A 401 no longer re-navigates when the tab is already on (or navigating to) sign-in, so a burst of concurrent 401s cannot restart the navigation repeatedly, and a late 401 cannot clobber an already-showing `NO_ACCOUNT` terminal screen. Revalidation is likewise skipped while one is in flight.
* **`403 ACCOUNT_NOT_PROVISIONED` gets the same revalidation, and its own dedupe.** Scope stretch, flagged deliberately: it is the identical defect via the sibling trigger (an account deactivated mid-session stutters the same way), and leaving it latent three lines below the fix seemed worse. Its dedupe guard is deliberately narrower than the 401's — keyed on the sign-in location already carrying `reason === NO_ACCOUNT` **and the same message**, rather than on the route alone, so it stops NO_ACCOUNT re-navigating over itself while still overriding a stale EXPIRED redirect in either arrival order. Reusing the 401 guard here would have let EXPIRED suppress the more specific diagnosis. The message is part of the key because `LoginPage` prefers `location.state.message`: a burst whose first 403 arrived with no body falls back to the generic permission copy, and a reason-only comparison would then suppress a later 403 carrying the real "account is not set up" text, freezing the terminal screen on the wrong copy.
* **Channel construction and `postMessage` are both wrapped in try/catch.** Construction is hardening — the constructor is not specified to throw — but this module builds the channel at import time and is imported at the top of `main.tsx`, so a throw would white-screen the app before it renders, strictly worse than the bug being fixed; `'BroadcastChannel' in window` proves the interface exists, not that constructing it succeeds. `postMessage` is the one that genuinely is spec'd to throw (`InvalidStateError`, `DataCloneError`), and `handleLogout` calls it after the session cookie is already dead but *before* the hash change and reload — so an escaping throw would strand the user on a dashboard they are no longer signed in to. Both degrade to the same no-op path as an absent API.

## Why BroadcastChannel

It is the purpose-built API for this: same-origin only, delivers to every other tab but never the sender, and messages are ephemeral. Nothing sensitive crosses it — the payload is the string `logout`, and the session cookie stays `httpOnly` and untouched. Nothing is written to disk either, so the signal itself leaves no residue behind. To be precise about the scope of that last point: it is a claim about this channel, not about the app as a whole — questionnaire drafts are still persisted (encrypted) by `draftStore` and cleared only when a different user signs in. Pre-existing and untouched here; filing it separately.

The cost is browser support: it needs Safari 15.4+ (Chrome, Edge and Firefox have had it for years). Older browsers do not get the proactive teardown, but they are not left broken — the revalidation fix above is plain router state and works everywhere, so those tabs sign out cleanly at their next request instead of instantly. The channel is feature-guarded, so a browser without it no-ops rather than throwing.

## Acceptance criteria

* [x] Logging out in one tab signs out all tabs — with one deliberate exception: a tab holding unsaved questionnaire edits can veto its own reload through the browser's `beforeunload` dialog, and keeps showing the dashboard until its next request. Protecting unsaved work wins over instant teardown; that tab still signs out cleanly a moment later.
* [x] No stuttering loop after a cross-tab logout.
* [x] No stuttering loop on plain session expiry (no logout involved).
* [x] Browsers without `BroadcastChannel` still sign out cleanly, just not proactively.
* [x] Unsaved questionnaire edits are not silently discarded by a cross-tab logout.
* [x] `NO_ACCOUNT` terminal state still wins over a concurrent `EXPIRED` redirect.
* [x] Verified manually on DEV (see below).

Verified on DEV, both code paths separately, since the cross-tab signal and the loop fix are independent:

* **Cross-tab signal.** Logged out in one tab; the other tabs signed out too. No stutter.
* **Loop fix.** Deleted the session cookies in DevTools (no logout, so no broadcast — the same path a plain expiry or an older browser without `BroadcastChannel` takes), then clicked into a system: routed to the sign-in page cleanly, once.

Not walked manually, covered by code and tests instead: the unsaved-questionnaire-edits prompt and the `NO_ACCOUNT` terminal state.

## Testing

* **`authInterceptor.integration.test.ts` (new) — drives a real `createMemoryRouter`, not a mock.** This is the one that actually proves the loop stops. The mocked suite can only assert that `revalidate()` is called and ordered before `navigate()`; with no router behind the mock there is nothing to loop. It also matters because the fix leans on react-router's `isRevalidationRequired` carry-over, which is an implementation detail with no public contract — a minor version bump could regress #606 with every mocked test still green. These tests assert the observable outcome instead: after a 401 against stale loader data, the sign-in navigation commits with **fresh** root loader data, and concurrent bursts (homogeneous and mixed 401/403) settle on sign-in with a bounded number of loader runs rather than one per rejection. Litmus-verified: removing `revalidate()` fails them with the stale `status: 200`, which is exactly the value LoginPage trusted when it bounced; removing the dedupe guards takes the burst to one loader run per rejection.
* `sessionSync.test.ts` (new): `broadcastLogout` posts; a received `logout` reloads without touching the hash; it reloads *even when already on `/signin`* (the race above); non-logout messages ignored; repeat `initLogoutListener()` calls are idempotent; a failing `postMessage` is swallowed so the logging-out tab still finishes; both functions are safe no-ops when `BroadcastChannel` is absent **and** when constructing it throws. The fake channel implements `addEventListener`/`dispatch` as well as `onmessage`, so the idempotency test fails for the right reason (two reloads from stacked handlers) rather than vacuously.
* `authInterceptor.test.ts`: revalidate when loader data is stale, not when it already reports no session, not while one is in flight, still revalidate when either redirect is suppressed, ordered before navigate, plus burst / trailing-slash / casing cases. Eight cases pin the NO_ACCOUNT branch from both directions — overriding a committed *and* a pending EXPIRED redirect, not re-navigating over a showing or pending NO_ACCOUNT, correcting the copy when the message differs while still deduping an identical one, and a late 401 not clobbering a showing NO_ACCOUNT. Litmus-verified: removing the guard fails the three dedupe cases while the override cases keep passing. Every pre-existing branch (`skipAuthHandling`, `FORBIDDEN_ORIGIN`, plain 403, non-auth, network error) still asserted unchanged.
* `Title.test.tsx`: `broadcastLogout` fires on logout, including when the logout POST rejects.
* `yarn jest`: full suite green; `eslint` clean on every touched file; `tsc --noEmit` reports nothing in these files (the `EmailModal` / `QuestionnairePage` JSX-type errors are pre-existing on `main` from the `react-is` v19 vs React 18 mismatch).
