### PR TITLE
Combined FY26 frontend fixes: ISSO Name unlock, carried-forward confirm, not-updated undercount

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -233,13 +233,7 @@ export type QuestionScores = {
   status?: ScoreStatus
   // Present when fetched with ?include=functionoption; functionid maps the
   // row back to its question.
-  functionoption?: {
-    functionoptionid: number
-    functionid: number
-    score: number
-    optionname: string
-    description: string
-  }
+  functionoption?: QuestionOption
   last_edited_at?: string | null
   last_edited_by?: LastEditedBy | null
   notes_is_ai_summary?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,14 @@ export type LastEditedBy = {
   role?: UserRole
 }
 
+/**
+ * The answer's review state for its data call (scores.status): 'not_started'
+ * = carried forward and untouched this cycle; 'done' = saved or confirmed
+ * this cycle. The same persisted fact the Data Call Progress count reads, so
+ * badges derived from it cannot disagree with the fraction.
+ */
+export type ScoreStatus = 'not_started' | 'done'
+
 export type QuestionScores = {
   scoreid: number
   fismasystemid: number
@@ -220,6 +228,18 @@ export type QuestionScores = {
   notes: string
   functionoptionid: number
   datacallid: number
+  // Optional: a backend that does not serve it degrades to no carried-forward
+  // badges rather than badging everything.
+  status?: ScoreStatus
+  // Present when fetched with ?include=functionoption; functionid maps the
+  // row back to its question.
+  functionoption?: {
+    functionoptionid: number
+    functionid: number
+    score: number
+    optionname: string
+    description: string
+  }
   last_edited_at?: string | null
   last_edited_by?: LastEditedBy | null
   notes_is_ai_summary?: boolean

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -223,6 +223,24 @@ describe('buildExtendedDiff', () => {
     expect(buildExtendedDiff(base, base, KEYS)).toEqual({})
   })
 
+  // isso_name is the one extended field whose displayed value can be resolved
+  // by the backend rather than stored, so the form is seeded with a name that
+  // is not in the column. Omitting it while untouched is what stops an
+  // unrelated edit from persisting the resolved name as a stored override.
+  it('omits an untouched isso_name that was resolved rather than stored', () => {
+    const keys = [...KEYS, 'isso_name'] as (keyof FismaSystemType)[]
+    const loaded = {
+      ...base,
+      isso_name: 'Resolved From User Record',
+    } as unknown as FismaSystemType
+    const edited = { ...loaded, fips: 'High' } as FismaSystemType
+
+    const diff = buildExtendedDiff(edited, loaded, keys)
+
+    expect(diff).toEqual({ fips: 'High' })
+    expect(diff).not.toHaveProperty('isso_name')
+  })
+
   it('includes only changed fields, at their typed value', () => {
     const edited = { ...base, fips: 'High', hva: false } as FismaSystemType
     expect(buildExtendedDiff(edited, base, KEYS)).toEqual({

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -167,6 +167,13 @@ export function formatList(v: string[] | null | undefined): string {
  * array []) passes through as the user's clear. On create, pass an empty
  * baseline so only the fields the user set are sent.
  *
+ * Omission is what protects a field the backend resolves rather than stores:
+ * the System Details form is seeded from a read that returns a resolved
+ * isso_name, so an untouched field must stay out of the payload or saving an
+ * unrelated edit would persist the resolved name as a stored override. A
+ * missing baseline defeats that, since every field then counts as changed;
+ * pass an empty system on create and a real one on update, never null.
+ *
  * @param edited - The edited system.
  * @param baseline - The system to diff against (the loaded system, or an empty
  *   one when creating); a missing baseline treats every field as unset.

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -140,6 +140,64 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
   expect(putBody).not.toHaveProperty('cloud_service_model')
 })
 
+test('an edited ISSO Name is sent in the save payload', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  expect(putBody).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name saves an empty string, which restores the derived name', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // '' clears the stored override so the name derived from the ISSO user
+  // record applies again; null would read as "leave unchanged".
+  expect(putBody).toHaveProperty('isso_name', '')
+})
+
 test('clearing a free-text field saves an empty string, not null', async () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   let putBody: Record<string, unknown> | undefined

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -181,7 +181,8 @@ export default function EditSystemModal({
   // or free text. Each control stores the field's typed clear signal when
   // emptied: enum '', boolean null, array [].
   const renderExtendedControl = (field: FieldConfig) => {
-    // isso_name is backend-resolved, so its control is read-only.
+    // A field marked read-only in fieldConfig renders disabled; the same flag
+    // keeps it out of the write payload.
     const disabled = field.readOnly
     if (field.type === 'select') {
       const current = editedFismaSystem[field.key] as string | null | undefined

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -261,4 +261,49 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
+
+  // --- Carried-forward wording on the current call ---
+
+  it('reads Awaiting confirmation for a current-call system with carried answers and zero updates', () => {
+    // The answers exist (carried forward) but none count as updated —
+    // "0/41 Not updated" read as data loss; the chip says the actual state.
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 41 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Awaiting confirmation')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('reads Not started for a current-call system with no answers at all', () => {
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 0 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
+    // ztmf#437 may not be deployed everywhere; without the field the split
+    // would be a guess, so the cell keeps saying what it always said.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
+    expect(screen.getByText('Not updated')).toBeInTheDocument()
+  })
+
+  it('describes the carried-forward state in the tooltip', () => {
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 41 })).toBe(
+      'Answers carried forward from a previous data call — not yet confirmed'
+    )
+    // No answers at all keeps the plain no-updates line.
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 0 })).toBe(
+      'No updates this data call'
+    )
+  })
 })

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -103,6 +103,19 @@ export function ProgressCell({
     )
   }
   const updated = entry.questionsupdated > 0
+  // Zero updates splits two materially different states: carried-forward
+  // answers awaiting confirmation vs no answers at all — a blanket "Not
+  // updated" read as data loss to ISSOs who had just reviewed everything.
+  // questionsanswered may be absent until ztmf#437 is deployed everywhere;
+  // keep the legacy wording then rather than guessing.
+  const answered = entry.questionsanswered
+  const label = updated
+    ? 'Updated'
+    : answered == null
+      ? 'Not updated'
+      : answered > 0
+        ? 'Awaiting confirmation'
+        : 'Not started'
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box
@@ -117,7 +130,7 @@ export function ProgressCell({
         </span>
         <Chip
           size="small"
-          label={updated ? 'Updated' : 'Not updated'}
+          label={label}
           color={updated ? 'success' : 'warning'}
           variant="outlined"
         />

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -26,8 +26,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
  *   - current call, any genuine edit: "Updated" (green);
- *   - current call, otherwise: "Not updated" (orange). The chip is derived from
- *     questionsupdated so it can never disagree with the fraction.
+ *   - current call, zero updates: "Awaiting confirmation" (carried answers
+ *     exist) or "Not started" (none do), both warning-colored laggards;
+ *     legacy "Not updated" when questionsanswered is not served.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -87,7 +88,7 @@ export function ProgressCell({
       )
     }
     return (
-      <Tooltip title={progressTooltip(entry)}>
+      <Tooltip title={progressTooltip(entry, { pastCall: true })}>
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
           <span>
             {answered}/{entry.questionsexpected}

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -66,7 +66,7 @@ export function progressSortValue(
  */
 export function progressTooltip(
   entry: ScoreProgress | undefined,
-  opts: { completed?: boolean } = {}
+  opts: { completed?: boolean; pastCall?: boolean } = {}
 ): string {
   if (!entry) return 'No progress data for this data call'
   if (entry.lastupdatedat) {
@@ -79,8 +79,9 @@ export function progressTooltip(
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
   // Mirrors the chip's carried-forward split: answers exist but none count
-  // as updated yet — awaiting confirmation, not missing.
-  if ((entry.questionsanswered ?? 0) > 0)
+  // as updated yet — awaiting confirmation, not missing. Current call only:
+  // a closed call has nothing left to confirm.
+  if (!opts.pastCall && (entry.questionsanswered ?? 0) > 0)
     return 'Answers carried forward from a previous data call — not yet confirmed'
   return 'No updates this data call'
 }

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -78,5 +78,9 @@ export function progressTooltip(
   if (hasNoQuestionnaire(entry))
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
+  // Mirrors the chip's carried-forward split: answers exist but none count
+  // as updated yet — awaiting confirmation, not missing.
+  if ((entry.questionsanswered ?? 0) > 0)
+    return 'Answers carried forward from a previous data call — not yet confirmed'
   return 'No updates this data call'
 }

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -39,8 +39,8 @@ export function datacallNameComparator(
  * a row is on.
  *
  * Resolution order: the call chosen by most-recently-updated in
- * buildDashboardMaps; else the newest-by-deadline call the system has scores
- * in; else a call that is actually in the current view.
+ * buildDashboardMaps; else the newest-by-deadline call the system appears in;
+ * else a call that is actually in the current view.
  *
  * That last rung matters. activeDataCallId collapses to the newest call
  * whenever more than one call is toggled on, and selecting a year toggles all
@@ -52,7 +52,8 @@ export function datacallNameComparator(
  * the label inside what the user is looking at.
  * @param {number} fismasystemid - The row's system id.
  * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
- * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids the
+ *   system appears in (score or progress rows).
  * @param {datacall[]} datacalls - All known data calls.
  * @param {number} activeDataCallId - The dashboard's active call id.
  * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -39,8 +39,8 @@ export function datacallNameComparator(
  * a row is on.
  *
  * Resolution order: the call chosen by most-recently-updated in
- * buildDashboardMaps; else the newest-by-deadline call the system appears in;
- * else a call that is actually in the current view.
+ * buildDashboardMaps; else the newest-by-deadline call the system has scores
+ * in; else a call that is actually in the current view.
  *
  * That last rung matters. activeDataCallId collapses to the newest call
  * whenever more than one call is toggled on, and selecting a year toggles all
@@ -52,8 +52,7 @@ export function datacallNameComparator(
  * the label inside what the user is looking at.
  * @param {number} fismasystemid - The row's system id.
  * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
- * @param {Record<number, number[]>} systemCallMap - System id -> call ids the
- *   system appears in (score or progress rows).
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
  * @param {datacall[]} datacalls - All known data calls.
  * @param {number} activeDataCallId - The dashboard's active call id.
  * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -50,22 +50,69 @@ describe('buildDashboardMaps', () => {
     expect(scoreMap[7]).toBeUndefined() // no fake score
     expect(progressMap[7].questionsexpected).toBe(40)
     expect(progressMap[7].questionsupdated).toBe(0)
-    expect(systemCallMap[7]).toEqual([38])
+    // systemCallMap is score-derived: a never-started system lists no calls, so
+    // export provenance and the call picker don't treat it as having real data.
+    expect(systemCallMap[7]).toEqual([])
     expect(chosenCallMap[7]).toBe(38)
+  })
+
+  it('keeps the newest call for a never-started system present in multiple calls', () => {
+    // System 7 is never-started in BOTH calls with no score anywhere, so every
+    // idx ties at -1. With no scored call to prefer, the tie-break leaves the
+    // newest-first fallback intact (idxs[0] = 38) and systemCallMap stays empty.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[], []],
+        [[prog(7, 0, null)], [prog(7, 0, null)]]
+      )
+    expect(scoreMap[7]).toBeUndefined()
+    expect(progressMap[7].questionsupdated).toBe(0)
+    expect(chosenCallMap[7]).toBe(38) // newest-first fallback
+    expect(systemCallMap[7]).toEqual([])
   })
 
   it('keeps a scored call as chosen when a never-started progress row exists in another call', () => {
     // System 1 is scored + completed in the newer call 38, and has a
     // never-started progress row (0 updated, null lastupdated) in the older call
-    // 3. The union now adds call 3 to its idxs, but that never-started row must
-    // not win `chosen` (its lastupdated is null -> -1) and blank the real score.
-    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+    // 3. The union adds call 3 to its idxs, but that never-started row must not
+    // win `chosen` and blank the real score, and systemCallMap must stay
+    // score-derived ([38], not the union [38, 3]).
+    const { scoreMap, chosenCallMap, systemCallMap } = buildDashboardMaps(
       CALL_IDS,
       [[agg(1, 88)], []], // score only in call 38
       [[prog(1, 40, '2025-09-01')], [prog(1, 0, null)]]
     )
     expect(scoreMap[1].score).toBe(88) // scored call kept
     expect(chosenCallMap[1]).toBe(38)
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
+  it('keeps the score when the older scored call has no progress rows', () => {
+    // Score only in the older call 3, but its /scores/progress fetch failed, so
+    // call 3 has no progress row -> lastUpdatedMs -1, tying with call 38's
+    // never-started row. Without the score-preference tie-break, chosen lands on
+    // 38 and the real score is lost.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], []]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
+  })
+
+  it('keeps the score when the scored call row has a null lastupdatedat', () => {
+    // Score in the older call 3, whose progress row has a null lastupdatedat (an
+    // imported call carries no edit events) -> -1, tying with call 38's
+    // never-started row. The tie-break must still keep the scored call.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], [prog(1, 12, null)]]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
   })
 
   it('lists a call once for a system in both its scores and progress', () => {

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -36,6 +36,49 @@ describe('buildDashboardMaps', () => {
     expect(systemCallMap[2]).toEqual([3])
   })
 
+  it('includes a system present only in progress (no score row)', () => {
+    // A never-started system in the current call: /scores/progress returns a row
+    // (40 expected, 0 updated) but there is no aggregate score row yet. It must
+    // still land in progressMap so the "Not updated only" facet can see it -
+    // keying off scores alone dropped these systems entirely.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[agg(1, 80)], []], // system 7 has no score row in either call
+        [[prog(1, 40, '2025-09-01'), prog(7, 0, null)], []]
+      )
+    expect(scoreMap[7]).toBeUndefined() // no fake score
+    expect(progressMap[7].questionsexpected).toBe(40)
+    expect(progressMap[7].questionsupdated).toBe(0)
+    expect(systemCallMap[7]).toEqual([38])
+    expect(chosenCallMap[7]).toBe(38)
+  })
+
+  it('keeps a scored call as chosen when a never-started progress row exists in another call', () => {
+    // System 1 is scored + completed in the newer call 38, and has a
+    // never-started progress row (0 updated, null lastupdated) in the older call
+    // 3. The union now adds call 3 to its idxs, but that never-started row must
+    // not win `chosen` (its lastupdated is null -> -1) and blank the real score.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 88)], []], // score only in call 38
+      [[prog(1, 40, '2025-09-01')], [prog(1, 0, null)]]
+    )
+    expect(scoreMap[1].score).toBe(88) // scored call kept
+    expect(chosenCallMap[1]).toBe(38)
+  })
+
+  it('lists a call once for a system in both its scores and progress', () => {
+    // System 1 appears in the score AND progress list for call 38; its call list
+    // must not double-count that call (the union is deduped per call index).
+    const { systemCallMap } = buildDashboardMaps(
+      [38],
+      [[agg(1, 80)]],
+      [[prog(1, 40, '2025-09-01')]]
+    )
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
   it('shows the call a multi-call system most recently updated, not the newest', () => {
     // System 1 is in both calls; it completed the OLDER call (3) recently and
     // never touched the newer call (38). Expect the older call's score/progress.

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -3,7 +3,7 @@ import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 export type DashboardMaps = {
   scoreMap: Record<number, SystemScoreEntry>
   progressMap: Record<number, ScoreProgress>
-  /** Which active data call(s) each system has scores in, for per-row actions. */
+  /** Which active data call(s) each system appears in (score or progress row). */
   systemCallMap: Record<number, number[]>
   /** The single call chosen for each system's dashboard row (most-recently-updated). */
   chosenCallMap: Record<number, number>
@@ -50,16 +50,20 @@ export function buildDashboardMaps(
     return m
   })
 
-  // The call indices each system appears in (scores drive the table), newest
-  // first since callIds is newest first.
+  // Call indices each system appears in, newest first. Union of scores AND
+  // progress per call: a never-started system has a progress row but no score,
+  // and keying off scores alone dropped it. Per call index keeps idxs deduped.
   const systemIdxs = new Map<number, number[]>()
-  scoreByCall.forEach((m, idx) => {
-    for (const sys of m.keys()) {
+  for (let idx = 0; idx < callIds.length; idx++) {
+    const sysIds = new Set<number>()
+    for (const sys of scoreByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of progressByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of sysIds) {
       const arr = systemIdxs.get(sys)
       if (arr) arr.push(idx)
       else systemIdxs.set(sys, [idx])
     }
-  })
+  }
 
   const scoreMap: Record<number, SystemScoreEntry> = {}
   const progressMap: Record<number, ScoreProgress> = {}
@@ -67,10 +71,12 @@ export function buildDashboardMaps(
   const chosenCallMap: Record<number, number> = {}
 
   for (const [sys, idxs] of systemIdxs) {
-    // Choose the call this system most recently updated; ties and
-    // never-updated systems keep the newest call (idxs[0]).
+    // Choose the call this system most recently updated; ties/never-updated keep
+    // the newest (idxs[0]). Safe under the score+progress union: a scoreless
+    // (progress-only) call always has null lastupdatedat (edits create scores),
+    // so it scores -1 and never wins `chosen` - a real score is never blanked.
     let chosen = idxs[0]
-    let bestT = lastUpdatedMs(progressByCall[chosen]?.get(sys))
+    let bestT = -Infinity
     for (const idx of idxs) {
       const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
       if (t > bestT) {

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -3,7 +3,7 @@ import type { ScoreAggregate, ScoreProgress, SystemScoreEntry } from '@/types'
 export type DashboardMaps = {
   scoreMap: Record<number, SystemScoreEntry>
   progressMap: Record<number, ScoreProgress>
-  /** Which active data call(s) each system appears in (score or progress row). */
+  /** Which active data call(s) each system has scores in, for per-row actions. */
   systemCallMap: Record<number, number[]>
   /** The single call chosen for each system's dashboard row (most-recently-updated). */
   chosenCallMap: Record<number, number>
@@ -50,13 +50,25 @@ export function buildDashboardMaps(
     return m
   })
 
-  // Call indices each system appears in, newest first. Union of scores AND
-  // progress per call: a never-started system has a progress row but no score,
-  // and keying off scores alone dropped it. Per call index keeps idxs deduped.
+  // Two per-call, newest-first index lists (callIds is newest first):
+  //   systemIdxs - union of score AND progress rows. Drives row membership,
+  //     progressMap, and the rank, so a never-started system (progress row, no
+  //     score) is included instead of dropped.
+  //   scoreIdxs  - score rows only. Drives systemCallMap, whose consumers
+  //     (export provenance, the #467 call picker in FismaTable) mean "calls this
+  //     system has a real score in". Feeding them the union would list
+  //     progress-only calls, disabling export and firing the picker spuriously.
+  // Per call index keeps both deduped.
   const systemIdxs = new Map<number, number[]>()
+  const scoreIdxs = new Map<number, number[]>()
   for (let idx = 0; idx < callIds.length; idx++) {
     const sysIds = new Set<number>()
-    for (const sys of scoreByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of scoreByCall[idx]?.keys() ?? []) {
+      sysIds.add(sys)
+      const arr = scoreIdxs.get(sys)
+      if (arr) arr.push(idx)
+      else scoreIdxs.set(sys, [idx])
+    }
     for (const sys of progressByCall[idx]?.keys() ?? []) sysIds.add(sys)
     for (const sys of sysIds) {
       const arr = systemIdxs.get(sys)
@@ -72,16 +84,22 @@ export function buildDashboardMaps(
 
   for (const [sys, idxs] of systemIdxs) {
     // Choose the call this system most recently updated; ties/never-updated keep
-    // the newest (idxs[0]). Safe under the score+progress union: a scoreless
-    // (progress-only) call always has null lastupdatedat (edits create scores),
-    // so it scores -1 and never wins `chosen` - a real score is never blanked.
+    // the newest (idxs[0]). Break ties toward a call the system actually has a
+    // score in: lastUpdatedMs returns -1 for a null OR missing progress row (a
+    // failed /scores/progress fetch, or an imported call with no edit events),
+    // so a scored call can tie at -1 with a never-started one. Without the
+    // score-preference the newer (progress-only) call would win and the real
+    // score would never land in scoreMap - the system would read as unscored.
     let chosen = idxs[0]
     let bestT = -Infinity
+    let bestHasScore = false
     for (const idx of idxs) {
       const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
-      if (t > bestT) {
+      const hasScore = scoreByCall[idx]?.has(sys) ?? false
+      if (t > bestT || (t === bestT && hasScore && !bestHasScore)) {
         bestT = t
         chosen = idx
+        bestHasScore = hasScore
       }
     }
 
@@ -91,7 +109,8 @@ export function buildDashboardMaps(
     }
     const progress = progressByCall[chosen]?.get(sys)
     if (progress) progressMap[sys] = progress
-    systemCallMap[sys] = idxs.map((idx) => callIds[idx])
+    // Score-derived (see scoreIdxs): a never-started system lists no calls here.
+    systemCallMap[sys] = (scoreIdxs.get(sys) ?? []).map((idx) => callIds[idx])
     chosenCallMap[sys] = callIds[chosen]
   }
 

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -90,6 +90,11 @@ export function buildDashboardMaps(
     // so a scored call can tie at -1 with a never-started one. Without the
     // score-preference the newer (progress-only) call would win and the real
     // score would never land in scoreMap - the system would read as unscored.
+    // The tie-break only covers the -1 tie; a scoreless call winning outright
+    // (strict >) is prevented only by the backend invariant "scoreless => null
+    // lastupdatedat" (edits create scores). If that ever changes - e.g. a
+    // non-answer event bumps lastupdatedat - a scoreless call could out-`>` a
+    // scored one and this is where the score would be blanked.
     let chosen = idxs[0]
     let bestT = -Infinity
     let bestHasScore = false

--- a/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
+++ b/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
@@ -1,0 +1,129 @@
+import { useId } from 'react'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Link from '@mui/material/Link'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import Typography from '@mui/material/Typography'
+import CloseIcon from '@mui/icons-material/Close'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import type { ConfirmSummary, ConfirmSummaryEntry } from './confirmState'
+
+type Props = {
+  /** null keeps the dialog closed. */
+  summary: ConfirmSummary | null
+  onClose: () => void
+  /** Navigate to the entry's question (the parent owns routing). */
+  onJump: (entry: ConfirmSummaryEntry) => void
+}
+
+/**
+ * The end-of-questionnaire summary shown by Complete on an open data call:
+ * one "are you sure" moment instead of 40 per-question dialogs. Lists
+ * carried-forward answers awaiting confirmation and unanswered questions as
+ * jump links; when neither remains it is the success state (which also
+ * retires the old silent loop back to question 1).
+ */
+const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
+  const titleId = useId()
+  const descId = useId()
+  if (!summary) return null
+
+  const outstanding = summary.unconfirmed.length + summary.unanswered.length
+  const complete = outstanding === 0
+
+  const entryList = (entries: ConfirmSummaryEntry[]) => (
+    <List dense sx={{ pt: 0 }}>
+      {entries.map((entry) => (
+        <ListItem key={entry.functionid} sx={{ py: 0.25 }}>
+          <Link
+            component="button"
+            type="button"
+            onClick={() => onJump(entry)}
+            sx={{ textAlign: 'left' }}
+          >
+            {entry.pillarName} — {entry.functionName}
+          </Link>
+        </ListItem>
+      ))}
+    </List>
+  )
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      <DialogTitle id={titleId}>
+        {complete ? 'Questionnaire complete' : 'Before you finish'}
+      </DialogTitle>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton onClick={onClose} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent>
+        {/* The headline count reads scores.status; without status data (the
+            backend not yet serving it) the count would be a lie built from
+            absence, so it is omitted and only row-presence facts render. */}
+        {summary.hasStatusData && (
+          <Typography id={descId} sx={{ mb: 1 }}>
+            {summary.updated} of {summary.total} answers counted as updated for
+            this data call.
+          </Typography>
+        )}
+        {complete ? (
+          <Alert severity="success" icon={false}>
+            Every question is answered
+            {summary.hasStatusData ? ' and counted as updated' : ''}. You are
+            done — no further action is needed.
+          </Alert>
+        ) : (
+          <>
+            {summary.unconfirmed.length > 0 && (
+              <Box sx={{ mb: 1.5 }}>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Carried forward — needs confirmation (
+                  {summary.unconfirmed.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These answers were carried over from the previous data call
+                  and do not count as updated until you confirm them. Open each
+                  question and select “Confirm this answer is still accurate,”
+                  or update the answer.
+                </Typography>
+                {entryList(summary.unconfirmed)}
+              </Box>
+            )}
+            {summary.unanswered.length > 0 && (
+              <Box>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Unanswered ({summary.unanswered.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These questions have no answer yet. Open each question, select
+                  an answer, and continue with Next to save it.
+                </Typography>
+                {entryList(summary.unanswered)}
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <CmsButton onClick={onClose}>Close</CmsButton>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmSummaryDialog

--- a/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
+++ b/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
@@ -61,7 +61,7 @@ const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
       maxWidth="sm"
       fullWidth
       aria-labelledby={titleId}
-      aria-describedby={descId}
+      aria-describedby={summary.hasStatusData ? descId : undefined}
     >
       <DialogTitle id={titleId}>
         {complete ? 'Questionnaire complete' : 'Before you finish'}
@@ -111,7 +111,7 @@ const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
                 </Typography>
                 <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                   These questions have no answer yet. Open each question, select
-                  an answer, and continue with Next to save it.
+                  an answer, and continue with Next or Complete to save it.
                 </Typography>
                 {entryList(summary.unanswered)}
               </Box>

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -939,8 +939,12 @@ describe('QuestionnairePage justification integration', () => {
     const complete = screen.getByRole('button', { name: 'Complete' })
     expect(complete).toBeDisabled()
 
-    // Accepting the required review is a current-call action, so the answer
-    // persists even though the text equals the seeded prior response.
+    // Accepting the required review must land even though the text equals
+    // the seeded prior response — via the confirm endpoint, since the old
+    // identical-body answer PUT was silently discarded by the backend's
+    // no-op guard. Insert alone performs no write (like the
+    // insights-suggestion card's Insert); the resolved review lands on the
+    // next navigation, so the two adjacent Insert buttons behave alike.
     fireEvent.click(
       screen.getByRole('button', {
         name: 'Insert previous ISSO response into current response',
@@ -948,18 +952,17 @@ describe('QuestionnairePage justification integration', () => {
     )
     expect(response).toHaveValue(PRIOR_RESPONSE)
     expect(complete).toBeEnabled()
+    expect(axios.put).not.toHaveBeenCalled()
 
     fireEvent.click(complete)
 
     await waitFor(() =>
-      expect(axios.put).toHaveBeenCalledWith('scores/5001', {
-        fismasystemid: 1002,
-        notes: PRIOR_RESPONSE,
-        functionoptionid: 100,
-        datacallid: 6,
-        notes_is_ai_summary: false,
-      })
+      expect(axios.put).toHaveBeenCalledWith('scores/5001/confirm')
     )
+    // The unchanged answer body must NOT be re-PUT — that path re-stamps
+    // nothing server-side and would clear notes_is_ai_summary on a real
+    // change-detection miss.
+    expect(axios.put).not.toHaveBeenCalledWith('scores/5001', expect.anything())
   })
 
   it('shows the insights panel, option badges, and suggestion for a CMS data call', async () => {
@@ -1076,5 +1079,305 @@ describe('QuestionnairePage justification integration', () => {
     expect(
       screen.queryByRole('textbox', { name: 'Current response' })
     ).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Carried-forward confirmation: badge, inline Confirm, the #413
+// browse-is-write-free guard, and the Complete summary.
+// ---------------------------------------------------------------------------
+
+describe('carried-forward confirmation', () => {
+  const OPTIONS_7001 = [
+    { functionoptionid: 200, description: 'Baseline', score: 1 },
+    { functionoptionid: 201, description: 'Advanced', score: 2 },
+  ]
+
+  // A row copied by the FY2026 rollover: status not_started, no edit event.
+  const carried7006 = (status: 'not_started' | 'done' = 'not_started') => ({
+    scoreid: 6001,
+    fismasystemid: 1002,
+    notes: 'carried justification',
+    functionoptionid: 100,
+    datacallid: 5,
+    status,
+    functionoption: {
+      functionoptionid: 100,
+      functionid: 7006,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+    last_edited_at: null,
+    last_edited_by: null,
+  })
+
+  const done7001 = () => ({
+    scoreid: 6002,
+    fismasystemid: 1002,
+    notes: 'answered this cycle',
+    functionoptionid: 200,
+    datacallid: 5,
+    status: 'done',
+    functionoption: {
+      functionoptionid: 200,
+      functionid: 7001,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+  })
+
+  const DEVICES_LINK =
+    '/questionnaire/ssd-ex/FY2026_Q1/devices/imperial-device-management'
+
+  // Serves a mutable scores list and, like the real backend, flips the
+  // targeted row to done when the confirm endpoint is hit — so the refetch
+  // after a confirm returns the confirmed row instead of resurrecting the
+  // original fixture.
+  function installScoreMocks(scores: Array<{ scoreid: number }>) {
+    let rows = scores
+    axios.get.mockImplementation((url: string) => {
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: QUESTIONS } })
+      if (url.startsWith('scores'))
+        return Promise.resolve({ data: { data: rows } })
+      if (url.includes('functions/7006/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7006 } })
+      if (url.includes('functions/7001/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7001 } })
+      return Promise.resolve({ data: { data: [] } })
+    })
+    axios.post.mockResolvedValue({ data: {} })
+    axios.put.mockImplementation((url: string) => {
+      const confirm = /^scores\/(\d+)\/confirm$/.exec(url)
+      if (confirm) {
+        rows = rows.map((row) =>
+          row.scoreid === Number(confirm[1]) ? { ...row, status: 'done' } : row
+        )
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+  }
+
+  it('badges an unconfirmed carried-forward answer in the question view and sidebar, and confirms it with one dedicated PUT', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    // Question-view badge (role="status" so the flip below is announced).
+    const badge = await screen.findByText('Carried forward — not yet confirmed')
+    expect(badge).toBeInTheDocument()
+    // Sidebar marker for the same fact, on the carried question only.
+    expect(screen.getAllByText('Not yet confirmed')).toHaveLength(1)
+
+    // The explicit act: exactly one confirm PUT, no answer PUT/POST.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    )
+    await waitFor(() =>
+      expect(axios.put).toHaveBeenCalledWith('scores/6001/confirm')
+    )
+    expect(axios.put).toHaveBeenCalledTimes(1)
+    expect(saveScorePosts()).toHaveLength(0)
+
+    // Feedback is the badge swapping to its confirmed state.
+    expect(
+      await screen.findByText('Updated this data call')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps Next write-free on an untouched carried-forward question (#413)', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByText('Carried forward — not yet confirmed')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+
+    // Navigation happened (the next question's options load)...
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7001/options')
+        )
+      ).toBe(true)
+    )
+    // ...and no write of any kind was issued.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+  })
+
+  it('yields the Confirm button to the edit path the moment the question is dirty', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByRole('button', {
+      name: 'Confirm this answer is still accurate',
+    })
+    fireEvent.click(screen.getByRole('radio', { name: /Advanced/ }))
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+    // The badge still shows — the row is still unconfirmed until saved.
+    expect(
+      screen.getByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+  })
+
+  it('shows the badge but no Confirm button to a read-only admin', async () => {
+    installScoreMocks([carried7006()])
+    setMockCtx(
+      makeCtx({
+        userInfo: {
+          userid: 'u-2',
+          email: 'auditor@hhs.gov',
+          fullname: 'Read Only',
+          role: 'HHS_READONLY_ADMIN',
+        } as userData,
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders no carried-forward treatment on a closed data call', async () => {
+    installScoreMocks([carried7006()])
+    const pastDeadline = '2001-01-01T00:00:00Z'
+    // OWNER stays writable past the deadline (isReadOnly false), isolating
+    // the open-call gate as the only thing hiding the treatment.
+    setMockCtx(
+      makeCtx({
+        latestDeadline: pastDeadline,
+        selectedDatacall: {
+          datacallid: 5,
+          datacall: 'FY2026 Q1',
+          datecreated: '',
+          deadline: pastDeadline,
+        },
+        datacalls: [
+          {
+            datacallid: 5,
+            datacall: 'FY2026 Q1',
+            datecreated: '',
+            deadline: pastDeadline,
+          },
+        ],
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    await waitFor(() =>
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    )
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('Complete summarizes unconfirmed and unanswered questions with working jump links', async () => {
+    // Devices (7001) is the last question; it has no row at all. Identity
+    // (7006) carries an unconfirmed answer.
+    installScoreMocks([carried7006()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    // The summary reads a freshly-awaited scores fetch, then opens.
+    expect(await screen.findByText('Before you finish')).toBeInTheDocument()
+    expect(
+      screen.getByText('0 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Carried forward — needs confirmation (1)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Unanswered (1)')).toBeInTheDocument()
+
+    // No loop back to question 1: Complete opened the summary instead of
+    // silently navigating.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
+
+    // The jump link navigates to the listed question.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Identity — Imperial Identity Verification',
+      })
+    )
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7006/options')
+        )
+      ).toBe(true)
+    )
+    expect(screen.queryByText('Before you finish')).not.toBeInTheDocument()
+  })
+
+  it('Complete shows the success state and stops looping when everything is updated', async () => {
+    installScoreMocks([carried7006('done'), done7001()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    expect(
+      await screen.findByText('Questionnaire complete')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('2 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    // No writes fired: everything was already done, and Complete must not
+    // manufacture one.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+    // And no silent wrap-around to the first question.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
   })
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+  configure as rtlConfigure,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
@@ -1088,6 +1095,20 @@ describe('QuestionnairePage justification integration', () => {
 // ---------------------------------------------------------------------------
 
 describe('carried-forward confirmation', () => {
+  // CI runners execute this suite ~3x slower than a dev machine, and these
+  // tests each begin by awaiting a full page load — RTL's default 1s
+  // findBy/waitFor timeout flaked there while the question was still
+  // loading. Raise the async ceiling for this block only; passing tests are
+  // unaffected (they resolve as soon as the DOM settles).
+  beforeAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 4000 })
+    jest.setTimeout(15000)
+  })
+  afterAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 1000 })
+    jest.setTimeout(5000)
+  })
+
   const OPTIONS_7001 = [
     { functionoptionid: 200, description: 'Baseline', score: 1 },
     { functionoptionid: 201, description: 'Advanced', score: 2 },

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import Typography from '@mui/material/Typography'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
@@ -63,6 +65,15 @@ import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+  type ConfirmSummary,
+  type ConfirmSummaryEntry,
+} from './confirmState'
+import ConfirmSummaryDialog from './ConfirmSummaryDialog'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
 import {
@@ -243,10 +254,14 @@ export default function QuestionnarePage() {
   // strictly required for the selection to update, but it is retained as a clean
   // reset of the subtree when a re-seed changes the answer out of band.
   const [radioKey, setRadioKey] = React.useState(0)
+  // Returns the fresh map alongside committing it to state, so a caller that
+  // must reason over the authoritative data in the same tick (the Complete
+  // summary) does not have to read a not-yet-rendered state value. undefined
+  // on failure — callers fall back to the state they already had.
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
-  ) => {
+  ): Promise<questionScoreMap | undefined> => {
     try {
       const response = await axiosInstance.get(
         `scores?datacallid=${datacallID}&fismasystemid=${systemId}&include=functionoption`
@@ -258,9 +273,11 @@ export default function QuestionnarePage() {
         }))
       )
       setQuestionScores(hashTable)
+      return hashTable
     } catch (error) {
-      if (isAuthHandled(error)) return
+      if (isAuthHandled(error)) return undefined
       console.error('Error fetching question scores:', error)
+      return undefined
     }
   }
   const handleChoiceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -599,6 +616,113 @@ export default function QuestionnarePage() {
     priorReviewNeedsSave,
   }
 
+  // Carried-forward confirmation state, read from scores.status — the same
+  // persisted fact the Data Call Progress fraction counts. Open call only:
+  // historical rows are legitimately not_started forever. Read-only sessions
+  // see the badges but never the Confirm button.
+  const isOpenCall = !isPastDeadline
+  const scoreByFunction = React.useMemo(
+    () => buildScoreByFunction(questionScores),
+    [questionScores]
+  )
+  // The saved row backing the current question. Keyed by initQuestionChoice
+  // (the seeded answer), not selectQuestionOption, so flipping the radio does
+  // not detach the badge from the row it describes.
+  const currentSavedScore =
+    initQuestionChoice !== -1 ? questionScores[initQuestionChoice] : undefined
+  const currentCarryState = carryForwardState(currentSavedScore, isOpenCall)
+  const showConfirmButton = canConfirmCarryForward({
+    state: currentCarryState,
+    // Any deviation from the seeded answer/notes: the edit is the explicit
+    // act, and Next saves it (flipping status server-side), so the button
+    // yields to avoid two visible paths to the same write.
+    dirty: selectQuestionOption !== initQuestionChoice || notes !== initNotes,
+    isReadOnly,
+    priorReviewBlocked:
+      priorReviewState === 'pending' || priorReviewState === 'initializing',
+  })
+  const [confirming, setConfirming] = React.useState(false)
+  // The Complete-time summary dialog. null = closed.
+  const [confirmSummary, setConfirmSummary] =
+    React.useState<ConfirmSummary | null>(null)
+
+  // The explicit act behind "Confirm this answer is still accurate": flips
+  // the row's status to done via the confirm endpoint — the ordinary PUT
+  // cannot express agreement, its no-op guard (correctly) drops an unchanged
+  // body (#412/#413). Shared with saveResponse's resolved-review path.
+  const confirmScoreById = async (id: number): Promise<boolean> => {
+    try {
+      await axiosInstance.put(`scores/${id}/confirm`)
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      clearCurrentDraft()
+      setPriorReview((current) =>
+        current.contextId === priorReviewContextId
+          ? { ...current, needsSave: false }
+          : current
+      )
+      // Flip the badge immediately (role="status" announces the change);
+      // the refetch then brings the authoritative row, audit fields included.
+      setQuestionScores((prev) => {
+        const entry = Object.entries(prev).find(([, s]) => s.scoreid === id)
+        if (!entry) return prev
+        return { ...prev, [entry[0]]: { ...entry[1], status: 'done' } }
+      })
+      fetchQuestionScores(system, setQuestionScores)
+      return true
+    } catch (error) {
+      if (isAuthHandled(error)) return false
+      console.error('Error confirming score:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+      return false
+    }
+  }
+
+  const handleConfirmClick = async () => {
+    if (!currentSavedScore || confirming) return
+    setConfirming(true)
+    try {
+      await confirmScoreById(currentSavedScore.scoreid)
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  // Complete on the open call: save the current question as Next always has,
+  // then show one end-of-questionnaire summary instead of silently looping
+  // back to question 1. Built from a freshly-awaited scores fetch so the
+  // just-saved answer counts; falls back to the on-screen map on failure.
+  const handleCompleteClick = async () => {
+    saveGenRef.current++
+    if (!isReadOnly) {
+      await saveResponse()
+    }
+    const fresh = await fetchQuestionScores(system, setQuestionScores)
+    setConfirmSummary(
+      buildConfirmSummary(
+        categories,
+        fresh ? buildScoreByFunction(fresh) : scoreByFunction,
+        isOpenCall
+      )
+    )
+  }
+
+  // Jump link from the Complete summary: same slug navigation + list-click
+  // path the sidebar uses, so the datacall context rides along (#501).
+  const jumpToSummaryEntry = (entry: ConfirmSummaryEntry) => {
+    setConfirmSummary(null)
+    const q = questions[entry.functionid]
+    if (q) {
+      navigate(
+        `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
+        {
+          state: { fismasystemid: system, ...datacallStateRef.current },
+          replace: true,
+        }
+      )
+    }
+    handleListItemClick(entry.functionid)
+  }
+
   const saveResponse = async () => {
     // Resolving a required carried-forward review is itself a current-call
     // action, even when the final text is byte-for-byte identical to the
@@ -607,7 +731,6 @@ export default function QuestionnarePage() {
     const resolvedPriorReview =
       priorReviewNeedsSave && selectQuestionOption >= 0
     if (
-      !resolvedPriorReview &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -615,6 +738,14 @@ export default function QuestionnarePage() {
         initNotes,
       })
     ) {
+      // Nothing changed on the answer fields. A resolved required review is
+      // still an affirmative act that must land — the ordinary PUT's no-op
+      // guard would silently drop an identical body, so route it through the
+      // confirm endpoint.
+      if (resolvedPriorReview && scoreid) {
+        await confirmScoreById(scoreid)
+        return
+      }
       clearCurrentDraft()
       return
     }
@@ -1238,11 +1369,17 @@ export default function QuestionnarePage() {
         : undefined
     if (priorReview.contextId === priorReviewContextId) return
 
+    // "Untouched this cycle": prefer the persisted scores.status so this gate
+    // and the progress count cannot diverge; fall back to the older
+    // no-edit-event proxy for a backend that does not serve status yet.
+    const untouchedThisCycle = currentScore?.status
+      ? currentScore.status === 'not_started'
+      : !currentScore?.last_edited_at
     const isUnreviewedCarryForward =
       !isReadOnly &&
       !!currentPriorResponse &&
       !!currentScore &&
-      !currentScore.last_edited_at &&
+      untouchedThisCycle &&
       draftStatus !== 'restored' &&
       notes.trim() === currentPriorResponse.text.trim()
     setPriorReview({
@@ -1434,6 +1571,14 @@ export default function QuestionnarePage() {
                       const text = addSpace(func.function.function)
                       const customFontSize =
                         text.length > 33 ? '0.9rem' : '1rem'
+                      // Sidebar confirmation marker: same classification the
+                      // question view's badge reads. Text-bearing, not
+                      // color-only (508); rendered as ListItemText secondary
+                      // so it is part of the button's accessible name.
+                      const sidebarCarryState = carryForwardState(
+                        scoreByFunction[func.function.functionid],
+                        isOpenCall
+                      )
                       // TODO: refactor this code such that it's going to be a single component instead of being rerendered everytime
                       return (
                         <ListItem
@@ -1475,6 +1620,20 @@ export default function QuestionnarePage() {
                           >
                             <ListItemText
                               primary={`${text}`}
+                              secondary={
+                                sidebarCarryState === 'unconfirmed'
+                                  ? 'Not yet confirmed'
+                                  : sidebarCarryState === 'updated'
+                                    ? 'Updated'
+                                    : undefined
+                              }
+                              secondaryTypographyProps={{
+                                fontSize: '0.75rem',
+                                color:
+                                  sidebarCarryState === 'unconfirmed'
+                                    ? 'warning.dark'
+                                    : 'success.dark',
+                              }}
                               sx={{ fontSize: customFontSize }}
                             />
                           </ListItemButton>
@@ -1624,6 +1783,55 @@ export default function QuestionnarePage() {
                       </Typography>
                     )}
                   </Box>
+                  {/* Carried-forward confirmation strip, in the same zone
+                      where the prior-response flow surfaces its "review
+                      before continuing" message, so every system shares one
+                      review area. The chip is a role="status" live region, so
+                      confirming — which swaps its label in place — is
+                      announced (508). The button yields the moment the
+                      question is dirty (the edit is the explicit act; Next
+                      saves it), and Next itself never writes on an untouched
+                      question (#413). */}
+                  {currentCarryState !== 'none' && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        flexWrap: 'wrap',
+                        gap: 1,
+                        mt: 1.5,
+                      }}
+                    >
+                      <Chip
+                        role="status"
+                        size="small"
+                        variant="outlined"
+                        color={
+                          currentCarryState === 'unconfirmed'
+                            ? 'warning'
+                            : 'success'
+                        }
+                        label={
+                          currentCarryState === 'unconfirmed'
+                            ? 'Carried forward — not yet confirmed'
+                            : 'Updated this data call'
+                        }
+                      />
+                      {showConfirmButton && (
+                        <Button
+                          variant="outlined"
+                          color="success"
+                          size="small"
+                          startIcon={<CheckCircleOutlineIcon />}
+                          onClick={handleConfirmClick}
+                          disabled={confirming}
+                          sx={{ textTransform: 'none' }}
+                        >
+                          Confirm this answer is still accurate
+                        </Button>
+                      )}
+                    </Box>
+                  )}
                   <Box
                     position="relative"
                     display="flex"
@@ -1675,12 +1883,21 @@ export default function QuestionnarePage() {
                     </CmsButton>
                     <CmsButton
                       onClick={() => {
-                        saveGenRef.current++
-                        const id =
+                        const isLastQuestion =
                           selectedIndex ===
                           stepFunctionId[stepFunctionId.length - 1]
-                            ? stepFunctionId[0]
-                            : stepFunctionId[functionIdIdx[selectedIndex] + 1]
+                        // Complete on the open call summarizes instead of
+                        // silently wrapping to question 1. A closed call
+                        // keeps the wrap-around — harmless paging for a
+                        // historical viewer.
+                        if (isLastQuestion && isOpenCall) {
+                          void handleCompleteClick()
+                          return
+                        }
+                        saveGenRef.current++
+                        const id = isLastQuestion
+                          ? stepFunctionId[0]
+                          : stepFunctionId[functionIdIdx[selectedIndex] + 1]
 
                         if (questions[id]) {
                           const q = questions[id]
@@ -1763,6 +1980,11 @@ export default function QuestionnarePage() {
             open={openAlert}
             onClose={() => setOpenAlert(false)}
             confirmClick={handleConfirmReturn}
+          />
+          <ConfirmSummaryDialog
+            summary={confirmSummary}
+            onClose={() => setConfirmSummary(null)}
+            onJump={jumpToSummaryEntry}
           />
         </Grid>
       </Container>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -697,6 +697,20 @@ export default function QuestionnarePage() {
       await saveResponse()
     }
     const fresh = await fetchQuestionScores(system, setQuestionScores)
+    if (fresh) {
+      // Re-seed the current question's saved state from the fresh map. The
+      // old Complete re-seeded implicitly by navigating to question 1; this
+      // one stays put, and without a re-seed a just-POSTed answer would
+      // still read as unsaved (scoreid 0) — a second Complete would POST a
+      // duplicate row and double-weight the question in the pillar average.
+      const sel = deriveScoreSelection(
+        optionsRef.current.map((o) => Number(o.value)),
+        fresh
+      )
+      setInitQuestionChoice(sel.choice)
+      setInitNotes(sel.notes)
+      setScoreId(sel.scoreid)
+    }
     setConfirmSummary(
       buildConfirmSummary(
         categories,
@@ -710,6 +724,10 @@ export default function QuestionnarePage() {
   // path the sidebar uses, so the datacall context rides along (#501).
   const jumpToSummaryEntry = (entry: ConfirmSummaryEntry) => {
     setConfirmSummary(null)
+    // Already on this question (e.g. the last question is itself unanswered):
+    // just close the dialog. handleListItemClick would set loading for a
+    // questionId change that never fires, stranding the spinner.
+    if (entry.functionid === questionId) return
     const q = questions[entry.functionid]
     if (q) {
       navigate(

--- a/src/views/QuestionnairePage/confirmState.test.ts
+++ b/src/views/QuestionnairePage/confirmState.test.ts
@@ -1,0 +1,204 @@
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+} from './confirmState'
+import type { QuestionScores, FismaQuestion, ScoreStatus } from '@/types'
+
+const score = (over: Partial<QuestionScores> = {}): QuestionScores => ({
+  scoreid: 1,
+  fismasystemid: 10,
+  datecalculated: 0,
+  notes: 'carried notes',
+  functionoptionid: 100,
+  datacallid: 5,
+  ...over,
+})
+
+const question = (
+  functionid: number,
+  name = `fn-${functionid}`
+): FismaQuestion => ({
+  questionid: functionid + 1000,
+  question: `Q ${functionid}`,
+  notesprompt: '',
+  pillar: { pillar: 'Devices', pillarid: 1, order: 1 },
+  function: {
+    functionid,
+    function: name,
+    description: '',
+    datacenterenvironment: 'Hybrid',
+  },
+})
+
+describe('carryForwardState', () => {
+  it('classifies a not_started row on the open call as unconfirmed', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), true)).toBe(
+      'unconfirmed'
+    )
+  })
+
+  it('classifies a done row on the open call as updated', () => {
+    expect(carryForwardState(score({ status: 'done' }), true)).toBe('updated')
+  })
+
+  it('renders nothing on a past call — historical rows are legitimately not_started forever', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), false)).toBe(
+      'none'
+    )
+    expect(carryForwardState(score({ status: 'done' }), false)).toBe('none')
+  })
+
+  it('renders nothing when the backend does not serve status (pre-deploy degrade)', () => {
+    expect(carryForwardState(score(), true)).toBe('none')
+  })
+
+  it('renders nothing without an answer row', () => {
+    expect(carryForwardState(undefined, true)).toBe('none')
+  })
+})
+
+describe('canConfirmCarryForward', () => {
+  const confirmable = {
+    state: 'unconfirmed' as const,
+    dirty: false,
+    isReadOnly: false,
+    priorReviewBlocked: false,
+  }
+
+  it('allows confirming an untouched carried-forward answer', () => {
+    expect(canConfirmCarryForward(confirmable)).toBe(true)
+  })
+
+  it('hides while dirty — the edit is the explicit act and Next saves it', () => {
+    expect(canConfirmCarryForward({ ...confirmable, dirty: true })).toBe(false)
+  })
+
+  it('hides for read-only sessions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, isReadOnly: true })).toBe(
+      false
+    )
+  })
+
+  it('hides while the CMS prior-response review blanks the field', () => {
+    expect(
+      canConfirmCarryForward({ ...confirmable, priorReviewBlocked: true })
+    ).toBe(false)
+  })
+
+  it('hides for updated and stateless questions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, state: 'updated' })).toBe(
+      false
+    )
+    expect(canConfirmCarryForward({ ...confirmable, state: 'none' })).toBe(
+      false
+    )
+  })
+})
+
+describe('buildScoreByFunction', () => {
+  it('re-keys rows by their owning functionid', () => {
+    const byFunction = buildScoreByFunction({
+      100: score({
+        functionoptionid: 100,
+        functionoption: {
+          functionoptionid: 100,
+          functionid: 7,
+          score: 2,
+          optionname: 'Defined',
+          description: '',
+        },
+      }),
+    })
+    expect(byFunction[7]?.functionoptionid).toBe(100)
+  })
+
+  it('skips rows without functionoption — they cannot be attributed to a question', () => {
+    expect(buildScoreByFunction({ 100: score() })).toEqual({})
+  })
+})
+
+describe('buildConfirmSummary', () => {
+  const withStatus = (
+    functionid: number,
+    status?: ScoreStatus
+  ): QuestionScores =>
+    score({
+      scoreid: functionid,
+      status,
+      functionoption: {
+        functionoptionid: functionid * 10,
+        functionid,
+        score: 1,
+        optionname: 'Traditional',
+        description: '',
+      },
+    })
+
+  const categories = [
+    { name: 'Devices', steps: [question(1), question(2)] },
+    { name: 'Networks', steps: [question(3), question(4)] },
+  ]
+
+  it('buckets unconfirmed, updated, and unanswered in sidebar order', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1, 'not_started'),
+        2: withStatus(2, 'done'),
+        3: withStatus(3, 'not_started'),
+        // 4 has no row at all.
+      },
+      true
+    )
+    expect(summary.total).toBe(4)
+    expect(summary.updated).toBe(1)
+    expect(summary.unconfirmed.map((e) => e.functionid)).toEqual([1, 3])
+    expect(summary.unconfirmed[0]).toEqual({
+      functionid: 1,
+      functionName: 'fn-1',
+      pillarName: 'Devices',
+    })
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(true)
+  })
+
+  it('keeps the unanswered list but flags missing status data pre-deploy', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1),
+        2: withStatus(2),
+        3: withStatus(3),
+      },
+      true
+    )
+    // Answered rows without status land in no bucket: not unconfirmed (that
+    // would badge everything) and not updated (that would claim knowledge the
+    // backend has not served).
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.updated).toBe(0)
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(false)
+  })
+
+  it('lists nothing as unconfirmed on a past call', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 1: withStatus(1, 'not_started') },
+      false
+    )
+    expect(summary.unconfirmed).toEqual([])
+  })
+
+  it('ignores score rows whose function is not in the questionnaire (inapplicable after an environment change)', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 99: withStatus(99, 'not_started') },
+      true
+    )
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.total).toBe(4)
+  })
+})

--- a/src/views/QuestionnairePage/confirmState.ts
+++ b/src/views/QuestionnairePage/confirmState.ts
@@ -1,0 +1,134 @@
+import type { QuestionScores, ScoreStatus, FismaQuestion } from '@/types'
+
+/**
+ * Carried-forward confirmation state, derived from the persisted
+ * scores.status column — the same fact the Data Call Progress fraction
+ * counts — so the badge, Confirm button, sidebar markers, and Complete
+ * summary can never disagree with the number the user is shown. Pure, so the
+ * classification rules live in one place (mirrors saveGuard.ts).
+ */
+
+/**
+ * The per-question classification every piece of confirmation UI reads.
+ * 'none' covers: no answer row, a closed call (historical rows are
+ * legitimately not_started forever), or a backend that does not serve status
+ * yet (degrade to no badges rather than badging everything).
+ */
+export type CarryForwardState = 'unconfirmed' | 'updated' | 'none'
+
+export const carryForwardState = (
+  score: QuestionScores | undefined,
+  isOpenCall: boolean
+): CarryForwardState => {
+  if (!isOpenCall || !score?.status) return 'none'
+  return score.status === 'not_started' ? 'unconfirmed' : 'updated'
+}
+
+/**
+ * Whether the inline Confirm button renders. It is the explicit act for an
+ * untouched carried-forward answer, so it hides whenever another act owns the
+ * write: dirty edits (Next saves those), a pending prior-response review (the
+ * field is blanked; same condition that disables Next), or a read-only
+ * session.
+ */
+export const canConfirmCarryForward = (s: {
+  state: CarryForwardState
+  dirty: boolean
+  isReadOnly: boolean
+  priorReviewBlocked: boolean
+}): boolean =>
+  s.state === 'unconfirmed' &&
+  !s.dirty &&
+  !s.isReadOnly &&
+  !s.priorReviewBlocked
+
+/**
+ * Re-key the score map (keyed by functionoptionid) by owning functionid, so
+ * the sidebar and Complete summary can look up a question's answer row
+ * directly. Rows without functionoption cannot be attributed and are skipped.
+ */
+export const buildScoreByFunction = (scores: {
+  [key: number]: QuestionScores
+}): Record<number, QuestionScores> => {
+  const byFunction: Record<number, QuestionScores> = {}
+  for (const score of Object.values(scores)) {
+    const functionid = score.functionoption?.functionid
+    if (functionid != null) byFunction[functionid] = score
+  }
+  return byFunction
+}
+
+export type ConfirmSummaryEntry = {
+  functionid: number
+  functionName: string
+  pillarName: string
+}
+
+export type ConfirmSummary = {
+  /** Total questions in the questionnaire (the summary's denominator). */
+  total: number
+  /** Questions whose answer counts as updated this cycle (status = 'done'). */
+  updated: number
+  /** Carried-forward answers still awaiting confirmation, in sidebar order. */
+  unconfirmed: ConfirmSummaryEntry[]
+  /** Questions with no answer row at all, in sidebar order. */
+  unanswered: ConfirmSummaryEntry[]
+  /**
+   * True when at least one row carries status. False = the backend does not
+   * serve it, so the updated count and unconfirmed list would be lies built
+   * from absence — callers must render neither. The unanswered list stays
+   * valid (derived from row presence, not status).
+   */
+  hasStatusData: boolean
+}
+
+/**
+ * Build the Complete-time summary from the sidebar's own category list, so
+ * entries come out in sidebar order with sidebar names, ready for the same
+ * slug-based navigation.
+ */
+export const buildConfirmSummary = (
+  categories: { name: string; steps: FismaQuestion[] }[],
+  scoreByFunction: Record<number, QuestionScores>,
+  isOpenCall: boolean
+): ConfirmSummary => {
+  const summary: ConfirmSummary = {
+    total: 0,
+    updated: 0,
+    unconfirmed: [],
+    unanswered: [],
+    hasStatusData: Object.values(scoreByFunction).some((s) => s.status != null),
+  }
+  for (const pillar of categories) {
+    for (const step of pillar.steps) {
+      summary.total++
+      const functionid = step.function.functionid
+      const score = scoreByFunction[functionid]
+      if (!score) {
+        summary.unanswered.push({
+          functionid,
+          functionName: step.function.function,
+          pillarName: pillar.name,
+        })
+        continue
+      }
+      switch (carryForwardState(score, isOpenCall)) {
+        case 'unconfirmed':
+          summary.unconfirmed.push({
+            functionid,
+            functionName: step.function.function,
+            pillarName: pillar.name,
+          })
+          break
+        case 'updated':
+          summary.updated++
+          break
+        // 'none' (no status served): answered, but neither confirmable nor
+        // countable as updated — deliberately absent from every bucket.
+      }
+    }
+  }
+  return summary
+}
+
+export type { ScoreStatus }

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -137,6 +137,30 @@ test('setting the boolean to Unknown emits null (the clear signal)', async () =>
   expect(onFieldChange).toHaveBeenCalledWith('hva', null)
 })
 
+test('ISSO Name renders as an editable control with its override guidance', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  expect(screen.getByRole('textbox', { name: 'ISSO Name' })).toBeEnabled()
+  // The guidance is what tells an admin that a typed name is a permanent
+  // override and that clearing returns the derived name.
+  expect(
+    screen.getByText(/overrides the name from the ISSO's user account/i)
+  ).toBeInTheDocument()
+})
+
+test('clearing ISSO Name emits the empty-string clear signal', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  const user = userEvent.setup()
+  const { onFieldChange } = renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  await user.clear(screen.getByRole('textbox', { name: 'ISSO Name' }))
+
+  // '' clears the stored override via blankToNil, restoring the name the
+  // backend derives from the ISSO user record; null would leave it unchanged.
+  expect(onFieldChange).toHaveBeenCalledWith('isso_name', '')
+})
+
 test('cloud dependents are hidden while cloud_system is No', () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   renderEditView({ cloud_system: false })

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -662,8 +662,8 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
       </Grid>
 
       {/* Extended Metadata — full width, 3-col grid. Standard system
-          attributes editable across all OpDivs. isso_name is display-only
-          (backend-resolved), so it renders disabled. */}
+          attributes editable across all OpDivs. A field marked read-only in
+          fieldConfig renders disabled. */}
       <Grid item xs={12}>
         <Card variant="outlined">
           <CardHeader

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -113,6 +113,10 @@ function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
       role,
     } as userData,
     datacenterEnvironments: [],
+    // The page refetches after a save instead of echoing its draft, so both of
+    // these have to be present or the save path throws.
+    fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
+    showDecommissioned: false,
   }
   return renderWithProviders(
     <Routes>
@@ -204,6 +208,48 @@ test('clearing ISSO Name sends the empty-string clear signal', async () => {
   // '' clears the stored override via blankToNil so the name derived from the
   // ISSO user record applies again; null would read as "leave unchanged".
   expect(captured.body).toHaveProperty('isso_name', '')
+})
+
+// The saved value of isso_name is resolved by the backend, so the draft the
+// page sent is not the truth once the field was cleared. Echoing the draft into
+// shared state would render the cleared field as empty instead of the derived
+// name, so the page has to refetch and must not write the draft.
+test('clearing ISSO Name refetches instead of echoing the draft', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(false)
+  )
+  expect(mockCtx.setFismaSystems).not.toHaveBeenCalled()
+})
+
+// A save must not silently change which systems the dashboard lists, so the
+// refetch carries the caller's current decommissioned view mode.
+test('the post-save refetch preserves the decommissioned view mode', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+  mockCtx.showDecommissioned = true
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(true)
+  )
 })
 
 test('an untouched ISSO Name is omitted from the save payload', async () => {

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -1,0 +1,223 @@
+// Role coverage for the ISSO Name control on the System Details page, plus the
+// two write signals it can send. The page-level isAdmin gate is the only gate
+// on the field: the whole edit surface (the Edit button and the edit view) is
+// admin-only, so the write-admin tiers get the control and every other tier
+// never reaches an editable form at all. A typed name is a permanent override
+// of the name derived from the ISSO user record; the empty string clears the
+// override.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+import MockAdapter from 'axios-mock-adapter'
+import SystemDetailPage from './SystemDetailPage'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, UserRole, userData } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+
+const SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  fismauid: 'UID-42',
+  component: 'CMS',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: 'admiral.piett@executor.empire',
+  datacallcontact: 'captain.needa@executor.empire',
+  opdiv_id: 1,
+  decommissioned: false,
+  // Both enrichment (ZTMF Insights) and the delegates roster are gated off in
+  // this fixture so the page's only network reads are opdivs and the
+  // system-attribute vocabulary.
+  sdl_sync_enabled: false,
+  isso_name: 'Conan Antonio Motti',
+  hva: null,
+  fips: null,
+  system_type: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+const WRITE_ADMIN_ROLES: UserRole[] = [
+  'OWNER',
+  'HHS_ADMIN',
+  'OPDIV_ADMIN',
+  'ADMIN',
+]
+
+const NON_WRITE_ROLES: UserRole[] = [
+  'HHS_READONLY_ADMIN',
+  'OPDIV_READONLY_ADMIN',
+  'READONLY_ADMIN',
+  'ISSO',
+  'ISSM',
+  'SYSTEM_DELEGATE',
+]
+
+beforeEach(() => {
+  mock.reset()
+  mock
+    .onGet('/opdivs')
+    .reply(200, {
+      data: [
+        {
+          opdiv_id: 1,
+          code: 'CMS',
+          name: 'CMS',
+          active: true,
+          system_delegate_enabled: false,
+        },
+      ],
+    })
+    .onGet('/systemattributes')
+    .reply(200, { data: [] })
+})
+
+/**
+ * Renders the page for a system owned by the given role, on the route the
+ * page reads :fismasystemid from.
+ */
+function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
+  mockCtx = {
+    fismaSystems: [system],
+    setFismaSystems: jest.fn(),
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    datacenterEnvironments: [],
+  }
+  return renderWithProviders(
+    <Routes>
+      <Route path="/systems/:fismasystemid" element={<SystemDetailPage />} />
+    </Routes>,
+    { initialEntries: ['/systems/42'] }
+  )
+}
+
+/**
+ * The page-level Edit buttons currently on screen. The target-maturity card
+ * renders its own Edit button in view mode (for admins and for an assigned
+ * ISSO/ISSM), so match the header button by its CMS design-system class to keep
+ * the two apart: only the header one opens the system form.
+ */
+function pageEditButtons(): HTMLElement[] {
+  return screen
+    .queryAllByRole('button', { name: 'Edit' })
+    .filter((button) => button.classList.contains('ds-c-button'))
+}
+
+/** Captures the body of the page's full-system PUT. */
+function captureSave() {
+  const captured: { body?: Record<string, unknown> } = {}
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    captured.body = JSON.parse(config.data)
+    return [200, {}]
+  })
+  return captured
+}
+
+test.each(WRITE_ADMIN_ROLES)(
+  'ISSO Name is an editable control for %s',
+  async (role) => {
+    const user = userEvent.setup()
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    await user.click(pageEditButtons()[0])
+
+    expect(
+      await screen.findByRole('textbox', { name: 'ISSO Name' })
+    ).toBeEnabled()
+  }
+)
+
+test.each(NON_WRITE_ROLES)(
+  '%s gets no system-form edit affordance and no ISSO Name control',
+  async (role) => {
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    expect(pageEditButtons()).toHaveLength(0)
+    // The read view is the only view these tiers reach, and it renders every
+    // field as text, so there is no control to disable.
+    expect(
+      screen.queryByRole('textbox', { name: 'ISSO Name' })
+    ).not.toBeInTheDocument()
+  }
+)
+
+test('an edited ISSO Name is sent in the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  expect(captured.body).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name sends the empty-string clear signal', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // '' clears the stored override via blankToNil so the name derived from the
+  // ISSO user record applies again; null would read as "leave unchanged".
+  expect(captured.body).toHaveProperty('isso_name', '')
+})
+
+test('an untouched ISSO Name is omitted from the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // The detail page shows the resolved name, so sending it back unedited would
+  // persist a derived name as an override on any unrelated save.
+  expect(captured.body).not.toHaveProperty('isso_name')
+})

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -45,8 +45,14 @@ import SystemDelegatesSection from './SystemDelegatesSection'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const { fismaSystems, setFismaSystems, userInfo, datacenterEnvironments } =
-    useContextProp()
+  const {
+    fismaSystems,
+    setFismaSystems,
+    userInfo,
+    datacenterEnvironments,
+    fetchFismaSystems,
+    showDecommissioned,
+  } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
@@ -362,11 +368,18 @@ export default function SystemDetailPage() {
       )
 
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-      setFismaSystems((prev) =>
-        prev.map((s) =>
-          s.fismasystemid !== editedSystem.fismasystemid ? s : editedSystem
-        )
-      )
+      // Refetch rather than echoing the local draft into state. The PUT returns
+      // no body, and the saved value of a field the backend resolves is not the
+      // value that was sent: clearing isso_name stores NULL, and the list read
+      // then resolves the name from the ISSO's user record. Echoing the draft
+      // would show the cleared field as empty until the next fetch.
+      //
+      // The caller's decommissioned view mode is preserved so saving does not
+      // change which systems the dashboard lists. That mode can exclude the
+      // system just saved, so clearing triedFetch lets the single-system
+      // fallback re-add it.
+      triedFetch.current = false
+      await fetchFismaSystems(showDecommissioned)
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -337,6 +337,16 @@ export default function SystemDetailPage() {
 
   const handleSave = async () => {
     if (!editedSystem) return
+    // The extended-metadata payload is a diff against the loaded system, and
+    // buildExtendedDiff treats a missing baseline as "every field is unset",
+    // which sends all of them. editedSystem outlives the system it was seeded
+    // from, so saving without a baseline would persist values the user never
+    // touched, including an ISSO name the backend derived rather than stored.
+    // Refuse the save rather than writing a payload built from no baseline.
+    if (!system) {
+      notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+      return
+    }
     setIsSaving(true)
     try {
       // Full-system PUT. The page-level Edit button is gated on isAdmin,

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -11,11 +11,12 @@ export interface FieldConfig {
   required: boolean
   type: FieldType
   // Display-only: rendered but never editable and excluded from the write
-  // payload. Used for values the backend resolves/owns (e.g. isso_name).
+  // payload. For a value whose only writer is the backend.
   readOnly?: boolean
-  // Short guidance shown under the control while editing. For terms of art
-  // whose label alone is ambiguous or easily misread. Rendered only when set;
-  // there is no backend dependency, the copy lives here.
+  // Short guidance shown under the control while editing. For a label that is
+  // ambiguous or easily misread on its own, or a value whose write semantics
+  // need saying at the point of edit. Rendered only when set; there is no
+  // backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
   // its read-view text). For a field whose label reads ambiguously against a
@@ -109,16 +110,17 @@ export const fieldConfigs: FieldConfig[] = [
   },
 
   // Extended Metadata section. Standard system attributes editable by any
-  // write admin across all OpDivs. isso_name is the exception: the backend
-  // resolves it (from the ISSO user record for CMS, from the import for HHS),
-  // so it is display-only here and the edit form still edits issoemail.
+  // write admin across all OpDivs. A stored isso_name overrides the name the
+  // backend derives from the ISSO user record, and the empty string clears the
+  // stored value so the derived name applies again.
   {
     key: 'isso_name',
     label: 'ISSO Name',
     section: 'extended',
     required: false,
     type: 'text',
-    readOnly: true,
+    helpText:
+      "A name entered here overrides the name from the ISSO's user account. Clear the field to show that name again.",
   },
   {
     key: 'hva',
@@ -204,10 +206,9 @@ export function getFieldsBySection(section: FieldSection): FieldConfig[] {
 }
 
 // Single source of truth for the extended metadata write list. Derived from the
-// `extended` section above (excluding read-only fields like isso_name) so a
-// field added to fieldConfig can't silently render-but-not-save, and a
-// display-only field can't silently be written (the modal/detail PUT loops
-// consume this).
+// `extended` section above (excluding read-only fields) so a field added to
+// fieldConfig can't silently render-but-not-save, and a display-only field
+// can't silently be written (the modal/detail PUT loops consume this).
 export const EXTENDED_METADATA_KEYS: (keyof FismaSystemType)[] = fieldConfigs
   .filter((f) => f.section === 'extended' && !f.readOnly)
   .map((f) => f.key)

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -109,10 +109,12 @@ export const fieldConfigs: FieldConfig[] = [
     type: 'email',
   },
 
-  // Extended Metadata section. Standard system attributes editable by any
-  // write admin across all OpDivs. A stored isso_name overrides the name the
-  // backend derives from the ISSO user record, and the empty string clears the
-  // stored value so the derived name applies again.
+  // Extended Metadata section. The system attributes below are writable only by
+  // an unscoped admin; the backend restores the stored values over anything an
+  // OpDiv-scoped admin sends for them. isso_name is the exception, writable by
+  // any write admin: a stored value overrides the name the backend derives from
+  // the ISSO user record, and the empty string clears it so the derived name
+  // applies again.
   {
     key: 'isso_name',
     label: 'ISSO Name',


### PR DESCRIPTION
## Summary

Combines the three outstanding FY26 frontend fixes into one branch, mirroring the backend batch. Each author's commits are cherry-picked as-is, so authorship and history stay intact and linear.

* #663 — unlock the ISSO Name control for write admins (closes #661)
* #664 — carried-forward badges, explicit confirm, Complete summary, progress wording (closes #659)
* #657 — count score-less systems in "Not updated only" (closes #655)

The three change sets touch disjoint files (verified with a cross-branch diff before combining), so the replay applied with zero conflicts. One empty CI-trigger commit from #663 was skipped; every commit with content is here unchanged.

## Verification on the combined branch

* `npx tsc --noEmit` clean
* `yarn test`: 799 passed, 3 skipped, 0 failed
* Each PR's distinctive work confirmed present after the replay, not just inferred from a green suite: the ISSO Name entry in `fieldConfig.ts` no longer carries `readOnly`, `confirmState.ts` and `ConfirmSummaryDialog.tsx` exist under QuestionnairePage, and `aggregateScores.ts` has the `scoreIdxs` / union split.

## Review status of the parts

* #657 was reviewed and approved on its own PR (tie-break and `systemCallMap` fixes verified there).
* #663 and #664 carry their own review discussion on their PRs.

The original PRs stay open until this one is approved, then get closed in favor of it so their review history remains reachable.

## Deploy order

#664's confirm flow requires CMS-Enterprise/ztmf#515 (`scores.status` on reads plus the confirm endpoint) — backend deploys first. Against an older backend the questionnaire degrades to current behavior rather than misrendering. #663 requires the backend `isso_name` write carve-out (CMS-Enterprise/ztmf#511) for the unlocked field to actually persist.
