### PR TITLE
fix(#659): carried-forward badges, explicit confirm, Complete summary, progress wording

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -233,13 +233,7 @@ export type QuestionScores = {
   status?: ScoreStatus
   // Present when fetched with ?include=functionoption; functionid maps the
   // row back to its question.
-  functionoption?: {
-    functionoptionid: number
-    functionid: number
-    score: number
-    optionname: string
-    description: string
-  }
+  functionoption?: QuestionOption
   last_edited_at?: string | null
   last_edited_by?: LastEditedBy | null
   notes_is_ai_summary?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,14 @@ export type LastEditedBy = {
   role?: UserRole
 }
 
+/**
+ * The answer's review state for its data call (scores.status): 'not_started'
+ * = carried forward and untouched this cycle; 'done' = saved or confirmed
+ * this cycle. The same persisted fact the Data Call Progress count reads, so
+ * badges derived from it cannot disagree with the fraction.
+ */
+export type ScoreStatus = 'not_started' | 'done'
+
 export type QuestionScores = {
   scoreid: number
   fismasystemid: number
@@ -220,6 +228,18 @@ export type QuestionScores = {
   notes: string
   functionoptionid: number
   datacallid: number
+  // Optional: a backend that does not serve it degrades to no carried-forward
+  // badges rather than badging everything.
+  status?: ScoreStatus
+  // Present when fetched with ?include=functionoption; functionid maps the
+  // row back to its question.
+  functionoption?: {
+    functionoptionid: number
+    functionid: number
+    score: number
+    optionname: string
+    description: string
+  }
   last_edited_at?: string | null
   last_edited_by?: LastEditedBy | null
   notes_is_ai_summary?: boolean

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -261,4 +261,49 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
+
+  // --- Carried-forward wording on the current call ---
+
+  it('reads Awaiting confirmation for a current-call system with carried answers and zero updates', () => {
+    // The answers exist (carried forward) but none count as updated —
+    // "0/41 Not updated" read as data loss; the chip says the actual state.
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 41 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Awaiting confirmation')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('reads Not started for a current-call system with no answers at all', () => {
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 0 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
+    // ztmf#437 may not be deployed everywhere; without the field the split
+    // would be a guess, so the cell keeps saying what it always said.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
+    expect(screen.getByText('Not updated')).toBeInTheDocument()
+  })
+
+  it('describes the carried-forward state in the tooltip', () => {
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 41 })).toBe(
+      'Answers carried forward from a previous data call — not yet confirmed'
+    )
+    // No answers at all keeps the plain no-updates line.
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 0 })).toBe(
+      'No updates this data call'
+    )
+  })
 })

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -103,6 +103,19 @@ export function ProgressCell({
     )
   }
   const updated = entry.questionsupdated > 0
