### PR TITLE
chore(#578): retire the hasScore score-presence proxy from ProgressCell (rehome of #646)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -334,9 +334,8 @@ export type ScoreProgress = {
   questionsexpected: number
   // Distinct applicable questions with an answer at all, any status (ztmf#437).
   // The completion signal a closed call needs: imported/carried answers are
-  // answered but never "updated this cycle". Optional so the UI degrades to the
-  // prior score-presence proxy until the backend field is deployed.
-  questionsanswered?: number
+  // answered but never "updated this cycle".
+  questionsanswered: number
   questionsupdated: number
   lastupdatedat?: string | null
   updatedsincestart: boolean

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -931,7 +931,6 @@ export default function FismaTable({
         <ProgressCell
           entry={progress?.[params.row.fismasystemid]}
           isCurrentCall={isRowCurrentCall(params.row.fismasystemid)}
-          hasScore={Boolean(scores[params.row.fismasystemid])}
         />
       ),
     },

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -102,6 +102,25 @@ describe('progressSortValue', () => {
       progressSortValue(pastComplete, false)
     )
   })
+
+  it('returns a usable rank for a past-call row missing the answered count', () => {
+    // The type requires the field, so absence can only be reached at runtime
+    // against a response that omits it, and the cast is how the test expresses
+    // that. Without coalescing this returned NaN, which compares equal to every
+    // other rank and drops the row at an arbitrary position instead of ranking
+    // it. Zero is the honest rank: nothing recorded as answered.
+    const missingAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    const rank = progressSortValue(missingAnswered, false)
+    expect(Number.isNaN(rank)).toBe(false)
+    expect(rank).toBe(0)
+    // Ranks with the genuinely unanswered rather than above a partial call.
+    expect(rank).toBeLessThan(
+      progressSortValue({ ...untouchedEntry, questionsanswered: 10 }, false)
+    )
+  })
 })
 
 describe('progressTooltip', () => {
@@ -201,6 +220,22 @@ describe('ProgressCell', () => {
     expect(screen.getByText('0/41')).toBeInTheDocument()
     expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('renders 0/total on a past call when the answered count is missing', () => {
+    // Reachable only at runtime against a response that omits the field, which
+    // the cast expresses. The fraction interpolates the value directly and React
+    // drops undefined, so without coalescing this rendered a bare "/41" beside a
+    // warning chip. This is the one input where retiring the score-presence
+    // proxy changes what a reader sees, so it is pinned here.
+    const missingAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    render(<ProgressCell entry={missingAnswered} isCurrentCall={false} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -307,18 +307,40 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
 
-  it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
-    // The field is now required on ScoreProgress, so absence can no longer be
-    // expressed through the type. It remains reachable at runtime against a
-    // backend that predates the field, which is exactly what the cell's
-    // fallback guards, so the cast is deliberate: it exercises the runtime
-    // path the type alone can no longer describe.
+  it('reads Not started on the current call when the answered count is absent', () => {
+    // The field is required on ScoreProgress, so absence is reachable only at
+    // runtime against a response that omits it, and the cast is how the test
+    // expresses that. Both branches now coalesce, so this reads as nothing
+    // answered rather than falling back to the retired "Not updated" wording.
     const withoutAnswered = {
       ...untouchedEntry,
       questionsanswered: undefined,
     } as unknown as ScoreProgress
     render(<ProgressCell entry={withoutAnswered} isCurrentCall={true} />)
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('no longer renders the retired Not updated wording in any state', () => {
+    // The label had one emit site, so this is the guard against it coming back
+    // through a future conditional rather than a restatement of the cases above.
+    for (const entry of [
+      updatedEntry,
+      untouchedEntry,
+      { ...untouchedEntry, questionsanswered: 41 },
+      {
+        ...untouchedEntry,
+        questionsanswered: undefined,
+      } as unknown as ScoreProgress,
+    ]) {
+      for (const isCurrentCall of [true, false]) {
+        const { unmount } = render(
+          <ProgressCell entry={entry} isCurrentCall={isCurrentCall} />
+        )
+        expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+        unmount()
+      }
+    }
   })
 
   it('describes the carried-forward state in the tooltip', () => {

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -6,6 +6,7 @@ import { progressSortValue, progressTooltip } from './progressHelpers'
 const updatedEntry: ScoreProgress = {
   fismasystemid: 1,
   questionsexpected: 41,
+  questionsanswered: 12,
   questionsupdated: 12,
   lastupdatedat: '2026-07-01T15:30:00Z',
   updatedsincestart: true,
@@ -14,6 +15,7 @@ const updatedEntry: ScoreProgress = {
 const untouchedEntry: ScoreProgress = {
   fismasystemid: 2,
   questionsexpected: 41,
+  questionsanswered: 0,
   questionsupdated: 0,
   lastupdatedat: null,
   updatedsincestart: false,
@@ -52,6 +54,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -69,6 +72,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -127,6 +131,7 @@ describe('progressTooltip', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -157,12 +162,14 @@ describe('ProgressCell', () => {
     expect(screen.getByText('Updated')).toBeInTheDocument()
   })
 
-  it('renders the fraction and a Not updated chip for a carried-over system', () => {
-    // A pre-populated questionnaire has answers but no edits this cycle -
-    // the whole point of ztmf#299 is that this renders as NOT updated.
+  it('renders the fraction and a laggard chip for an unstarted system', () => {
+    // No answers and no edits this cycle, so the cell shows the honest
+    // fraction alongside the warning chip. The fixture carries zero answers,
+    // which is the "Not started" half of the wording split; the carried-answers
+    // half is covered below.
     render(<ProgressCell entry={untouchedEntry} />)
     expect(screen.getByText('0/41')).toBeInTheDocument()
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
   })
 
   it('renders an em-dash when progress data is missing', () => {
@@ -176,6 +183,7 @@ describe('ProgressCell', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -185,49 +193,25 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
-  it('renders a neutral Complete chip for a scored past-call system', () => {
-    // ztmf#537: a past call reads 0 updates this cycle for everyone. A system
-    // with a score for that call was completed - show a neutral Complete chip,
-    // never the orange "0/40 Not updated" laggard chip.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={true}
-      />
-    )
-    expect(screen.getByText('Complete')).toBeInTheDocument()
+  it('renders 0/total + Incomplete for a fully-unanswered past call', () => {
+    // ztmf#537 kept a past call off the orange laggard chip; ztmf-ui#578
+    // retires the score-presence proxy, so a past call nobody answered reads
+    // an honest 0/41 with the neutral-warning Incomplete chip instead.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={false} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
-    expect(screen.queryByText('0/41')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 
   it('keeps the current-cycle chip for the same entry on the active call', () => {
-    // Same untouched entry, but on the current call it is a genuine laggard.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={true}
-        hasScore={true}
-      />
-    )
+    // Same untouched entry, but on the current call it is a genuine laggard,
+    // so it wears the warning chip rather than the past-call Incomplete one.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
     expect(screen.getByText('0/41')).toBeInTheDocument()
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
-  })
-
-  it('renders an em-dash for a past-call system with no score', () => {
-    // Defensive: a past-call row must never show the orange laggard chip even
-    // without a score to prove completion.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={false}
-      />
-    )
-    expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
-    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
-    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+    expect(screen.queryByText('Incomplete')).not.toBeInTheDocument()
   })
 
   it('renders Complete for a fully-answered past call even with zero updates', () => {
@@ -238,7 +222,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 41 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('Complete')).toBeInTheDocument()
@@ -253,7 +236,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 10 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('10/41')).toBeInTheDocument()
@@ -291,9 +273,16 @@ describe('ProgressCell', () => {
   })
 
   it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
-    // ztmf#437 may not be deployed everywhere; without the field the split
-    // would be a guess, so the cell keeps saying what it always said.
-    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
+    // The field is now required on ScoreProgress, so absence can no longer be
+    // expressed through the type. It remains reachable at runtime against a
+    // backend that predates the field, which is exactly what the cell's
+    // fallback guards, so the cast is deliberate: it exercises the runtime
+    // path the type alone can no longer describe.
+    const withoutAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    render(<ProgressCell entry={withoutAnswered} isCurrentCall={true} />)
     expect(screen.getByText('Not updated')).toBeInTheDocument()
   })
 

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -63,7 +63,12 @@ export function ProgressCell({
   // fully-answered past call is a neutral "Complete"; a partially-answered
   // one shows an honest answered/total with an "Incomplete" chip.
   if (!isCurrentCall) {
-    const answered = entry.questionsanswered
+    // Coalesce so a response that omits the count renders an honest 0/N rather
+    // than a bare "/N": the fraction interpolates the value directly, and React
+    // drops undefined from the output. The current-call branch below keeps its
+    // own null check because it has a distinct legacy wording to fall back to;
+    // here zero and missing describe the same state to the reader.
+    const answered = entry.questionsanswered ?? 0
     if (answered >= entry.questionsexpected) {
       return (
         <Tooltip title={progressTooltip(entry, { completed: true })}>

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -14,9 +14,10 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * "Updated this cycle" only has meaning for the current/active data call. For a
  * past call nobody has touched anything this cycle, so questionsupdated is 0 for
  * every system - showing "0/40 Not updated" wrongly reads a completed historical
- * call as missing (ztmf#537). A past call with a score for that system was
- * completed, so it gets a neutral "Complete" chip instead of the current-cycle
- * fraction and Updated/Not-updated chip.
+ * call as missing (ztmf#537). A past call is judged on how much of it was
+ * answered instead: fully answered reads as a neutral "Complete" chip, and
+ * partially answered keeps the answered/total fraction with an "Incomplete"
+ * chip, rather than the current-cycle Updated/Not-updated framing.
  *
  * States:
  *   - past call (isCurrentCall false), fully answered: neutral "Complete" chip;

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -66,9 +66,8 @@ export function ProgressCell({
   if (!isCurrentCall) {
     // Coalesce so a response that omits the count renders an honest 0/N rather
     // than a bare "/N": the fraction interpolates the value directly, and React
-    // drops undefined from the output. The current-call branch below keeps its
-    // own null check because it has a distinct legacy wording to fall back to;
-    // here zero and missing describe the same state to the reader.
+    // drops undefined from the output. Zero and missing describe the same state
+    // to the reader.
     const answered = entry.questionsanswered ?? 0
     if (answered >= entry.questionsexpected) {
       return (

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -19,9 +19,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * fraction and Updated/Not-updated chip.
  *
  * States:
- *   - past call (isCurrentCall false) with a score: neutral "Complete" chip -
- *     the score is the completion signal (ScoreProgress has no "total answered"
- *     field); the orange laggard chip never appears off the active call;
+ *   - past call (isCurrentCall false), fully answered: neutral "Complete" chip;
+ *     partially answered: answered/total fraction with an "Incomplete" chip.
+ *     The orange laggard chip never appears off the active call;
  *   - a system with no applicable questionnaire (0/0) renders a neutral
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
@@ -35,19 +35,14 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * @param {boolean} [props.isCurrentCall=true] - Whether the row's displayed call
  *   is the current/active one. Defaults true so callers without call context
  *   keep the original current-cycle rendering.
- * @param {boolean} [props.hasScore=false] - Whether the system has a score for
- *   the displayed call. Used only for a past call, where a score means the call
- *   was completed.
  * @returns {JSX.Element} The progress cell.
  */
 export function ProgressCell({
   entry,
   isCurrentCall = true,
-  hasScore = false,
 }: {
   entry: ScoreProgress | undefined
   isCurrentCall?: boolean
-  hasScore?: boolean
 }) {
   if (!entry) {
     return <span aria-label="No progress data">—</span>
@@ -62,24 +57,12 @@ export function ProgressCell({
   // A past data call is closed: "updated this cycle" is meaningless, so never
   // show the orange laggard chip here. But completion is answered/total, NOT
   // updated/total - imported and carried-over answers are answered yet never
-  // "updated this cycle", so gating on updates (or on mere score presence)
-  // would either drop them or, worse, mask a partially-answered historical
-  // call as done. Prefer QuestionsAnswered (ztmf#437): a fully-answered past
-  // call is a neutral "Complete"; a partially-answered one shows an honest
-  // answered/total with an "Incomplete" chip. Until the backend field ships,
-  // fall back to the prior score-presence proxy.
+  // "updated this cycle", so gating on updates would either drop them or,
+  // worse, mask a partially-answered historical call as done (ztmf#437): a
+  // fully-answered past call is a neutral "Complete"; a partially-answered
+  // one shows an honest answered/total with an "Incomplete" chip.
   if (!isCurrentCall) {
     const answered = entry.questionsanswered
-    if (answered == null) {
-      if (!hasScore) {
-        return <span aria-label="No progress data">—</span>
-      }
-      return (
-        <Tooltip title={progressTooltip(entry, { completed: true })}>
-          <Chip size="small" label="Complete" variant="outlined" />
-        </Tooltip>
-      )
-    }
     if (answered >= entry.questionsexpected) {
       return (
         <Tooltip title={progressTooltip(entry, { completed: true })}>

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -28,8 +28,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  *     there is nothing to nudge;
  *   - current call, any genuine edit: "Updated" (green);
  *   - current call, zero updates: "Awaiting confirmation" (carried answers
- *     exist) or "Not started" (none do), both warning-colored laggards;
- *     legacy "Not updated" when questionsanswered is not served.
+ *     exist) or "Not started" (none do), both warning-colored laggards. A
+ *     response omitting the answered count reads as "Not started", the same
+ *     way the past-call branch treats it as zero.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -96,16 +97,16 @@ export function ProgressCell({
   // Zero updates splits two materially different states: carried-forward
   // answers awaiting confirmation vs no answers at all — a blanket "Not
   // updated" read as data loss to ISSOs who had just reviewed everything.
-  // questionsanswered may be absent until ztmf#437 is deployed everywhere;
-  // keep the legacy wording then rather than guessing.
-  const answered = entry.questionsanswered
+  // Coalesce as the past-call branch does, so both branches read the count the
+  // same way rather than one trusting the type and the other guarding against
+  // it. A response that omits the count describes a system with nothing
+  // recorded as answered, which is what "Not started" already says.
+  const answered = entry.questionsanswered ?? 0
   const label = updated
     ? 'Updated'
-    : answered == null
-      ? 'Not updated'
-      : answered > 0
-        ? 'Awaiting confirmation'
-        : 'Not started'
+    : answered > 0
+      ? 'Awaiting confirmation'
+      : 'Not started'
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -29,9 +29,7 @@ export function hasNoQuestionnaire(entry: ScoreProgress | undefined): boolean {
  * For a PAST call the "-1 needs a nudge" ranking is wrong - a closed call has no
  * updates to chase, so ranking by questionsupdated would sort every historical
  * row to the laggard top, contradicting its own Complete/Incomplete chip. Past
- * calls are ranked by completion (answered/total) instead, never -1. Prefer
- * QuestionsAnswered (ztmf#437); without it, a past-call row with progress is
- * treated as complete (1) so it never ranks as urgent.
+ * calls are ranked by completion (answered/total, ztmf#437) instead, never -1.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
  * @param {boolean} [isCurrentCall=true] - Whether the row's displayed call is
  *   the current/active one. Past calls sort by completion, not updates.
@@ -44,9 +42,10 @@ export function progressSortValue(
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
   if (!isCurrentCall) {
-    const answered = entry.questionsanswered
-    if (answered == null) return 1
-    return Math.min(Math.max(answered, 0) / entry.questionsexpected, 1)
+    return Math.min(
+      Math.max(entry.questionsanswered, 0) / entry.questionsexpected,
+      1
+    )
   }
   if (entry.questionsupdated <= 0) return -1
   return entry.questionsupdated / entry.questionsexpected

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -42,8 +42,14 @@ export function progressSortValue(
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
   if (!isCurrentCall) {
+    // Coalesce before the arithmetic. The type says the field is always served,
+    // but a response that omits it would otherwise produce NaN here, and a NaN
+    // sort key compares equal to every other row, so the row lands in an
+    // arbitrary position rather than anywhere meaningful. Treating a missing
+    // count as zero ranks it with the genuinely unanswered, which is the
+    // honest reading and matches what the cell renders.
     return Math.min(
-      Math.max(entry.questionsanswered, 0) / entry.questionsexpected,
+      Math.max(entry.questionsanswered ?? 0, 0) / entry.questionsexpected,
       1
     )
   }


### PR DESCRIPTION
> **Note:** In-repo copy of #646 by @voidspooks (Cameron Testerman). Moved from the fork so Snyk
> and the deploy CI gates can run, since those jobs need org secrets that fork PRs cannot
> access. Commits and authorship are unchanged.
>
> Refs #646

---

Closes #578.

`ProgressCell` decided between a neutral "Complete" chip and an em dash for a past call by asking whether the system had any score row at all, passed down as `hasScore`. That proxy existed because `ScoreProgress` had no count of answered questions. ztmf#437 added one, so the cell can compare answered against expected directly and the proxy can go.

`questionsanswered` moves from optional to required on `ScoreProgress`, the `answered == null` fallback branches come out of `progressColumn.tsx` and `progressHelpers.ts`, and `FismaTable.tsx` stops passing `hasScore`. A past call now reads as "Complete" when fully answered and as an `answered/total` fraction with an "Incomplete" chip when partially answered, rather than collapsing both into "Complete".

## Why retiring the proxy is safe

`hasScore` was already redundant. `buildDashboardMaps` derives `systemIdxs` from the score map, and the chosen call is always one the system has scores in, so `scoreMap[sys]` is populated whenever `progressMap[sys]` is. The `!hasScore` branch inside the `answered == null` case was therefore unreachable in normal operation; it only did anything during the ztmf#437 deploy window when the backend genuinely omitted the field.

It is also a small improvement against a known failure mode. `hasScore` only asked whether a score row existed, and a system whose answers point at another environment's functions still produces one, so it read as "Complete" regardless. `questionsanswered` is computed through an INNER JOIN on `functionoptions` with the function's environment re-matched against the system's, so those answers are excluded from the numerator instead of counted.

## Added on top of the original commit

One extra commit, `73f3e25`, fixing a docblock paragraph the original left behind. The `States:` list was updated to the answered/expected rule, but the paragraph above it still said a past call with a score for that system was treated as completed, so the two contradicted each other in the same comment block. Comment-only, no behaviour change.

## Test plan

- [x] `npx jest src/views/FismaTable src/views/Home` — 75 passing
- [x] `tsc --noEmit` clean, `eslint` clean, `prettier --check` clean on the changed files
- [x] `0/0` still renders the neutral N/A chip, since `hasNoQuestionnaire()` short-circuits ahead of the past-call branch
- [ ] Dashboard spot check on dev: a fully answered past call reads Complete, a partially answered one reads the fraction with Incomplete

## Known follow-up, not addressed here

`questionsanswered` being required is enforced only by TypeScript. `Home.tsx` casts the response with `as ScoreProgress[]` rather than validating it, so if a row ever arrived without the field the cell would render the literal string `undefined/41` and `progressSortValue` would return `NaN`, leaving that row's sort position undefined. ztmf#437 has been live in prod since 2026-07-17, so the assumption holds today, but the last runtime guard against a contract violation is gone. A `Number.isFinite` check at ingestion that logs rather than renders would close it. Worth its own ticket rather than widening this one.
