### PR TITLE
Use fresh caller scope in the Assign OpDivs modal

### DIFF
--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -31,11 +31,13 @@ const mock = new MockAdapter(axiosInstance)
 
 const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const USER_ID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CALLER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 
-// Represents the caller's grantable scope (children, active, and — for an
-// OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
-// so scope-filter tests can verify it is stripped from the PUT body.
-const opdivOptions: OpDiv[] = [
+// The full assignable universe: active, non-parent OpDivs, NOT narrowed to the
+// caller. The modal narrows this against the caller's fresh grants itself. 99 is
+// intentionally absent (parent/inactive) so it can only ever appear as a
+// current grant, never as a selectable option.
+const assignableOpDivs: OpDiv[] = [
   {
     opdiv_id: 1,
     code: 'AAA',
@@ -56,13 +58,20 @@ const opdivOptions: OpDiv[] = [
 
 // Full label source (incl. the non-assignable OpDiv 99, e.g. a parent/inactive
 // division), so the modal can label a grant to it even though it is absent from
-// opdivOptions. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
+// assignableOpDivs. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
 // fallback.
 const opdivLabelMap: Record<number, { code: string; name: string }> = {
   1: { code: 'AAA', name: 'Division A' },
   2: { code: 'BBB', name: 'Division B' },
   99: { code: 'ZZZ', name: 'Parent Division' },
 }
+
+// The acting caller's own current grants, served fresh by the modal's on-open
+// fetch. Mutable so a test can change it between two opens (the staleness case).
+let callerGrants: number[] = [1, 2]
+// Status the caller-scope fetch returns; non-200 exercises the failure paths
+// (500 = generic error guard, 401 = auth redirect).
+let callerFetchStatus = 200
 
 function renderModal(
   overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
@@ -73,19 +82,37 @@ function renderModal(
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
       {...overrides}
     />
   )
 }
 
+// Waits for the modal's on-open fetches to settle (Save enabled = not loading).
+// Fetch-count-agnostic, so it survives the extra caller-scope fetch.
+const waitForReady = () =>
+  waitFor(() =>
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled()
+  )
+
 beforeEach(() => {
   mock.reset()
   mockedNavigate.mockReset()
+  callerGrants = [1, 2]
+  callerFetchStatus = 200
+  // The caller-scope fetch is read at request time, so mutating callerGrants
+  // (or callerFetchStatus) between opens changes what the next open sees.
+  mock
+    .onGet(`/users/${CALLER_ID}/assignedopdivs`)
+    .reply(() =>
+      callerFetchStatus === 200
+        ? [200, { data: callerGrants }]
+        : [callerFetchStatus, {}]
+    )
 })
 
 // Scoped caller (OPDIV_ADMIN, enforceCallerScope=true): the save strips
@@ -99,7 +126,7 @@ test('scoped caller: PUT body excludes grants the target holds outside caller sc
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
   renderModal({ enforceCallerScope: true })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -120,7 +147,7 @@ test('unscoped caller: PUT body preserves grants outside the assignable set', as
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
   renderModal({ enforceCallerScope: false })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -141,8 +168,9 @@ test('scoped caller: preserves a caller-held grant that is no longer assignable'
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  callerGrants = [1, 99]
+  renderModal()
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -150,6 +178,123 @@ test('scoped caller: preserves a caller-held grant that is no longer assignable'
   const body = JSON.parse(mock.history.put[0].data)
   expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 99]))
   expect(body.opdiv_ids).toHaveLength(2)
+})
+
+// The staleness AC: an OPDIV_ADMIN whose OWN grants change mid-session gets the
+// current scope on the NEXT open, no reload. First open the caller does not hold
+// 99; between opens they gain it; the second open must preserve the target's
+// grant to 99, not strip it (which the backend would then revoke). Fetching the
+// caller's scope fresh on each open is what makes the second open see the newer
+// set - a session-cached scope would still be missing 99.
+test('scoped caller: a mid-session scope change is picked up on the next open', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  const modal = (open: boolean) => (
+    <OpDivGrantModal
+      open={open}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      assignableOpDivs={assignableOpDivs}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerUserId={CALLER_ID}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // First open: caller does not hold 99 yet.
+  callerGrants = [1]
+  const { rerender } = renderWithProviders(modal(true))
+  await waitForReady()
+
+  // Close, the caller gains 99, then reopen.
+  rerender(modal(false))
+  callerGrants = [1, 99]
+  rerender(modal(true))
+  await waitForReady()
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  // The second open used the fresher scope, so 99 survives.
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 99]))
+  expect(body.opdiv_ids).toHaveLength(2)
+})
+
+// The data-integrity guard: if the caller-scope fetch fails, the modal must
+// block the save. Filtering the target's grants against an empty fallback scope
+// would strip - and the backend then revoke - grants the caller actually holds.
+test('scoped caller: a caller-scope fetch failure disables the modal and blocks save', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerFetchStatus = 500
+
+  renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(mock.history.put).toHaveLength(0)
+})
+
+// A scoped caller whose own grants were all revoked mid-session has an empty
+// (but successfully fetched) scope. Save must be blocked so it can't PUT an
+// empty desired set - distinct from the fetch-failure guard: the picker is
+// enabled (load succeeded), only Save is blocked.
+test('scoped caller: an empty caller scope blocks save without a fetch error', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerGrants = []
+
+  renderModal()
+
+  // Picker enabled proves the load finished (not a loading/fetchFailed state)...
+  await waitFor(() => expect(screen.getByRole('combobox')).toBeEnabled())
+  // ...but Save stays disabled because the caller has no scope to grant from.
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  expect(mock.history.put).toHaveLength(0)
+})
+
+// Both fetches failing surfaces exactly one error toast, not one per fetch.
+test('surfaces a single error snackbar when both fetches fail', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+  callerFetchStatus = 500
+
+  renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getAllByText(ERROR_MESSAGES.tryAgain)).toHaveLength(1)
+})
+
+// A 401 on the caller-scope fetch (target ok) redirects to sign-in via the auth
+// interceptor and suppresses the generic error toast, same as a 401 on the
+// target fetch.
+test('a 401 on the caller-scope fetch redirects to sign-in without a generic toast', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerFetchStatus = 401
+
+  renderModal()
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+// Self-row: an admin opening the modal on their own row (userid === callerUserId)
+// hits the same endpoint for both fetches, so it must fire a single request.
+test('self-row: caller opening their own row fires a single grants fetch', async () => {
+  renderModal({ userid: CALLER_ID })
+  await waitForReady()
+
+  const selfGets = mock.history.get.filter(
+    (g) => g.url === `/users/${CALLER_ID}/assignedopdivs`
+  )
+  expect(selfGets).toHaveLength(1)
 })
 
 // A grant to a non-assignable OpDiv (99, absent from opdivOptions) still chips
@@ -180,8 +325,9 @@ test('dropdown excludes a non-assignable grant even though it chips', async () =
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
 
   renderModal()
-  // The grant chips (so the fetch has resolved and options are settled).
-  await screen.findByText('ZZZ - Parent Division')
+  // Wait for both fetches so the picker is enabled and the assignable set is
+  // narrowed against the caller's fresh scope.
+  await waitForReady()
 
   // Open the dropdown.
   await userEvent.click(screen.getByRole('combobox'))
@@ -199,11 +345,13 @@ test('dropdown excludes a non-assignable grant even though it chips', async () =
 test('scoped caller: a chip outside the caller scope is not deletable', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 2] })
+  // Caller holds [1, 2]; 99 is held by the target via another admin.
+  renderModal()
+  await waitForReady()
 
-  const inScope = (await screen.findByText('AAA - Division A')).closest(
-    '.MuiChip-root'
-  ) as HTMLElement
+  const inScope = screen
+    .getByText('AAA - Division A')
+    .closest('.MuiChip-root') as HTMLElement
   const outOfScope = screen
     .getByText('ZZZ - Parent Division')
     .closest('.MuiChip-root') as HTMLElement
@@ -218,11 +366,13 @@ test('scoped caller: a chip outside the caller scope is not deletable', async ()
 test('scoped caller: a caller-held but non-assignable chip stays deletable', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
+  callerGrants = [1, 99]
+  renderModal()
+  await waitForReady()
 
-  const heldNonAssignable = (
-    await screen.findByText('ZZZ - Parent Division')
-  ).closest('.MuiChip-root') as HTMLElement
+  const heldNonAssignable = screen
+    .getByText('ZZZ - Parent Division')
+    .closest('.MuiChip-root') as HTMLElement
 
   expect(heldNonAssignable.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
 })
@@ -249,7 +399,7 @@ test('success: modal closes and onChanged fires after save', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -266,7 +416,7 @@ test('modal stays open on save error and does not call onChanged', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
@@ -281,7 +431,7 @@ test('403 shows the permission snackbar and does not close the modal', async () 
   const handleClose = jest.fn()
   renderModal({ handleClose })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
@@ -293,7 +443,7 @@ test('401 redirects to sign-in without firing a generic error snackbar', async (
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
 
   renderModal()
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -313,7 +463,7 @@ test('save button is disabled while the request is in flight', async () => {
   renderModal()
   const saveButton = screen.getByRole('button', { name: /^save$/i })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(saveButton)
 
   expect(saveButton).toBeDisabled()
@@ -379,10 +529,10 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
     />
   )
@@ -392,10 +542,10 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
     />
   )
@@ -444,16 +594,16 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       handleClose={jest.fn()}
       userid={USER_ID_B}
       userName="Test User B"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={onChanged}
     />
   )
 
-  // Both GETs have been sent; user B's has already resolved.
-  await waitFor(() => expect(mock.history.get).toHaveLength(2))
+  // User B's fetches have resolved (Save enabled); user A's is still pending.
+  await waitForReady()
 
   // Release user A's stale fetch — the cancelled flag should swallow the result.
   resolveUserA()

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -23,14 +23,16 @@ type Props = {
   userid: GridRowId
   userName: string
   /**
-   * Assignable OpDivs, already scoped by the caller (children only, active,
-   * and - for an OPDIV_ADMIN actor - limited to their own OpDivs). The modal
-   * does not re-scope; it renders exactly what it is given. Drives the dropdown.
+   * All assignable OpDivs (active, non-parent) - the full universe BEFORE any
+   * caller-scope narrowing. For a scoped caller the modal narrows this to the
+   * caller's own current grants itself, fetched fresh on open, so the dropdown
+   * reflects a mid-session change to the caller's grants rather than the
+   * session-old userInfo. Drives the dropdown.
    */
-  opdivOptions: OpDiv[]
+  assignableOpDivs: OpDiv[]
   /**
    * Full label source (all OpDivs, incl. parent/inactive), keyed by opdiv_id.
-   * Separate from opdivOptions so a grant to a non-assignable OpDiv still
+   * Separate from assignableOpDivs so a grant to a non-assignable OpDiv still
    * resolves to a readable chip instead of a blank one. Ids missing here fall
    * back to "OpDiv #{id}".
    */
@@ -44,18 +46,16 @@ type Props = {
    */
   enforceCallerScope: boolean
   /**
-   * The caller's RAW own-grant ids - the backend's true add/remove scope
-   * (IsAssignedOpDiv), unfiltered by parent/active. This is the save-time
-   * preserve boundary and MUST be a superset of the dropdown's assignable set:
-   * opdivOptions is additionally narrowed to !is_parent && active, so a grant
-   * the caller holds to an OpDiv that was later re-parented or deactivated is
-   * absent from opdivOptions but still in the caller's backend scope. Filtering
-   * the save on the narrower opdivOptions would strip such a grant from the PUT
-   * and the backend would then revoke it (its toRemove gate is pure grant
-   * membership) - the same silent-revocation this modal exists to prevent.
-   * Only consulted when enforceCallerScope is true.
+   * The acting admin's own user id. When enforceCallerScope is true the modal
+   * fetches this user's CURRENT OpDiv grants on open - the backend's true
+   * add/remove scope (IsAssignedOpDiv) - and uses that fresh set as BOTH the
+   * dropdown's assignable narrowing and the save-time preserve boundary. Read
+   * from a fresh fetch rather than the session userInfo, whose assignedopdivids
+   * is loaded once and never refreshed, so a mid-session grant change to the
+   * caller can't silently revoke a target's grant on save. Only fetched when
+   * enforceCallerScope is true.
    */
-  callerGrantIds: number[]
+  callerUserId: string
   /**
    * Fired after a successful save so the caller can refresh the user's row
    * (grants + derived identity_provider) against post-mutation server state.
@@ -68,31 +68,46 @@ export default function OpDivGrantModal({
   handleClose,
   userid,
   userName,
-  opdivOptions,
+  assignableOpDivs,
   opdivLabelMap,
   enforceCallerScope,
-  callerGrantIds,
+  callerUserId,
   onChanged,
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
+  // The caller's own current grants, fetched fresh on open (scoped callers
+  // only). The backend's true add/remove scope (IsAssignedOpDiv), used for both
+  // the dropdown narrowing and the save-time preserve boundary.
+  const [callerGrantIds, setCallerGrantIds] = React.useState<number[]>([])
   const [saving, setSaving] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
   const [fetchFailed, setFetchFailed] = React.useState(false)
 
-  // The assignable set drives the dropdown (what may be newly selected).
-  const assignableIds = React.useMemo(
-    () => new Set(opdivOptions.map((od) => od.opdiv_id)),
-    [opdivOptions]
-  )
-
   // The caller's raw backend scope (IsAssignedOpDiv). Superset of assignableIds
   // - it also covers grants to OpDivs since re-parented/deactivated. Gates the
-  // scoped save and the chip lock, so both agree with what the backend will act
-  // on (see the callerGrantIds prop docs).
+  // scoped save and the chip lock, so both agree with what the backend acts on.
   const callerScope = React.useMemo(
     () => new Set(callerGrantIds),
     [callerGrantIds]
   )
+
+  // A scoped caller with no grants of their own has nothing they may grant, and
+  // a save would PUT an empty desired set. That is a no-op under the backend's
+  // grant-membership toRemove gate (nothing the caller doesn't hold is removed),
+  // but block it anyway: it avoids a pointless request and keeps the frontend
+  // safe if that gate ever changes. (During loading callerScope is empty too,
+  // but Save is already disabled by `loading`, so this only bites post-fetch.)
+  const callerHasNoScope = enforceCallerScope && callerScope.size === 0
+
+  // The dropdown's assignable set: all active/non-parent OpDivs, narrowed to the
+  // caller's own fresh scope for a scoped caller so it never offers an OpDiv the
+  // backend would 403 on. Kept a subset of callerScope, which is what keeps the
+  // save from stripping a legitimately-held grant.
+  const assignableIds = React.useMemo(() => {
+    const full = assignableOpDivs.map((od) => od.opdiv_id)
+    if (!enforceCallerScope) return new Set(full)
+    return new Set(full.filter((id) => callerScope.has(id)))
+  }, [assignableOpDivs, enforceCallerScope, callerScope])
 
   // Label from the full map (assignable or not), with an identifiable fallback
   // so a grant to an OpDiv missing from the map never chips blank.
@@ -130,13 +145,44 @@ export default function OpDivGrantModal({
       setLoading(true)
       setFetchFailed(false)
       setLocalOpDivs([])
-      fetchUserOpDivs(String(userid))
-        .then((grants) => {
-          if (!cancelled) setLocalOpDivs(grants)
-        })
-        .catch((error) => {
-          if (!cancelled) {
-            handleError(error)
+      setCallerGrantIds([])
+      // Fetch the target's grants and, for a scoped caller, the caller's own
+      // current grants. Fetching the caller's scope fresh (rather than reading
+      // the session-old userInfo) is what closes the staleness gap: an admin
+      // whose own grants changed mid-session gets the current scope on open.
+      // A seconds-wide open-to-save TOCTOU remains by design - a concurrent
+      // change to the caller's OWN grants during an active edit isn't caught
+      // until the next open. That's unclosable client-side (a save-time refetch
+      // only narrows it) and the backend's grant-membership gate is the final
+      // authority; don't move this to save-time to chase it.
+      // When the caller opens the modal on their OWN row the two are the same
+      // request, so reuse the one promise instead of an identical second GET.
+      const targetPromise = fetchUserOpDivs(String(userid))
+      const callerScopePromise = !enforceCallerScope
+        ? Promise.resolve<number[]>([])
+        : callerUserId === String(userid)
+          ? targetPromise
+          : fetchUserOpDivs(callerUserId)
+      Promise.allSettled([targetPromise, callerScopePromise])
+        .then(([targetRes, callerRes]) => {
+          if (cancelled) return
+          if (targetRes.status === 'fulfilled') setLocalOpDivs(targetRes.value)
+          if (callerRes.status === 'fulfilled')
+            setCallerGrantIds(callerRes.value)
+          // Either fetch failing blocks the save: a missing target list, or
+          // (worse) a missing caller scope, could revoke grants - fetchFailed
+          // disables the picker and Save so the empty fallback scope is never
+          // acted on. Surface a single error; a second identical toast when both
+          // fail adds nothing, and any 401 redirect is handled by the axios
+          // interceptor regardless of which reason we pass here.
+          const failure =
+            targetRes.status === 'rejected'
+              ? targetRes.reason
+              : callerRes.status === 'rejected'
+                ? callerRes.reason
+                : null
+          if (failure) {
+            handleError(failure)
             setFetchFailed(true)
           }
         })
@@ -150,8 +196,9 @@ export default function OpDivGrantModal({
       setFetchFailed(false)
       setLoading(false)
       setLocalOpDivs([])
+      setCallerGrantIds([])
     }
-  }, [open, userid, handleError])
+  }, [open, userid, callerUserId, enforceCallerScope, handleError])
 
   const handleSave = () => {
     setSaving(true)
@@ -251,7 +298,7 @@ export default function OpDivGrantModal({
         </CmsButton>
         <CmsButton
           onClick={handleSave}
-          disabled={saving || loading || fetchFailed}
+          disabled={saving || loading || fetchFailed || callerHasNoScope}
         >
           Save
         </CmsButton>

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -188,6 +188,10 @@ export default function UserTable() {
   const [opdivLabelMap, setOpDivLabelMap] = useState<
     Record<number, { code: string; name: string }>
   >({})
+  // All assignable OpDivs (active, non-parent), NOT narrowed to the caller's
+  // scope. The grant modal narrows this against the caller's fresh grants
+  // itself, so it isn't fed the session-old scope that opdivOptions carries.
+  const [allAssignableOpDivs, setAllAssignableOpDivs] = useState<OpDiv[]>([])
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older
@@ -585,7 +589,13 @@ export default function UserTable() {
         setOpDivCodeMap(codeMap)
         setOpDivLabelMap(labelMap)
 
-        let assignable = all.filter((od) => !od.is_parent && od.active)
+        const activeNonParent = all.filter((od) => !od.is_parent && od.active)
+        setAllAssignableOpDivs(activeNonParent)
+
+        // opdivOptions stays caller-narrowed for the inline EditOpDivCell. The
+        // grant modal does NOT use this; it narrows the full set against the
+        // caller's fresh scope itself, so it isn't fed this session-old value.
+        let assignable = activeNonParent
         if (isOpDivTier(userInfo)) {
           const own = new Set(userInfo.assignedopdivids ?? [])
           assignable = assignable.filter((od) => own.has(od.opdiv_id))
@@ -594,6 +604,7 @@ export default function UserTable() {
       } catch {
         // Non-fatal: the grant modal simply shows no options if this fails.
         setOpDivOptions([])
+        setAllAssignableOpDivs([])
         setOpDivCodeMap({})
         setOpDivLabelMap({})
       }
@@ -934,7 +945,7 @@ export default function UserTable() {
         handleClose={handleCloseOpDivModal}
         userid={opdivModalUserId}
         userName={opdivModalUserName}
-        opdivOptions={opdivOptions}
+        assignableOpDivs={allAssignableOpDivs}
         opdivLabelMap={opdivLabelMap}
         // Scoped callers (every admin except an unscoped write admin) must not
         // silently revoke the target's out-of-scope grants on save, so gate the
@@ -942,10 +953,11 @@ export default function UserTable() {
         // send the grant set as-is. This is the inverse of the backend's
         // unscoped-write branch, the predicate it actually decides on.
         enforceCallerScope={!isUnscopedWriteAdmin(userInfo)}
-        // The caller's RAW grants (unfiltered by parent/active) - the save-time
-        // preserve boundary. Wider than opdivOptions so a caller-held grant to a
-        // since re-parented/deactivated OpDiv is preserved, not silently revoked.
-        callerGrantIds={userInfo.assignedopdivids ?? []}
+        // The acting admin's own id. The modal fetches this user's CURRENT
+        // grants on open for its scope, rather than reading the session-old
+        // userInfo.assignedopdivids, so a mid-session grant change can't
+        // silently revoke a target's grant on save.
+        callerUserId={userInfo.userid}
         onChanged={refreshUserRow}
       />
       <ConfirmDialog


### PR DESCRIPTION
## Summary

Closes #643. Builds on #642.

The Assign OpDivs modal decided what to preserve on save from the acting admin's own OpDiv grants, read from `userInfo.assignedopdivids`. That value comes from the route loader's `/users/current` once per session and is never refreshed, so an `OPDIV_ADMIN` whose own grants change mid-session works from a stale scope. #642 made that scope the save-time preserve boundary, so a stale value now has a data-integrity consequence, not just a cosmetic one:

* **Stale-narrow (caller gained a grant B the target also holds):** B isn't in the stale scope, so the save strips it from the PUT, and the backend's `toRemove` gate (pure grant membership) still sees `IsAssignedOpDiv(B)=true` and silently revokes the target's grant.
* **Stale-wide (caller lost a grant A):** the PUT still carries A and the backend's pre-gate 403s the whole unmodified save.

This is the last freshness gap between the frontend's idea of caller scope and the backend's (#642 closed the last derivation gap).

## Changes

* **Fresh scope on open.** The modal now fetches the caller's own current grants on open (scoped callers only), alongside the target's grants in the same `Promise.allSettled`. Both the dropdown's assignable set and the save-time preserve boundary derive from that fresh set, keeping the `callerScope ⊇ assignableIds` invariant.
* **UserTable** passes the full active/non-parent OpDiv list plus the caller's user ID, instead of a caller-narrowed, session-stale list. Its own `opdivOptions` (and the inline `EditOpDivCell`) are left untouched.
* **Hardening (from review):** a caller-scope fetch failure - or an empty-but-fetched scope - blocks Save, so an incomplete scope can never filter the PUT; a single error toast when both fetches fail; and a self-row open (`userid === callerUserId`) reuses the one grants request instead of a duplicate GET.

## Acceptance criteria

* [x] An `OPDIV_ADMIN` whose own grants change mid-session gets the current scope on the next Assign OpDivs open, without a reload or navigation round-trip.
* [x] The stale-narrow case preserves the grant instead of silently revoking it.
* [x] The stale-wide case no longer 403s an unmodified modal.
* [x] A regression test covers the mid-session change between two opens, and the second open uses the newer set.
* [x] The dropdown's assignable set stays within scope (`callerScope ⊇ assignableIds`).
* [x] No extra `/users/current` fetches - the modal hits the scoped `assignedopdivs` endpoint on open, not `current`.

## Testing

* `OpDivGrantModal` suite reworked and extended to cover fresh-scope save behavior, the mid-session regression, the caller-fetch-failure / empty-scope / self-row / single-toast / caller-401 paths, plus the existing coverage.
* Verified the load-bearing FE/BE contract by hand against the backend: `enforceCallerScope` (`!isUnscopedWriteAdmin`) is the exact match for `IsUnscoped()` for every role that can reach the modal (`OWNER` / `HHS_ADMIN` unscoped, `OPDIV_ADMIN` scoped).
* `yarn jest`: full suite green (723 passing); `tsc --noEmit` and lint clean (pre-existing unrelated warnings only).
* Behavior-only fix; no visual changes.

## Notes / out of scope

* **A seconds-wide open-to-save TOCTOU remains by design.** A concurrent change to the caller's own grants during an active edit isn't caught until the next open. It's unclosable client-side (a save-time refetch only narrows it), and the backend grant-membership gate is the final authority. Documented at the fetch site.
* `EditOpDivCell` (the inline grid edit) is not affected by this class. It only calls `setEditCellValue` (writes nothing), and `setUserOpDivs` has a single call site on the new-user (`isNew`) path: a new user has no prior grants to revoke, and the existing-user save PUTs only `email/fullname/role`. So stale caller scope cannot cause a silent revocation there. (Separately, pre-existing and out of scope, inline-editing an existing user's OpDivs is silently discarded on save while still showing "Saved", which is worth its own bug ticket, unrelated to freshness.)