+  // Zero updates splits two materially different states: carried-forward
+  // answers awaiting confirmation vs no answers at all — a blanket "Not
+  // updated" read as data loss to ISSOs who had just reviewed everything.
+  // questionsanswered may be absent until ztmf#437 is deployed everywhere;
+  // keep the legacy wording then rather than guessing.
+  const answered = entry.questionsanswered
+  const label = updated
+    ? 'Updated'
+    : answered == null
+      ? 'Not updated'
+      : answered > 0
+        ? 'Awaiting confirmation'
+        : 'Not started'
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box
@@ -117,7 +130,7 @@ export function ProgressCell({
         </span>
         <Chip
           size="small"
-          label={updated ? 'Updated' : 'Not updated'}
+          label={label}
           color={updated ? 'success' : 'warning'}
           variant="outlined"
         />

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -26,8 +26,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
  *   - current call, any genuine edit: "Updated" (green);
- *   - current call, otherwise: "Not updated" (orange). The chip is derived from
- *     questionsupdated so it can never disagree with the fraction.
+ *   - current call, zero updates: "Awaiting confirmation" (carried answers
+ *     exist) or "Not started" (none do), both warning-colored laggards;
+ *     legacy "Not updated" when questionsanswered is not served.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -87,7 +88,7 @@ export function ProgressCell({
       )
     }
     return (
-      <Tooltip title={progressTooltip(entry)}>
+      <Tooltip title={progressTooltip(entry, { pastCall: true })}>
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
           <span>
             {answered}/{entry.questionsexpected}

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -66,7 +66,7 @@ export function progressSortValue(
  */
 export function progressTooltip(
   entry: ScoreProgress | undefined,
-  opts: { completed?: boolean } = {}
+  opts: { completed?: boolean; pastCall?: boolean } = {}
 ): string {
   if (!entry) return 'No progress data for this data call'
   if (entry.lastupdatedat) {
@@ -79,8 +79,9 @@ export function progressTooltip(
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
   // Mirrors the chip's carried-forward split: answers exist but none count
-  // as updated yet — awaiting confirmation, not missing.
-  if ((entry.questionsanswered ?? 0) > 0)
+  // as updated yet — awaiting confirmation, not missing. Current call only:
+  // a closed call has nothing left to confirm.
+  if (!opts.pastCall && (entry.questionsanswered ?? 0) > 0)
     return 'Answers carried forward from a previous data call — not yet confirmed'
   return 'No updates this data call'
 }

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -78,5 +78,9 @@ export function progressTooltip(
   if (hasNoQuestionnaire(entry))
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
+  // Mirrors the chip's carried-forward split: answers exist but none count
+  // as updated yet — awaiting confirmation, not missing.
+  if ((entry.questionsanswered ?? 0) > 0)
+    return 'Answers carried forward from a previous data call — not yet confirmed'
   return 'No updates this data call'
 }

--- a/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
+++ b/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
@@ -1,0 +1,129 @@
+import { useId } from 'react'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Link from '@mui/material/Link'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import Typography from '@mui/material/Typography'
+import CloseIcon from '@mui/icons-material/Close'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import type { ConfirmSummary, ConfirmSummaryEntry } from './confirmState'
+
+type Props = {
+  /** null keeps the dialog closed. */
+  summary: ConfirmSummary | null
+  onClose: () => void
+  /** Navigate to the entry's question (the parent owns routing). */
+  onJump: (entry: ConfirmSummaryEntry) => void
+}
+
+/**
+ * The end-of-questionnaire summary shown by Complete on an open data call:
+ * one "are you sure" moment instead of 40 per-question dialogs. Lists
+ * carried-forward answers awaiting confirmation and unanswered questions as
+ * jump links; when neither remains it is the success state (which also
+ * retires the old silent loop back to question 1).
+ */
+const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
+  const titleId = useId()
+  const descId = useId()
+  if (!summary) return null
+
+  const outstanding = summary.unconfirmed.length + summary.unanswered.length
+  const complete = outstanding === 0
+
+  const entryList = (entries: ConfirmSummaryEntry[]) => (
+    <List dense sx={{ pt: 0 }}>
+      {entries.map((entry) => (
+        <ListItem key={entry.functionid} sx={{ py: 0.25 }}>
+          <Link
+            component="button"
+            type="button"
+            onClick={() => onJump(entry)}
+            sx={{ textAlign: 'left' }}
+          >
+            {entry.pillarName} — {entry.functionName}
+          </Link>
+        </ListItem>
+      ))}
+    </List>
+  )
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      <DialogTitle id={titleId}>
+        {complete ? 'Questionnaire complete' : 'Before you finish'}
+      </DialogTitle>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton onClick={onClose} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent>
+        {/* The headline count reads scores.status; without status data (the
+            backend not yet serving it) the count would be a lie built from
+            absence, so it is omitted and only row-presence facts render. */}
+        {summary.hasStatusData && (
+          <Typography id={descId} sx={{ mb: 1 }}>
+            {summary.updated} of {summary.total} answers counted as updated for
+            this data call.
+          </Typography>
+        )}
+        {complete ? (
+          <Alert severity="success" icon={false}>
+            Every question is answered
+            {summary.hasStatusData ? ' and counted as updated' : ''}. You are
+            done — no further action is needed.
+          </Alert>
+        ) : (
+          <>
+            {summary.unconfirmed.length > 0 && (
+              <Box sx={{ mb: 1.5 }}>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Carried forward — needs confirmation (
+                  {summary.unconfirmed.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These answers were carried over from the previous data call
+                  and do not count as updated until you confirm them. Open each
+                  question and select “Confirm this answer is still accurate,”
+                  or update the answer.
+                </Typography>
+                {entryList(summary.unconfirmed)}
+              </Box>
+            )}
+            {summary.unanswered.length > 0 && (
+              <Box>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Unanswered ({summary.unanswered.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These questions have no answer yet. Open each question, select
+                  an answer, and continue with Next to save it.
+                </Typography>
+                {entryList(summary.unanswered)}
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <CmsButton onClick={onClose}>Close</CmsButton>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmSummaryDialog

--- a/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
+++ b/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
@@ -61,7 +61,7 @@ const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
       maxWidth="sm"
       fullWidth
       aria-labelledby={titleId}
-      aria-describedby={descId}
+      aria-describedby={summary.hasStatusData ? descId : undefined}
     >
       <DialogTitle id={titleId}>
         {complete ? 'Questionnaire complete' : 'Before you finish'}
@@ -111,7 +111,7 @@ const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
                 </Typography>
                 <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                   These questions have no answer yet. Open each question, select
-                  an answer, and continue with Next to save it.
+                  an answer, and continue with Next or Complete to save it.
                 </Typography>
                 {entryList(summary.unanswered)}
               </Box>

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -939,8 +939,12 @@ describe('QuestionnairePage justification integration', () => {
     const complete = screen.getByRole('button', { name: 'Complete' })
     expect(complete).toBeDisabled()
 
-    // Accepting the required review is a current-call action, so the answer
-    // persists even though the text equals the seeded prior response.
+    // Accepting the required review must land even though the text equals
+    // the seeded prior response — via the confirm endpoint, since the old
+    // identical-body answer PUT was silently discarded by the backend's
+    // no-op guard. Insert alone performs no write (like the
+    // insights-suggestion card's Insert); the resolved review lands on the
+    // next navigation, so the two adjacent Insert buttons behave alike.
     fireEvent.click(
       screen.getByRole('button', {
         name: 'Insert previous ISSO response into current response',
@@ -948,18 +952,17 @@ describe('QuestionnairePage justification integration', () => {
     )
     expect(response).toHaveValue(PRIOR_RESPONSE)
     expect(complete).toBeEnabled()
+    expect(axios.put).not.toHaveBeenCalled()
 
     fireEvent.click(complete)
 
     await waitFor(() =>
-      expect(axios.put).toHaveBeenCalledWith('scores/5001', {
-        fismasystemid: 1002,
-        notes: PRIOR_RESPONSE,
-        functionoptionid: 100,
-        datacallid: 6,
-        notes_is_ai_summary: false,
-      })
+      expect(axios.put).toHaveBeenCalledWith('scores/5001/confirm')
     )
+    // The unchanged answer body must NOT be re-PUT — that path re-stamps
+    // nothing server-side and would clear notes_is_ai_summary on a real
+    // change-detection miss.
+    expect(axios.put).not.toHaveBeenCalledWith('scores/5001', expect.anything())
   })
 
   it('shows the insights panel, option badges, and suggestion for a CMS data call', async () => {
@@ -1076,5 +1079,305 @@ describe('QuestionnairePage justification integration', () => {
     expect(
       screen.queryByRole('textbox', { name: 'Current response' })
     ).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Carried-forward confirmation: badge, inline Confirm, the #413
+// browse-is-write-free guard, and the Complete summary.
+// ---------------------------------------------------------------------------
+
+describe('carried-forward confirmation', () => {
+  const OPTIONS_7001 = [
+    { functionoptionid: 200, description: 'Baseline', score: 1 },
+    { functionoptionid: 201, description: 'Advanced', score: 2 },
+  ]
+
+  // A row copied by the FY2026 rollover: status not_started, no edit event.
+  const carried7006 = (status: 'not_started' | 'done' = 'not_started') => ({
+    scoreid: 6001,
+    fismasystemid: 1002,
+    notes: 'carried justification',
+    functionoptionid: 100,
+    datacallid: 5,
+    status,
+    functionoption: {
+      functionoptionid: 100,
+      functionid: 7006,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+    last_edited_at: null,
+    last_edited_by: null,
+  })
+
+  const done7001 = () => ({
+    scoreid: 6002,
+    fismasystemid: 1002,
+    notes: 'answered this cycle',
+    functionoptionid: 200,
+    datacallid: 5,
+    status: 'done',
+    functionoption: {
+      functionoptionid: 200,
+      functionid: 7001,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+  })
+
+  const DEVICES_LINK =
+    '/questionnaire/ssd-ex/FY2026_Q1/devices/imperial-device-management'
+
+  // Serves a mutable scores list and, like the real backend, flips the
+  // targeted row to done when the confirm endpoint is hit — so the refetch
+  // after a confirm returns the confirmed row instead of resurrecting the
+  // original fixture.
+  function installScoreMocks(scores: Array<{ scoreid: number }>) {
+    let rows = scores
+    axios.get.mockImplementation((url: string) => {
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: QUESTIONS } })
+      if (url.startsWith('scores'))
+        return Promise.resolve({ data: { data: rows } })
+      if (url.includes('functions/7006/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7006 } })
+      if (url.includes('functions/7001/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7001 } })
+      return Promise.resolve({ data: { data: [] } })
+    })
+    axios.post.mockResolvedValue({ data: {} })
+    axios.put.mockImplementation((url: string) => {
+      const confirm = /^scores\/(\d+)\/confirm$/.exec(url)
+      if (confirm) {
+        rows = rows.map((row) =>
+          row.scoreid === Number(confirm[1]) ? { ...row, status: 'done' } : row
+        )
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+  }
+
+  it('badges an unconfirmed carried-forward answer in the question view and sidebar, and confirms it with one dedicated PUT', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    // Question-view badge (role="status" so the flip below is announced).
+    const badge = await screen.findByText('Carried forward — not yet confirmed')
+    expect(badge).toBeInTheDocument()
+    // Sidebar marker for the same fact, on the carried question only.
+    expect(screen.getAllByText('Not yet confirmed')).toHaveLength(1)
+
+    // The explicit act: exactly one confirm PUT, no answer PUT/POST.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    )
+    await waitFor(() =>
+      expect(axios.put).toHaveBeenCalledWith('scores/6001/confirm')
+    )
+    expect(axios.put).toHaveBeenCalledTimes(1)
+    expect(saveScorePosts()).toHaveLength(0)
+
+    // Feedback is the badge swapping to its confirmed state.
+    expect(
+      await screen.findByText('Updated this data call')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps Next write-free on an untouched carried-forward question (#413)', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByText('Carried forward — not yet confirmed')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+
+    // Navigation happened (the next question's options load)...
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7001/options')
+        )
+      ).toBe(true)
+    )
+    // ...and no write of any kind was issued.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+  })
+
+  it('yields the Confirm button to the edit path the moment the question is dirty', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByRole('button', {
+      name: 'Confirm this answer is still accurate',
+    })
+    fireEvent.click(screen.getByRole('radio', { name: /Advanced/ }))
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+    // The badge still shows — the row is still unconfirmed until saved.
+    expect(
+      screen.getByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+  })
+
+  it('shows the badge but no Confirm button to a read-only admin', async () => {
+    installScoreMocks([carried7006()])
+    setMockCtx(
+      makeCtx({
+        userInfo: {
+          userid: 'u-2',
+          email: 'auditor@hhs.gov',
+          fullname: 'Read Only',
+          role: 'HHS_READONLY_ADMIN',
+        } as userData,
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders no carried-forward treatment on a closed data call', async () => {
+    installScoreMocks([carried7006()])
+    const pastDeadline = '2001-01-01T00:00:00Z'
+    // OWNER stays writable past the deadline (isReadOnly false), isolating
+    // the open-call gate as the only thing hiding the treatment.
+    setMockCtx(
+      makeCtx({
+        latestDeadline: pastDeadline,
+        selectedDatacall: {
+          datacallid: 5,
+          datacall: 'FY2026 Q1',
+          datecreated: '',
+          deadline: pastDeadline,
+        },
+        datacalls: [
+          {
+            datacallid: 5,
+            datacall: 'FY2026 Q1',
+            datecreated: '',
+            deadline: pastDeadline,
+          },
+        ],
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    await waitFor(() =>
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    )
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('Complete summarizes unconfirmed and unanswered questions with working jump links', async () => {
+    // Devices (7001) is the last question; it has no row at all. Identity
+    // (7006) carries an unconfirmed answer.
+    installScoreMocks([carried7006()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    // The summary reads a freshly-awaited scores fetch, then opens.
+    expect(await screen.findByText('Before you finish')).toBeInTheDocument()
+    expect(
+      screen.getByText('0 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Carried forward — needs confirmation (1)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Unanswered (1)')).toBeInTheDocument()
+
+    // No loop back to question 1: Complete opened the summary instead of
+    // silently navigating.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
+
+    // The jump link navigates to the listed question.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Identity — Imperial Identity Verification',
+      })
+    )
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7006/options')
+        )
+      ).toBe(true)
+    )
+    expect(screen.queryByText('Before you finish')).not.toBeInTheDocument()
+  })
+
+  it('Complete shows the success state and stops looping when everything is updated', async () => {
+    installScoreMocks([carried7006('done'), done7001()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    expect(
+      await screen.findByText('Questionnaire complete')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('2 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    // No writes fired: everything was already done, and Complete must not
+    // manufacture one.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+    // And no silent wrap-around to the first question.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
   })
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+  configure as rtlConfigure,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
@@ -1088,6 +1095,20 @@ describe('QuestionnairePage justification integration', () => {
 // ---------------------------------------------------------------------------
 
 describe('carried-forward confirmation', () => {
+  // CI runners execute this suite ~3x slower than a dev machine, and these
+  // tests each begin by awaiting a full page load — RTL's default 1s
+  // findBy/waitFor timeout flaked there while the question was still
+  // loading. Raise the async ceiling for this block only; passing tests are
+  // unaffected (they resolve as soon as the DOM settles).
+  beforeAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 4000 })
+    jest.setTimeout(15000)
+  })
+  afterAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 1000 })
+    jest.setTimeout(5000)
+  })
+
   const OPTIONS_7001 = [
     { functionoptionid: 200, description: 'Baseline', score: 1 },
     { functionoptionid: 201, description: 'Advanced', score: 2 },

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import Typography from '@mui/material/Typography'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
@@ -63,6 +65,15 @@ import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+  type ConfirmSummary,
+  type ConfirmSummaryEntry,
+} from './confirmState'
+import ConfirmSummaryDialog from './ConfirmSummaryDialog'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
 import {
@@ -243,10 +254,14 @@ export default function QuestionnarePage() {
   // strictly required for the selection to update, but it is retained as a clean
   // reset of the subtree when a re-seed changes the answer out of band.
   const [radioKey, setRadioKey] = React.useState(0)
+  // Returns the fresh map alongside committing it to state, so a caller that
+  // must reason over the authoritative data in the same tick (the Complete
+  // summary) does not have to read a not-yet-rendered state value. undefined
+  // on failure — callers fall back to the state they already had.
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
-  ) => {
+  ): Promise<questionScoreMap | undefined> => {
     try {
       const response = await axiosInstance.get(
         `scores?datacallid=${datacallID}&fismasystemid=${systemId}&include=functionoption`
@@ -258,9 +273,11 @@ export default function QuestionnarePage() {
         }))
       )
       setQuestionScores(hashTable)
+      return hashTable
     } catch (error) {
-      if (isAuthHandled(error)) return
+      if (isAuthHandled(error)) return undefined
       console.error('Error fetching question scores:', error)
+      return undefined
     }
   }
   const handleChoiceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -599,6 +616,113 @@ export default function QuestionnarePage() {
     priorReviewNeedsSave,
   }
 
+  // Carried-forward confirmation state, read from scores.status — the same
+  // persisted fact the Data Call Progress fraction counts. Open call only:
+  // historical rows are legitimately not_started forever. Read-only sessions
+  // see the badges but never the Confirm button.
+  const isOpenCall = !isPastDeadline
+  const scoreByFunction = React.useMemo(
+    () => buildScoreByFunction(questionScores),
+    [questionScores]
+  )
+  // The saved row backing the current question. Keyed by initQuestionChoice
+  // (the seeded answer), not selectQuestionOption, so flipping the radio does
+  // not detach the badge from the row it describes.
+  const currentSavedScore =
+    initQuestionChoice !== -1 ? questionScores[initQuestionChoice] : undefined
+  const currentCarryState = carryForwardState(currentSavedScore, isOpenCall)
+  const showConfirmButton = canConfirmCarryForward({
+    state: currentCarryState,
+    // Any deviation from the seeded answer/notes: the edit is the explicit
+    // act, and Next saves it (flipping status server-side), so the button
+    // yields to avoid two visible paths to the same write.
+    dirty: selectQuestionOption !== initQuestionChoice || notes !== initNotes,
+    isReadOnly,
+    priorReviewBlocked:
+      priorReviewState === 'pending' || priorReviewState === 'initializing',
+  })
+  const [confirming, setConfirming] = React.useState(false)
+  // The Complete-time summary dialog. null = closed.
+  const [confirmSummary, setConfirmSummary] =
+    React.useState<ConfirmSummary | null>(null)
+
+  // The explicit act behind "Confirm this answer is still accurate": flips
+  // the row's status to done via the confirm endpoint — the ordinary PUT
+  // cannot express agreement, its no-op guard (correctly) drops an unchanged
+  // body (#412/#413). Shared with saveResponse's resolved-review path.
+  const confirmScoreById = async (id: number): Promise<boolean> => {
+    try {
+      await axiosInstance.put(`scores/${id}/confirm`)
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      clearCurrentDraft()
+      setPriorReview((current) =>
+        current.contextId === priorReviewContextId
+          ? { ...current, needsSave: false }
+          : current
+      )
+      // Flip the badge immediately (role="status" announces the change);
+      // the refetch then brings the authoritative row, audit fields included.
+      setQuestionScores((prev) => {
+        const entry = Object.entries(prev).find(([, s]) => s.scoreid === id)
+        if (!entry) return prev
+        return { ...prev, [entry[0]]: { ...entry[1], status: 'done' } }
+      })
+      fetchQuestionScores(system, setQuestionScores)
+      return true
+    } catch (error) {
+      if (isAuthHandled(error)) return false
+      console.error('Error confirming score:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+      return false
+    }
+  }
+
+  const handleConfirmClick = async () => {
+    if (!currentSavedScore || confirming) return
+    setConfirming(true)
+    try {
+      await confirmScoreById(currentSavedScore.scoreid)
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  // Complete on the open call: save the current question as Next always has,
+  // then show one end-of-questionnaire summary instead of silently looping
+  // back to question 1. Built from a freshly-awaited scores fetch so the
+  // just-saved answer counts; falls back to the on-screen map on failure.
+  const handleCompleteClick = async () => {
+    saveGenRef.current++
+    if (!isReadOnly) {
+      await saveResponse()
+    }
+    const fresh = await fetchQuestionScores(system, setQuestionScores)
+    setConfirmSummary(
+      buildConfirmSummary(
+        categories,
+        fresh ? buildScoreByFunction(fresh) : scoreByFunction,
+        isOpenCall
+      )
+    )
+  }
+
+  // Jump link from the Complete summary: same slug navigation + list-click
+  // path the sidebar uses, so the datacall context rides along (#501).
+  const jumpToSummaryEntry = (entry: ConfirmSummaryEntry) => {
+    setConfirmSummary(null)
+    const q = questions[entry.functionid]
+    if (q) {
+      navigate(
+        `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
+        {
+          state: { fismasystemid: system, ...datacallStateRef.current },
+          replace: true,
+        }
+      )
+    }
+    handleListItemClick(entry.functionid)
+  }
+
   const saveResponse = async () => {
     // Resolving a required carried-forward review is itself a current-call
     // action, even when the final text is byte-for-byte identical to the
@@ -607,7 +731,6 @@ export default function QuestionnarePage() {
     const resolvedPriorReview =
       priorReviewNeedsSave && selectQuestionOption >= 0
     if (
-      !resolvedPriorReview &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -615,6 +738,14 @@ export default function QuestionnarePage() {
         initNotes,
       })
     ) {
+      // Nothing changed on the answer fields. A resolved required review is
+      // still an affirmative act that must land — the ordinary PUT's no-op
+      // guard would silently drop an identical body, so route it through the
+      // confirm endpoint.
+      if (resolvedPriorReview && scoreid) {
+        await confirmScoreById(scoreid)
+        return
+      }
       clearCurrentDraft()
       return
     }
@@ -1238,11 +1369,17 @@ export default function QuestionnarePage() {
         : undefined
     if (priorReview.contextId === priorReviewContextId) return
 
+    // "Untouched this cycle": prefer the persisted scores.status so this gate
+    // and the progress count cannot diverge; fall back to the older
+    // no-edit-event proxy for a backend that does not serve status yet.
+    const untouchedThisCycle = currentScore?.status
+      ? currentScore.status === 'not_started'
+      : !currentScore?.last_edited_at
     const isUnreviewedCarryForward =
       !isReadOnly &&
       !!currentPriorResponse &&
       !!currentScore &&
-      !currentScore.last_edited_at &&
+      untouchedThisCycle &&
       draftStatus !== 'restored' &&
       notes.trim() === currentPriorResponse.text.trim()
     setPriorReview({
@@ -1434,6 +1571,14 @@ export default function QuestionnarePage() {
                       const text = addSpace(func.function.function)
                       const customFontSize =
                         text.length > 33 ? '0.9rem' : '1rem'
+                      // Sidebar confirmation marker: same classification the
+                      // question view's badge reads. Text-bearing, not
+                      // color-only (508); rendered as ListItemText secondary
+                      // so it is part of the button's accessible name.
+                      const sidebarCarryState = carryForwardState(
+                        scoreByFunction[func.function.functionid],
+                        isOpenCall
+                      )
                       // TODO: refactor this code such that it's going to be a single component instead of being rerendered everytime
                       return (
                         <ListItem
@@ -1475,6 +1620,20 @@ export default function QuestionnarePage() {
                           >
                             <ListItemText
                               primary={`${text}`}
+                              secondary={
+                                sidebarCarryState === 'unconfirmed'
+                                  ? 'Not yet confirmed'
+                                  : sidebarCarryState === 'updated'
+                                    ? 'Updated'
+                                    : undefined
+                              }
+                              secondaryTypographyProps={{
+                                fontSize: '0.75rem',
+                                color:
+                                  sidebarCarryState === 'unconfirmed'
+                                    ? 'warning.dark'
+                                    : 'success.dark',
+                              }}
                               sx={{ fontSize: customFontSize }}
                             />
                           </ListItemButton>
@@ -1624,6 +1783,55 @@ export default function QuestionnarePage() {
                       </Typography>
                     )}
                   </Box>
+                  {/* Carried-forward confirmation strip, in the same zone
+                      where the prior-response flow surfaces its "review
+                      before continuing" message, so every system shares one
+                      review area. The chip is a role="status" live region, so
+                      confirming — which swaps its label in place — is
+                      announced (508). The button yields the moment the
+                      question is dirty (the edit is the explicit act; Next
+                      saves it), and Next itself never writes on an untouched
+                      question (#413). */}
+                  {currentCarryState !== 'none' && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        flexWrap: 'wrap',
+                        gap: 1,
+                        mt: 1.5,
+                      }}
+                    >
+                      <Chip
+                        role="status"
+                        size="small"
+                        variant="outlined"
+                        color={
+                          currentCarryState === 'unconfirmed'
+                            ? 'warning'
+                            : 'success'
+                        }
+                        label={
+                          currentCarryState === 'unconfirmed'
+                            ? 'Carried forward — not yet confirmed'
+                            : 'Updated this data call'
+                        }
+                      />
+                      {showConfirmButton && (
+                        <Button
+                          variant="outlined"
+                          color="success"
+                          size="small"
+                          startIcon={<CheckCircleOutlineIcon />}
+                          onClick={handleConfirmClick}
+                          disabled={confirming}
+                          sx={{ textTransform: 'none' }}
+                        >
+                          Confirm this answer is still accurate
+                        </Button>
+                      )}
+                    </Box>
+                  )}
                   <Box
                     position="relative"
                     display="flex"
@@ -1675,12 +1883,21 @@ export default function QuestionnarePage() {
                     </CmsButton>
                     <CmsButton
                       onClick={() => {
-                        saveGenRef.current++
-                        const id =
+                        const isLastQuestion =
                           selectedIndex ===
                           stepFunctionId[stepFunctionId.length - 1]
-                            ? stepFunctionId[0]
-                            : stepFunctionId[functionIdIdx[selectedIndex] + 1]
+                        // Complete on the open call summarizes instead of
+                        // silently wrapping to question 1. A closed call
+                        // keeps the wrap-around — harmless paging for a
+                        // historical viewer.
+                        if (isLastQuestion && isOpenCall) {
+                          void handleCompleteClick()
+                          return
+                        }
+                        saveGenRef.current++
+                        const id = isLastQuestion
+                          ? stepFunctionId[0]
+                          : stepFunctionId[functionIdIdx[selectedIndex] + 1]
 
                         if (questions[id]) {
                           const q = questions[id]
@@ -1763,6 +1980,11 @@ export default function QuestionnarePage() {
             open={openAlert}
             onClose={() => setOpenAlert(false)}
             confirmClick={handleConfirmReturn}
+          />
+          <ConfirmSummaryDialog
+            summary={confirmSummary}
+            onClose={() => setConfirmSummary(null)}
+            onJump={jumpToSummaryEntry}
           />
         </Grid>
       </Container>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -697,6 +697,20 @@ export default function QuestionnarePage() {
       await saveResponse()
     }
     const fresh = await fetchQuestionScores(system, setQuestionScores)
+    if (fresh) {
+      // Re-seed the current question's saved state from the fresh map. The
+      // old Complete re-seeded implicitly by navigating to question 1; this
+      // one stays put, and without a re-seed a just-POSTed answer would
+      // still read as unsaved (scoreid 0) — a second Complete would POST a
+      // duplicate row and double-weight the question in the pillar average.
+      const sel = deriveScoreSelection(
+        optionsRef.current.map((o) => Number(o.value)),
+        fresh
+      )
+      setInitQuestionChoice(sel.choice)
+      setInitNotes(sel.notes)
+      setScoreId(sel.scoreid)
+    }
     setConfirmSummary(
       buildConfirmSummary(
         categories,
@@ -710,6 +724,10 @@ export default function QuestionnarePage() {
   // path the sidebar uses, so the datacall context rides along (#501).
   const jumpToSummaryEntry = (entry: ConfirmSummaryEntry) => {
     setConfirmSummary(null)
+    // Already on this question (e.g. the last question is itself unanswered):
+    // just close the dialog. handleListItemClick would set loading for a
+    // questionId change that never fires, stranding the spinner.
+    if (entry.functionid === questionId) return
     const q = questions[entry.functionid]
     if (q) {
       navigate(

--- a/src/views/QuestionnairePage/confirmState.test.ts
+++ b/src/views/QuestionnairePage/confirmState.test.ts
@@ -1,0 +1,204 @@
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+} from './confirmState'
+import type { QuestionScores, FismaQuestion, ScoreStatus } from '@/types'
+
+const score = (over: Partial<QuestionScores> = {}): QuestionScores => ({
+  scoreid: 1,
+  fismasystemid: 10,
+  datecalculated: 0,
+  notes: 'carried notes',
+  functionoptionid: 100,
+  datacallid: 5,
+  ...over,
+})
+
+const question = (
+  functionid: number,
+  name = `fn-${functionid}`
+): FismaQuestion => ({
+  questionid: functionid + 1000,
+  question: `Q ${functionid}`,
+  notesprompt: '',
+  pillar: { pillar: 'Devices', pillarid: 1, order: 1 },
+  function: {
+    functionid,
+    function: name,
+    description: '',
+    datacenterenvironment: 'Hybrid',
+  },
+})
+
+describe('carryForwardState', () => {
+  it('classifies a not_started row on the open call as unconfirmed', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), true)).toBe(
+      'unconfirmed'
+    )
+  })
+
+  it('classifies a done row on the open call as updated', () => {
+    expect(carryForwardState(score({ status: 'done' }), true)).toBe('updated')
+  })
+
+  it('renders nothing on a past call — historical rows are legitimately not_started forever', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), false)).toBe(
+      'none'
+    )
+    expect(carryForwardState(score({ status: 'done' }), false)).toBe('none')
+  })
+
+  it('renders nothing when the backend does not serve status (pre-deploy degrade)', () => {
+    expect(carryForwardState(score(), true)).toBe('none')
+  })
+
+  it('renders nothing without an answer row', () => {
+    expect(carryForwardState(undefined, true)).toBe('none')
+  })
+})
+
+describe('canConfirmCarryForward', () => {
+  const confirmable = {
+    state: 'unconfirmed' as const,
+    dirty: false,
+    isReadOnly: false,
+    priorReviewBlocked: false,
+  }
+
+  it('allows confirming an untouched carried-forward answer', () => {
+    expect(canConfirmCarryForward(confirmable)).toBe(true)
+  })
+
+  it('hides while dirty — the edit is the explicit act and Next saves it', () => {
+    expect(canConfirmCarryForward({ ...confirmable, dirty: true })).toBe(false)
+  })
+
+  it('hides for read-only sessions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, isReadOnly: true })).toBe(
+      false
+    )
+  })
+
+  it('hides while the CMS prior-response review blanks the field', () => {
+    expect(
+      canConfirmCarryForward({ ...confirmable, priorReviewBlocked: true })
+    ).toBe(false)
+  })
+
+  it('hides for updated and stateless questions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, state: 'updated' })).toBe(
+      false
+    )
+    expect(canConfirmCarryForward({ ...confirmable, state: 'none' })).toBe(
+      false
+    )
+  })
+})
+
+describe('buildScoreByFunction', () => {
+  it('re-keys rows by their owning functionid', () => {
+    const byFunction = buildScoreByFunction({
+      100: score({
+        functionoptionid: 100,
+        functionoption: {
+          functionoptionid: 100,
+          functionid: 7,
+          score: 2,
+          optionname: 'Defined',
+          description: '',
+        },
+      }),
+    })
+    expect(byFunction[7]?.functionoptionid).toBe(100)
+  })
+
+  it('skips rows without functionoption — they cannot be attributed to a question', () => {
+    expect(buildScoreByFunction({ 100: score() })).toEqual({})
+  })
+})
+
+describe('buildConfirmSummary', () => {
+  const withStatus = (
+    functionid: number,
+    status?: ScoreStatus
+  ): QuestionScores =>
+    score({
+      scoreid: functionid,
+      status,
+      functionoption: {
+        functionoptionid: functionid * 10,
+        functionid,
+        score: 1,
+        optionname: 'Traditional',
+        description: '',
+      },
+    })
+
+  const categories = [
+    { name: 'Devices', steps: [question(1), question(2)] },
+    { name: 'Networks', steps: [question(3), question(4)] },
+  ]
+
+  it('buckets unconfirmed, updated, and unanswered in sidebar order', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1, 'not_started'),
+        2: withStatus(2, 'done'),
+        3: withStatus(3, 'not_started'),
+        // 4 has no row at all.
+      },
+      true
+    )
+    expect(summary.total).toBe(4)
+    expect(summary.updated).toBe(1)
+    expect(summary.unconfirmed.map((e) => e.functionid)).toEqual([1, 3])
+    expect(summary.unconfirmed[0]).toEqual({
+      functionid: 1,
+      functionName: 'fn-1',
+      pillarName: 'Devices',
+    })
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(true)
+  })
+
+  it('keeps the unanswered list but flags missing status data pre-deploy', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1),
+        2: withStatus(2),
+        3: withStatus(3),
+      },
+      true
+    )
+    // Answered rows without status land in no bucket: not unconfirmed (that
+    // would badge everything) and not updated (that would claim knowledge the
+    // backend has not served).
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.updated).toBe(0)
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(false)
+  })
+
+  it('lists nothing as unconfirmed on a past call', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 1: withStatus(1, 'not_started') },
+      false
+    )
+    expect(summary.unconfirmed).toEqual([])
+  })
+
+  it('ignores score rows whose function is not in the questionnaire (inapplicable after an environment change)', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 99: withStatus(99, 'not_started') },
+      true
+    )
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.total).toBe(4)
+  })
+})

--- a/src/views/QuestionnairePage/confirmState.ts
+++ b/src/views/QuestionnairePage/confirmState.ts
@@ -1,0 +1,134 @@
+import type { QuestionScores, ScoreStatus, FismaQuestion } from '@/types'
+
+/**
+ * Carried-forward confirmation state, derived from the persisted
+ * scores.status column — the same fact the Data Call Progress fraction
+ * counts — so the badge, Confirm button, sidebar markers, and Complete
+ * summary can never disagree with the number the user is shown. Pure, so the
+ * classification rules live in one place (mirrors saveGuard.ts).
+ */
+
+/**
+ * The per-question classification every piece of confirmation UI reads.
+ * 'none' covers: no answer row, a closed call (historical rows are
+ * legitimately not_started forever), or a backend that does not serve status
+ * yet (degrade to no badges rather than badging everything).
+ */
+export type CarryForwardState = 'unconfirmed' | 'updated' | 'none'
+
+export const carryForwardState = (
+  score: QuestionScores | undefined,
+  isOpenCall: boolean
+): CarryForwardState => {
+  if (!isOpenCall || !score?.status) return 'none'
+  return score.status === 'not_started' ? 'unconfirmed' : 'updated'
+}
+
+/**
+ * Whether the inline Confirm button renders. It is the explicit act for an
+ * untouched carried-forward answer, so it hides whenever another act owns the
+ * write: dirty edits (Next saves those), a pending prior-response review (the
+ * field is blanked; same condition that disables Next), or a read-only
+ * session.
+ */
+export const canConfirmCarryForward = (s: {
+  state: CarryForwardState
+  dirty: boolean
+  isReadOnly: boolean
+  priorReviewBlocked: boolean
+}): boolean =>
+  s.state === 'unconfirmed' &&
+  !s.dirty &&
+  !s.isReadOnly &&
+  !s.priorReviewBlocked
+
+/**
+ * Re-key the score map (keyed by functionoptionid) by owning functionid, so
+ * the sidebar and Complete summary can look up a question's answer row
+ * directly. Rows without functionoption cannot be attributed and are skipped.
+ */
+export const buildScoreByFunction = (scores: {
+  [key: number]: QuestionScores
+}): Record<number, QuestionScores> => {
+  const byFunction: Record<number, QuestionScores> = {}
+  for (const score of Object.values(scores)) {
+    const functionid = score.functionoption?.functionid
+    if (functionid != null) byFunction[functionid] = score
+  }
+  return byFunction
+}
+
+export type ConfirmSummaryEntry = {
+  functionid: number
+  functionName: string
+  pillarName: string
+}
+
+export type ConfirmSummary = {
+  /** Total questions in the questionnaire (the summary's denominator). */
+  total: number
+  /** Questions whose answer counts as updated this cycle (status = 'done'). */
+  updated: number
+  /** Carried-forward answers still awaiting confirmation, in sidebar order. */
+  unconfirmed: ConfirmSummaryEntry[]
+  /** Questions with no answer row at all, in sidebar order. */
+  unanswered: ConfirmSummaryEntry[]
+  /**
+   * True when at least one row carries status. False = the backend does not
+   * serve it, so the updated count and unconfirmed list would be lies built
+   * from absence — callers must render neither. The unanswered list stays
+   * valid (derived from row presence, not status).
+   */
+  hasStatusData: boolean
+}
+
+/**
+ * Build the Complete-time summary from the sidebar's own category list, so
+ * entries come out in sidebar order with sidebar names, ready for the same
+ * slug-based navigation.
+ */
+export const buildConfirmSummary = (
+  categories: { name: string; steps: FismaQuestion[] }[],
+  scoreByFunction: Record<number, QuestionScores>,
+  isOpenCall: boolean
+): ConfirmSummary => {
+  const summary: ConfirmSummary = {
+    total: 0,
+    updated: 0,
+    unconfirmed: [],
+    unanswered: [],
+    hasStatusData: Object.values(scoreByFunction).some((s) => s.status != null),
+  }
+  for (const pillar of categories) {
+    for (const step of pillar.steps) {
+      summary.total++
+      const functionid = step.function.functionid
+      const score = scoreByFunction[functionid]
+      if (!score) {
+        summary.unanswered.push({
+          functionid,
+          functionName: step.function.function,
+          pillarName: pillar.name,
+        })
+        continue
+      }
+      switch (carryForwardState(score, isOpenCall)) {
+        case 'unconfirmed':
+          summary.unconfirmed.push({
+            functionid,
+            functionName: step.function.function,
+            pillarName: pillar.name,
+          })
+          break
+        case 'updated':
+          summary.updated++
+          break
+        // 'none' (no status served): answered, but neither confirmable nor
+        // countable as updated — deliberately absent from every bucket.
+      }
+    }
+  }
+  return summary
+}
+
+export type { ScoreStatus }


### PR DESCRIPTION
Closes #659

## Problem

Carried-forward answers looked answered but never registered. Browsing is write-free by design (#413 — viewers must never be stamped as editors), so "review and agree" performed no write, and nothing in the UI showed the outstanding work. The reporting ISSO reviewed all 40 questions and saw 14/40 with no explanation; view events confirmed full coverage and exactly 14 saves.

## Changes, mapped to the issue's four items

**1. Visible state per question.** Unconfirmed carried answers get a warning chip ("Carried forward — not yet confirmed") in the question view and a "Not yet confirmed" marker in the sidebar; rows counted as updated show the confirmed state. Everything derives from the persisted `scores.status` — the same fact the Data Call Progress fraction counts — through one pure classifier (`confirmState.ts`), so the badges, the button, the summary, and the dashboard number cannot disagree. Open call only: historical rows are legitimately `not_started` forever. Read-only users see the badges (that's the triage information) but never the button.

**2. Explicit confirm, inline — not a dialog.** A review strip sits between the content and the navigation — the same zone where the CMS prior-response flow surfaces its "review before continuing" message, so every system shares one review area. The strip pairs the state chip with a small outlined "Confirm this answer is still accurate" button: one deliberate click issues `PUT scores/{id}/confirm` and the chip swaps in place (`role="status"`, so the change is announced — 508). The button yields the moment the question is dirty (an edit is its own explicit act and Next saves it, flipping status server-side), while a required prior-response review is pending, and for read-only sessions. **Next remains pure navigation and never writes on an untouched question** — pinned by a dedicated regression test.

The CMS insights flow keeps its shape (Insert only edits the field, exactly like the suggestion card's Insert) — but a resolved required review now routes through the confirm endpoint instead of the identical-body answer PUT the backend's no-op guard silently dropped. The whole insert-and-continue ritual finally counts.

**3. End-of-questionnaire summary.** Complete on an open call opens a summary — "N of M answers counted as updated" — listing carried-forward-unconfirmed and unanswered questions as separate groups with jump links, instead of silently looping back to question 1 (also retires the Complete-button loop report). When nothing remains it's the success state. Closed calls keep the old wrap-around (harmless paging for historical viewers).

**4. Progress wording.** The dashboard's Data Call Progress chip splits "Awaiting confirmation" (answers exist, none updated) from "Not started" (no answers), with matching tooltips, so `0/40` stops reading as data loss. The legacy "Not updated" wording is preserved when the backend doesn't serve `questionsanswered`.

## Degrade behavior

Against a backend that doesn't serve `scores.status` yet: no badges, no Confirm button, no summary counts (row-presence facts like "unanswered" still render), and the CMS prior-review falls back to its previous save path. Nothing misrenders during a staggered deploy.

## Out of scope

The dashboard em-dash for systems with **no score rows at all** (523 live systems) is #655's fix — its root cause is `buildDashboardMaps` building its universe from scores only, and the map change carries its own regression surface (Data Call column, per-row call picker). This PR delivers the wording half of the related comment; #655 delivers the rendering half.

## Testing

- New pure-helper suite (`confirmState.test.ts`, 16 tests): classification × status × call-state × row presence, degrade cases, summary bucketing in sidebar order
- `QuestionnairePage.test.tsx`: badge in view + sidebar; Confirm issues exactly one dedicated PUT and no answer write, chip flips after refetch; **Next write-free on untouched carried questions (#413 guard)**; button yields when dirty / read-only / pending review; no treatment on closed calls; CMS insert→navigation lands via confirm with no identical-body PUT; Complete summary with working jump links; success state with no loop and no manufactured writes
- `progressColumn.test.tsx`: three-way wording, absent-field fallback, tooltip split
- Full suite: 773 passing; lint clean; no new type errors

## UI

**Review strip on a carried-forward question (non-CMS):** the state chip and the explicit confirm action, between the justification field and the navigation.

<img width="3416" height="1728" alt="image (18)" src="https://github.com/user-attachments/assets/6c4d68db-a4af-4b78-b1c8-9cc82dafc5e7" />

**After confirming / saving:** the chip flips to "Updated this data call" in place, and the sidebar marker follows.

<img width="3430" height="1720" alt="image (16)" src="https://github.com/user-attachments/assets/54d07e27-4b1f-485b-a81f-f9ff310fc891" />

**CMS insights flow, unchanged shape:** the prior-response card still gates with "Review required"; the strip below shows the same carried-forward state every other system gets.

<img width="3362" height="1734" alt="image (15)" src="https://github.com/user-attachments/assets/467168eb-6dad-49c9-b659-8d1b5bac7a9d" />

**Complete summary:** the single "are you sure" moment — carried-forward-unconfirmed and unanswered as separate groups with jump links.

<img width="3424" height="1728" alt="image (17)" src="https://github.com/user-attachments/assets/605af4b8-a75f-4f2e-8e7b-bbc40fa0d170" />


**Dashboard progress wording:** "Awaiting confirmation" instead of "0/40 Not updated" for carried systems, with the matching tooltip.

<img width="782" height="248" alt="image (19)" src="https://github.com/user-attachments/assets/86ca69b2-a9ff-4944-81db-98389ddbf83c" />


## Acceptance criteria

From the issue body:

- [x] **Item 1 — visible state per question**: "Carried forward — not yet confirmed" chip in the question view + "Not yet confirmed" sidebar marker, both driven by `scores.status` through one classifier (`confirmState.ts`), text-bearing rather than color-only
- [x] **Item 2 — explicit confirm, inline, not a dialog**: one click saves the unchanged answer (`status` → `done`) and swaps the badge to its confirmed state in place; native button (keyboard-reachable); the chip is a `role="status"` live region so the change is announced (508); changing the answer keeps today's behavior (edit saves via Next)
- [x] **Item 2 — Next remains pure navigation and never writes**: pinned by a dedicated regression test (`keeps Next write-free on an untouched carried-forward question (#413)`)
- [x] **Item 3 — end-of-questionnaire summary**: Complete shows "N of M answers counted as updated" with carried-forward-unconfirmed and unanswered groups, each entry a jump link to the question
- [x] **Item 4 — progress wording**: "Awaiting confirmation" (answered last year, awaiting confirmation) distinguished from "Not started" (unanswered), so 0/40 stops reading as data loss

From the acceptance comment:

- [x] **Retro-serves affected users with no data migration**: the badge renders from nothing beyond the existing `not_started` state; the live 26-row case badges immediately on deploy
- [x] **Confirm flips rows to `done` with the confirming user's own identity and timestamps** (via the backend's events hook; pinned by `TestConfirmScoreIntegration`)
- [~] **Dash renders as 0/40**: deferred to #655 (its root cause is the dashboard map construction, out of this PR's scope); the carried-forward-unconfirmed vs not-started distinction from the same comment is delivered here

## Deploy order

Requires CMS-Enterprise/ztmf#515 (scores.status on reads + the confirm endpoint) — deploy backend first.
