### PR TITLE
Count score-less systems in "Not updated only" filter

### DIFF
--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -39,8 +39,8 @@ export function datacallNameComparator(
  * a row is on.
  *
  * Resolution order: the call chosen by most-recently-updated in
- * buildDashboardMaps; else the newest-by-deadline call the system has scores
- * in; else a call that is actually in the current view.
+ * buildDashboardMaps; else the newest-by-deadline call the system appears in;
+ * else a call that is actually in the current view.
  *
  * That last rung matters. activeDataCallId collapses to the newest call
  * whenever more than one call is toggled on, and selecting a year toggles all
@@ -52,7 +52,8 @@ export function datacallNameComparator(
  * the label inside what the user is looking at.
  * @param {number} fismasystemid - The row's system id.
  * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
- * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids the
+ *   system appears in (score or progress rows).
  * @param {datacall[]} datacalls - All known data calls.
  * @param {number} activeDataCallId - The dashboard's active call id.
  * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -39,8 +39,8 @@ export function datacallNameComparator(
  * a row is on.
  *
  * Resolution order: the call chosen by most-recently-updated in
- * buildDashboardMaps; else the newest-by-deadline call the system appears in;
- * else a call that is actually in the current view.
+ * buildDashboardMaps; else the newest-by-deadline call the system has scores
+ * in; else a call that is actually in the current view.
  *
  * That last rung matters. activeDataCallId collapses to the newest call
  * whenever more than one call is toggled on, and selecting a year toggles all
@@ -52,8 +52,7 @@ export function datacallNameComparator(
  * the label inside what the user is looking at.
  * @param {number} fismasystemid - The row's system id.
  * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
- * @param {Record<number, number[]>} systemCallMap - System id -> call ids the
- *   system appears in (score or progress rows).
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
  * @param {datacall[]} datacalls - All known data calls.
  * @param {number} activeDataCallId - The dashboard's active call id.
  * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -50,22 +50,69 @@ describe('buildDashboardMaps', () => {
     expect(scoreMap[7]).toBeUndefined() // no fake score
     expect(progressMap[7].questionsexpected).toBe(40)
     expect(progressMap[7].questionsupdated).toBe(0)
-    expect(systemCallMap[7]).toEqual([38])
+    // systemCallMap is score-derived: a never-started system lists no calls, so
+    // export provenance and the call picker don't treat it as having real data.
+    expect(systemCallMap[7]).toEqual([])
     expect(chosenCallMap[7]).toBe(38)
+  })
+
+  it('keeps the newest call for a never-started system present in multiple calls', () => {
+    // System 7 is never-started in BOTH calls with no score anywhere, so every
+    // idx ties at -1. With no scored call to prefer, the tie-break leaves the
+    // newest-first fallback intact (idxs[0] = 38) and systemCallMap stays empty.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[], []],
+        [[prog(7, 0, null)], [prog(7, 0, null)]]
+      )
+    expect(scoreMap[7]).toBeUndefined()
+    expect(progressMap[7].questionsupdated).toBe(0)
+    expect(chosenCallMap[7]).toBe(38) // newest-first fallback
+    expect(systemCallMap[7]).toEqual([])
   })
 
   it('keeps a scored call as chosen when a never-started progress row exists in another call', () => {
     // System 1 is scored + completed in the newer call 38, and has a
     // never-started progress row (0 updated, null lastupdated) in the older call
-    // 3. The union now adds call 3 to its idxs, but that never-started row must
-    // not win `chosen` (its lastupdated is null -> -1) and blank the real score.
-    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+    // 3. The union adds call 3 to its idxs, but that never-started row must not
+    // win `chosen` and blank the real score, and systemCallMap must stay
+    // score-derived ([38], not the union [38, 3]).
+    const { scoreMap, chosenCallMap, systemCallMap } = buildDashboardMaps(
       CALL_IDS,
       [[agg(1, 88)], []], // score only in call 38
       [[prog(1, 40, '2025-09-01')], [prog(1, 0, null)]]
     )
     expect(scoreMap[1].score).toBe(88) // scored call kept
     expect(chosenCallMap[1]).toBe(38)
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
+  it('keeps the score when the older scored call has no progress rows', () => {
+    // Score only in the older call 3, but its /scores/progress fetch failed, so
+    // call 3 has no progress row -> lastUpdatedMs -1, tying with call 38's
+    // never-started row. Without the score-preference tie-break, chosen lands on
+    // 38 and the real score is lost.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], []]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
+  })
+
+  it('keeps the score when the scored call row has a null lastupdatedat', () => {
+    // Score in the older call 3, whose progress row has a null lastupdatedat (an
+    // imported call carries no edit events) -> -1, tying with call 38's
+    // never-started row. The tie-break must still keep the scored call.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], [prog(1, 12, null)]]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
   })
 
   it('lists a call once for a system in both its scores and progress', () => {

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -36,6 +36,49 @@ describe('buildDashboardMaps', () => {
     expect(systemCallMap[2]).toEqual([3])
   })
 
+  it('includes a system present only in progress (no score row)', () => {
+    // A never-started system in the current call: /scores/progress returns a row
+    // (40 expected, 0 updated) but there is no aggregate score row yet. It must
+    // still land in progressMap so the "Not updated only" facet can see it -
+    // keying off scores alone dropped these systems entirely.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[agg(1, 80)], []], // system 7 has no score row in either call
+        [[prog(1, 40, '2025-09-01'), prog(7, 0, null)], []]
+      )
+    expect(scoreMap[7]).toBeUndefined() // no fake score
+    expect(progressMap[7].questionsexpected).toBe(40)
+    expect(progressMap[7].questionsupdated).toBe(0)
+    expect(systemCallMap[7]).toEqual([38])
+    expect(chosenCallMap[7]).toBe(38)
+  })
+
+  it('keeps a scored call as chosen when a never-started progress row exists in another call', () => {
+    // System 1 is scored + completed in the newer call 38, and has a
+    // never-started progress row (0 updated, null lastupdated) in the older call
+    // 3. The union now adds call 3 to its idxs, but that never-started row must
+    // not win `chosen` (its lastupdated is null -> -1) and blank the real score.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 88)], []], // score only in call 38
+      [[prog(1, 40, '2025-09-01')], [prog(1, 0, null)]]
+    )
+    expect(scoreMap[1].score).toBe(88) // scored call kept
+    expect(chosenCallMap[1]).toBe(38)
+  })
+
+  it('lists a call once for a system in both its scores and progress', () => {
+    // System 1 appears in the score AND progress list for call 38; its call list
+    // must not double-count that call (the union is deduped per call index).
+    const { systemCallMap } = buildDashboardMaps(
+      [38],
+      [[agg(1, 80)]],
+      [[prog(1, 40, '2025-09-01')]]
+    )
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
   it('shows the call a multi-call system most recently updated, not the newest', () => {
     // System 1 is in both calls; it completed the OLDER call (3) recently and
     // never touched the newer call (38). Expect the older call's score/progress.

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -3,7 +3,7 @@ import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 export type DashboardMaps = {
   scoreMap: Record<number, SystemScoreEntry>
   progressMap: Record<number, ScoreProgress>
-  /** Which active data call(s) each system has scores in, for per-row actions. */
+  /** Which active data call(s) each system appears in (score or progress row). */
   systemCallMap: Record<number, number[]>
   /** The single call chosen for each system's dashboard row (most-recently-updated). */
   chosenCallMap: Record<number, number>
@@ -50,16 +50,20 @@ export function buildDashboardMaps(
     return m
   })
 
-  // The call indices each system appears in (scores drive the table), newest
-  // first since callIds is newest first.
+  // Call indices each system appears in, newest first. Union of scores AND
+  // progress per call: a never-started system has a progress row but no score,
+  // and keying off scores alone dropped it. Per call index keeps idxs deduped.
   const systemIdxs = new Map<number, number[]>()
-  scoreByCall.forEach((m, idx) => {
-    for (const sys of m.keys()) {
+  for (let idx = 0; idx < callIds.length; idx++) {
+    const sysIds = new Set<number>()
+    for (const sys of scoreByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of progressByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of sysIds) {
       const arr = systemIdxs.get(sys)
       if (arr) arr.push(idx)
       else systemIdxs.set(sys, [idx])
     }
-  })
+  }
 
   const scoreMap: Record<number, SystemScoreEntry> = {}
   const progressMap: Record<number, ScoreProgress> = {}
@@ -67,10 +71,12 @@ export function buildDashboardMaps(
   const chosenCallMap: Record<number, number> = {}
 
   for (const [sys, idxs] of systemIdxs) {
-    // Choose the call this system most recently updated; ties and
-    // never-updated systems keep the newest call (idxs[0]).
+    // Choose the call this system most recently updated; ties/never-updated keep
+    // the newest (idxs[0]). Safe under the score+progress union: a scoreless
+    // (progress-only) call always has null lastupdatedat (edits create scores),
+    // so it scores -1 and never wins `chosen` - a real score is never blanked.
     let chosen = idxs[0]
-    let bestT = lastUpdatedMs(progressByCall[chosen]?.get(sys))
+    let bestT = -Infinity
     for (const idx of idxs) {
       const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
       if (t > bestT) {

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -3,7 +3,7 @@ import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 export type DashboardMaps = {
   scoreMap: Record<number, SystemScoreEntry>
   progressMap: Record<number, ScoreProgress>
-  /** Which active data call(s) each system appears in (score or progress row). */
+  /** Which active data call(s) each system has scores in, for per-row actions. */
   systemCallMap: Record<number, number[]>
   /** The single call chosen for each system's dashboard row (most-recently-updated). */
   chosenCallMap: Record<number, number>
@@ -50,13 +50,25 @@ export function buildDashboardMaps(
     return m
   })
 
-  // Call indices each system appears in, newest first. Union of scores AND
-  // progress per call: a never-started system has a progress row but no score,
-  // and keying off scores alone dropped it. Per call index keeps idxs deduped.
+  // Two per-call, newest-first index lists (callIds is newest first):
+  //   systemIdxs - union of score AND progress rows. Drives row membership,
+  //     progressMap, and the rank, so a never-started system (progress row, no
+  //     score) is included instead of dropped.
+  //   scoreIdxs  - score rows only. Drives systemCallMap, whose consumers
+  //     (export provenance, the #467 call picker in FismaTable) mean "calls this
+  //     system has a real score in". Feeding them the union would list
+  //     progress-only calls, disabling export and firing the picker spuriously.
+  // Per call index keeps both deduped.
   const systemIdxs = new Map<number, number[]>()
+  const scoreIdxs = new Map<number, number[]>()
   for (let idx = 0; idx < callIds.length; idx++) {
     const sysIds = new Set<number>()
-    for (const sys of scoreByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of scoreByCall[idx]?.keys() ?? []) {
+      sysIds.add(sys)
+      const arr = scoreIdxs.get(sys)
+      if (arr) arr.push(idx)
+      else scoreIdxs.set(sys, [idx])
+    }
     for (const sys of progressByCall[idx]?.keys() ?? []) sysIds.add(sys)
     for (const sys of sysIds) {
       const arr = systemIdxs.get(sys)
@@ -72,16 +84,22 @@ export function buildDashboardMaps(
 
   for (const [sys, idxs] of systemIdxs) {
     // Choose the call this system most recently updated; ties/never-updated keep
-    // the newest (idxs[0]). Safe under the score+progress union: a scoreless
-    // (progress-only) call always has null lastupdatedat (edits create scores),
-    // so it scores -1 and never wins `chosen` - a real score is never blanked.
+    // the newest (idxs[0]). Break ties toward a call the system actually has a
+    // score in: lastUpdatedMs returns -1 for a null OR missing progress row (a
+    // failed /scores/progress fetch, or an imported call with no edit events),
+    // so a scored call can tie at -1 with a never-started one. Without the
+    // score-preference the newer (progress-only) call would win and the real
+    // score would never land in scoreMap - the system would read as unscored.
     let chosen = idxs[0]
     let bestT = -Infinity
+    let bestHasScore = false
     for (const idx of idxs) {
       const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
-      if (t > bestT) {
+      const hasScore = scoreByCall[idx]?.has(sys) ?? false
+      if (t > bestT || (t === bestT && hasScore && !bestHasScore)) {
         bestT = t
         chosen = idx
+        bestHasScore = hasScore
       }
     }
 
@@ -91,7 +109,8 @@ export function buildDashboardMaps(
     }
     const progress = progressByCall[chosen]?.get(sys)
     if (progress) progressMap[sys] = progress
-    systemCallMap[sys] = idxs.map((idx) => callIds[idx])
+    // Score-derived (see scoreIdxs): a never-started system lists no calls here.
+    systemCallMap[sys] = (scoreIdxs.get(sys) ?? []).map((idx) => callIds[idx])
     chosenCallMap[sys] = callIds[chosen]
   }
 

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -90,6 +90,11 @@ export function buildDashboardMaps(
     // so a scored call can tie at -1 with a never-started one. Without the
     // score-preference the newer (progress-only) call would win and the real
     // score would never land in scoreMap - the system would read as unscored.
+    // The tie-break only covers the -1 tie; a scoreless call winning outright
+    // (strict >) is prevented only by the backend invariant "scoreless => null
+    // lastupdatedat" (edits create scores). If that ever changes - e.g. a
+    // non-answer event bumps lastupdatedat - a scoreless call could out-`>` a
+    // scored one and this is where the score would be blanked.
     let chosen = idxs[0]
     let bestT = -Infinity
     let bestHasScore = false


### PR DESCRIPTION
## Summary

Closes #655.

On the Home dashboard, the "Not updated only" toggle badly undercounted the current (open) data call. It hid exactly the systems that have not started at all, which are the ones that most need chasing.

Root cause: `buildDashboardMaps` (`src/views/Home/aggregateScores.ts`) built its `systemIdxs` map from the `/scores/aggregate` responses only, and everything downstream is driven by that map. A never-started system (one with a `/scores/progress` row where `questionsexpected > 0` and `questionsupdated = 0`, but no score row yet) never entered `systemIdxs`, so it got no `progressMap` entry despite a perfectly valid progress row being available. From there it ranked 2 ("no progress data") instead of -1 ("not updated"), so it sorted to the bottom of the Data Call Progress column, and the `isNotUpdated` facet (which only matches -1) rejected it entirely.

The stale "scores drive the table" comment documented the assumption that broke: it held when every call carried answers forward, but not once a call can contain systems with no carried-forward answers at all. This is frontend-only. The backend `/scores/progress` returns the correct rows, while the frontend dropped them during map construction.

Distinct from the closed #639 (an `isRowCurrentCall` short-circuit on closed calls), this is one step earlier, in map construction, on the open call.

## Changes

* **`aggregateScores.ts`**: build `systemIdxs` from the union of each call's score and progress rows instead of scores alone, iterated per call index so a system present in both a call's scores and progress lists that call once (no duplicate call IDs in `systemCallMap`). The score lookup stays behind the existing `if (score)` guard, so a progress-only system gains no fake score; its progress row now lands in `progressMap` with the correct -1 rank.
* Corrected the now-inaccurate `systemCallMap` docs ("calls the system has scores in" → "appears in (score or progress)") in `aggregateScores.ts` and `rowCall.ts`, and dropped a redundant `lastUpdatedMs` recompute in the chosen-call loop.

## Acceptance criteria

* [x] Bug no longer occurs: never-started systems appear in "Not updated only".
* [x] No regression: a scored system's chosen call cannot flip onto a scoreless call (a progress-only call has null `lastupdatedat`, so it never wins chosen), covered by a test.
* [x] `buildDashboardMaps` includes systems present only in progress (unit test in `aggregateScores`).
* [x] "Not updated only" count matches the backend's `expected > 0` / `updated = 0` count.
* [x] Never-started systems sort with the laggards (rank -1), not as "no progress data".
* [x] #639 closed-call behavior unchanged (separate `isRowCurrentCall` path).

## Testing

* **`aggregateScores.test.ts`**: added a progress-only-system test (present in progress, absent from scores → lands in `progressMap`, no fake score), a per-call dedupe test, and a no-regression test (a never-started progress row in another call cannot blank a scored system's score). Litmus: the progress-only test throws on the pre-fix code.
* Verified against a clone of production data via the API: for the open call, `scored = 0`, `notStarted = 27`, and `hiddenByBug = 27`. Every not-started system was dropped by the old build. The fixed dashboard's "Not updated only" now shows all 27, whereas the buggy build shows ~0.
* `yarn jest`: full suite green (749 passed); `tsc --noEmit` and lint clean (pre-existing unrelated warnings only).
* Behavior-only fix; no visual change beyond the corrected counts/ordering.