### PR TITLE
Gate ZTMF Insights by the system's OpDiv instead of the data call name

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,12 @@ export type OpDiv = {
   // (defaults false), so every OpDiv resolves to a real boolean. Gates the
   // ISSO delegate self-service surface for systems in this OpDiv.
   system_delegate_enabled: boolean
+  // Per-OpDiv ZTMF Insights capability. When true, systems in this OpDiv
+  // surface the internal insights layer (panel, option badges, suggested
+  // justification) in the questionnaire. Backed by opdivs.insights_enabled;
+  // the backend serializes it from a nullable column, so treat a missing
+  // value as disabled.
+  insights_enabled?: boolean | null
 }
 
 // A system delegate as returned by GET /fismasystems/:id/delegates (the

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -150,6 +150,7 @@ const SSD_EX = {
   fismaacronym: 'SSD-EX',
   fismaname: 'Super Star Destroyer Executor Command Systems',
   datacenterenvironment: 'Imperial-Fleet',
+  opdiv_id: 9,
 }
 
 function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
@@ -771,9 +772,11 @@ test('the questionId effect reads live scores via ref and seeds the answer at mo
 
 // ---------------------------------------------------------------------------
 // 4. ZTMF Insights justification-field wiring (#527/#529).
-//    - HHS data calls render the review-aware JustificationField but hide the
-//      CMS-internal insights layer (panel, option badges, suggestion).
-//    - CMS data calls render both the JustificationField and the insights layer.
+//    - The insights layer (panel, option badges, suggestion) is gated on the
+//      SYSTEM's OpDiv (opdivs.insights_enabled), not the viewed call's name:
+//      an enabled OpDiv keeps its insights inside the unified HHS-named cycle
+//      (the FY2026 regression), and a disabled OpDiv never sees the layer.
+//    - The review-aware JustificationField renders regardless of OpDiv.
 //    - A carried-forward prior response blocks submission until reviewed, and
 //      the initial insights lookup blocks submission until it settles.
 //    - A question with no justification context keeps the plain notes field.
@@ -841,17 +844,44 @@ const HHS_ZTM = {
 const HHS_DEEP_LINK =
   '/questionnaire/ssd-ex/FY25_ZTM/identity/imperial-identity-verification'
 
+// SSD-EX (opdiv_id 9) belongs to the insights-enabled OpDiv; 2 is a disabled
+// OpDiv for the negative case.
+const OPDIV_ROWS = [
+  {
+    opdiv_id: 9,
+    code: 'CMS',
+    name: 'Centers for Medicare & Medicaid Services',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+    insights_enabled: true,
+  },
+  {
+    opdiv_id: 2,
+    code: 'ACF',
+    name: 'Administration for Children and Families',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+    insights_enabled: false,
+  },
+]
+
 describe('QuestionnairePage justification integration', () => {
   type InsightsResponse = { data: { data: unknown[] } }
 
   function installMocks({
     insightRows = [INSIGHT_ROW] as unknown[],
     insightsResponse,
+    opdivRows = OPDIV_ROWS as unknown[],
   }: {
     insightRows?: unknown[]
     insightsResponse?: Promise<InsightsResponse>
+    opdivRows?: unknown[]
   } = {}) {
     axios.get.mockImplementation((url: string) => {
+      if (url === '/opdivs')
+        return Promise.resolve({ data: { data: opdivRows } })
       if (url === 'insights') {
         return (
           insightsResponse ?? Promise.resolve({ data: { data: insightRows } })
@@ -869,7 +899,7 @@ describe('QuestionnairePage justification integration', () => {
     axios.put.mockResolvedValue({ data: {} })
   }
 
-  it('renders the justification field but hides the insights layer for an HHS data call, and persists an accepted prior response', async () => {
+  it('keeps the insights layer on an HHS-named call for an insights-enabled OpDiv, and persists an accepted prior response', async () => {
     installMocks()
     setMockCtx(
       makeCtx({
@@ -893,14 +923,16 @@ describe('QuestionnairePage justification integration', () => {
     // The FIPS baseline is a federal-wide concept and must appear for HHS too.
     expect(await screen.findByText('Low baseline')).toBeInTheDocument()
 
-    // The CMS-internal insights layer is suppressed for HHS calls.
-    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    // The insights layer follows the system's OpDiv, not the call name: an
+    // insights-enabled OpDiv keeps its panel inside the HHS-named cycle (the
+    // FY2026 single-call regression this gate change fixes).
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
     expect(
-      screen.queryByText('ZTMF Insights option badge')
-    ).not.toBeInTheDocument()
+      (await screen.findAllByText('ZTMF Insights option badge')).length
+    ).toBeGreaterThan(0)
     expect(
-      screen.queryByText('Suggested justification')
-    ).not.toBeInTheDocument()
+      await screen.findByText('Suggested justification')
+    ).toBeInTheDocument()
 
     const complete = screen.getByRole('button', { name: 'Complete' })
     expect(complete).toBeDisabled()
@@ -944,6 +976,28 @@ describe('QuestionnairePage justification integration', () => {
     expect(
       await screen.findByText("Last year's response — FY2025 Q1")
     ).toBeInTheDocument()
+  })
+
+  it('hides the insights layer when the system belongs to an insights-disabled OpDiv', async () => {
+    installMocks({
+      opdivRows: [{ ...OPDIV_ROWS[0], insights_enabled: false }, OPDIV_ROWS[1]],
+    })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    // The justification review context still renders...
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    // ...and the federal-wide FIPS baseline treatment stays.
+    expect(await screen.findByText('Low baseline')).toBeInTheDocument()
+    // ...but every insights surface is suppressed, regardless of call name.
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('ZTMF Insights option badge')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Suggested justification')
+    ).not.toBeInTheDocument()
   })
 
   it('blocks submission until the initial insights lookup settles', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -874,14 +874,16 @@ describe('QuestionnairePage justification integration', () => {
     insightRows = [INSIGHT_ROW] as unknown[],
     insightsResponse,
     opdivRows = OPDIV_ROWS as unknown[],
+    opdivsResponse,
   }: {
     insightRows?: unknown[]
     insightsResponse?: Promise<InsightsResponse>
     opdivRows?: unknown[]
+    opdivsResponse?: Promise<InsightsResponse>
   } = {}) {
     axios.get.mockImplementation((url: string) => {
       if (url === '/opdivs')
-        return Promise.resolve({ data: { data: opdivRows } })
+        return opdivsResponse ?? Promise.resolve({ data: { data: opdivRows } })
       if (url === 'insights') {
         return (
           insightsResponse ?? Promise.resolve({ data: { data: insightRows } })
@@ -997,6 +999,36 @@ describe('QuestionnairePage justification integration', () => {
     ).not.toBeInTheDocument()
     expect(
       screen.queryByText('Suggested justification')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the gate closed and submission blocked until the OpDiv lookup settles', async () => {
+    let resolveOpdivs: ((value: InsightsResponse) => void) | null = null
+    const opdivsResponse = new Promise<InsightsResponse>((resolve) => {
+      resolveOpdivs = resolve
+    })
+    installMocks({ opdivsResponse })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    // Insights rows resolved instantly, but the OpDiv capability list has
+    // not - the gate stays closed and the page still reads as pending, so
+    // the panel cannot pop in after the user has already advanced.
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    expect(
+      await screen.findByText('Checking for prior responses…')
+    ).toBeInTheDocument()
+    expect(complete).toBeDisabled()
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveOpdivs?.({ data: { data: OPDIV_ROWS } })
+    })
+
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Checking for prior responses…')
     ).not.toBeInTheDocument()
   })
 

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -335,7 +335,10 @@ export default function QuestionnarePage() {
     React.useState<Set<number> | null>(null)
   React.useEffect(() => {
     const controller = new AbortController()
-    fetchOpDivs(false, controller.signal)
+    // includeInactive: the backend serves insights rows for any
+    // insights-enabled OpDiv regardless of its active flag, so the UI gate
+    // must see inactive rows too or the two would diverge.
+    fetchOpDivs(true, controller.signal)
       .then((rows) =>
         setInsightsOpdivIds(
           new Set(
@@ -524,23 +527,26 @@ export default function QuestionnarePage() {
   // rendered and the page is unchanged.
   const currentDatabaseQuestionId =
     questionId != null ? questions[questionId]?.questionid : undefined
+  // Pending until BOTH lookups settle: the per-system insights rows and the
+  // per-OpDiv capability list the gate below keys on. Without the second
+  // condition a fast /insights response could enable Next/Complete before
+  // /opdivs resolves, letting the panel pop in after the user advanced.
   const insightsPending =
     !!system &&
-    (insightsLoadState.system !== system || !insightsLoadState.settled)
+    (insightsLoadState.system !== system ||
+      !insightsLoadState.settled ||
+      insightsOpdivIds === null)
   const currentInsight =
     insightsLoadState.system === system && currentDatabaseQuestionId != null
       ? insightsByQuestion.get(currentDatabaseQuestionId)
       : undefined
-  // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights UI
-  // (panel, suggestion). The carried-forward prior-response review still
-  // applies so a copied answer is affirmatively reviewed.
   // ZTMF Insights are a per-OpDiv capability (opdivs.insights_enabled), so
   // the gate keys on the SYSTEM's OpDiv. Gating on the viewed call's tenant
   // (the FY23-25 behavior) hid the layer for every system once FY2026 merged
-  // all OpDivs into a single HHS-named call.
-  const systemOpdivId =
-    fismaSystems.find((s) => s.fismasystemid === system)?.opdiv_id ??
-    decommissionedSystems?.find((s) => s.fismasystemid === system)?.opdiv_id
+  // all OpDivs into a single HHS-named call. The carried-forward
+  // prior-response review is deliberately NOT gated here, so a copied answer
+  // is affirmatively reviewed for every system regardless of OpDiv.
+  const systemOpdivId = systemInfo?.opdiv_id
   // Single source of truth for all internal insight UI gates.
   const showCmsInsights =
     systemOpdivId != null && (insightsOpdivIds?.has(systemOpdivId) ?? false)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -37,7 +37,7 @@ import {
   NOTES_UPDATE_REQUIRED_MSG,
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
-import { parseDatacallName } from '@/utils/datacallGrouping'
+import { fetchOpDivs } from '@/utils/opdivs'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
@@ -273,13 +273,14 @@ export default function QuestionnarePage() {
     // (per-option warn styling, divider, above-baseline badge/notice) that a flat
     // ChoiceList can't express.
     //
-    // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights layer.
-    // Always pass insight so the FIPS baseline markers (a federal-wide concept)
-    // render for all systems including HHS. showInsightBadges suppresses the
-    // CMS-specific option chips (suggested + prior-answer) for HHS calls while
-    // leaving the baseline treatment intact. The Insights panel, suggestion,
-    // and per-option insight badges are each separately gated (showInsights /
-    // showInsightSuggestion / showInsightBadges) — all derive from showCmsInsights.
+    // Systems whose OpDiv has insights disabled do not surface the internal
+    // ZTMF Insights layer. Always pass insight so the FIPS baseline markers (a
+    // federal-wide concept) render for every system regardless of OpDiv.
+    // showInsightBadges suppresses the insights option chips (suggested +
+    // prior-answer) for disabled OpDivs while leaving the baseline treatment
+    // intact. The Insights panel, suggestion, and per-option insight badges are
+    // each separately gated (showInsights / showInsightSuggestion /
+    // showInsightBadges) — all derive from showCmsInsights.
     return (
       <QuestionRadioGroup
         options={options}
@@ -322,6 +323,35 @@ export default function QuestionnarePage() {
   const [decommissionedSystems, setDecommissionedSystems] = React.useState<
     FismaSystemType[] | null
   >(null)
+  // OpDivs whose systems surface the internal ZTMF Insights layer
+  // (opdivs.insights_enabled - CMS today). Fetched once per page mount. The
+  // insights gate keys on the SYSTEM's OpDiv, not the viewed data call's
+  // name: the FY23-25 era used call tenant (CMS-named vs ZTM-named calls) as
+  // a proxy, which broke when FY2026 unified every OpDiv into one HHS-named
+  // call and silently hid the insights layer for every insights-enabled
+  // system. null = not loaded yet; the gate stays closed until it resolves,
+  // so the panel can appear late but never flashes for a disabled OpDiv.
+  const [insightsOpdivIds, setInsightsOpdivIds] =
+    React.useState<Set<number> | null>(null)
+  React.useEffect(() => {
+    const controller = new AbortController()
+    fetchOpDivs(false, controller.signal)
+      .then((rows) =>
+        setInsightsOpdivIds(
+          new Set(
+            rows
+              .filter((o) => o.insights_enabled === true)
+              .map((o) => o.opdiv_id)
+          )
+        )
+      )
+      .catch(() => {
+        // Insights are additive and optional; a failed lookup leaves the
+        // gate closed rather than surfacing an error.
+        if (!controller.signal.aborted) setInsightsOpdivIds(new Set())
+      })
+    return () => controller.abort()
+  }, [])
   const resolvedDecommissioned = React.useMemo(
     () => resolveSystemIdByAcronym(decommissionedSystems ?? [], fismaacronym),
     [decommissionedSystems, fismaacronym]
@@ -504,10 +534,16 @@ export default function QuestionnarePage() {
   // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights UI
   // (panel, suggestion). The carried-forward prior-response review still
   // applies so a copied answer is affirmatively reviewed.
-  const isHhsDatacall =
-    parseDatacallName(datacall.replaceAll('_', ' ')).tenant === 'HHS'
-  // Single source of truth for all CMS-internal insight UI gates.
-  const showCmsInsights = !isHhsDatacall
+  // ZTMF Insights are a per-OpDiv capability (opdivs.insights_enabled), so
+  // the gate keys on the SYSTEM's OpDiv. Gating on the viewed call's tenant
+  // (the FY23-25 behavior) hid the layer for every system once FY2026 merged
+  // all OpDivs into a single HHS-named call.
+  const systemOpdivId =
+    fismaSystems.find((s) => s.fismasystemid === system)?.opdiv_id ??
+    decommissionedSystems?.find((s) => s.fismasystemid === system)?.opdiv_id
+  // Single source of truth for all internal insight UI gates.
+  const showCmsInsights =
+    systemOpdivId != null && (insightsOpdivIds?.has(systemOpdivId) ?? false)
   const showInsights = Boolean(currentInsight) && showCmsInsights
   const currentSuggestion = showCmsInsights
     ? buildInsightJustification(currentInsight)


### PR DESCRIPTION
## Summary

ZTMF Insights (the panel, per-option badges, and suggested justification in the questionnaire) disappeared for every CMS system when the FY2026 data call opened. Nothing was wrong with the data: enrichment and insights rows were synced and current. The layer was hidden by a UI gate keyed to the viewed data call's name. Call names ending in "ZTM" parse as HHS-tenant, and the gate suppressed the insights layer on HHS calls. That proxy held while CMS worked in CMS-named calls (FY2023 Q4, FY2025 Q3), but FY2026 runs every OpDiv in a single HHS-named call, so the gate closed for everyone.

This re-keys the gate to the system's own OpDiv using the `insights_enabled` flag the OpDiv API already serves:

- The page fetches `GET /opdivs` once per mount and builds the set of insights-enabled OpDiv ids.
- `showCmsInsights` is now true when the current system's `opdiv_id` is in that set, on any data call. Systems in OpDivs without insights never see the layer, regardless of call name.
- The gate defaults closed until the lookup resolves, and the unresolved state is folded into `insightsPending`, so submission stays blocked until both the insights rows and the capability list have settled. The panel can appear late but can never flash for a disabled OpDiv or pop in after the user advanced.
- FIPS baseline markers are a federal-wide concept and remain ungated, as before.
- The carried-forward prior-response review remains ungated, so a copied answer is affirmatively reviewed for every system.

`fetchOpDivs` is called with `includeInactive` because the backend's insights data gate keys on `insights_enabled` alone, and the UI must not diverge from it.

## Testing

- The HHS-call justification test now expects the insights layer visible for an insights-enabled OpDiv; its carried-forward review flow and persistence assertions are unchanged.
- New test: a system in an insights-disabled OpDiv hides the panel, badges, and suggestion on a CMS-named call, proving the gate ignores the call name in both directions, while the review context and FIPS baseline still render.
- New test: the gate stays closed and Complete stays disabled while `/opdivs` is unresolved, then the panel appears once it settles.
- 245 tests pass across the questionnaire suites; typecheck and lint clean.

## Notes

Verified against a production clone: `opdivs.insights_enabled` is true for CMS only, and insights/enrichment rows exist only for CMS systems, so behavior for HHS OpDivs is unchanged.
