### PR TITLE
feat(auth): enable the IdP login flow for prod

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -56,8 +56,11 @@ jobs:
         # VITE_* vars are baked into the bundle at build time, so they must
         # be set on the build step itself, not on the deployed container.
         # Default off; flip per environment as IdP rollout progresses.
+        # Prod joins dev now that its backend has dual-IdP enabled. Impl stays
+        # off until its own backend flag is, or its lookup call would fall
+        # through to the OIDC-gated /api/* rule and break sign-in.
         env:
-          VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
+          VITE_IDP_ENABLED: ${{ (inputs.environment == 'dev' || inputs.environment == 'prod') && 'true' || 'false' }}
           # Insights "How to fix" remediation — trialed in impl only; off in dev/prod.
           VITE_INSIGHTS_SUGGEST_FIX_ENABLED: ${{ inputs.environment == 'impl' && 'true' || 'false' }}
           # Dev-only banner overrides. Sourced from secrets so the feedback form


### PR DESCRIPTION
Turns the IdP login flow on for prod.

ztmf#495 enabled dual-IdP on the prod backend earlier tonight, so the ALB now carries the `/login/entra*` rule and `/auth/lookup` answers in prod. This flag stayed off, though, so prod kept building the single-Okta landing page: no email prompt, so nothing ever calls lookup, so there is no route to `/login/entra` at all. HHS and OpDiv accounts are still blocked, which is what #495 existed to fix.

Found by comparing the two environments after that rollout. Dev shows the email prompt, prod still shows the old Sign in button.

Impl stays off on purpose. `impl.tfvars` does not set `entra_enabled` and the variable defaults false, so impl has no `/login/entra` rule, and its lookup call would fall through to the OIDC-gated `/api/*` rule and break sign-in. Flip it there once impl's backend flag is on.

Worth knowing this also turns on the IdP selector in the user table (`UserTable.tsx:150` gates it on the same flag), which is the admin affordance from ztmf#352 for setting `identity_provider` on user create. That is wanted, but it means this is not only the login page.

## Test plan

- [x] `prettier --check` passes on the changed file, so `yarn lint:other` stays green
- [x] YAML parses, and the expression is the same shape as the sibling flags on adjacent lines
- [ ] After deploy, prod shows the email prompt instead of the Sign in button
- [ ] After deploy, a CMS account still signs in through Okta, since lookup should route it exactly as before
- [ ] Impl still shows the Sign in button and signs in normally

The prod backend prerequisite is already live, so the ordering is safe: backend first, then frontend. The reverse would have failed, since the lookup call had nowhere to land.

Refs CMS-Enterprise/ztmf#495, CMS-Enterprise/ztmf-misc#260
