### PR TITLE
chore(#578): retire the hasScore score-presence proxy from ProgressCell

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -314,9 +314,8 @@ export type ScoreProgress = {
   questionsexpected: number
   // Distinct applicable questions with an answer at all, any status (ztmf#437).
   // The completion signal a closed call needs: imported/carried answers are
-  // answered but never "updated this cycle". Optional so the UI degrades to the
-  // prior score-presence proxy until the backend field is deployed.
-  questionsanswered?: number
+  // answered but never "updated this cycle".
+  questionsanswered: number
   questionsupdated: number
   lastupdatedat?: string | null
   updatedsincestart: boolean

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -783,7 +783,6 @@ export default function FismaTable({
         <ProgressCell
           entry={progress?.[params.row.fismasystemid]}
           isCurrentCall={isRowCurrentCall(params.row.fismasystemid)}
-          hasScore={Boolean(scores[params.row.fismasystemid])}
         />
       ),
     },

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -6,6 +6,7 @@ import { progressSortValue, progressTooltip } from './progressHelpers'
 const updatedEntry: ScoreProgress = {
   fismasystemid: 1,
   questionsexpected: 41,
+  questionsanswered: 12,
   questionsupdated: 12,
   lastupdatedat: '2026-07-01T15:30:00Z',
   updatedsincestart: true,
@@ -14,6 +15,7 @@ const updatedEntry: ScoreProgress = {
 const untouchedEntry: ScoreProgress = {
   fismasystemid: 2,
   questionsexpected: 41,
+  questionsanswered: 0,
   questionsupdated: 0,
   lastupdatedat: null,
   updatedsincestart: false,
@@ -52,6 +54,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -69,6 +72,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -127,6 +131,7 @@ describe('progressTooltip', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -176,6 +181,7 @@ describe('ProgressCell', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -185,48 +191,22 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
-  it('renders a neutral Complete chip for a scored past-call system', () => {
-    // ztmf#537: a past call reads 0 updates this cycle for everyone. A system
-    // with a score for that call was completed - show a neutral Complete chip,
-    // never the orange "0/40 Not updated" laggard chip.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={true}
-      />
-    )
-    expect(screen.getByText('Complete')).toBeInTheDocument()
+  it('renders 0/total + Incomplete for a fully-unanswered past call', () => {
+    // ztmf#537 kept a past call off the orange laggard chip; ztmf-ui#578
+    // retires the score-presence proxy, so a past call nobody answered reads
+    // an honest 0/41 with the neutral-warning Incomplete chip instead.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={false} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
-    expect(screen.queryByText('0/41')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 
   it('keeps the current-cycle chip for the same entry on the active call', () => {
     // Same untouched entry, but on the current call it is a genuine laggard.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={true}
-        hasScore={true}
-      />
-    )
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
     expect(screen.getByText('0/41')).toBeInTheDocument()
     expect(screen.getByText('Not updated')).toBeInTheDocument()
-    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
-  })
-
-  it('renders an em-dash for a past-call system with no score', () => {
-    // Defensive: a past-call row must never show the orange laggard chip even
-    // without a score to prove completion.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={false}
-      />
-    )
-    expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
-    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 
@@ -238,7 +218,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 41 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('Complete')).toBeInTheDocument()
@@ -253,7 +232,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 10 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('10/41')).toBeInTheDocument()

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -19,9 +19,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * fraction and Updated/Not-updated chip.
  *
  * States:
- *   - past call (isCurrentCall false) with a score: neutral "Complete" chip -
- *     the score is the completion signal (ScoreProgress has no "total answered"
- *     field); the orange laggard chip never appears off the active call;
+ *   - past call (isCurrentCall false), fully answered: neutral "Complete" chip;
+ *     partially answered: answered/total fraction with an "Incomplete" chip.
+ *     The orange laggard chip never appears off the active call;
  *   - a system with no applicable questionnaire (0/0) renders a neutral
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
@@ -34,19 +34,14 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * @param {boolean} [props.isCurrentCall=true] - Whether the row's displayed call
  *   is the current/active one. Defaults true so callers without call context
  *   keep the original current-cycle rendering.
- * @param {boolean} [props.hasScore=false] - Whether the system has a score for
- *   the displayed call. Used only for a past call, where a score means the call
- *   was completed.
  * @returns {JSX.Element} The progress cell.
  */
 export function ProgressCell({
   entry,
   isCurrentCall = true,
-  hasScore = false,
 }: {
   entry: ScoreProgress | undefined
   isCurrentCall?: boolean
-  hasScore?: boolean
 }) {
   if (!entry) {
     return <span aria-label="No progress data">—</span>
@@ -61,24 +56,12 @@ export function ProgressCell({
   // A past data call is closed: "updated this cycle" is meaningless, so never
   // show the orange laggard chip here. But completion is answered/total, NOT
   // updated/total - imported and carried-over answers are answered yet never
-  // "updated this cycle", so gating on updates (or on mere score presence)
-  // would either drop them or, worse, mask a partially-answered historical
-  // call as done. Prefer QuestionsAnswered (ztmf#437): a fully-answered past
-  // call is a neutral "Complete"; a partially-answered one shows an honest
-  // answered/total with an "Incomplete" chip. Until the backend field ships,
-  // fall back to the prior score-presence proxy.
+  // "updated this cycle", so gating on updates would either drop them or,
+  // worse, mask a partially-answered historical call as done (ztmf#437): a
+  // fully-answered past call is a neutral "Complete"; a partially-answered
+  // one shows an honest answered/total with an "Incomplete" chip.
   if (!isCurrentCall) {
     const answered = entry.questionsanswered
-    if (answered == null) {
-      if (!hasScore) {
-        return <span aria-label="No progress data">—</span>
-      }
-      return (
-        <Tooltip title={progressTooltip(entry, { completed: true })}>
-          <Chip size="small" label="Complete" variant="outlined" />
-        </Tooltip>
-      )
-    }
     if (answered >= entry.questionsexpected) {
       return (
         <Tooltip title={progressTooltip(entry, { completed: true })}>

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -29,9 +29,7 @@ export function hasNoQuestionnaire(entry: ScoreProgress | undefined): boolean {
  * For a PAST call the "-1 needs a nudge" ranking is wrong - a closed call has no
  * updates to chase, so ranking by questionsupdated would sort every historical
  * row to the laggard top, contradicting its own Complete/Incomplete chip. Past
- * calls are ranked by completion (answered/total) instead, never -1. Prefer
- * QuestionsAnswered (ztmf#437); without it, a past-call row with progress is
- * treated as complete (1) so it never ranks as urgent.
+ * calls are ranked by completion (answered/total, ztmf#437) instead, never -1.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
  * @param {boolean} [isCurrentCall=true] - Whether the row's displayed call is
  *   the current/active one. Past calls sort by completion, not updates.
@@ -44,9 +42,10 @@ export function progressSortValue(
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
   if (!isCurrentCall) {
-    const answered = entry.questionsanswered
-    if (answered == null) return 1
-    return Math.min(Math.max(answered, 0) / entry.questionsexpected, 1)
+    return Math.min(
+      Math.max(entry.questionsanswered, 0) / entry.questionsexpected,
+      1
+    )
   }
   if (entry.questionsupdated <= 0) return -1
   return entry.questionsupdated / entry.questionsexpected


### PR DESCRIPTION
Retires the score-presence proxy left in `ProgressCell` as graceful degradation for the ztmf#437 deploy window. `questionsanswered` becomes required on `ScoreProgress` since a #437 backend always returns it (`int32`, `COALESCE(..., 0)`, no `omitempty`), which is what lets the null-fallback branches be deleted rather than stranded as dead code. Past-call progress now renders and sorts solely from `questionsanswered` vs `questionsexpected`. Beyond the ticket's file list, `progressSortValue` carried the same proxy-era fallback (`answered == null` ranks as complete) and is retired in the same pass. Visible change: a past call with zero answers reads 0/N Incomplete instead of an em-dash. Assumes #437 is deployed everywhere per the ready-to-work move; flag if prod is still pending. `tsc`, `eslint`, and jest (52 suites / 677 tests) green locally. Snyk and deploy checks will show red as usual for fork PRs.

Closes #578