### PR TITLE
fix(#661): unlock the ISSO Name control for write admins

### DIFF
--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -223,6 +223,24 @@ describe('buildExtendedDiff', () => {
     expect(buildExtendedDiff(base, base, KEYS)).toEqual({})
   })
 
+  // isso_name is the one extended field whose displayed value can be resolved
+  // by the backend rather than stored, so the form is seeded with a name that
+  // is not in the column. Omitting it while untouched is what stops an
+  // unrelated edit from persisting the resolved name as a stored override.
+  it('omits an untouched isso_name that was resolved rather than stored', () => {
+    const keys = [...KEYS, 'isso_name'] as (keyof FismaSystemType)[]
+    const loaded = {
+      ...base,
+      isso_name: 'Resolved From User Record',
+    } as unknown as FismaSystemType
+    const edited = { ...loaded, fips: 'High' } as FismaSystemType
+
+    const diff = buildExtendedDiff(edited, loaded, keys)
+
+    expect(diff).toEqual({ fips: 'High' })
+    expect(diff).not.toHaveProperty('isso_name')
+  })
+
   it('includes only changed fields, at their typed value', () => {
     const edited = { ...base, fips: 'High', hva: false } as FismaSystemType
     expect(buildExtendedDiff(edited, base, KEYS)).toEqual({

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -167,6 +167,13 @@ export function formatList(v: string[] | null | undefined): string {
  * array []) passes through as the user's clear. On create, pass an empty
  * baseline so only the fields the user set are sent.
  *
+ * Omission is what protects a field the backend resolves rather than stores:
+ * the System Details form is seeded from a read that returns a resolved
+ * isso_name, so an untouched field must stay out of the payload or saving an
+ * unrelated edit would persist the resolved name as a stored override. A
+ * missing baseline defeats that, since every field then counts as changed;
+ * pass an empty system on create and a real one on update, never null.
+ *
  * @param edited - The edited system.
  * @param baseline - The system to diff against (the loaded system, or an empty
  *   one when creating); a missing baseline treats every field as unset.

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -140,6 +140,64 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
   expect(putBody).not.toHaveProperty('cloud_service_model')
 })
 
+test('an edited ISSO Name is sent in the save payload', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  expect(putBody).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name saves an empty string, which restores the derived name', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // '' clears the stored override so the name derived from the ISSO user
+  // record applies again; null would read as "leave unchanged".
+  expect(putBody).toHaveProperty('isso_name', '')
+})
+
 test('clearing a free-text field saves an empty string, not null', async () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   let putBody: Record<string, unknown> | undefined

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -181,7 +181,8 @@ export default function EditSystemModal({
   // or free text. Each control stores the field's typed clear signal when
   // emptied: enum '', boolean null, array [].
   const renderExtendedControl = (field: FieldConfig) => {
-    // isso_name is backend-resolved, so its control is read-only.
+    // A field marked read-only in fieldConfig renders disabled; the same flag
+    // keeps it out of the write payload.
     const disabled = field.readOnly
     if (field.type === 'select') {
       const current = editedFismaSystem[field.key] as string | null | undefined

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -137,6 +137,30 @@ test('setting the boolean to Unknown emits null (the clear signal)', async () =>
   expect(onFieldChange).toHaveBeenCalledWith('hva', null)
 })
 
+test('ISSO Name renders as an editable control with its override guidance', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  expect(screen.getByRole('textbox', { name: 'ISSO Name' })).toBeEnabled()
+  // The guidance is what tells an admin that a typed name is a permanent
+  // override and that clearing returns the derived name.
+  expect(
+    screen.getByText(/overrides the name from the ISSO's user account/i)
+  ).toBeInTheDocument()
+})
+
+test('clearing ISSO Name emits the empty-string clear signal', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  const user = userEvent.setup()
+  const { onFieldChange } = renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  await user.clear(screen.getByRole('textbox', { name: 'ISSO Name' }))
+
+  // '' clears the stored override via blankToNil, restoring the name the
+  // backend derives from the ISSO user record; null would leave it unchanged.
+  expect(onFieldChange).toHaveBeenCalledWith('isso_name', '')
+})
+
 test('cloud dependents are hidden while cloud_system is No', () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   renderEditView({ cloud_system: false })

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -662,8 +662,8 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
       </Grid>
 
       {/* Extended Metadata — full width, 3-col grid. Standard system
-          attributes editable across all OpDivs. isso_name is display-only
-          (backend-resolved), so it renders disabled. */}
+          attributes editable across all OpDivs. A field marked read-only in
+          fieldConfig renders disabled. */}
       <Grid item xs={12}>
         <Card variant="outlined">
           <CardHeader

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -113,6 +113,10 @@ function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
       role,
     } as userData,
     datacenterEnvironments: [],
+    // The page refetches after a save instead of echoing its draft, so both of
+    // these have to be present or the save path throws.
+    fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
+    showDecommissioned: false,
   }
   return renderWithProviders(
     <Routes>
@@ -204,6 +208,48 @@ test('clearing ISSO Name sends the empty-string clear signal', async () => {
   // '' clears the stored override via blankToNil so the name derived from the
   // ISSO user record applies again; null would read as "leave unchanged".
   expect(captured.body).toHaveProperty('isso_name', '')
+})
+
+// The saved value of isso_name is resolved by the backend, so the draft the
+// page sent is not the truth once the field was cleared. Echoing the draft into
+// shared state would render the cleared field as empty instead of the derived
+// name, so the page has to refetch and must not write the draft.
+test('clearing ISSO Name refetches instead of echoing the draft', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(false)
+  )
+  expect(mockCtx.setFismaSystems).not.toHaveBeenCalled()
+})
+
+// A save must not silently change which systems the dashboard lists, so the
+// refetch carries the caller's current decommissioned view mode.
+test('the post-save refetch preserves the decommissioned view mode', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+  mockCtx.showDecommissioned = true
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(true)
+  )
 })
 
 test('an untouched ISSO Name is omitted from the save payload', async () => {

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -1,0 +1,223 @@
+// Role coverage for the ISSO Name control on the System Details page, plus the
+// two write signals it can send. The page-level isAdmin gate is the only gate
+// on the field: the whole edit surface (the Edit button and the edit view) is
+// admin-only, so the write-admin tiers get the control and every other tier
+// never reaches an editable form at all. A typed name is a permanent override
+// of the name derived from the ISSO user record; the empty string clears the
+// override.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+import MockAdapter from 'axios-mock-adapter'
+import SystemDetailPage from './SystemDetailPage'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, UserRole, userData } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+
+const SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  fismauid: 'UID-42',
+  component: 'CMS',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: 'admiral.piett@executor.empire',
+  datacallcontact: 'captain.needa@executor.empire',
+  opdiv_id: 1,
+  decommissioned: false,
+  // Both enrichment (ZTMF Insights) and the delegates roster are gated off in
+  // this fixture so the page's only network reads are opdivs and the
+  // system-attribute vocabulary.
+  sdl_sync_enabled: false,
+  isso_name: 'Conan Antonio Motti',
+  hva: null,
+  fips: null,
+  system_type: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+const WRITE_ADMIN_ROLES: UserRole[] = [
+  'OWNER',
+  'HHS_ADMIN',
+  'OPDIV_ADMIN',
+  'ADMIN',
+]
+
+const NON_WRITE_ROLES: UserRole[] = [
+  'HHS_READONLY_ADMIN',
+  'OPDIV_READONLY_ADMIN',
+  'READONLY_ADMIN',
+  'ISSO',
+  'ISSM',
+  'SYSTEM_DELEGATE',
+]
+
+beforeEach(() => {
+  mock.reset()
+  mock
+    .onGet('/opdivs')
+    .reply(200, {
+      data: [
+        {
+          opdiv_id: 1,
+          code: 'CMS',
+          name: 'CMS',
+          active: true,
+          system_delegate_enabled: false,
+        },
+      ],
+    })
+    .onGet('/systemattributes')
+    .reply(200, { data: [] })
+})
+
+/**
+ * Renders the page for a system owned by the given role, on the route the
+ * page reads :fismasystemid from.
+ */
+function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
+  mockCtx = {
+    fismaSystems: [system],
+    setFismaSystems: jest.fn(),
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    datacenterEnvironments: [],
+  }
+  return renderWithProviders(
+    <Routes>
+      <Route path="/systems/:fismasystemid" element={<SystemDetailPage />} />
+    </Routes>,
+    { initialEntries: ['/systems/42'] }
+  )
+}
+
+/**
+ * The page-level Edit buttons currently on screen. The target-maturity card
+ * renders its own Edit button in view mode (for admins and for an assigned
+ * ISSO/ISSM), so match the header button by its CMS design-system class to keep
+ * the two apart: only the header one opens the system form.
+ */
+function pageEditButtons(): HTMLElement[] {
+  return screen
+    .queryAllByRole('button', { name: 'Edit' })
+    .filter((button) => button.classList.contains('ds-c-button'))
+}
+
+/** Captures the body of the page's full-system PUT. */
+function captureSave() {
+  const captured: { body?: Record<string, unknown> } = {}
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    captured.body = JSON.parse(config.data)
+    return [200, {}]
+  })
+  return captured
+}
+
+test.each(WRITE_ADMIN_ROLES)(
+  'ISSO Name is an editable control for %s',
+  async (role) => {
+    const user = userEvent.setup()
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    await user.click(pageEditButtons()[0])
+
+    expect(
+      await screen.findByRole('textbox', { name: 'ISSO Name' })
+    ).toBeEnabled()
+  }
+)
+
+test.each(NON_WRITE_ROLES)(
+  '%s gets no system-form edit affordance and no ISSO Name control',
+  async (role) => {
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    expect(pageEditButtons()).toHaveLength(0)
+    // The read view is the only view these tiers reach, and it renders every
+    // field as text, so there is no control to disable.
+    expect(
+      screen.queryByRole('textbox', { name: 'ISSO Name' })
+    ).not.toBeInTheDocument()
+  }
+)
+
+test('an edited ISSO Name is sent in the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  expect(captured.body).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name sends the empty-string clear signal', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // '' clears the stored override via blankToNil so the name derived from the
+  // ISSO user record applies again; null would read as "leave unchanged".
+  expect(captured.body).toHaveProperty('isso_name', '')
+})
+
+test('an untouched ISSO Name is omitted from the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // The detail page shows the resolved name, so sending it back unedited would
+  // persist a derived name as an override on any unrelated save.
+  expect(captured.body).not.toHaveProperty('isso_name')
+})

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -45,8 +45,14 @@ import SystemDelegatesSection from './SystemDelegatesSection'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const { fismaSystems, setFismaSystems, userInfo, datacenterEnvironments } =
-    useContextProp()
+  const {
+    fismaSystems,
+    setFismaSystems,
+    userInfo,
+    datacenterEnvironments,
+    fetchFismaSystems,
+    showDecommissioned,
+  } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
@@ -362,11 +368,18 @@ export default function SystemDetailPage() {
       )
 
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-      setFismaSystems((prev) =>
-        prev.map((s) =>
-          s.fismasystemid !== editedSystem.fismasystemid ? s : editedSystem
-        )
-      )
+      // Refetch rather than echoing the local draft into state. The PUT returns
+      // no body, and the saved value of a field the backend resolves is not the
+      // value that was sent: clearing isso_name stores NULL, and the list read
+      // then resolves the name from the ISSO's user record. Echoing the draft
+      // would show the cleared field as empty until the next fetch.
+      //
+      // The caller's decommissioned view mode is preserved so saving does not
+      // change which systems the dashboard lists. That mode can exclude the
+      // system just saved, so clearing triedFetch lets the single-system
+      // fallback re-add it.
+      triedFetch.current = false
+      await fetchFismaSystems(showDecommissioned)
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -337,6 +337,16 @@ export default function SystemDetailPage() {
 
   const handleSave = async () => {
     if (!editedSystem) return
+    // The extended-metadata payload is a diff against the loaded system, and
+    // buildExtendedDiff treats a missing baseline as "every field is unset",
+    // which sends all of them. editedSystem outlives the system it was seeded
+    // from, so saving without a baseline would persist values the user never
+    // touched, including an ISSO name the backend derived rather than stored.
+    // Refuse the save rather than writing a payload built from no baseline.
+    if (!system) {
+      notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+      return
+    }
     setIsSaving(true)
     try {
       // Full-system PUT. The page-level Edit button is gated on isAdmin,

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -11,11 +11,12 @@ export interface FieldConfig {
   required: boolean
   type: FieldType
   // Display-only: rendered but never editable and excluded from the write
-  // payload. Used for values the backend resolves/owns (e.g. isso_name).
+  // payload. For a value whose only writer is the backend.
   readOnly?: boolean
-  // Short guidance shown under the control while editing. For terms of art
-  // whose label alone is ambiguous or easily misread. Rendered only when set;
-  // there is no backend dependency, the copy lives here.
+  // Short guidance shown under the control while editing. For a label that is
+  // ambiguous or easily misread on its own, or a value whose write semantics
+  // need saying at the point of edit. Rendered only when set; there is no
+  // backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
   // its read-view text). For a field whose label reads ambiguously against a
@@ -109,16 +110,17 @@ export const fieldConfigs: FieldConfig[] = [
   },
 
   // Extended Metadata section. Standard system attributes editable by any
-  // write admin across all OpDivs. isso_name is the exception: the backend
-  // resolves it (from the ISSO user record for CMS, from the import for HHS),
-  // so it is display-only here and the edit form still edits issoemail.
+  // write admin across all OpDivs. A stored isso_name overrides the name the
+  // backend derives from the ISSO user record, and the empty string clears the
+  // stored value so the derived name applies again.
   {
     key: 'isso_name',
     label: 'ISSO Name',
     section: 'extended',
     required: false,
     type: 'text',
-    readOnly: true,
+    helpText:
+      "A name entered here overrides the name from the ISSO's user account. Clear the field to show that name again.",
   },
   {
     key: 'hva',
@@ -204,10 +206,9 @@ export function getFieldsBySection(section: FieldSection): FieldConfig[] {
 }
 
 // Single source of truth for the extended metadata write list. Derived from the
-// `extended` section above (excluding read-only fields like isso_name) so a
-// field added to fieldConfig can't silently render-but-not-save, and a
-// display-only field can't silently be written (the modal/detail PUT loops
-// consume this).
+// `extended` section above (excluding read-only fields) so a field added to
+// fieldConfig can't silently render-but-not-save, and a display-only field
+// can't silently be written (the modal/detail PUT loops consume this).
 export const EXTENDED_METADATA_KEYS: (keyof FismaSystemType)[] = fieldConfigs
   .filter((f) => f.section === 'extended' && !f.readOnly)
   .map((f) => f.key)

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -109,10 +109,12 @@ export const fieldConfigs: FieldConfig[] = [
     type: 'email',
   },
 
-  // Extended Metadata section. Standard system attributes editable by any
-  // write admin across all OpDivs. A stored isso_name overrides the name the
-  // backend derives from the ISSO user record, and the empty string clears the
-  // stored value so the derived name applies again.
+  // Extended Metadata section. The system attributes below are writable only by
+  // an unscoped admin; the backend restores the stored values over anything an
+  // OpDiv-scoped admin sends for them. isso_name is the exception, writable by
+  // any write admin: a stored value overrides the name the backend derives from
+  // the ISSO user record, and the empty string clears it so the derived name
+  // applies again.
   {
     key: 'isso_name',
     label: 'ISSO Name',


### PR DESCRIPTION
Closes #661

## Merge ordering

Ready for review and for CI. The one constraint is on the **merge**, not on the review: the backend carve-out in CMS-Enterprise/ztmf#511 has to be deployed first. Merging this ahead of it would give an OpDiv admin an editable field, a success toast, and a discarded write, which is the same defect already tracked as #651. `#511` is approved and green, so the sequence is its merge and deploy, then this one.

Reviewing and deploying this branch to dev in the meantime is useful rather than just harmless. Dev's backend is currently running `#511`'s branch, since dev deploys from whichever PR branch last landed there, so the whole flow can be exercised end to end on dev right now: correct a name as an OpDiv admin, confirm it persists, clear it, confirm the derived name comes back. That holds until some other backend PR deploys to dev and replaces it.

One behavior change here is not scoped to this field and is worth a reviewer's attention: the post-save refetch below fires on **every** system save, not only an ISSO Name edit. It replaces an in-place state update with a list refetch, so each save now costs one additional GET.

## What was wrong

`fieldConfig.ts` marked the `isso_name` entry `readOnly: true`. That one flag did two things: it rendered the control disabled on both the System Details edit view and the Edit System modal, and it excluded the key from `EXTENDED_METADATA_KEYS`, the derived write list both PUT paths iterate. So the field was absent from the request body, not merely greyed out, and a stale ISSO name could not be corrected through the UI by anyone.

The original reasoning was sound when written: the backend resolves the name, so the form edited `issoemail` and let the name follow. That holds only where the stored column is NULL. Where the onboarding import populated it, the stored value shadows the email lookup and editing the email changes nothing visible.

## The change

Drop the flag from that one entry and add help text at the point of edit, since the semantics are not guessable: a name typed here becomes a stored override of the name derived from the ISSO's user record, and clearing the field is what restores the derived name.

`readOnly` stays a supported concept on `FieldConfig` and in the write-list derivation, so a genuinely backend-owned field added later still gets the same protection. No entry currently uses it, which is worth knowing if someone adds one.

**No new permission gate.** The whole detail-page edit surface is already gated on `isAdmin`, which is `OWNER` / `HHS_ADMIN` / `OPDIV_ADMIN` plus the legacy `ADMIN`, so the read-only admin tiers, `ISSO`, `ISSM`, and `SYSTEM_DELEGATE` cannot reach an editable system form at all. Tests pin that per role rather than adding a second gate that could drift from the first.

Worth knowing for anyone extending this: `EditSystemModal` has exactly one production render, in `Title.tsx`, with `mode` hardcoded to `create`. There is no production edit-mode caller, so it governs what can be set at system creation and edits go through the detail page.

## Second commit: the post-save refetch

A review pass found a defect this unlock exposed, worth reading as its own change.

The page wrote its own edited draft into shared state after a successful PUT. That is accurate for a field whose stored value is the value sent, which was every extended field until now. `isso_name` is the first one the backend resolves: clearing it stores NULL and the list read then derives the name, so the draft held an empty string where the saved system carries a name. The read view rendered the cleared field as an em dash, the exact opposite of what the new help text promises, and it affected `OWNER` and `HHS_ADMIN` immediately since they were never behind the backend gate.

The page now refetches instead. The PUT returns no body, and the single-system read returns the raw column rather than the derived name, so the list read is the only source that reflects what was saved. The refetch carries the caller's decommissioned view mode so saving does not change which systems the dashboard lists, and the fallback guard is cleared so a system excluded by that mode is re-added rather than leaving the page empty.

Two tests pin this. Both fail with the fix reverted and pass with it, which was verified rather than assumed.

## Known gap, deliberately not fixed here

For a **decommissioned** system viewed with the toggle off, clearing ISSO Name still displays an em dash. The refetch drops the system from the active-only list and the fallback re-populates it from the single-system read, which returns the raw column.

This is not a regression: before this branch the same scenario echoed the draft and rendered the same em dash. It is one path the fix does not resolve, and it cannot be resolved cleanly on the frontend, because no read available to the client returns a derived name for a system outside the current list view. Refetching with `decommissioned=true` returns only decommissioned systems, so it would change the dashboard as a side effect of saving.

The fix belongs in CMS-Enterprise/ztmf#510, where the read split is tracked and this is now recorded as evidence. Scope: needs a decommissioned system, the toggle off, and specifically clearing the field rather than typing a value, since a typed value displays correctly on that path. The stored data is correct throughout; only the view is stale and it self-corrects on reload.

## Test plan

- `npx tsc --noEmit`: clean
- 80 tests pass across `src/views/SystemDetailPage/` and `src/views/EditSystemModal/`, including 15 in a new `SystemDetailPage.issoName.test.tsx` covering all ten roles, the three write signals, and the refetch behavior
- eslint and prettier clean on the touched files
- the husky pre-commit ran the full suite: 763 passed, 3 skipped, no failures

Note for local runs: the full jest suite is flaky on some machines under parallel worker load, independent of any change. A bare `main` control run has produced more failures than a feature branch, disjoint and all timeout-shaped. Run the touched suites alone for the real signal, and control against `main` before attributing a failure to a change.
