### PR TITLE
fix(#639): call-scoped dashboard toggles, past-call graying, and a Data Call column

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -53,7 +53,7 @@ import { hasSystemAccess } from '@/utils/userRoles'
 import { TIERS } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
-import { resolveRowCallId } from './rowCall'
+import { resolveRowCallId, datacallNameComparator } from './rowCall'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
@@ -62,6 +62,7 @@ import type { OpDiv } from '@/types'
 import {
   applyDashboardFilters,
   hasNoActiveFilters,
+  isOpenCallInView,
   EMPTY_DASHBOARD_FILTERS,
   type DashboardFilterState,
 } from './dashboardFilters'
@@ -475,11 +476,15 @@ export function QuickSearchToolbar(props: {
       {/* Toolbar-row captions crowd the filter cluster and wrap it (ui#639),
           so the call-scope notice renders as its own slim banner between the
           filters and the column headers. */}
+      {/* role="status": this is a standing contextual notice, not an alert —
+          MUI's default role="alert" would interrupt screen readers at mount
+          and on every year switch. It is also the keyboard/SR-reachable
+          counterpart of the disabled switches' hover tooltips. */}
       {!openCallInView && (
-        <Alert severity="info" sx={{ borderRadius: 0, py: 0 }}>
+        <Alert severity="info" role="status" sx={{ borderRadius: 0, py: 0 }}>
           {hasOpenCall
             ? 'The open data call is not in the selected view'
-            : "No open data call; showing each system's latest completed call"}
+            : "No open data call; showing each system's most recently updated call"}
         </Alert>
       )}
     </>
@@ -528,6 +533,10 @@ export default function FismaTable({
   // not-updated filter) only makes sense then; a past/closed call shows a
   // neutral Complete/Incomplete chip instead (ztmf#537). Rows without a chosen
   // call, or before latestDataCallId has loaded, keep the current rendering.
+  // Agrees with resolveRowCallId (the Data Call column) by construction:
+  // buildDashboardMaps fills chosenCallMap and systemCallMap for the same key
+  // set, so a row is grayed iff its column names a non-open call. Keep the
+  // two in step if either resolution changes.
   const isRowCurrentCall = useCallback(
     (fismasystemid: number): boolean => {
       const chosen = chosenCallMap[fismasystemid]
@@ -544,8 +553,11 @@ export default function FismaTable({
   // Without the in-view check the first toggle silently empties the grid (the
   // reported bug) and the second keeps only rows with no call data.
   const hasOpenCall = Boolean(latestDataCallId) && !latestDeadlinePassed
-  const openCallInView =
-    hasOpenCall && activeDatacallIds.includes(latestDataCallId)
+  const openCallInView = isOpenCallInView(
+    latestDataCallId,
+    latestDeadlinePassed,
+    activeDatacallIds
+  )
   const callById = useMemo(
     () => new Map(datacalls.map((d) => [d.datacallid, d])),
     [datacalls]
@@ -676,8 +688,11 @@ export default function FismaTable({
 
   // The call-scoped facets only mean something while the open call is in
   // view (their switches gray out otherwise). Drop any stored true when it is
-  // not, so a deadline passing mid-session or a switch to a historical year
-  // cannot leave an invisible filter emptying the grid (ui#639).
+  // not, so a year-picker move to a historical group, or a /datacalls refetch
+  // that flips the newest call closed, cannot leave an invisible filter
+  // emptying the grid (ui#639). (openness is evaluated when datacalls load,
+  // not continuously, so a deadline passing while the page sits open takes
+  // effect on the next fetch or reload.)
   useEffect(() => {
     if (openCallInView) return
     setFilters((prev) =>
@@ -865,7 +880,7 @@ export default function FismaTable({
       // Renders as the column-header tooltip: the resolution is not obvious
       // from the name (it is not simply "last completed call").
       description:
-        "The data call this row's score and progress are shown from; a system with no data in the selected calls shows the open call it is expected to answer.",
+        "The data call this row's score and progress are shown from: the system's most recently updated call among the selected calls, or the dashboard's active call for a system with no data in them.",
       width: 130,
       align: 'center',
       headerAlign: 'center',
@@ -879,9 +894,7 @@ export default function FismaTable({
             activeDataCallId
           )
         )?.datacall ?? '',
-      sortComparator: (a, b) =>
-        (deadlineByCallName.get(a as string) ?? 0) -
-        (deadlineByCallName.get(b as string) ?? 0),
+      sortComparator: datacallNameComparator(deadlineByCallName),
     },
     {
       // Questionnaire progress for the active data call (ztmf#299). The
@@ -1093,8 +1106,16 @@ export default function FismaTable({
           '& .MuiDataGrid-columnHeaders .MuiSvgIcon-root': {
             color: 'white',
           },
+          // De-emphasis must not dim interactive elements: whole-row opacity
+          // drops the name link, checkbox, and action icons below WCAG
+          // contrast minima while they stay clickable. Tint the row and mute
+          // only the cell text (rgba .6 on white holds AA); links, controls,
+          // and chips keep their own full-contrast colors.
           '& .past-call-row': {
-            opacity: 0.55,
+            backgroundColor: '#f5f5f5',
+          },
+          '& .past-call-row .MuiDataGrid-cell': {
+            color: 'rgba(0, 0, 0, 0.6)',
           },
         }}
       />

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -476,17 +476,26 @@ export function QuickSearchToolbar(props: {
       {/* Toolbar-row captions crowd the filter cluster and wrap it (ui#639),
           so the call-scope notice renders as its own slim banner between the
           filters and the column headers. */}
-      {/* role="status": this is a standing contextual notice, not an alert —
-          MUI's default role="alert" would interrupt screen readers at mount
-          and on every year switch. It is also the keyboard/SR-reachable
-          counterpart of the disabled switches' hover tooltips. */}
-      {!openCallInView && (
-        <Alert severity="info" role="status" sx={{ borderRadius: 0, py: 0 }}>
-          {hasOpenCall
-            ? 'The open data call is not in the selected view'
-            : "No open data call; showing each system's most recently updated call"}
-        </Alert>
-      )}
+      {/* role="status" rather than MUI's default role="alert": this is a
+          standing contextual notice, and an assertive role would interrupt
+          screen readers at mount and on every year switch.
+
+          The live region is the keyboard- and screen-reader-reachable
+          counterpart of the disabled switches' hover tooltips, so it has to
+          actually announce. That is why the wrapper stays mounted and only its
+          contents change: a live region inserted into the DOM at the same
+          moment as its text is generally not announced, so gating the region
+          itself on the condition would have made it silent in exactly the
+          cases it exists to cover. */}
+      <Box role="status" aria-live="polite">
+        {!openCallInView && (
+          <Alert severity="info" sx={{ borderRadius: 0, py: 0 }}>
+            {hasOpenCall
+              ? 'The open data call is not in the selected view'
+              : "No open data call; showing each system's most recently updated call"}
+          </Alert>
+        )}
+      </Box>
     </>
   )
 }
@@ -741,7 +750,8 @@ export default function FismaTable({
       chosenCallMap,
       systemCallMap,
       datacalls,
-      activeDataCallId
+      activeDataCallId,
+      activeDatacallIds
     )
 
     try {
@@ -880,7 +890,7 @@ export default function FismaTable({
       // Renders as the column-header tooltip: the resolution is not obvious
       // from the name (it is not simply "last completed call").
       description:
-        "The data call this row's score and progress are shown from: the system's most recently updated call among the selected calls, or the dashboard's active call for a system with no data in them.",
+        "The data call this row's score and progress are shown from: the system's most recently updated call among the selected calls, or the newest selected call for a system with no data in them.",
       width: 130,
       align: 'center',
       headerAlign: 'center',
@@ -891,7 +901,8 @@ export default function FismaTable({
             chosenCallMap,
             systemCallMap,
             datacalls,
-            activeDataCallId
+            activeDataCallId,
+            activeDatacallIds
           )
         )?.datacall ?? '',
       sortComparator: datacallNameComparator(deadlineByCallName),

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -850,6 +850,10 @@ export default function FismaTable({
       // on the grayed styling.
       field: 'rowdatacall',
       headerName: 'Data Call',
+      // Renders as the column-header tooltip: the resolution is not obvious
+      // from the name (it is not simply "last completed call").
+      description:
+        "The data call this row's score and progress are shown from; a system with no data in the selected calls shows the open call it is expected to answer.",
       width: 130,
       align: 'center',
       headerAlign: 'center',

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -27,7 +27,7 @@ import {
   ListSubheader,
   Menu,
   Button,
-  Typography,
+  Alert,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { useState, useEffect, useMemo, useCallback } from 'react'
@@ -82,6 +82,8 @@ declare module '@mui/x-data-grid' {
     opdivOptions: OpDivOption[]
     showEnvFilter: boolean
     showOpDivFilter: boolean
+    hasOpenCall: boolean
+    openCallInView: boolean
   }
 }
 
@@ -267,210 +269,220 @@ export function QuickSearchToolbar(props: {
   }
 
   return (
-    <Box
-      sx={{
-        py: 1,
-        px: 1,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 1.5,
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      }}
-    >
-      <GridToolbarQuickFilter
-        debounceMs={250}
-        sx={{
-          '& .MuiInputBase-input::placeholder': {
-            color: '#404040',
-            opacity: 0.8,
-          },
-          '& .MuiInputBase-root:after': {
-            borderBottomColor: '#5666b8',
-          },
-          '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
-            borderBottomColor: '#5666b8',
-          },
-        }}
-      />
-      {/* All facet filters live in one right-aligned cluster next to the
-          Show Decommissioned toggle. */}
+    <>
       <Box
         sx={{
+          py: 1,
+          px: 1,
           display: 'flex',
           flexWrap: 'wrap',
           gap: 1.5,
+          justifyContent: 'space-between',
           alignItems: 'center',
-          justifyContent: 'flex-end',
         }}
       >
-        {showEnvFilter && (
-          <FormControl size="small" sx={{ width: 200 }}>
-            <Select
-              multiple
-              displayEmpty
-              value={filters.environments}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  environments: e.target.value as string[],
-                })
-              }
-              inputProps={{ 'aria-label': 'Filter by environment' }}
-              renderValue={(selected) => {
-                const vals = selected as string[]
-                if (vals.length === 0)
-                  return <span style={{ color: '#6b6b6b' }}>Environment</span>
-                if (vals.length === 1) return vals[0]
-                return `${vals.length} environments`
-              }}
-              sx={selectValueSx}
-            >
-              {envOptions.map((opt) => (
-                <MenuItem key={opt} value={opt}>
-                  <Checkbox
-                    checked={filters.environments.includes(opt)}
-                    readOnly
-                    size="small"
-                  />
-                  <ListItemText primary={opt} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-        {showOpDivFilter && (
-          <FormControl size="small" sx={{ width: 200 }}>
-            <Select
-              multiple
-              displayEmpty
-              value={filters.opdivIds}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  opdivIds: e.target.value as number[],
-                })
-              }
-              inputProps={{ 'aria-label': 'Filter by OpDiv' }}
-              renderValue={(selected) => {
-                const ids = selected as number[]
-                if (ids.length === 0)
-                  return <span style={{ color: '#6b6b6b' }}>OpDiv</span>
-                if (ids.length === 1)
-                  return (
-                    opdivOptions.find((o) => o.id === ids[0])?.label ??
-                    String(ids[0])
-                  )
-                return `${ids.length} OpDivs`
-              }}
-              sx={selectValueSx}
-            >
-              {opdivOptions.map((o) => (
-                <MenuItem key={o.id} value={o.id}>
-                  <Checkbox
-                    checked={filters.opdivIds.includes(o.id)}
-                    readOnly
-                    size="small"
-                  />
-                  <ListItemText primary={o.label} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-        {!openCallInView && (
-          <Typography variant="caption" sx={{ color: '#6b6b6b' }}>
-            {hasOpenCall
-              ? 'The open data call is not in the selected view'
-              : "No open data call; showing each system's latest completed call"}
-          </Typography>
-        )}
-        {/* Both call-scoped toggles gray out when the open call is not in
+        <GridToolbarQuickFilter
+          debounceMs={250}
+          sx={{
+            '& .MuiInputBase-input::placeholder': {
+              color: '#404040',
+              opacity: 0.8,
+            },
+            '& .MuiInputBase-root:after': {
+              borderBottomColor: '#5666b8',
+            },
+            '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
+              borderBottomColor: '#5666b8',
+            },
+          }}
+        />
+        {/* All facet filters live in one right-aligned cluster next to the
+          Show Decommissioned toggle. */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1.5,
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {showEnvFilter && (
+            <FormControl size="small" sx={{ width: 200 }}>
+              <Select
+                multiple
+                displayEmpty
+                value={filters.environments}
+                onChange={(e) =>
+                  onFiltersChange({
+                    ...filters,
+                    environments: e.target.value as string[],
+                  })
+                }
+                inputProps={{ 'aria-label': 'Filter by environment' }}
+                renderValue={(selected) => {
+                  const vals = selected as string[]
+                  if (vals.length === 0)
+                    return <span style={{ color: '#6b6b6b' }}>Environment</span>
+                  if (vals.length === 1) return vals[0]
+                  return `${vals.length} environments`
+                }}
+                sx={selectValueSx}
+              >
+                {envOptions.map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    <Checkbox
+                      checked={filters.environments.includes(opt)}
+                      readOnly
+                      size="small"
+                    />
+                    <ListItemText primary={opt} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {showOpDivFilter && (
+            <FormControl size="small" sx={{ width: 200 }}>
+              <Select
+                multiple
+                displayEmpty
+                value={filters.opdivIds}
+                onChange={(e) =>
+                  onFiltersChange({
+                    ...filters,
+                    opdivIds: e.target.value as number[],
+                  })
+                }
+                inputProps={{ 'aria-label': 'Filter by OpDiv' }}
+                renderValue={(selected) => {
+                  const ids = selected as number[]
+                  if (ids.length === 0)
+                    return <span style={{ color: '#6b6b6b' }}>OpDiv</span>
+                  if (ids.length === 1)
+                    return (
+                      opdivOptions.find((o) => o.id === ids[0])?.label ??
+                      String(ids[0])
+                    )
+                  return `${ids.length} OpDivs`
+                }}
+                sx={selectValueSx}
+              >
+                {opdivOptions.map((o) => (
+                  <MenuItem key={o.id} value={o.id}>
+                    <Checkbox
+                      checked={filters.opdivIds.includes(o.id)}
+                      readOnly
+                      size="small"
+                    />
+                    <ListItemText primary={o.label} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {/* Both call-scoped toggles gray out when the open call is not in
             view (ui#639): "Not updated only" is a current-cycle laggard
             signal with nothing to match, and "Open data call only" would
             empty the grid. The span wrappers keep the tooltips firing on the
             disabled controls. */}
-        <Tooltip title={callScopeHint}>
-          <span>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={filters.openCallOnly}
-                  onChange={(e) =>
-                    onFiltersChange({
-                      ...filters,
-                      openCallOnly: e.target.checked,
-                    })
-                  }
-                  disabled={!openCallInView}
-                  sx={switchSx}
-                />
-              }
-              label="Open data call only"
-              sx={{ m: 0 }}
-            />
-          </span>
-        </Tooltip>
-        <Tooltip title={callScopeHint}>
-          <span>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={filters.notUpdatedOnly}
-                  onChange={(e) =>
-                    onFiltersChange({
-                      ...filters,
-                      notUpdatedOnly: e.target.checked,
-                    })
-                  }
-                  disabled={!openCallInView}
-                  sx={switchSx}
-                />
-              }
-              label="Not updated only"
-              sx={{ m: 0 }}
-            />
-          </span>
-        </Tooltip>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={showDecommissioned}
-              onChange={(e) => setShowDecommissioned(e.target.checked)}
-              sx={switchSx}
-            />
-          }
-          label="Show Decommissioned"
-          sx={{ m: 0 }}
-        />
-        <Button
-          size="small"
-          startIcon={<CloseIcon />}
-          onClick={() => {
-            onFiltersChange(EMPTY_DASHBOARD_FILTERS)
-            // Show Decommissioned lives in Title context (it gates a refetch),
-            // not in the client-side filter model — so clear it separately or it
-            // would survive "Clear filters".
-            setShowDecommissioned(false)
-            // The DataGrid quick-filter is grid state, not DashboardFilterState,
-            // so reset it via the grid API or the typed term survives (#573).
-            apiRef.current.setQuickFilterValues([])
-          }}
-          // ...and both Show Decommissioned and the quick-filter are active
-          // filters for the button's own enabled state: without this, toggling
-          // only Show Decommissioned left Clear filters greyed out (#566), and
-          // typing only a search term would leave it greyed out too (#573).
-          disabled={
-            hasNoActiveFilters(filters) &&
-            !showDecommissioned &&
-            !hasQuickFilter
-          }
-          sx={{ color: '#004297', textTransform: 'none', mr: 2, flexShrink: 0 }}
-        >
-          Clear filters
-        </Button>
+          <Tooltip title={callScopeHint}>
+            <span>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={filters.openCallOnly}
+                    onChange={(e) =>
+                      onFiltersChange({
+                        ...filters,
+                        openCallOnly: e.target.checked,
+                      })
+                    }
+                    disabled={!openCallInView}
+                    sx={switchSx}
+                  />
+                }
+                label="Open data call only"
+                sx={{ m: 0 }}
+              />
+            </span>
+          </Tooltip>
+          <Tooltip title={callScopeHint}>
+            <span>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={filters.notUpdatedOnly}
+                    onChange={(e) =>
+                      onFiltersChange({
+                        ...filters,
+                        notUpdatedOnly: e.target.checked,
+                      })
+                    }
+                    disabled={!openCallInView}
+                    sx={switchSx}
+                  />
+                }
+                label="Not updated only"
+                sx={{ m: 0 }}
+              />
+            </span>
+          </Tooltip>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showDecommissioned}
+                onChange={(e) => setShowDecommissioned(e.target.checked)}
+                sx={switchSx}
+              />
+            }
+            label="Show Decommissioned"
+            sx={{ m: 0 }}
+          />
+          <Button
+            size="small"
+            startIcon={<CloseIcon />}
+            onClick={() => {
+              onFiltersChange(EMPTY_DASHBOARD_FILTERS)
+              // Show Decommissioned lives in Title context (it gates a refetch),
+              // not in the client-side filter model — so clear it separately or it
+              // would survive "Clear filters".
+              setShowDecommissioned(false)
+              // The DataGrid quick-filter is grid state, not DashboardFilterState,
+              // so reset it via the grid API or the typed term survives (#573).
+              apiRef.current.setQuickFilterValues([])
+            }}
+            // ...and both Show Decommissioned and the quick-filter are active
+            // filters for the button's own enabled state: without this, toggling
+            // only Show Decommissioned left Clear filters greyed out (#566), and
+            // typing only a search term would leave it greyed out too (#573).
+            disabled={
+              hasNoActiveFilters(filters) &&
+              !showDecommissioned &&
+              !hasQuickFilter
+            }
+            sx={{
+              color: '#004297',
+              textTransform: 'none',
+              mr: 2,
+              flexShrink: 0,
+            }}
+          >
+            Clear filters
+          </Button>
+        </Box>
       </Box>
-    </Box>
+      {/* Toolbar-row captions crowd the filter cluster and wrap it (ui#639),
+          so the call-scope notice renders as its own slim banner between the
+          filters and the column headers. */}
+      {!openCallInView && (
+        <Alert severity="info" sx={{ borderRadius: 0, py: 0 }}>
+          {hasOpenCall
+            ? 'The open data call is not in the selected view'
+            : "No open data call; showing each system's latest completed call"}
+        </Alert>
+      )}
+    </>
   )
 }
 // Cache for pillar scores to avoid repeated API calls

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -27,6 +27,7 @@ import {
   ListSubheader,
   Menu,
   Button,
+  Typography,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { useState, useEffect, useMemo, useCallback } from 'react'
@@ -52,6 +53,7 @@ import { hasSystemAccess } from '@/utils/userRoles'
 import { TIERS } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
+import { resolveRowCallId } from './rowCall'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
@@ -218,6 +220,8 @@ export function QuickSearchToolbar(props: {
   opdivOptions?: OpDivOption[]
   showEnvFilter?: boolean
   showOpDivFilter?: boolean
+  hasOpenCall?: boolean
+  openCallInView?: boolean
 }) {
   const { showDecommissioned, setShowDecommissioned } = useContextProp()
   // The free-text quick-filter lives in the grid's own filter model, not in
@@ -235,6 +239,16 @@ export function QuickSearchToolbar(props: {
   const opdivOptions = props.opdivOptions ?? []
   const showEnvFilter = props.showEnvFilter ?? false
   const showOpDivFilter = props.showOpDivFilter ?? false
+  const hasOpenCall = props.hasOpenCall ?? true
+  const openCallInView = props.openCallInView ?? true
+  // Why the call-scoped toggles are grayed out, when they are: no call open
+  // at all vs an open call outside the selected year. Empty while they apply
+  // (an empty title suppresses the Tooltip).
+  const callScopeHint = openCallInView
+    ? ''
+    : hasOpenCall
+      ? 'The open data call is not in the selected view'
+      : 'No data call is currently open'
 
   const switchSx = {
     '& .MuiSwitch-switchBase.Mui-checked': { color: '#004297' },
@@ -364,22 +378,60 @@ export function QuickSearchToolbar(props: {
             </Select>
           </FormControl>
         )}
-        <FormControlLabel
-          control={
-            <Switch
-              checked={filters.notUpdatedOnly}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  notUpdatedOnly: e.target.checked,
-                })
+        {!openCallInView && (
+          <Typography variant="caption" sx={{ color: '#6b6b6b' }}>
+            {hasOpenCall
+              ? 'The open data call is not in the selected view'
+              : "No open data call; showing each system's latest completed call"}
+          </Typography>
+        )}
+        {/* Both call-scoped toggles gray out when the open call is not in
+            view (ui#639): "Not updated only" is a current-cycle laggard
+            signal with nothing to match, and "Open data call only" would
+            empty the grid. The span wrappers keep the tooltips firing on the
+            disabled controls. */}
+        <Tooltip title={callScopeHint}>
+          <span>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={filters.openCallOnly}
+                  onChange={(e) =>
+                    onFiltersChange({
+                      ...filters,
+                      openCallOnly: e.target.checked,
+                    })
+                  }
+                  disabled={!openCallInView}
+                  sx={switchSx}
+                />
               }
-              sx={switchSx}
+              label="Open data call only"
+              sx={{ m: 0 }}
             />
-          }
-          label="Not updated only"
-          sx={{ m: 0 }}
-        />
+          </span>
+        </Tooltip>
+        <Tooltip title={callScopeHint}>
+          <span>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={filters.notUpdatedOnly}
+                  onChange={(e) =>
+                    onFiltersChange({
+                      ...filters,
+                      notUpdatedOnly: e.target.checked,
+                    })
+                  }
+                  disabled={!openCallInView}
+                  sx={switchSx}
+                />
+              }
+              label="Not updated only"
+              sx={{ m: 0 }}
+            />
+          </span>
+        </Tooltip>
         <FormControlLabel
           control={
             <Switch
@@ -440,6 +492,7 @@ export default function FismaTable({
     latestDataCallId,
     selectedDatacall,
     datacalls,
+    activeDatacallIds,
     userInfo,
     datacenterEnvironments,
   } = useContextProp()
@@ -470,6 +523,29 @@ export default function FismaTable({
       return chosen === latestDataCallId && !latestDeadlinePassed
     },
     [chosenCallMap, latestDataCallId, latestDeadlinePassed]
+  )
+  // Whether any data call is open at all, and whether that open call is part
+  // of what the table is showing. The year picker can select a historical
+  // group while a newer call is open; in that view no row is current, so the
+  // call-scoped toggles ("Not updated only", "Open data call only") and the
+  // past-call graying key on the viewed calls, not the calendar (ui#639).
+  // Without the in-view check the first toggle silently empties the grid (the
+  // reported bug) and the second keeps only rows with no call data.
+  const hasOpenCall = Boolean(latestDataCallId) && !latestDeadlinePassed
+  const openCallInView =
+    hasOpenCall && activeDatacallIds.includes(latestDataCallId)
+  const callById = useMemo(
+    () => new Map(datacalls.map((d) => [d.datacallid, d])),
+    [datacalls]
+  )
+  // Sort key for the Data Call column: call names do not sort chronologically
+  // ("FY2025 Q3" vs "FY25 ZTM"), so the column orders by deadline instead.
+  const deadlineByCallName = useMemo(
+    () =>
+      new Map(
+        datacalls.map((d) => [d.datacall, new Date(d.deadline).getTime()])
+      ),
+    [datacalls]
   )
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
@@ -586,6 +662,19 @@ export default function FismaTable({
     })
   }, [envOptions, opdivOptions, showEnvFilter, showOpDivFilter])
 
+  // The call-scoped facets only mean something while the open call is in
+  // view (their switches gray out otherwise). Drop any stored true when it is
+  // not, so a deadline passing mid-session or a switch to a historical year
+  // cannot leave an invisible filter emptying the grid (ui#639).
+  useEffect(() => {
+    if (openCallInView) return
+    setFilters((prev) =>
+      prev.notUpdatedOnly || prev.openCallOnly
+        ? { ...prev, notUpdatedOnly: false, openCallOnly: false }
+        : prev
+    )
+  }, [openCallInView])
+
   const filteredRows = useMemo(
     () =>
       applyDashboardFilters(
@@ -618,19 +707,15 @@ export default function FismaTable({
   }
 
   const handleOpenPillarScores = async (row: FismaSystemType) => {
-    // Use the same call the dashboard row is displaying (chosen by most-recently-updated
-    // in buildDashboardMaps) so the modal's "current" always matches the table cell.
-    // Falls back to newest-by-deadline if chosenCallMap has no entry (e.g. single-call
-    // system or map not yet populated), then to activeDataCallId as a last resort.
-    const chosenId = chosenCallMap[row.fismasystemid]
-    const rowDataCallId =
-      chosenId ??
-      sortDatacallsByDeadline(
-        (systemCallMap[row.fismasystemid] ?? [])
-          .map((id) => datacalls.find((d) => d.datacallid === id))
-          .filter((d): d is datacall => Boolean(d))
-      )[0]?.datacallid ??
+    // Same resolution as the Data Call column, so the modal's "current"
+    // always matches the call the row displays.
+    const rowDataCallId = resolveRowCallId(
+      row.fismasystemid,
+      chosenCallMap,
+      systemCallMap,
+      datacalls,
       activeDataCallId
+    )
 
     try {
       // Check cache first
@@ -758,6 +843,29 @@ export default function FismaTable({
           </Box>
         )
       },
+    },
+    {
+      // Which call the row is displaying (ui#639), named plainly so a
+      // past-call row is identifiable and quick-searchable without relying
+      // on the grayed styling.
+      field: 'rowdatacall',
+      headerName: 'Data Call',
+      width: 130,
+      align: 'center',
+      headerAlign: 'center',
+      valueGetter: (value) =>
+        callById.get(
+          resolveRowCallId(
+            value.row.fismasystemid,
+            chosenCallMap,
+            systemCallMap,
+            datacalls,
+            activeDataCallId
+          )
+        )?.datacall ?? '',
+      sortComparator: (a, b) =>
+        (deadlineByCallName.get(a as string) ?? 0) -
+        (deadlineByCallName.get(b as string) ?? 0),
     },
     {
       // Questionnaire progress for the active data call (ztmf#299). The
@@ -892,6 +1000,16 @@ export default function FismaTable({
         isRowSelectable={(params: GridRowParams) =>
           params.row.fismasystemid in scores
         }
+        // De-emphasize rows displaying a closed call while the open call is
+        // in view (ui#639). Only in that mixed view: between calls, or on a
+        // historical year, every row is past-call and graying the whole grid
+        // distinguishes nothing. The Data Call column carries the same state
+        // as text.
+        getRowClassName={(params) =>
+          openCallInView && !isRowCurrentCall(params.row.fismasystemid)
+            ? 'past-call-row'
+            : ''
+        }
         columns={columns}
         checkboxSelection
         apiRef={apiRef}
@@ -915,6 +1033,8 @@ export default function FismaTable({
             opdivOptions,
             showEnvFilter,
             showOpDivFilter,
+            hasOpenCall,
+            openCallInView,
           },
           filterPanel: {
             sx: {
@@ -956,6 +1076,9 @@ export default function FismaTable({
           },
           '& .MuiDataGrid-columnHeaders .MuiSvgIcon-root': {
             color: 'white',
+          },
+          '& .past-call-row': {
+            opacity: 0.55,
           },
         }}
       />

--- a/src/views/FismaTable/QuickSearchToolbar.test.tsx
+++ b/src/views/FismaTable/QuickSearchToolbar.test.tsx
@@ -43,10 +43,16 @@ jest.mock('@/views/Title/Context', () => ({
 
 function renderToolbar(
   filters: DashboardFilterState = EMPTY_DASHBOARD_FILTERS,
-  onFiltersChange = jest.fn()
+  onFiltersChange = jest.fn(),
+  { hasOpenCall = true, openCallInView = true } = {}
 ) {
   return render(
-    <QuickSearchToolbar filters={filters} onFiltersChange={onFiltersChange} />
+    <QuickSearchToolbar
+      filters={filters}
+      onFiltersChange={onFiltersChange}
+      hasOpenCall={hasOpenCall}
+      openCallInView={openCallInView}
+    />
   )
 }
 
@@ -96,6 +102,74 @@ describe('QuickSearchToolbar — Clear filters vs Show Decommissioned (#566)', (
     })
     fireEvent.click(toggle)
     expect(mockSetShowDecommissioned).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('QuickSearchToolbar — call-scoped toggles (#639)', () => {
+  const openCallToggle = () =>
+    screen.getByRole('checkbox', { name: /open data call only/i })
+  const notUpdatedToggle = () =>
+    screen.getByRole('checkbox', { name: /not updated only/i })
+
+  it('flipping Open data call only drives the filter model', () => {
+    const onFiltersChange = jest.fn()
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, onFiltersChange)
+    fireEvent.click(openCallToggle())
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_DASHBOARD_FILTERS,
+      openCallOnly: true,
+    })
+  })
+
+  it('enables Clear filters when only Open data call only is on', () => {
+    renderToolbar({ ...EMPTY_DASHBOARD_FILTERS, openCallOnly: true })
+    expect(clearBtn()).toBeEnabled()
+  })
+
+  it('disables both call-scoped toggles when no call is open', () => {
+    // The bug: "Not updated only" stayed live on a closed call and silently
+    // emptied the grid. Both call-scoped toggles gray out instead;
+    // Show Decommissioned is not call-scoped and stays live.
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: false,
+      openCallInView: false,
+    })
+    expect(openCallToggle()).toBeDisabled()
+    expect(notUpdatedToggle()).toBeDisabled()
+    expect(
+      screen.getByRole('checkbox', { name: /show decommissioned/i })
+    ).toBeEnabled()
+  })
+
+  it('shows the no-open-call caption only when no call is open', () => {
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: false,
+      openCallInView: false,
+    })
+    expect(screen.getByText(/no open data call/i)).toBeInTheDocument()
+  })
+
+  it('disables the toggles with the out-of-view caption on a historical year', () => {
+    // A call can be open while the year picker shows a historical group; no
+    // viewed row is current, so the toggles gray out with wording that does
+    // not falsely claim nothing is open.
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: true,
+      openCallInView: false,
+    })
+    expect(openCallToggle()).toBeDisabled()
+    expect(notUpdatedToggle()).toBeDisabled()
+    expect(
+      screen.getByText(/open data call is not in the selected view/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/no open data call/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps the toggles live and the caption hidden while a call is open', () => {
+    renderToolbar()
+    expect(screen.queryByText(/no open data call/i)).not.toBeInTheDocument()
+    expect(openCallToggle()).toBeEnabled()
+    expect(notUpdatedToggle()).toBeEnabled()
   })
 })
 

--- a/src/views/FismaTable/dashboardFilters.test.ts
+++ b/src/views/FismaTable/dashboardFilters.test.ts
@@ -135,6 +135,47 @@ test('facets combine with AND', () => {
   expect(out.map((r) => r.fismasystemid)).toEqual([1])
 })
 
+test('open-call-only filter keeps only current-call rows', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true }),
+    (id) => id !== 1 && id !== 4 // sys1 and sys4 display a past call
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([2, 3])
+})
+
+test('open-call-only filter is a no-op without call context', () => {
+  // Callers without a predicate treat every row as current (the documented
+  // default), so the facet passes everything through.
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true })
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1, 2, 3, 4])
+})
+
+test('open-call-only defaults off and counts as an active filter when on', () => {
+  // Default-off is deliberate (ui#639): default-on would hide closed-call
+  // rows silently and desync the export and stat tiles from the table.
+  expect(EMPTY_DASHBOARD_FILTERS.openCallOnly).toBe(false)
+  expect(hasNoActiveFilters(filters({ openCallOnly: true }))).toBe(false)
+})
+
+test('open-call-only composes with not-updated: current-call laggards only', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true, notUpdatedOnly: true }),
+    () => true
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
 test('a row whose environment is not in the category map is excluded when env filter is active', () => {
   const rows = [
     { fismasystemid: 9, datacenterenvironment: 'unknown-env', opdiv_id: 10 },

--- a/src/views/FismaTable/dashboardFilters.test.ts
+++ b/src/views/FismaTable/dashboardFilters.test.ts
@@ -3,6 +3,7 @@ import {
   applyDashboardFilters,
   isNotUpdated,
   hasNoActiveFilters,
+  isOpenCallInView,
   EMPTY_DASHBOARD_FILTERS,
 } from './dashboardFilters'
 
@@ -174,6 +175,21 @@ test('open-call-only composes with not-updated: current-call laggards only', () 
     () => true
   )
   expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
+test('isOpenCallInView requires the open call to be among the viewed calls', () => {
+  // The whole point of the gate (ui#639): a call being open is not enough,
+  // it must be in the year-picker selection or no viewed row can be current.
+  expect(isOpenCallInView(5, false, [5, 4])).toBe(true)
+  expect(isOpenCallInView(5, false, [103, 4])).toBe(false) // open, out of view
+  expect(isOpenCallInView(5, true, [5, 4])).toBe(false) // in view, closed
+})
+
+test('isOpenCallInView is false before the datacall list loads', () => {
+  // latestDataCallId initializes to 0 in context; the gate must not treat
+  // that as an open call.
+  expect(isOpenCallInView(0, false, [0])).toBe(false)
+  expect(isOpenCallInView(0, false, [])).toBe(false)
 })
 
 test('a row whose environment is not in the category map is excluded when env filter is active', () => {

--- a/src/views/FismaTable/dashboardFilters.ts
+++ b/src/views/FismaTable/dashboardFilters.ts
@@ -44,6 +44,31 @@ export function hasNoActiveFilters(filters: DashboardFilterState): boolean {
 }
 
 /**
+ * True when the open data call is part of what the dashboard is showing:
+ * a newest-by-deadline call exists, is still open, and is among the calls
+ * selected in the year picker. Every call-scoped affordance (the "Not
+ * updated only" and "Open data call only" switches, past-call row graying)
+ * keys on this, not merely on a call being open: the year picker can select
+ * a historical group while a newer call is open, and in that view no row is
+ * current, so a live call-scoped filter would empty the grid (ui#639).
+ * @param {number} latestDataCallId - Newest-by-deadline call id (0 before load).
+ * @param {boolean} latestDeadlinePassed - Whether that call's deadline passed.
+ * @param {number[]} activeDatacallIds - Call ids selected in the year picker.
+ * @returns {boolean} True when the open call is in the selected view.
+ */
+export function isOpenCallInView(
+  latestDataCallId: number,
+  latestDeadlinePassed: boolean,
+  activeDatacallIds: number[]
+): boolean {
+  return (
+    latestDataCallId > 0 &&
+    !latestDeadlinePassed &&
+    activeDatacallIds.includes(latestDataCallId)
+  )
+}
+
+/**
  * True when a system is a genuine "Not updated" laggard for the active data
  * call: it has a questionnaire but zero functions updated. Reuses the column's
  * own classifier (`progressSortValue === -1`) so the filter and the Data Call

--- a/src/views/FismaTable/dashboardFilters.ts
+++ b/src/views/FismaTable/dashboardFilters.ts
@@ -12,6 +12,13 @@ export type DashboardFilterState = {
   opdivIds: number[]
   /** When true, keep only systems that have a questionnaire but zero updates. */
   notUpdatedOnly: boolean
+  /**
+   * When true, keep only systems whose displayed call is the open one (ui#639).
+   * An opt-in focus filter, deliberately default-off: hiding closed-call rows
+   * by default would drop them silently from the view and the row-selection
+   * export, and disagree with the stat tiles, which count all systems.
+   */
+  openCallOnly: boolean
 }
 
 /** An empty filter state — nothing selected, everything passes. */
@@ -19,6 +26,7 @@ export const EMPTY_DASHBOARD_FILTERS: DashboardFilterState = {
   environments: [],
   opdivIds: [],
   notUpdatedOnly: false,
+  openCallOnly: false,
 }
 
 /**
@@ -30,7 +38,8 @@ export function hasNoActiveFilters(filters: DashboardFilterState): boolean {
   return (
     filters.environments.length === 0 &&
     filters.opdivIds.length === 0 &&
-    !filters.notUpdatedOnly
+    !filters.notUpdatedOnly &&
+    !filters.openCallOnly
   )
 }
 
@@ -68,8 +77,9 @@ export function isNotUpdated(
  * @param {DashboardFilterState} filters - The active selections.
  * @param {(fismasystemid: number) => boolean} [isCurrentCall] - Whether a row's
  *   displayed call is the current/active one. The "Not updated" facet only
- *   matches current-call laggards (ztmf#537); defaults to treating every row as
- *   current so callers without call context keep the original behavior.
+ *   matches current-call laggards (ztmf#537), and the "Open data call only"
+ *   facet keeps only current-call rows (ui#639); defaults to treating every
+ *   row as current so callers without call context keep the original behavior.
  * @returns {FismaSystemType[]} The subset of rows passing every active facet.
  */
 export function applyDashboardFilters(
@@ -85,6 +95,9 @@ export function applyDashboardFilters(
   const opdivSet = new Set(filters.opdivIds)
 
   return rows.filter((row) => {
+    if (filters.openCallOnly && !isCurrentCall(row.fismasystemid)) {
+      return false
+    }
     if (envSet.size > 0) {
       const category = categoryMap[row.datacenterenvironment]
       if (!category || !envSet.has(category)) return false

--- a/src/views/FismaTable/rowCall.test.ts
+++ b/src/views/FismaTable/rowCall.test.ts
@@ -1,5 +1,5 @@
 import type { datacall } from '@/types'
-import { resolveRowCallId } from './rowCall'
+import { resolveRowCallId, datacallNameComparator } from './rowCall'
 
 const call = (datacallid: number, deadline: string): datacall => ({
   datacallid,
@@ -30,4 +30,30 @@ test('falls back to the active call when the system has no call data', () => {
 
 test('ignores score-call ids that resolve to no known call', () => {
   expect(resolveRowCallId(7, {}, { 7: [99] }, DATACALLS, 3)).toBe(3)
+})
+
+describe('datacallNameComparator', () => {
+  // Names chosen so string order CONTRADICTS deadline order: "FY2025 Q3"
+  // string-sorts before "FY25 ZTM" but has the newer deadline here, so a
+  // regression to name comparison fails these assertions.
+  const deadlines = new Map([
+    ['FY25 ZTM', Date.parse('2025-09-30T00:00:00Z')],
+    ['FY2025 Q3', Date.parse('2026-03-31T00:00:00Z')],
+  ])
+  const cmp = datacallNameComparator(deadlines)
+
+  it('orders by deadline, not by name', () => {
+    expect(cmp('FY25 ZTM', 'FY2025 Q3')).toBeLessThan(0)
+    expect(cmp('FY2025 Q3', 'FY25 ZTM')).toBeGreaterThan(0)
+  })
+
+  it('returns 0 on equal deadlines and on two unknown names', () => {
+    expect(cmp('FY25 ZTM', 'FY25 ZTM')).toBe(0)
+    expect(cmp('', 'nonsense')).toBe(0)
+  })
+
+  it('sinks an unknown or blank name to the oldest end', () => {
+    expect(cmp('', 'FY25 ZTM')).toBeLessThan(0)
+    expect(cmp('FY2025 Q3', '')).toBeGreaterThan(0)
+  })
 })

--- a/src/views/FismaTable/rowCall.test.ts
+++ b/src/views/FismaTable/rowCall.test.ts
@@ -32,6 +32,35 @@ test('ignores score-call ids that resolve to no known call', () => {
   expect(resolveRowCallId(7, {}, { 7: [99] }, DATACALLS, 3)).toBe(3)
 })
 
+describe('last-resort call for a system with no data in the view', () => {
+  // Call 2 has the newest deadline, so it stands in for the open call; calls 1
+  // and 3 stand in for a historical year the picker has selected.
+  it('prefers the newest selected call when the active call is out of view', () => {
+    // The reported shape: selecting a year toggles all of its calls on, which
+    // collapses activeDataCallId to the open call even though the user is
+    // looking at a historical group. Labelling the row with call 2 there would
+    // name a call that is not on screen.
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [1, 3])).toBe(3)
+  })
+
+  it('keeps the active call when it is one of the selected calls', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 1, [1, 3])).toBe(1)
+  })
+
+  it('falls back to the active call when no calls are selected', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [])).toBe(2)
+  })
+
+  it('falls back to the active call when the selection resolves to no known call', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [99])).toBe(2)
+  })
+
+  it('still prefers real row data over the view', () => {
+    expect(resolveRowCallId(7, { 7: 1 }, {}, DATACALLS, 2, [2, 3])).toBe(1)
+    expect(resolveRowCallId(7, {}, { 7: [1] }, DATACALLS, 2, [2, 3])).toBe(1)
+  })
+})
+
 describe('datacallNameComparator', () => {
   // Names chosen so string order CONTRADICTS deadline order: "FY2025 Q3"
   // string-sorts before "FY25 ZTM" but has the newer deadline here, so a
@@ -55,5 +84,34 @@ describe('datacallNameComparator', () => {
   it('sinks an unknown or blank name to the oldest end', () => {
     expect(cmp('', 'FY25 ZTM')).toBeLessThan(0)
     expect(cmp('FY2025 Q3', '')).toBeGreaterThan(0)
+  })
+
+  describe('unparseable deadlines', () => {
+    // A record whose deadline is present but malformed maps to NaN, which is
+    // not the same as being absent from the map. Returning NaN from a
+    // comparator is outside Array.prototype.sort's contract and leaves the
+    // row's position up to the engine, so NaN has to reach the same sentinel
+    // an unknown name does.
+    const withBad = new Map([
+      ['bad-deadline', Number.NaN],
+      ['also-bad', Number.NaN],
+      ['FY25 ZTM', Date.parse('2025-09-30T00:00:00Z')],
+    ])
+    const cmpBad = datacallNameComparator(withBad)
+
+    it('never returns NaN', () => {
+      expect(cmpBad('bad-deadline', 'FY25 ZTM')).not.toBeNaN()
+      expect(cmpBad('FY25 ZTM', 'bad-deadline')).not.toBeNaN()
+      expect(cmpBad('bad-deadline', 'also-bad')).not.toBeNaN()
+    })
+
+    it('sinks a malformed deadline to the oldest end', () => {
+      expect(cmpBad('bad-deadline', 'FY25 ZTM')).toBeLessThan(0)
+      expect(cmpBad('FY25 ZTM', 'bad-deadline')).toBeGreaterThan(0)
+    })
+
+    it('treats two malformed deadlines as equal', () => {
+      expect(cmpBad('bad-deadline', 'also-bad')).toBe(0)
+    })
   })
 })

--- a/src/views/FismaTable/rowCall.test.ts
+++ b/src/views/FismaTable/rowCall.test.ts
@@ -1,0 +1,33 @@
+import type { datacall } from '@/types'
+import { resolveRowCallId } from './rowCall'
+
+const call = (datacallid: number, deadline: string): datacall => ({
+  datacallid,
+  datacall: `call-${datacallid}`,
+  datecreated: deadline,
+  deadline,
+})
+
+// Deliberately not in deadline order: id 2 has the newest deadline, so any
+// resolution that keys on id order instead of deadline gets caught.
+const DATACALLS = [
+  call(1, '2025-01-15T00:00:00Z'),
+  call(3, '2025-07-15T00:00:00Z'),
+  call(2, '2026-01-15T00:00:00Z'),
+]
+
+test('prefers the chosen (most-recently-updated) call', () => {
+  expect(resolveRowCallId(7, { 7: 1 }, { 7: [1, 2, 3] }, DATACALLS, 3)).toBe(1)
+})
+
+test('falls back to the newest-by-deadline call the system has scores in', () => {
+  expect(resolveRowCallId(7, {}, { 7: [1, 2] }, DATACALLS, 3)).toBe(2)
+})
+
+test('falls back to the active call when the system has no call data', () => {
+  expect(resolveRowCallId(7, {}, {}, DATACALLS, 3)).toBe(3)
+})
+
+test('ignores score-call ids that resolve to no known call', () => {
+  expect(resolveRowCallId(7, {}, { 7: [99] }, DATACALLS, 3)).toBe(3)
+})

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -2,6 +2,37 @@ import type { datacall } from '@/types'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 
 /**
+ * Sort comparator for the Data Call column. Cell values are call NAMES (so
+ * the quick filter can match them), but names do not sort chronologically
+ * ("FY2025 Q3" string-sorts near "FY25 ZTM" by accident only), so ordering
+ * goes through each call's deadline. A name with no known deadline, or one
+ * whose deadline failed to parse, sinks to the oldest end rather than
+ * interleaving (mirrors sortDatacallsByDeadline's bad-value handling).
+ * Duplicate call names collapse to one deadline (last-write-wins in the map);
+ * the admin call-name grammar keeps names unique in practice.
+ * @param {Map<string, number>} deadlineByName - Call name -> deadline epoch ms.
+ * @returns {(a: string, b: string) => number} Ascending-by-deadline comparator.
+ */
+export function datacallNameComparator(
+  deadlineByName: Map<string, number>
+): (a: string, b: string) => number {
+  // A name absent from the map and a name mapped to NaN (empty or malformed
+  // deadline on a real record) both have to land on the same finite sentinel.
+  // Returning NaN from a comparator is outside Array.prototype.sort's contract
+  // and leaves the row's position engine-dependent.
+  const key = (name: string): number => {
+    const value = deadlineByName.get(name)
+    return value === undefined || Number.isNaN(value) ? -Infinity : value
+  }
+  return (a, b) => {
+    const av = key(a)
+    const bv = key(b)
+    if (av === bv) return 0
+    return av - bv
+  }
+}
+
+/**
  * The data call a dashboard row is displaying. One source of truth shared by
  * the Data Call column, the past-call row styling, and the Pillar Scores
  * modal, so a cell and the modal it opens can never disagree about which call
@@ -9,52 +40,51 @@ import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
  *
  * Resolution order: the call chosen by most-recently-updated in
  * buildDashboardMaps; else the newest-by-deadline call the system has scores
- * in; else the dashboard's active call as a last resort (e.g. single-call
- * system or maps not yet populated).
+ * in; else a call that is actually in the current view.
+ *
+ * That last rung matters. activeDataCallId collapses to the newest call
+ * whenever more than one call is toggled on, and selecting a year toggles all
+ * of its calls, so for any multi-call year it points at the open call rather
+ * than anything on screen. Naming it would label a row in a historical view
+ * with the current call, and hand the Pillar Scores modal an id the row has no
+ * score for, which sends the modal down its own fallback and lets the column
+ * and the modal name different calls. Preferring the newest call in view keeps
+ * the label inside what the user is looking at.
  * @param {number} fismasystemid - The row's system id.
  * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
  * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
  * @param {datacall[]} datacalls - All known data calls.
  * @param {number} activeDataCallId - The dashboard's active call id.
+ * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.
+ *   Omit to keep the pre-existing activeDataCallId-only behavior.
  * @returns {number} The resolved data call id.
  */
-/**
- * Sort comparator for the Data Call column. Cell values are call NAMES (so
- * the quick filter can match them), but names do not sort chronologically
- * ("FY2025 Q3" string-sorts near "FY25 ZTM" by accident only), so ordering
- * goes through each call's deadline. A name with no known deadline sinks to
- * the oldest end rather than interleaving (mirrors sortDatacallsByDeadline's
- * bad-value handling). Duplicate call names collapse to one deadline
- * (last-write-wins in the map); the admin call-name grammar keeps names
- * unique in practice.
- * @param {Map<string, number>} deadlineByName - Call name -> deadline epoch ms.
- * @returns {(a: string, b: string) => number} Ascending-by-deadline comparator.
- */
-export function datacallNameComparator(
-  deadlineByName: Map<string, number>
-): (a: string, b: string) => number {
-  return (a, b) => {
-    const av = deadlineByName.get(a) ?? -Infinity
-    const bv = deadlineByName.get(b) ?? -Infinity
-    if (av === bv) return 0
-    return av - bv
-  }
-}
-
 export function resolveRowCallId(
   fismasystemid: number,
   chosenCallMap: Record<number, number>,
   systemCallMap: Record<number, number[]>,
   datacalls: datacall[],
-  activeDataCallId: number
+  activeDataCallId: number,
+  activeDatacallIds?: number[]
 ): number {
-  return (
-    chosenCallMap[fismasystemid] ??
-    sortDatacallsByDeadline(
-      (systemCallMap[fismasystemid] ?? [])
+  const chosen = chosenCallMap[fismasystemid]
+  if (chosen != null) return chosen
+
+  const scored = sortDatacallsByDeadline(
+    (systemCallMap[fismasystemid] ?? [])
+      .map((id) => datacalls.find((d) => d.datacallid === id))
+      .filter((d): d is datacall => Boolean(d))
+  )[0]?.datacallid
+  if (scored != null) return scored
+
+  if (activeDatacallIds?.length) {
+    if (activeDatacallIds.includes(activeDataCallId)) return activeDataCallId
+    const newestInView = sortDatacallsByDeadline(
+      activeDatacallIds
         .map((id) => datacalls.find((d) => d.datacallid === id))
         .filter((d): d is datacall => Boolean(d))
-    )[0]?.datacallid ??
-    activeDataCallId
-  )
+    )[0]?.datacallid
+    if (newestInView != null) return newestInView
+  }
+  return activeDataCallId
 }

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -1,0 +1,37 @@
+import type { datacall } from '@/types'
+import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
+
+/**
+ * The data call a dashboard row is displaying. One source of truth shared by
+ * the Data Call column, the past-call row styling, and the Pillar Scores
+ * modal, so a cell and the modal it opens can never disagree about which call
+ * a row is on.
+ *
+ * Resolution order: the call chosen by most-recently-updated in
+ * buildDashboardMaps; else the newest-by-deadline call the system has scores
+ * in; else the dashboard's active call as a last resort (e.g. single-call
+ * system or maps not yet populated).
+ * @param {number} fismasystemid - The row's system id.
+ * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
+ * @param {datacall[]} datacalls - All known data calls.
+ * @param {number} activeDataCallId - The dashboard's active call id.
+ * @returns {number} The resolved data call id.
+ */
+export function resolveRowCallId(
+  fismasystemid: number,
+  chosenCallMap: Record<number, number>,
+  systemCallMap: Record<number, number[]>,
+  datacalls: datacall[],
+  activeDataCallId: number
+): number {
+  return (
+    chosenCallMap[fismasystemid] ??
+    sortDatacallsByDeadline(
+      (systemCallMap[fismasystemid] ?? [])
+        .map((id) => datacalls.find((d) => d.datacallid === id))
+        .filter((d): d is datacall => Boolean(d))
+    )[0]?.datacallid ??
+    activeDataCallId
+  )
+}

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -18,6 +18,29 @@ import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
  * @param {number} activeDataCallId - The dashboard's active call id.
  * @returns {number} The resolved data call id.
  */
+/**
+ * Sort comparator for the Data Call column. Cell values are call NAMES (so
+ * the quick filter can match them), but names do not sort chronologically
+ * ("FY2025 Q3" string-sorts near "FY25 ZTM" by accident only), so ordering
+ * goes through each call's deadline. A name with no known deadline sinks to
+ * the oldest end rather than interleaving (mirrors sortDatacallsByDeadline's
+ * bad-value handling). Duplicate call names collapse to one deadline
+ * (last-write-wins in the map); the admin call-name grammar keeps names
+ * unique in practice.
+ * @param {Map<string, number>} deadlineByName - Call name -> deadline epoch ms.
+ * @returns {(a: string, b: string) => number} Ascending-by-deadline comparator.
+ */
+export function datacallNameComparator(
+  deadlineByName: Map<string, number>
+): (a: string, b: string) => number {
+  return (a, b) => {
+    const av = deadlineByName.get(a) ?? -Infinity
+    const bv = deadlineByName.get(b) ?? -Infinity
+    if (av === bv) return 0
+    return av - bv
+  }
+}
+
 export function resolveRowCallId(
   fismasystemid: number,
   chosenCallMap: Record<number, number>,


### PR DESCRIPTION
> **Note:** In-repo copy of #647 by @voidspooks. Moved from the fork so Snyk
> and the deploy CI gates can run — those jobs require org secrets unavailable
> to fork PRs. Commits and authorship are unchanged.
>
> Refs #647

---

Fixes the reported bug and implements both optional ACs plus the design agreed in the Slack feedback thread.

The bug: "Not updated only" is a current-cycle signal, and once the newest call's deadline passes it silently filtered every row and emptied the grid. Both call-scoped toggles ("Not updated only" and the new "Open data call only") now disable with an explanatory tooltip whenever the open call is not part of what the table is showing, and a slim banner (`role=status`) explains the state: "No open data call; showing each system's most recently updated call", or "The open data call is not in the selected view" when a call is open but the year picker sits on a historical group. A stored-on filter value is neutralized when the view changes, so a year switch or a refetch that closes the newest call cannot leave an invisible filter emptying the grid.

The gate is deliberately "the open call is in view", not "a call is open": the year picker can select a historical group while a newer call is open, and in that view no row is current, so a live call-scoped filter would empty the grid and graying would wash out every row. The derivation lives in `isOpenCallInView` with tests, including the pre-load `latestDataCallId = 0` case.

One divergence from the optional AC as written: "Open data call only" ships default OFF. Default-on would hide closed-call rows silently as the default view (the same failure mode as the bug), drop them from the row-selection export, and disagree with the stat tiles, which count all systems. It is an opt-in focus filter, and flipping it counts as an active filter for Clear filters.

Beyond the ticket text, per the Slack thread: rows displaying a closed call are de-emphasized while the open call is in view, and a new Data Call column names each row's displayed call so the state is text, sortable, and quick-searchable rather than color-only. De-emphasis is a background tint plus muted cell text, deliberately not whole-row opacity, which pushed the name link, checkbox, and action icons below WCAG contrast minima while leaving them clickable. The column sorts by call deadline, not name (`datacallNameComparator`, tested; names do not sort chronologically), and carries a header tooltip explaining the resolution. A new `resolveRowCallId` helper is the single source of truth for which call a row is displaying, shared by the column and the pillar-scores modal so they cannot disagree.

Known limitation, accepted for now: the disabled switches' tooltips are hover-only and the column header tooltip is a native `title` attribute, so keyboard and screen-reader users rely on the banner, which carries the same information. Worth folding into a broader a11y pass.

Visible behavior for review: the new column, the graying in mixed views, the disabled toggles plus banner between calls.

<img width="1700" height="900" alt="closed" src="https://github.com/user-attachments/assets/9c6876a2-5907-433c-97f5-a80d82038997" />
<img width="1700" height="900" alt="focus" src="https://github.com/user-attachments/assets/bd8bded6-ed71-45e4-999f-5de8bfb2019d" />
<img width="1700" height="900" alt="mixed" src="https://github.com/user-attachments/assets/33440234-7ed5-4adf-b7c1-241cde270a51" />
<img width="1700" height="900" alt="notupdated" src="https://github.com/user-attachments/assets/563dbf8d-a95d-40b6-9522-c130a4ee09c8" />

Gate: `tsc` clean, `eslint` zero errors (2 pre-existing InsightsPanel warnings), jest 53 suites / 697 tests green.

Closes #639
