### PR TITLE
Nightly sync: main -> impl (2026-08-04)

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -56,8 +56,11 @@ jobs:
         # VITE_* vars are baked into the bundle at build time, so they must
         # be set on the build step itself, not on the deployed container.
         # Default off; flip per environment as IdP rollout progresses.
+        # Prod joins dev now that its backend has dual-IdP enabled. Impl stays
+        # off until its own backend flag is, or its lookup call would fall
+        # through to the OIDC-gated /api/* rule and break sign-in.
         env:
-          VITE_IDP_ENABLED: ${{ inputs.environment == 'dev' && 'true' || 'false' }}
+          VITE_IDP_ENABLED: ${{ (inputs.environment == 'dev' || inputs.environment == 'prod') && 'true' || 'false' }}
           # Insights "How to fix" remediation — trialed in impl only; off in dev/prod.
           VITE_INSIGHTS_SUGGEST_FIX_ENABLED: ${{ inputs.environment == 'impl' && 'true' || 'false' }}
           # Dev-only banner overrides. Sourced from secrets so the feedback form

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,9 +10,13 @@ import router from '@/router/router'
 import { SIGN_IN_GREETING } from '@/locales/en'
 import '@/sass/style.scss'
 import onPerfEntry from './utils/onPerfEntry'
+import { initLogoutListener } from '@/utils/sessionSync'
 import { SnackbarProvider } from 'notistack'
 // IIFE that initializes the root node and renders the application.
 ;(async function () {
+  // Once per tab lifetime, outside React so StrictMode cannot double-invoke it.
+  initLogoutListener()
+
   // create the root element in the DOM
   const rootElement = document.getElementById('root') as HTMLElement
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,14 @@ export type LastEditedBy = {
   role?: UserRole
 }
 
+/**
+ * The answer's review state for its data call (scores.status): 'not_started'
+ * = carried forward and untouched this cycle; 'done' = saved or confirmed
+ * this cycle. The same persisted fact the Data Call Progress count reads, so
+ * badges derived from it cannot disagree with the fraction.
+ */
+export type ScoreStatus = 'not_started' | 'done'
+
 export type QuestionScores = {
   scoreid: number
   fismasystemid: number
@@ -220,6 +228,12 @@ export type QuestionScores = {
   notes: string
   functionoptionid: number
   datacallid: number
+  // Optional: a backend that does not serve it degrades to no carried-forward
+  // badges rather than badging everything.
+  status?: ScoreStatus
+  // Present when fetched with ?include=functionoption; functionid maps the
+  // row back to its question.
+  functionoption?: QuestionOption
   last_edited_at?: string | null
   last_edited_by?: LastEditedBy | null
   notes_is_ai_summary?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,12 @@ export type OpDiv = {
   // (defaults false), so every OpDiv resolves to a real boolean. Gates the
   // ISSO delegate self-service surface for systems in this OpDiv.
   system_delegate_enabled: boolean
+  // Per-OpDiv ZTMF Insights capability. When true, systems in this OpDiv
+  // surface the internal insights layer (panel, option badges, suggested
+  // justification) in the questionnaire. Backed by opdivs.insights_enabled;
+  // the backend serializes it from a nullable column, so treat a missing
+  // value as disabled.
+  insights_enabled?: boolean | null
 }
 
 // A system delegate as returned by GET /fismasystems/:id/delegates (the

--- a/src/utils/authInterceptor.integration.test.ts
+++ b/src/utils/authInterceptor.integration.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The #606 loop fix against a REAL router. authInterceptor.test.ts mocks the
+ * router, so it can pin that revalidate() runs before navigate() but not that
+ * the loop stops. That matters because the fix relies on react-router keeping
+ * its internal isRevalidationRequired flag across the interrupting navigation -
+ * public behavior of a private detail, so a version bump could regress #606
+ * with every mocked test still green. These assert the outcome instead: the
+ * /signin navigation commits with FRESH loader data.
+ */
+import type { AxiosError } from 'axios'
+import { createMemoryRouter } from 'react-router-dom'
+import { AuthCodes, SignInReasons } from '@/utils/authCodes'
+import { Routes, RouteIds } from '@/router/constants'
+
+// The interceptor imports the router singleton; point that import at whichever
+// memory router the current test built. Getters resolve lazily, so it stays live.
+const mockRouterRef: { current: ReturnType<typeof createMemoryRouter> | null } =
+  { current: null }
+
+jest.mock('@/router/router', () => ({
+  __esModule: true,
+  default: {
+    get state() {
+      return mockRouterRef.current?.state
+    },
+    navigate: (...args: unknown[]) =>
+      (
+        mockRouterRef.current?.navigate as unknown as (
+          ...a: unknown[]
+        ) => Promise<void>
+      )(...args),
+    revalidate: () => mockRouterRef.current?.revalidate(),
+  },
+}))
+
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  markAuthHandled: (e: object) => Object.assign(e, { __authHandled: true }),
+}))
+
+import { handleAuthError } from './authInterceptor'
+
+// Mirrors authLoader's discriminated return.
+let sessionAlive = true
+let rootLoaderRuns = 0
+
+function rootLoader() {
+  rootLoaderRuns++
+  return sessionAlive
+    ? { status: 200, response: { userid: 'u1' } }
+    : { ok: false, reason: SignInReasons.EXPIRED, response: {} }
+}
+
+async function buildSignedInRouter() {
+  sessionAlive = true
+  rootLoaderRuns = 0
+  const router = createMemoryRouter(
+    [
+      {
+        id: RouteIds.ROOT,
+        path: Routes.ROOT,
+        loader: rootLoader,
+        children: [
+          { index: true, id: 'home' },
+          { path: RouteIds.SIGNIN, id: RouteIds.SIGNIN },
+        ],
+      },
+    ],
+    { initialEntries: [Routes.ROOT] }
+  )
+  mockRouterRef.current = router
+  router.initialize()
+  await waitForIdle(router)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({ status: 200 })
+  return router
+}
+
+/**
+ * Settle the router. It yields before checking, so `expectWorkStarted` asserts
+ * something was actually in flight - otherwise an interceptor that ever awaited
+ * before navigating would make the loader-count assertions vacuously pass.
+ */
+async function waitForIdle(
+  router: ReturnType<typeof createMemoryRouter>,
+  expectWorkStarted = false
+): Promise<void> {
+  if (expectWorkStarted) {
+    const busy =
+      router.state.navigation.state !== 'idle' ||
+      router.state.revalidation !== 'idle'
+    if (!busy) {
+      throw new Error(
+        'expected a navigation or revalidation to be in flight, but the router was idle'
+      )
+    }
+  }
+  for (let i = 0; i < 50; i++) {
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+    if (
+      router.state.initialized &&
+      router.state.navigation.state === 'idle' &&
+      router.state.revalidation === 'idle'
+    ) {
+      return
+    }
+  }
+  throw new Error('router did not settle')
+}
+
+function authError(
+  status: number,
+  code: string
+): AxiosError<{ error?: string; code?: string }> {
+  return {
+    config: {},
+    response: {
+      status,
+      data: { code },
+      statusText: '',
+      headers: {},
+      config: {},
+    },
+    isAxiosError: true,
+    toJSON: () => ({}),
+    name: 'AxiosError',
+    message: 'mock',
+  } as unknown as AxiosError<{ error?: string; code?: string }>
+}
+
+afterEach(() => {
+  // Optional across versions, hence the guard.
+  mockRouterRef.current?.dispose?.()
+  mockRouterRef.current = null
+})
+
+test('a 401 against a signed-in dashboard lands on sign-in with FRESH loader data (#606)', async () => {
+  const router = await buildSignedInRouter()
+
+  // Session dies out from under the tab.
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await expect(
+    handleAuthError(authError(401, AuthCodes.UNAUTHORIZED))
+  ).rejects.toMatchObject({ __authHandled: true })
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  // The load-bearing assertion: without revalidate() this still reads 200.
+  expect(rootLoaderRuns).toBeGreaterThan(runsBefore)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({
+    ok: false,
+    reason: SignInReasons.EXPIRED,
+  })
+  expect(router.state.loaderData[RouteIds.ROOT]).not.toMatchObject({
+    status: 200,
+  })
+})
+
+test('the sign-in navigation carries the expired reason for LoginPage', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+
+  await expect(
+    handleAuthError(authError(401, AuthCodes.UNAUTHORIZED))
+  ).rejects.toMatchObject({ __authHandled: true })
+  await waitForIdle(router, true)
+
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.EXPIRED,
+  })
+})
+
+test('a burst of 401s settles on sign-in once, without a redirect storm (#606)', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  // What a dashboard mount does: several requests rejecting together.
+  await Promise.all(
+    Array.from({ length: 4 }, () =>
+      handleAuthError(authError(401, AuthCodes.UNAUTHORIZED)).catch(() => {})
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.loaderData[RouteIds.ROOT]).toMatchObject({ ok: false })
+  // Empirical bound for a homogeneous burst: lands on exactly 2, and goes to
+  // 5 without the guards. A mixed burst reaches 3 - separate test below.
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(2)
+})
+
+test('a 403 ACCOUNT_NOT_PROVISIONED burst settles on the NO_ACCOUNT terminal state', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await Promise.all(
+    Array.from({ length: 4 }, () =>
+      handleAuthError(authError(403, AuthCodes.ACCOUNT_NOT_PROVISIONED)).catch(
+        () => {}
+      )
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(2)
+})
+
+test('a mixed 401/403 burst settles on NO_ACCOUNT with a bounded number of loader runs', async () => {
+  // Interleaved: NO_ACCOUNT must win regardless of order, and runs stay
+  // bounded. Costs one more run than a homogeneous burst, since the first 403
+  // is allowed through to override the 401's EXPIRED redirect.
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+  const runsBefore = rootLoaderRuns
+
+  await Promise.all(
+    [401, 403, 401, 403, 401, 403].map((s) =>
+      handleAuthError(
+        authError(
+          s,
+          s === 401 ? AuthCodes.UNAUTHORIZED : AuthCodes.ACCOUNT_NOT_PROVISIONED
+        )
+      ).catch(() => {})
+    )
+  )
+  await waitForIdle(router, true)
+
+  expect(router.state.location.pathname).toBe(Routes.SIGNIN)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+  expect(rootLoaderRuns - runsBefore).toBeLessThanOrEqual(3)
+})
+
+test('NO_ACCOUNT still overrides an EXPIRED redirect already committed', async () => {
+  const router = await buildSignedInRouter()
+  sessionAlive = false
+
+  await handleAuthError(authError(401, AuthCodes.UNAUTHORIZED)).catch(() => {})
+  await waitForIdle(router, true)
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.EXPIRED,
+  })
+
+  // The more specific diagnosis arrives second and must win.
+  await handleAuthError(
+    authError(403, AuthCodes.ACCOUNT_NOT_PROVISIONED)
+  ).catch(() => {})
+  await waitForIdle(router, true)
+
+  expect(router.state.location.state).toMatchObject({
+    reason: SignInReasons.NO_ACCOUNT,
+  })
+})

--- a/src/utils/authInterceptor.test.ts
+++ b/src/utils/authInterceptor.test.ts
@@ -5,7 +5,18 @@ import { AuthCodes, SignInReasons } from '@/utils/authCodes'
 
 jest.mock('@/router/router', () => ({
   __esModule: true,
-  default: { navigate: jest.fn() },
+  default: {
+    navigate: jest.fn(),
+    revalidate: jest.fn(),
+    state: {
+      location: { pathname: '/' },
+      navigation: { location: undefined },
+      revalidation: 'idle',
+      // Keyed by route id; 'root' is RouteIds.ROOT (factory can't reference
+      // the enum). status 200 = the stale-active-session shape the fix targets.
+      loaderData: { root: { status: 200 } },
+    },
+  },
 }))
 
 jest.mock('@/utils/notify', () => ({
@@ -19,7 +30,48 @@ import { notify } from '@/utils/notify'
 import { handleAuthError } from './authInterceptor'
 
 const mockedNavigate = (router as unknown as { navigate: jest.Mock }).navigate
+const mockedRevalidate = (router as unknown as { revalidate: jest.Mock })
+  .revalidate
 const mockedNotify = notify as jest.Mock
+const mockedRouter = router as unknown as {
+  state: {
+    location: {
+      pathname: string
+      state?: { reason?: string; message?: string }
+    }
+    navigation: {
+      location?: {
+        pathname: string
+        state?: { reason?: string; message?: string }
+      }
+    }
+    revalidation: 'idle' | 'loading'
+    loaderData: Record<string, { status?: number; ok?: boolean }>
+  }
+}
+
+function setCurrentPath(pathname: string): void {
+  mockedRouter.state.location.pathname = pathname
+}
+
+function setPendingPath(
+  pathname: string | undefined,
+  state?: { reason?: string; message?: string }
+): void {
+  mockedRouter.state.navigation.location = pathname
+    ? { pathname, state }
+    : undefined
+}
+
+function setCurrentState(
+  state: { reason?: string; message?: string } | undefined
+): void {
+  mockedRouter.state.location.state = state
+}
+
+function setRootLoaderStatus(status: number | undefined): void {
+  mockedRouter.state.loaderData.root = status ? { status } : { ok: false }
+}
 
 function makeError(
   status: number | undefined,
@@ -41,7 +93,16 @@ function makeError(
 
 beforeEach(() => {
   mockedNavigate.mockReset()
+  mockedRevalidate.mockReset()
   mockedNotify.mockReset()
+  // Default: dashboard state - not on the sign-in route, no navigation in
+  // flight, and loader data still claiming an active session (the stale
+  // shape a surprise 401 arrives against).
+  setCurrentPath('/')
+  setCurrentState(undefined)
+  setPendingPath(undefined)
+  setRootLoaderStatus(200)
+  mockedRouter.state.revalidation = 'idle'
 })
 
 test('401 redirects to sign-in with the expired-session message and reason', async () => {
@@ -157,4 +218,246 @@ test('network errors with no response pass through untouched', async () => {
   await expect(handleAuthError(error)).rejects.toBe(error)
   expect(mockedNavigate).not.toHaveBeenCalled()
   expect(mockedNotify).not.toHaveBeenCalled()
+})
+
+test('401 does not re-navigate when already on the sign-in route (loop-guard)', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  // Redundant redirect suppressed. (Dedupe only - the loop itself is broken
+  // by the revalidate() call, pinned further down.)
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('the sign-in route guard tolerates a trailing slash and casing', async () => {
+  setCurrentPath('/SignIn/')
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED still navigates over a committed EXPIRED redirect so the terminal state wins', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({ reason: SignInReasons.EXPIRED })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: ERROR_MESSAGES.permission,
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED overrides a PENDING EXPIRED redirect too (either arrival order)', async () => {
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN, { reason: SignInReasons.EXPIRED })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(
+    Routes.SIGNIN,
+    expect.objectContaining({
+      state: expect.objectContaining({ reason: SignInReasons.NO_ACCOUNT }),
+    })
+  )
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED does not re-navigate over an already-showing NO_ACCOUNT state', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  // Same message the body-less 403 resolves to, so this is a true duplicate.
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED does not re-navigate while a NO_ACCOUNT navigation is pending', async () => {
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN, {
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED suppressed by its own guard still revalidates stale loader data', async () => {
+  // revalidate() must sit OUTSIDE the navigate guard: a suppressed redirect
+  // still needs fresh loaderData, or the tab keeps bouncing.
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  setRootLoaderStatus(200)
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with a different message navigates so the terminal copy corrects itself', async () => {
+  // A body-less first 403 falls back to generic copy; a later one carrying the
+  // real text must not be deduped away.
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: ERROR_MESSAGES.permission,
+  })
+  const error = makeError(403, {
+    code: AuthCodes.ACCOUNT_NOT_PROVISIONED,
+    error: 'Your ZTMF account is not set up.',
+  })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: 'Your ZTMF account is not set up.',
+      reason: SignInReasons.NO_ACCOUNT,
+    },
+  })
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with the SAME message is still deduped', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({
+    reason: SignInReasons.NO_ACCOUNT,
+    message: 'Your ZTMF account is not set up.',
+  })
+  const error = makeError(403, {
+    code: AuthCodes.ACCOUNT_NOT_PROVISIONED,
+    error: 'Your ZTMF account is not set up.',
+  })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('a 401 does not clobber an already-showing NO_ACCOUNT terminal state', async () => {
+  setCurrentPath(Routes.SIGNIN)
+  setCurrentState({ reason: SignInReasons.NO_ACCOUNT })
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('401 does not re-navigate while a navigation to sign-in is already pending (burst)', async () => {
+  // The first 401 started the /signin navigation but it has not committed, so
+  // location still shows the old route. Stragglers must not restart it.
+  setCurrentPath('/')
+  setPendingPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+})
+
+test('a pending navigation to a non-sign-in route does not suppress the redirect', async () => {
+  setCurrentPath('/')
+  setPendingPath('/users')
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+    replace: true,
+    state: {
+      message: ERROR_MESSAGES.expired,
+      reason: SignInReasons.EXPIRED,
+    },
+  })
+})
+
+test('401 with stale active-session loader data revalidates the root loader before navigating', async () => {
+  // The loop-breaker: navigate() alone leaves the root loader un-run.
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).toHaveBeenCalled()
+  // Revalidate first so the /signin navigation commits with fresh loader data.
+  expect(mockedRevalidate.mock.invocationCallOrder[0]).toBeLessThan(
+    mockedNavigate.mock.invocationCallOrder[0]
+  )
+})
+
+test('401 while loader data already reports no session does not fire a redundant revalidation', async () => {
+  setRootLoaderStatus(undefined)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).not.toHaveBeenCalled()
+})
+
+test('401 suppressed by the sign-in guard still revalidates stale loader data', async () => {
+  // The mid-bounce state: skipping the redirect must not skip the fix.
+  setCurrentPath(Routes.SIGNIN)
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedNavigate).not.toHaveBeenCalled()
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('403 ACCOUNT_NOT_PROVISIONED with stale loader data also revalidates', async () => {
+  const error = makeError(403, { code: AuthCodes.ACCOUNT_NOT_PROVISIONED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).toHaveBeenCalled()
+})
+
+test('401 while a revalidation is already in flight does not re-fire revalidate', async () => {
+  // loaderData is stale until the re-run lands; re-firing revalidate() would
+  // restart the pending navigation for no benefit.
+  mockedRouter.state.revalidation = 'loading'
+  const error = makeError(401, { code: AuthCodes.UNAUTHORIZED })
+
+  await expect(handleAuthError(error)).rejects.toMatchObject({
+    __authHandled: true,
+  })
+  expect(mockedRevalidate).not.toHaveBeenCalled()
 })

--- a/src/utils/authInterceptor.ts
+++ b/src/utils/authInterceptor.ts
@@ -4,7 +4,7 @@
 // node throws "Cannot use 'import.meta' outside a module" at load time).
 import type { AxiosError } from 'axios'
 import router from '@/router/router'
-import { Routes } from '@/router/constants'
+import { RouteIds, Routes } from '@/router/constants'
 import { ERROR_MESSAGES } from '@/constants'
 import { markAuthHandled, notify } from '@/utils/notify'
 import { AuthCodes, SignInReasons } from '@/utils/authCodes'
@@ -47,28 +47,77 @@ export async function handleAuthError(
   const code = error.response?.data?.code
   const backendMessage = error.response?.data?.error
 
+  // Navigating to /signin leaves the root route matched, so react-router does
+  // not re-run its loader: loaderData keeps reporting status 200, LoginPage
+  // trusts it and <Navigate>s back to the dashboard, whose mount 401s again
+  // (#606). revalidate() is what breaks that cycle, so it must stay OUTSIDE
+  // the redirect guards below - a suppressed redirect still needs fresh data.
+  // Path normalization mirrors Title.tsx.
+  const normalizePath = (pathname: string | undefined) =>
+    (pathname ?? '').toLowerCase().replace(/\/$/, '')
+  const signInPath = Routes.SIGNIN.toLowerCase()
+  const onSignIn = (loc?: { pathname?: string }) =>
+    normalizePath(loc?.pathname) === signInPath
+  const alreadyOnSignIn =
+    onSignIn(router.state?.location) ||
+    onSignIn(router.state?.navigation?.location)
+  const backendMessageOrPermission =
+    typeof backendMessage === 'string' && backendMessage.length > 0
+      ? backendMessage
+      : ERROR_MESSAGES.permission
+  // NO_ACCOUNT cannot reuse alreadyOnSignIn: an EXPIRED redirect landing first
+  // in a burst would suppress the more specific diagnosis. Keying on reason
+  // dedupes it against itself instead. The message is part of the key because
+  // LoginPage prefers location.state.message, so a body-less 403 that fell back
+  // to generic copy would otherwise freeze out a later one carrying the real
+  // text.
+  const showingNoAccount = (loc?: { pathname?: string; state?: unknown }) => {
+    if (!onSignIn(loc)) return false
+    const locState = loc?.state as
+      | { reason?: string; message?: string }
+      | null
+      | undefined
+    return (
+      locState?.reason === SignInReasons.NO_ACCOUNT &&
+      locState?.message === backendMessageOrPermission
+    )
+  }
+  const alreadyShowingNoAccount =
+    showingNoAccount(router.state?.location) ||
+    showingNoAccount(router.state?.navigation?.location)
+  const rootLoaderData = router.state?.loaderData?.[RouteIds.ROOT] as
+    | { status?: number }
+    | undefined
+  // loaderData stays stale until a revalidation lands, so without the in-flight
+  // check every straggler in a burst would restart the pending navigation.
+  const needsRevalidation =
+    rootLoaderData?.status === 200 && router.state?.revalidation !== 'loading'
+
   if (status === 401) {
-    router.navigate(Routes.SIGNIN, {
-      replace: true,
-      state: {
-        message: ERROR_MESSAGES.expired,
-        reason: SignInReasons.EXPIRED,
-      },
-    })
+    if (needsRevalidation) void router.revalidate()
+    if (!alreadyOnSignIn) {
+      router.navigate(Routes.SIGNIN, {
+        replace: true,
+        state: {
+          message: ERROR_MESSAGES.expired,
+          reason: SignInReasons.EXPIRED,
+        },
+      })
+    }
     throw markAuthHandled(error)
   }
   if (status === 403) {
     if (code === AuthCodes.ACCOUNT_NOT_PROVISIONED) {
-      router.navigate(Routes.SIGNIN, {
-        replace: true,
-        state: {
-          message:
-            typeof backendMessage === 'string' && backendMessage.length > 0
-              ? backendMessage
-              : ERROR_MESSAGES.permission,
-          reason: SignInReasons.NO_ACCOUNT,
-        },
-      })
+      if (needsRevalidation) void router.revalidate()
+      if (!alreadyShowingNoAccount) {
+        router.navigate(Routes.SIGNIN, {
+          replace: true,
+          state: {
+            message: backendMessageOrPermission,
+            reason: SignInReasons.NO_ACCOUNT,
+          },
+        })
+      }
       throw markAuthHandled(error)
     }
     if (code === AuthCodes.FORBIDDEN_ORIGIN) {
@@ -76,12 +125,7 @@ export async function handleAuthError(
       notify(ERROR_MESSAGES.permission, 'error')
       throw markAuthHandled(error)
     }
-    notify(
-      typeof backendMessage === 'string' && backendMessage.length > 0
-        ? backendMessage
-        : ERROR_MESSAGES.permission,
-      'error'
-    )
+    notify(backendMessageOrPermission, 'error')
     throw markAuthHandled(error)
   }
   throw error

--- a/src/utils/sessionSync.test.ts
+++ b/src/utils/sessionSync.test.ts
@@ -1,0 +1,181 @@
+import { Routes } from '@/router/constants'
+
+// Stand-in for the channel the module builds at load time. `dispatch` delivers
+// to onmessage AND addEventListener handlers like a browser does, so the
+// idempotency test can observe stacked handlers - driving onmessage directly
+// never could, since the property holds one function.
+class FakeBroadcastChannel {
+  static last: FakeBroadcastChannel | null = null
+  name: string
+  onmessage: ((e: MessageEvent) => void) | null = null
+  listeners: ((e: MessageEvent) => void)[] = []
+  posted: unknown[] = []
+  constructor(name: string) {
+    this.name = name
+    FakeBroadcastChannel.last = this
+  }
+  postMessage(data: unknown): void {
+    this.posted.push(data)
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.push(fn)
+  }
+  /** Deliver a message the way the browser would: onmessage AND every listener. */
+  dispatch(data: unknown): void {
+    const event = { data } as MessageEvent
+    this.onmessage?.(event)
+    this.listeners.forEach((fn) => fn(event))
+  }
+  close(): void {}
+}
+
+const originalLocation = window.location
+const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown })
+  .BroadcastChannel
+
+beforeEach(() => {
+  jest.resetModules()
+  FakeBroadcastChannel.last = null
+  // jsdom forbids assigning hash / calling reload on the real location; swap in
+  // a writable stub so the redirect is observable.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { hash: '', reload: jest.fn() },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+  ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+    originalBroadcastChannel
+})
+
+describe('with BroadcastChannel available', () => {
+  function loadModule() {
+    ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+      FakeBroadcastChannel as unknown
+    // Fresh import so the module-level channel is built against the fake.
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('broadcastLogout posts a logout message on the channel', () => {
+    const { broadcastLogout } = loadModule()
+    broadcastLogout()
+    expect(FakeBroadcastChannel.last?.posted).toEqual(['logout'])
+  })
+
+  it('a received logout reloads the tab without touching the hash', () => {
+    // Leaving the hash alone means a user who vetoes the reload via the
+    // questionnaire's beforeunload guard loses nothing.
+    window.location.hash = '#/users'
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.dispatch('logout')
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+    expect(window.location.hash).toBe('#/users')
+  })
+
+  it('ignores non-logout messages', () => {
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.dispatch('other')
+
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent across repeat initLogoutListener calls', () => {
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.dispatch('logout')
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows a postMessage failure so the logging-out tab still finishes', () => {
+    // handleLogout calls this before its own reload with the session already
+    // dead, so an escaping throw would strand the user mid-logout.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const { broadcastLogout } = loadModule()
+    const channel = FakeBroadcastChannel.last!
+    channel.postMessage = () => {
+      throw new Error('InvalidStateError')
+    }
+
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(errSpy).toHaveBeenCalled()
+
+    errSpy.mockRestore()
+  })
+
+  it('reloads even when the tab is already on the sign-in route', () => {
+    // A tab can sit on /signin with stale loader data still claiming a
+    // session; skipping the reload would wedge it.
+    window.location.hash = `#${Routes.SIGNIN}`
+    const { initLogoutListener } = loadModule()
+    initLogoutListener()
+
+    FakeBroadcastChannel.last?.dispatch('logout')
+
+    expect(window.location.reload as jest.Mock).toHaveBeenCalled()
+  })
+})
+
+describe('without BroadcastChannel (unsupported browser)', () => {
+  function loadModule() {
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('broadcastLogout and initLogoutListener are safe no-ops', () => {
+    const { broadcastLogout, initLogoutListener } = loadModule()
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(() => initLogoutListener()).not.toThrow()
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+  })
+})
+
+describe('when constructing the channel throws', () => {
+  // Import-time throw would white-screen the app; degrade to the no-op path.
+  function loadModule() {
+    ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+      function ThrowingChannel() {
+        throw new Error('blocked by policy')
+      } as unknown
+    let mod!: typeof import('./sessionSync')
+    jest.isolateModules(() => {
+      mod = require('./sessionSync')
+    })
+    return mod
+  }
+
+  it('does not throw at import and leaves both functions as no-ops', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => loadModule()).not.toThrow()
+    const { broadcastLogout, initLogoutListener } = loadModule()
+    expect(() => broadcastLogout()).not.toThrow()
+    expect(() => initLogoutListener()).not.toThrow()
+    expect(window.location.reload as jest.Mock).not.toHaveBeenCalled()
+    expect(errSpy).toHaveBeenCalled()
+
+    errSpy.mockRestore()
+  })
+})

--- a/src/utils/sessionSync.ts
+++ b/src/utils/sessionSync.ts
@@ -1,0 +1,56 @@
+// Cross-tab logout (#606). Logging out clears the HTTP-only session cookie
+// browser-wide, but other tabs keep rendering off stale root loader data until
+// something re-runs the authLoader. The logging-out tab signals here.
+
+// Guarded because this runs at import time via main.tsx: a throw would
+// white-screen the app before it renders. Feature detection proves the
+// interface exists, not that constructing it succeeds.
+let channel: BroadcastChannel | null = null
+try {
+  if (typeof window !== 'undefined' && 'BroadcastChannel' in window) {
+    channel = new BroadcastChannel('ztmf-auth')
+  }
+} catch (error) {
+  console.error(
+    'BroadcastChannel unavailable; cross-tab logout disabled',
+    error
+  )
+}
+
+const LOGOUT = 'logout'
+
+/**
+ * Signal every other tab. No-op without a channel; callers reload themselves
+ * regardless.
+ *
+ * postMessage is spec'd to throw (InvalidStateError, DataCloneError). Neither
+ * should be reachable, but handleLogout calls this after the session is already
+ * dead and before its own reload, so an escaping throw would strand the user
+ * mid-logout.
+ */
+export function broadcastLogout(): void {
+  try {
+    channel?.postMessage(LOGOUT)
+  } catch (error) {
+    console.error('Cross-tab logout signal failed', error)
+  }
+}
+
+/**
+ * Registered once at startup. Reloading is the whole reaction: it re-runs the
+ * authLoader, and Title renders LoginPage on any route once that reports no
+ * session.
+ *
+ * Do not add a hash write or an "already on /signin" skip. The questionnaire's
+ * beforeunload guard can veto this reload, and a hash write would move the tab
+ * anyway when a user cancels it to save their work; the skip would wedge a tab
+ * sitting on /signin whose loader data still claims a session. `onmessage`
+ * rather than addEventListener keeps repeat registration idempotent.
+ */
+export function initLogoutListener(): void {
+  if (!channel) return
+  channel.onmessage = (e: MessageEvent) => {
+    if (e.data !== LOGOUT) return
+    window.location.reload()
+  }
+}

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -223,6 +223,24 @@ describe('buildExtendedDiff', () => {
     expect(buildExtendedDiff(base, base, KEYS)).toEqual({})
   })
 
+  // isso_name is the one extended field whose displayed value can be resolved
+  // by the backend rather than stored, so the form is seeded with a name that
+  // is not in the column. Omitting it while untouched is what stops an
+  // unrelated edit from persisting the resolved name as a stored override.
+  it('omits an untouched isso_name that was resolved rather than stored', () => {
+    const keys = [...KEYS, 'isso_name'] as (keyof FismaSystemType)[]
+    const loaded = {
+      ...base,
+      isso_name: 'Resolved From User Record',
+    } as unknown as FismaSystemType
+    const edited = { ...loaded, fips: 'High' } as FismaSystemType
+
+    const diff = buildExtendedDiff(edited, loaded, keys)
+
+    expect(diff).toEqual({ fips: 'High' })
+    expect(diff).not.toHaveProperty('isso_name')
+  })
+
   it('includes only changed fields, at their typed value', () => {
     const edited = { ...base, fips: 'High', hva: false } as FismaSystemType
     expect(buildExtendedDiff(edited, base, KEYS)).toEqual({

--- a/src/utils/systemMetadataVocab.test.ts
+++ b/src/utils/systemMetadataVocab.test.ts
@@ -145,9 +145,9 @@ describe('booleanOptions', () => {
   })
 
   it('overrides the true/false labels but keeps values and Unknown', () => {
-    expect(booleanOptions({ true: 'Not funded', false: 'Funded' })).toEqual([
-      { value: 'true', label: 'Not funded' },
-      { value: 'false', label: 'Funded' },
+    expect(booleanOptions({ true: 'Active', false: 'Inactive' })).toEqual([
+      { value: 'true', label: 'Active' },
+      { value: 'false', label: 'Inactive' },
       { value: '', label: 'Unknown' },
     ])
   })
@@ -162,9 +162,9 @@ describe('display formatting', () => {
   })
 
   it('applies custom true/false labels, leaving Unknown', () => {
-    const labels = { true: 'Not funded', false: 'Funded' }
-    expect(formatBool(true, labels)).toBe('Not funded')
-    expect(formatBool(false, labels)).toBe('Funded')
+    const labels = { true: 'Active', false: 'Inactive' }
+    expect(formatBool(true, labels)).toBe('Active')
+    expect(formatBool(false, labels)).toBe('Inactive')
     expect(formatBool(null, labels)).toBe('Unknown')
   })
 

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -167,6 +167,13 @@ export function formatList(v: string[] | null | undefined): string {
  * array []) passes through as the user's clear. On create, pass an empty
  * baseline so only the fields the user set are sent.
  *
+ * Omission is what protects a field the backend resolves rather than stores:
+ * the System Details form is seeded from a read that returns a resolved
+ * isso_name, so an untouched field must stay out of the payload or saving an
+ * unrelated edit would persist the resolved name as a stored override. A
+ * missing baseline defeats that, since every field then counts as changed;
+ * pass an empty system on create and a real one on update, never null.
+ *
  * @param edited - The edited system.
  * @param baseline - The system to diff against (the loaded system, or an empty
  *   one when creating); a missing baseline treats every field as unset.

--- a/src/utils/systemMetadataVocab.ts
+++ b/src/utils/systemMetadataVocab.ts
@@ -80,8 +80,7 @@ export function optionsForField(
 
 // Custom labels for the true/false ends of a tri-state boolean. For fields
 // whose Yes/No reads ambiguously against the label (e.g. a negatively-phrased
-// "Not Funded for Remediation", where "No" would mean "it is funded"). Unknown
-// is always Unknown.
+// label where "No" would be a double negative). Unknown is always Unknown.
 export type BooleanLabels = { true: string; false: string }
 
 /**

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -140,6 +140,64 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
   expect(putBody).not.toHaveProperty('cloud_service_model')
 })
 
+test('an edited ISSO Name is sent in the save payload', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  expect(putBody).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name saves an empty string, which restores the derived name', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  let putBody: Record<string, unknown> | undefined
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    putBody = JSON.parse(config.data)
+    return [200, {}]
+  })
+  const user = userEvent.setup()
+
+  renderWithProviders(
+    <EditSystemModal
+      title="Edit"
+      open
+      onClose={jest.fn()}
+      system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
+      mode="edit"
+      datacenterEnvironments={[]}
+    />
+  )
+
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(putBody).toBeDefined())
+  // '' clears the stored override so the name derived from the ISSO user
+  // record applies again; null would read as "leave unchanged".
+  expect(putBody).toHaveProperty('isso_name', '')
+})
+
 test('clearing a free-text field saves an empty string, not null', async () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   let putBody: Record<string, unknown> | undefined

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -181,7 +181,8 @@ export default function EditSystemModal({
   // or free text. Each control stores the field's typed clear signal when
   // emptied: enum '', boolean null, array [].
   const renderExtendedControl = (field: FieldConfig) => {
-    // isso_name is backend-resolved, so its control is read-only.
+    // A field marked read-only in fieldConfig renders disabled; the same flag
+    // keeps it out of the write payload.
     const disabled = field.readOnly
     if (field.type === 'select') {
       const current = editedFismaSystem[field.key] as string | null | undefined

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -27,6 +27,7 @@ import {
   ListSubheader,
   Menu,
   Button,
+  Alert,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { useState, useEffect, useMemo, useCallback } from 'react'
@@ -52,6 +53,7 @@ import { hasSystemAccess } from '@/utils/userRoles'
 import { TIERS } from '@/utils/tierStyles'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
+import { resolveRowCallId, datacallNameComparator } from './rowCall'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
@@ -60,6 +62,7 @@ import type { OpDiv } from '@/types'
 import {
   applyDashboardFilters,
   hasNoActiveFilters,
+  isOpenCallInView,
   EMPTY_DASHBOARD_FILTERS,
   type DashboardFilterState,
 } from './dashboardFilters'
@@ -80,6 +83,8 @@ declare module '@mui/x-data-grid' {
     opdivOptions: OpDivOption[]
     showEnvFilter: boolean
     showOpDivFilter: boolean
+    hasOpenCall: boolean
+    openCallInView: boolean
   }
 }
 
@@ -218,6 +223,8 @@ export function QuickSearchToolbar(props: {
   opdivOptions?: OpDivOption[]
   showEnvFilter?: boolean
   showOpDivFilter?: boolean
+  hasOpenCall?: boolean
+  openCallInView?: boolean
 }) {
   const { showDecommissioned, setShowDecommissioned } = useContextProp()
   // The free-text quick-filter lives in the grid's own filter model, not in
@@ -235,6 +242,16 @@ export function QuickSearchToolbar(props: {
   const opdivOptions = props.opdivOptions ?? []
   const showEnvFilter = props.showEnvFilter ?? false
   const showOpDivFilter = props.showOpDivFilter ?? false
+  const hasOpenCall = props.hasOpenCall ?? true
+  const openCallInView = props.openCallInView ?? true
+  // Why the call-scoped toggles are grayed out, when they are: no call open
+  // at all vs an open call outside the selected year. Empty while they apply
+  // (an empty title suppresses the Tooltip).
+  const callScopeHint = openCallInView
+    ? ''
+    : hasOpenCall
+      ? 'The open data call is not in the selected view'
+      : 'No data call is currently open'
 
   const switchSx = {
     '& .MuiSwitch-switchBase.Mui-checked': { color: '#004297' },
@@ -253,172 +270,233 @@ export function QuickSearchToolbar(props: {
   }
 
   return (
-    <Box
-      sx={{
-        py: 1,
-        px: 1,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 1.5,
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      }}
-    >
-      <GridToolbarQuickFilter
-        debounceMs={250}
-        sx={{
-          '& .MuiInputBase-input::placeholder': {
-            color: '#404040',
-            opacity: 0.8,
-          },
-          '& .MuiInputBase-root:after': {
-            borderBottomColor: '#5666b8',
-          },
-          '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
-            borderBottomColor: '#5666b8',
-          },
-        }}
-      />
-      {/* All facet filters live in one right-aligned cluster next to the
-          Show Decommissioned toggle. */}
+    <>
       <Box
         sx={{
+          py: 1,
+          px: 1,
           display: 'flex',
           flexWrap: 'wrap',
           gap: 1.5,
+          justifyContent: 'space-between',
           alignItems: 'center',
-          justifyContent: 'flex-end',
         }}
       >
-        {showEnvFilter && (
-          <FormControl size="small" sx={{ width: 200 }}>
-            <Select
-              multiple
-              displayEmpty
-              value={filters.environments}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  environments: e.target.value as string[],
-                })
-              }
-              inputProps={{ 'aria-label': 'Filter by environment' }}
-              renderValue={(selected) => {
-                const vals = selected as string[]
-                if (vals.length === 0)
-                  return <span style={{ color: '#6b6b6b' }}>Environment</span>
-                if (vals.length === 1) return vals[0]
-                return `${vals.length} environments`
-              }}
-              sx={selectValueSx}
-            >
-              {envOptions.map((opt) => (
-                <MenuItem key={opt} value={opt}>
-                  <Checkbox
-                    checked={filters.environments.includes(opt)}
-                    readOnly
-                    size="small"
-                  />
-                  <ListItemText primary={opt} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-        {showOpDivFilter && (
-          <FormControl size="small" sx={{ width: 200 }}>
-            <Select
-              multiple
-              displayEmpty
-              value={filters.opdivIds}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  opdivIds: e.target.value as number[],
-                })
-              }
-              inputProps={{ 'aria-label': 'Filter by OpDiv' }}
-              renderValue={(selected) => {
-                const ids = selected as number[]
-                if (ids.length === 0)
-                  return <span style={{ color: '#6b6b6b' }}>OpDiv</span>
-                if (ids.length === 1)
-                  return (
-                    opdivOptions.find((o) => o.id === ids[0])?.label ??
-                    String(ids[0])
-                  )
-                return `${ids.length} OpDivs`
-              }}
-              sx={selectValueSx}
-            >
-              {opdivOptions.map((o) => (
-                <MenuItem key={o.id} value={o.id}>
-                  <Checkbox
-                    checked={filters.opdivIds.includes(o.id)}
-                    readOnly
-                    size="small"
-                  />
-                  <ListItemText primary={o.label} />
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-        <FormControlLabel
-          control={
-            <Switch
-              checked={filters.notUpdatedOnly}
-              onChange={(e) =>
-                onFiltersChange({
-                  ...filters,
-                  notUpdatedOnly: e.target.checked,
-                })
-              }
-              sx={switchSx}
-            />
-          }
-          label="Not updated only"
-          sx={{ m: 0 }}
-        />
-        <FormControlLabel
-          control={
-            <Switch
-              checked={showDecommissioned}
-              onChange={(e) => setShowDecommissioned(e.target.checked)}
-              sx={switchSx}
-            />
-          }
-          label="Show Decommissioned"
-          sx={{ m: 0 }}
-        />
-        <Button
-          size="small"
-          startIcon={<CloseIcon />}
-          onClick={() => {
-            onFiltersChange(EMPTY_DASHBOARD_FILTERS)
-            // Show Decommissioned lives in Title context (it gates a refetch),
-            // not in the client-side filter model — so clear it separately or it
-            // would survive "Clear filters".
-            setShowDecommissioned(false)
-            // The DataGrid quick-filter is grid state, not DashboardFilterState,
-            // so reset it via the grid API or the typed term survives (#573).
-            apiRef.current.setQuickFilterValues([])
+        <GridToolbarQuickFilter
+          debounceMs={250}
+          sx={{
+            '& .MuiInputBase-input::placeholder': {
+              color: '#404040',
+              opacity: 0.8,
+            },
+            '& .MuiInputBase-root:after': {
+              borderBottomColor: '#5666b8',
+            },
+            '& .MuiInputBase-root:hover:not(.Mui-disabled):before': {
+              borderBottomColor: '#5666b8',
+            },
           }}
-          // ...and both Show Decommissioned and the quick-filter are active
-          // filters for the button's own enabled state: without this, toggling
-          // only Show Decommissioned left Clear filters greyed out (#566), and
-          // typing only a search term would leave it greyed out too (#573).
-          disabled={
-            hasNoActiveFilters(filters) &&
-            !showDecommissioned &&
-            !hasQuickFilter
-          }
-          sx={{ color: '#004297', textTransform: 'none', mr: 2, flexShrink: 0 }}
+        />
+        {/* All facet filters live in one right-aligned cluster next to the
+          Show Decommissioned toggle. */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1.5,
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+          }}
         >
-          Clear filters
-        </Button>
+          {showEnvFilter && (
+            <FormControl size="small" sx={{ width: 200 }}>
+              <Select
+                multiple
+                displayEmpty
+                value={filters.environments}
+                onChange={(e) =>
+                  onFiltersChange({
+                    ...filters,
+                    environments: e.target.value as string[],
+                  })
+                }
+                inputProps={{ 'aria-label': 'Filter by environment' }}
+                renderValue={(selected) => {
+                  const vals = selected as string[]
+                  if (vals.length === 0)
+                    return <span style={{ color: '#6b6b6b' }}>Environment</span>
+                  if (vals.length === 1) return vals[0]
+                  return `${vals.length} environments`
+                }}
+                sx={selectValueSx}
+              >
+                {envOptions.map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    <Checkbox
+                      checked={filters.environments.includes(opt)}
+                      readOnly
+                      size="small"
+                    />
+                    <ListItemText primary={opt} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {showOpDivFilter && (
+            <FormControl size="small" sx={{ width: 200 }}>
+              <Select
+                multiple
+                displayEmpty
+                value={filters.opdivIds}
+                onChange={(e) =>
+                  onFiltersChange({
+                    ...filters,
+                    opdivIds: e.target.value as number[],
+                  })
+                }
+                inputProps={{ 'aria-label': 'Filter by OpDiv' }}
+                renderValue={(selected) => {
+                  const ids = selected as number[]
+                  if (ids.length === 0)
+                    return <span style={{ color: '#6b6b6b' }}>OpDiv</span>
+                  if (ids.length === 1)
+                    return (
+                      opdivOptions.find((o) => o.id === ids[0])?.label ??
+                      String(ids[0])
+                    )
+                  return `${ids.length} OpDivs`
+                }}
+                sx={selectValueSx}
+              >
+                {opdivOptions.map((o) => (
+                  <MenuItem key={o.id} value={o.id}>
+                    <Checkbox
+                      checked={filters.opdivIds.includes(o.id)}
+                      readOnly
+                      size="small"
+                    />
+                    <ListItemText primary={o.label} />
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {/* Both call-scoped toggles gray out when the open call is not in
+            view (ui#639): "Not updated only" is a current-cycle laggard
+            signal with nothing to match, and "Open data call only" would
+            empty the grid. The span wrappers keep the tooltips firing on the
+            disabled controls. */}
+          <Tooltip title={callScopeHint}>
+            <span>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={filters.openCallOnly}
+                    onChange={(e) =>
+                      onFiltersChange({
+                        ...filters,
+                        openCallOnly: e.target.checked,
+                      })
+                    }
+                    disabled={!openCallInView}
+                    sx={switchSx}
+                  />
+                }
+                label="Open data call only"
+                sx={{ m: 0 }}
+              />
+            </span>
+          </Tooltip>
+          <Tooltip title={callScopeHint}>
+            <span>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={filters.notUpdatedOnly}
+                    onChange={(e) =>
+                      onFiltersChange({
+                        ...filters,
+                        notUpdatedOnly: e.target.checked,
+                      })
+                    }
+                    disabled={!openCallInView}
+                    sx={switchSx}
+                  />
+                }
+                label="Not updated only"
+                sx={{ m: 0 }}
+              />
+            </span>
+          </Tooltip>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showDecommissioned}
+                onChange={(e) => setShowDecommissioned(e.target.checked)}
+                sx={switchSx}
+              />
+            }
+            label="Show Decommissioned"
+            sx={{ m: 0 }}
+          />
+          <Button
+            size="small"
+            startIcon={<CloseIcon />}
+            onClick={() => {
+              onFiltersChange(EMPTY_DASHBOARD_FILTERS)
+              // Show Decommissioned lives in Title context (it gates a refetch),
+              // not in the client-side filter model — so clear it separately or it
+              // would survive "Clear filters".
+              setShowDecommissioned(false)
+              // The DataGrid quick-filter is grid state, not DashboardFilterState,
+              // so reset it via the grid API or the typed term survives (#573).
+              apiRef.current.setQuickFilterValues([])
+            }}
+            // ...and both Show Decommissioned and the quick-filter are active
+            // filters for the button's own enabled state: without this, toggling
+            // only Show Decommissioned left Clear filters greyed out (#566), and
+            // typing only a search term would leave it greyed out too (#573).
+            disabled={
+              hasNoActiveFilters(filters) &&
+              !showDecommissioned &&
+              !hasQuickFilter
+            }
+            sx={{
+              color: '#004297',
+              textTransform: 'none',
+              mr: 2,
+              flexShrink: 0,
+            }}
+          >
+            Clear filters
+          </Button>
+        </Box>
       </Box>
-    </Box>
+      {/* Toolbar-row captions crowd the filter cluster and wrap it (ui#639),
+          so the call-scope notice renders as its own slim banner between the
+          filters and the column headers. */}
+      {/* role="status" rather than MUI's default role="alert": this is a
+          standing contextual notice, and an assertive role would interrupt
+          screen readers at mount and on every year switch.
+
+          The live region is the keyboard- and screen-reader-reachable
+          counterpart of the disabled switches' hover tooltips, so it has to
+          actually announce. That is why the wrapper stays mounted and only its
+          contents change: a live region inserted into the DOM at the same
+          moment as its text is generally not announced, so gating the region
+          itself on the condition would have made it silent in exactly the
+          cases it exists to cover. */}
+      <Box role="status" aria-live="polite">
+        {!openCallInView && (
+          <Alert severity="info" sx={{ borderRadius: 0, py: 0 }}>
+            {hasOpenCall
+              ? 'The open data call is not in the selected view'
+              : "No open data call; showing each system's most recently updated call"}
+          </Alert>
+        )}
+      </Box>
+    </>
   )
 }
 // Cache for pillar scores to avoid repeated API calls
@@ -440,6 +518,7 @@ export default function FismaTable({
     latestDataCallId,
     selectedDatacall,
     datacalls,
+    activeDatacallIds,
     userInfo,
     datacenterEnvironments,
   } = useContextProp()
@@ -463,6 +542,10 @@ export default function FismaTable({
   // not-updated filter) only makes sense then; a past/closed call shows a
   // neutral Complete/Incomplete chip instead (ztmf#537). Rows without a chosen
   // call, or before latestDataCallId has loaded, keep the current rendering.
+  // Agrees with resolveRowCallId (the Data Call column) by construction:
+  // buildDashboardMaps fills chosenCallMap and systemCallMap for the same key
+  // set, so a row is grayed iff its column names a non-open call. Keep the
+  // two in step if either resolution changes.
   const isRowCurrentCall = useCallback(
     (fismasystemid: number): boolean => {
       const chosen = chosenCallMap[fismasystemid]
@@ -470,6 +553,32 @@ export default function FismaTable({
       return chosen === latestDataCallId && !latestDeadlinePassed
     },
     [chosenCallMap, latestDataCallId, latestDeadlinePassed]
+  )
+  // Whether any data call is open at all, and whether that open call is part
+  // of what the table is showing. The year picker can select a historical
+  // group while a newer call is open; in that view no row is current, so the
+  // call-scoped toggles ("Not updated only", "Open data call only") and the
+  // past-call graying key on the viewed calls, not the calendar (ui#639).
+  // Without the in-view check the first toggle silently empties the grid (the
+  // reported bug) and the second keeps only rows with no call data.
+  const hasOpenCall = Boolean(latestDataCallId) && !latestDeadlinePassed
+  const openCallInView = isOpenCallInView(
+    latestDataCallId,
+    latestDeadlinePassed,
+    activeDatacallIds
+  )
+  const callById = useMemo(
+    () => new Map(datacalls.map((d) => [d.datacallid, d])),
+    [datacalls]
+  )
+  // Sort key for the Data Call column: call names do not sort chronologically
+  // ("FY2025 Q3" vs "FY25 ZTM"), so the column orders by deadline instead.
+  const deadlineByCallName = useMemo(
+    () =>
+      new Map(
+        datacalls.map((d) => [d.datacall, new Date(d.deadline).getTime()])
+      ),
+    [datacalls]
   )
   const hasSystemDetailAccess = hasSystemAccess(userInfo)
   const [open, setOpen] = useState<boolean>(false)
@@ -586,6 +695,22 @@ export default function FismaTable({
     })
   }, [envOptions, opdivOptions, showEnvFilter, showOpDivFilter])
 
+  // The call-scoped facets only mean something while the open call is in
+  // view (their switches gray out otherwise). Drop any stored true when it is
+  // not, so a year-picker move to a historical group, or a /datacalls refetch
+  // that flips the newest call closed, cannot leave an invisible filter
+  // emptying the grid (ui#639). (openness is evaluated when datacalls load,
+  // not continuously, so a deadline passing while the page sits open takes
+  // effect on the next fetch or reload.)
+  useEffect(() => {
+    if (openCallInView) return
+    setFilters((prev) =>
+      prev.notUpdatedOnly || prev.openCallOnly
+        ? { ...prev, notUpdatedOnly: false, openCallOnly: false }
+        : prev
+    )
+  }, [openCallInView])
+
   const filteredRows = useMemo(
     () =>
       applyDashboardFilters(
@@ -618,19 +743,16 @@ export default function FismaTable({
   }
 
   const handleOpenPillarScores = async (row: FismaSystemType) => {
-    // Use the same call the dashboard row is displaying (chosen by most-recently-updated
-    // in buildDashboardMaps) so the modal's "current" always matches the table cell.
-    // Falls back to newest-by-deadline if chosenCallMap has no entry (e.g. single-call
-    // system or map not yet populated), then to activeDataCallId as a last resort.
-    const chosenId = chosenCallMap[row.fismasystemid]
-    const rowDataCallId =
-      chosenId ??
-      sortDatacallsByDeadline(
-        (systemCallMap[row.fismasystemid] ?? [])
-          .map((id) => datacalls.find((d) => d.datacallid === id))
-          .filter((d): d is datacall => Boolean(d))
-      )[0]?.datacallid ??
-      activeDataCallId
+    // Same resolution as the Data Call column, so the modal's "current"
+    // always matches the call the row displays.
+    const rowDataCallId = resolveRowCallId(
+      row.fismasystemid,
+      chosenCallMap,
+      systemCallMap,
+      datacalls,
+      activeDataCallId,
+      activeDatacallIds
+    )
 
     try {
       // Check cache first
@@ -758,6 +880,32 @@ export default function FismaTable({
           </Box>
         )
       },
+    },
+    {
+      // Which call the row is displaying (ui#639), named plainly so a
+      // past-call row is identifiable and quick-searchable without relying
+      // on the grayed styling.
+      field: 'rowdatacall',
+      headerName: 'Data Call',
+      // Renders as the column-header tooltip: the resolution is not obvious
+      // from the name (it is not simply "last completed call").
+      description:
+        "The data call this row's score and progress are shown from: the system's most recently updated call among the selected calls, or the newest selected call for a system with no data in them.",
+      width: 130,
+      align: 'center',
+      headerAlign: 'center',
+      valueGetter: (value) =>
+        callById.get(
+          resolveRowCallId(
+            value.row.fismasystemid,
+            chosenCallMap,
+            systemCallMap,
+            datacalls,
+            activeDataCallId,
+            activeDatacallIds
+          )
+        )?.datacall ?? '',
+      sortComparator: datacallNameComparator(deadlineByCallName),
     },
     {
       // Questionnaire progress for the active data call (ztmf#299). The
@@ -892,6 +1040,16 @@ export default function FismaTable({
         isRowSelectable={(params: GridRowParams) =>
           params.row.fismasystemid in scores
         }
+        // De-emphasize rows displaying a closed call while the open call is
+        // in view (ui#639). Only in that mixed view: between calls, or on a
+        // historical year, every row is past-call and graying the whole grid
+        // distinguishes nothing. The Data Call column carries the same state
+        // as text.
+        getRowClassName={(params) =>
+          openCallInView && !isRowCurrentCall(params.row.fismasystemid)
+            ? 'past-call-row'
+            : ''
+        }
         columns={columns}
         checkboxSelection
         apiRef={apiRef}
@@ -915,6 +1073,8 @@ export default function FismaTable({
             opdivOptions,
             showEnvFilter,
             showOpDivFilter,
+            hasOpenCall,
+            openCallInView,
           },
           filterPanel: {
             sx: {
@@ -956,6 +1116,17 @@ export default function FismaTable({
           },
           '& .MuiDataGrid-columnHeaders .MuiSvgIcon-root': {
             color: 'white',
+          },
+          // De-emphasis must not dim interactive elements: whole-row opacity
+          // drops the name link, checkbox, and action icons below WCAG
+          // contrast minima while they stay clickable. Tint the row and mute
+          // only the cell text (rgba .6 on white holds AA); links, controls,
+          // and chips keep their own full-contrast colors.
+          '& .past-call-row': {
+            backgroundColor: '#f5f5f5',
+          },
+          '& .past-call-row .MuiDataGrid-cell': {
+            color: 'rgba(0, 0, 0, 0.6)',
           },
         }}
       />

--- a/src/views/FismaTable/QuickSearchToolbar.test.tsx
+++ b/src/views/FismaTable/QuickSearchToolbar.test.tsx
@@ -43,10 +43,16 @@ jest.mock('@/views/Title/Context', () => ({
 
 function renderToolbar(
   filters: DashboardFilterState = EMPTY_DASHBOARD_FILTERS,
-  onFiltersChange = jest.fn()
+  onFiltersChange = jest.fn(),
+  { hasOpenCall = true, openCallInView = true } = {}
 ) {
   return render(
-    <QuickSearchToolbar filters={filters} onFiltersChange={onFiltersChange} />
+    <QuickSearchToolbar
+      filters={filters}
+      onFiltersChange={onFiltersChange}
+      hasOpenCall={hasOpenCall}
+      openCallInView={openCallInView}
+    />
   )
 }
 
@@ -96,6 +102,74 @@ describe('QuickSearchToolbar — Clear filters vs Show Decommissioned (#566)', (
     })
     fireEvent.click(toggle)
     expect(mockSetShowDecommissioned).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('QuickSearchToolbar — call-scoped toggles (#639)', () => {
+  const openCallToggle = () =>
+    screen.getByRole('checkbox', { name: /open data call only/i })
+  const notUpdatedToggle = () =>
+    screen.getByRole('checkbox', { name: /not updated only/i })
+
+  it('flipping Open data call only drives the filter model', () => {
+    const onFiltersChange = jest.fn()
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, onFiltersChange)
+    fireEvent.click(openCallToggle())
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_DASHBOARD_FILTERS,
+      openCallOnly: true,
+    })
+  })
+
+  it('enables Clear filters when only Open data call only is on', () => {
+    renderToolbar({ ...EMPTY_DASHBOARD_FILTERS, openCallOnly: true })
+    expect(clearBtn()).toBeEnabled()
+  })
+
+  it('disables both call-scoped toggles when no call is open', () => {
+    // The bug: "Not updated only" stayed live on a closed call and silently
+    // emptied the grid. Both call-scoped toggles gray out instead;
+    // Show Decommissioned is not call-scoped and stays live.
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: false,
+      openCallInView: false,
+    })
+    expect(openCallToggle()).toBeDisabled()
+    expect(notUpdatedToggle()).toBeDisabled()
+    expect(
+      screen.getByRole('checkbox', { name: /show decommissioned/i })
+    ).toBeEnabled()
+  })
+
+  it('shows the no-open-call caption only when no call is open', () => {
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: false,
+      openCallInView: false,
+    })
+    expect(screen.getByText(/no open data call/i)).toBeInTheDocument()
+  })
+
+  it('disables the toggles with the out-of-view caption on a historical year', () => {
+    // A call can be open while the year picker shows a historical group; no
+    // viewed row is current, so the toggles gray out with wording that does
+    // not falsely claim nothing is open.
+    renderToolbar(EMPTY_DASHBOARD_FILTERS, jest.fn(), {
+      hasOpenCall: true,
+      openCallInView: false,
+    })
+    expect(openCallToggle()).toBeDisabled()
+    expect(notUpdatedToggle()).toBeDisabled()
+    expect(
+      screen.getByText(/open data call is not in the selected view/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/no open data call/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps the toggles live and the caption hidden while a call is open', () => {
+    renderToolbar()
+    expect(screen.queryByText(/no open data call/i)).not.toBeInTheDocument()
+    expect(openCallToggle()).toBeEnabled()
+    expect(notUpdatedToggle()).toBeEnabled()
   })
 })
 

--- a/src/views/FismaTable/dashboardFilters.test.ts
+++ b/src/views/FismaTable/dashboardFilters.test.ts
@@ -3,6 +3,7 @@ import {
   applyDashboardFilters,
   isNotUpdated,
   hasNoActiveFilters,
+  isOpenCallInView,
   EMPTY_DASHBOARD_FILTERS,
 } from './dashboardFilters'
 
@@ -133,6 +134,62 @@ test('facets combine with AND', () => {
   )
   // Cloud ∩ opdiv 10 = {1,3}; not-updated of those = {1}
   expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
+test('open-call-only filter keeps only current-call rows', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true }),
+    (id) => id !== 1 && id !== 4 // sys1 and sys4 display a past call
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([2, 3])
+})
+
+test('open-call-only filter is a no-op without call context', () => {
+  // Callers without a predicate treat every row as current (the documented
+  // default), so the facet passes everything through.
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true })
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1, 2, 3, 4])
+})
+
+test('open-call-only defaults off and counts as an active filter when on', () => {
+  // Default-off is deliberate (ui#639): default-on would hide closed-call
+  // rows silently and desync the export and stat tiles from the table.
+  expect(EMPTY_DASHBOARD_FILTERS.openCallOnly).toBe(false)
+  expect(hasNoActiveFilters(filters({ openCallOnly: true }))).toBe(false)
+})
+
+test('open-call-only composes with not-updated: current-call laggards only', () => {
+  const out = applyDashboardFilters(
+    ROWS,
+    PROGRESS,
+    CATEGORY_MAP,
+    filters({ openCallOnly: true, notUpdatedOnly: true }),
+    () => true
+  )
+  expect(out.map((r) => r.fismasystemid)).toEqual([1])
+})
+
+test('isOpenCallInView requires the open call to be among the viewed calls', () => {
+  // The whole point of the gate (ui#639): a call being open is not enough,
+  // it must be in the year-picker selection or no viewed row can be current.
+  expect(isOpenCallInView(5, false, [5, 4])).toBe(true)
+  expect(isOpenCallInView(5, false, [103, 4])).toBe(false) // open, out of view
+  expect(isOpenCallInView(5, true, [5, 4])).toBe(false) // in view, closed
+})
+
+test('isOpenCallInView is false before the datacall list loads', () => {
+  // latestDataCallId initializes to 0 in context; the gate must not treat
+  // that as an open call.
+  expect(isOpenCallInView(0, false, [0])).toBe(false)
+  expect(isOpenCallInView(0, false, [])).toBe(false)
 })
 
 test('a row whose environment is not in the category map is excluded when env filter is active', () => {

--- a/src/views/FismaTable/dashboardFilters.ts
+++ b/src/views/FismaTable/dashboardFilters.ts
@@ -12,6 +12,13 @@ export type DashboardFilterState = {
   opdivIds: number[]
   /** When true, keep only systems that have a questionnaire but zero updates. */
   notUpdatedOnly: boolean
+  /**
+   * When true, keep only systems whose displayed call is the open one (ui#639).
+   * An opt-in focus filter, deliberately default-off: hiding closed-call rows
+   * by default would drop them silently from the view and the row-selection
+   * export, and disagree with the stat tiles, which count all systems.
+   */
+  openCallOnly: boolean
 }
 
 /** An empty filter state — nothing selected, everything passes. */
@@ -19,6 +26,7 @@ export const EMPTY_DASHBOARD_FILTERS: DashboardFilterState = {
   environments: [],
   opdivIds: [],
   notUpdatedOnly: false,
+  openCallOnly: false,
 }
 
 /**
@@ -30,7 +38,33 @@ export function hasNoActiveFilters(filters: DashboardFilterState): boolean {
   return (
     filters.environments.length === 0 &&
     filters.opdivIds.length === 0 &&
-    !filters.notUpdatedOnly
+    !filters.notUpdatedOnly &&
+    !filters.openCallOnly
+  )
+}
+
+/**
+ * True when the open data call is part of what the dashboard is showing:
+ * a newest-by-deadline call exists, is still open, and is among the calls
+ * selected in the year picker. Every call-scoped affordance (the "Not
+ * updated only" and "Open data call only" switches, past-call row graying)
+ * keys on this, not merely on a call being open: the year picker can select
+ * a historical group while a newer call is open, and in that view no row is
+ * current, so a live call-scoped filter would empty the grid (ui#639).
+ * @param {number} latestDataCallId - Newest-by-deadline call id (0 before load).
+ * @param {boolean} latestDeadlinePassed - Whether that call's deadline passed.
+ * @param {number[]} activeDatacallIds - Call ids selected in the year picker.
+ * @returns {boolean} True when the open call is in the selected view.
+ */
+export function isOpenCallInView(
+  latestDataCallId: number,
+  latestDeadlinePassed: boolean,
+  activeDatacallIds: number[]
+): boolean {
+  return (
+    latestDataCallId > 0 &&
+    !latestDeadlinePassed &&
+    activeDatacallIds.includes(latestDataCallId)
   )
 }
 
@@ -68,8 +102,9 @@ export function isNotUpdated(
  * @param {DashboardFilterState} filters - The active selections.
  * @param {(fismasystemid: number) => boolean} [isCurrentCall] - Whether a row's
  *   displayed call is the current/active one. The "Not updated" facet only
- *   matches current-call laggards (ztmf#537); defaults to treating every row as
- *   current so callers without call context keep the original behavior.
+ *   matches current-call laggards (ztmf#537), and the "Open data call only"
+ *   facet keeps only current-call rows (ui#639); defaults to treating every
+ *   row as current so callers without call context keep the original behavior.
  * @returns {FismaSystemType[]} The subset of rows passing every active facet.
  */
 export function applyDashboardFilters(
@@ -85,6 +120,9 @@ export function applyDashboardFilters(
   const opdivSet = new Set(filters.opdivIds)
 
   return rows.filter((row) => {
+    if (filters.openCallOnly && !isCurrentCall(row.fismasystemid)) {
+      return false
+    }
     if (envSet.size > 0) {
       const category = categoryMap[row.datacenterenvironment]
       if (!category || !envSet.has(category)) return false

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -261,4 +261,49 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
+
+  // --- Carried-forward wording on the current call ---
+
+  it('reads Awaiting confirmation for a current-call system with carried answers and zero updates', () => {
+    // The answers exist (carried forward) but none count as updated —
+    // "0/41 Not updated" read as data loss; the chip says the actual state.
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 41 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Awaiting confirmation')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('reads Not started for a current-call system with no answers at all', () => {
+    render(
+      <ProgressCell
+        entry={{ ...untouchedEntry, questionsanswered: 0 }}
+        isCurrentCall={true}
+      />
+    )
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
+    // ztmf#437 may not be deployed everywhere; without the field the split
+    // would be a guess, so the cell keeps saying what it always said.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
+    expect(screen.getByText('Not updated')).toBeInTheDocument()
+  })
+
+  it('describes the carried-forward state in the tooltip', () => {
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 41 })).toBe(
+      'Answers carried forward from a previous data call — not yet confirmed'
+    )
+    // No answers at all keeps the plain no-updates line.
+    expect(progressTooltip({ ...untouchedEntry, questionsanswered: 0 })).toBe(
+      'No updates this data call'
+    )
+  })
 })

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -26,8 +26,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
  *   - current call, any genuine edit: "Updated" (green);
- *   - current call, otherwise: "Not updated" (orange). The chip is derived from
- *     questionsupdated so it can never disagree with the fraction.
+ *   - current call, zero updates: "Awaiting confirmation" (carried answers
+ *     exist) or "Not started" (none do), both warning-colored laggards;
+ *     legacy "Not updated" when questionsanswered is not served.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -87,7 +88,7 @@ export function ProgressCell({
       )
     }
     return (
-      <Tooltip title={progressTooltip(entry)}>
+      <Tooltip title={progressTooltip(entry, { pastCall: true })}>
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
           <span>
             {answered}/{entry.questionsexpected}
@@ -103,6 +104,19 @@ export function ProgressCell({
     )
   }
   const updated = entry.questionsupdated > 0
+  // Zero updates splits two materially different states: carried-forward
+  // answers awaiting confirmation vs no answers at all — a blanket "Not
+  // updated" read as data loss to ISSOs who had just reviewed everything.
+  // questionsanswered may be absent until ztmf#437 is deployed everywhere;
+  // keep the legacy wording then rather than guessing.
+  const answered = entry.questionsanswered
+  const label = updated
+    ? 'Updated'
+    : answered == null
+      ? 'Not updated'
+      : answered > 0
+        ? 'Awaiting confirmation'
+        : 'Not started'
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box
@@ -117,7 +131,7 @@ export function ProgressCell({
         </span>
         <Chip
           size="small"
-          label={updated ? 'Updated' : 'Not updated'}
+          label={label}
           color={updated ? 'success' : 'warning'}
           variant="outlined"
         />

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -66,7 +66,7 @@ export function progressSortValue(
  */
 export function progressTooltip(
   entry: ScoreProgress | undefined,
-  opts: { completed?: boolean } = {}
+  opts: { completed?: boolean; pastCall?: boolean } = {}
 ): string {
   if (!entry) return 'No progress data for this data call'
   if (entry.lastupdatedat) {
@@ -78,5 +78,10 @@ export function progressTooltip(
   if (hasNoQuestionnaire(entry))
     return 'No questionnaire applies to this system'
   if (entry.questionsupdated > 0) return 'Updated (time unavailable)'
+  // Mirrors the chip's carried-forward split: answers exist but none count
+  // as updated yet — awaiting confirmation, not missing. Current call only:
+  // a closed call has nothing left to confirm.
+  if (!opts.pastCall && (entry.questionsanswered ?? 0) > 0)
+    return 'Answers carried forward from a previous data call — not yet confirmed'
   return 'No updates this data call'
 }

--- a/src/views/FismaTable/rowCall.test.ts
+++ b/src/views/FismaTable/rowCall.test.ts
@@ -1,0 +1,117 @@
+import type { datacall } from '@/types'
+import { resolveRowCallId, datacallNameComparator } from './rowCall'
+
+const call = (datacallid: number, deadline: string): datacall => ({
+  datacallid,
+  datacall: `call-${datacallid}`,
+  datecreated: deadline,
+  deadline,
+})
+
+// Deliberately not in deadline order: id 2 has the newest deadline, so any
+// resolution that keys on id order instead of deadline gets caught.
+const DATACALLS = [
+  call(1, '2025-01-15T00:00:00Z'),
+  call(3, '2025-07-15T00:00:00Z'),
+  call(2, '2026-01-15T00:00:00Z'),
+]
+
+test('prefers the chosen (most-recently-updated) call', () => {
+  expect(resolveRowCallId(7, { 7: 1 }, { 7: [1, 2, 3] }, DATACALLS, 3)).toBe(1)
+})
+
+test('falls back to the newest-by-deadline call the system has scores in', () => {
+  expect(resolveRowCallId(7, {}, { 7: [1, 2] }, DATACALLS, 3)).toBe(2)
+})
+
+test('falls back to the active call when the system has no call data', () => {
+  expect(resolveRowCallId(7, {}, {}, DATACALLS, 3)).toBe(3)
+})
+
+test('ignores score-call ids that resolve to no known call', () => {
+  expect(resolveRowCallId(7, {}, { 7: [99] }, DATACALLS, 3)).toBe(3)
+})
+
+describe('last-resort call for a system with no data in the view', () => {
+  // Call 2 has the newest deadline, so it stands in for the open call; calls 1
+  // and 3 stand in for a historical year the picker has selected.
+  it('prefers the newest selected call when the active call is out of view', () => {
+    // The reported shape: selecting a year toggles all of its calls on, which
+    // collapses activeDataCallId to the open call even though the user is
+    // looking at a historical group. Labelling the row with call 2 there would
+    // name a call that is not on screen.
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [1, 3])).toBe(3)
+  })
+
+  it('keeps the active call when it is one of the selected calls', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 1, [1, 3])).toBe(1)
+  })
+
+  it('falls back to the active call when no calls are selected', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [])).toBe(2)
+  })
+
+  it('falls back to the active call when the selection resolves to no known call', () => {
+    expect(resolveRowCallId(7, {}, {}, DATACALLS, 2, [99])).toBe(2)
+  })
+
+  it('still prefers real row data over the view', () => {
+    expect(resolveRowCallId(7, { 7: 1 }, {}, DATACALLS, 2, [2, 3])).toBe(1)
+    expect(resolveRowCallId(7, {}, { 7: [1] }, DATACALLS, 2, [2, 3])).toBe(1)
+  })
+})
+
+describe('datacallNameComparator', () => {
+  // Names chosen so string order CONTRADICTS deadline order: "FY2025 Q3"
+  // string-sorts before "FY25 ZTM" but has the newer deadline here, so a
+  // regression to name comparison fails these assertions.
+  const deadlines = new Map([
+    ['FY25 ZTM', Date.parse('2025-09-30T00:00:00Z')],
+    ['FY2025 Q3', Date.parse('2026-03-31T00:00:00Z')],
+  ])
+  const cmp = datacallNameComparator(deadlines)
+
+  it('orders by deadline, not by name', () => {
+    expect(cmp('FY25 ZTM', 'FY2025 Q3')).toBeLessThan(0)
+    expect(cmp('FY2025 Q3', 'FY25 ZTM')).toBeGreaterThan(0)
+  })
+
+  it('returns 0 on equal deadlines and on two unknown names', () => {
+    expect(cmp('FY25 ZTM', 'FY25 ZTM')).toBe(0)
+    expect(cmp('', 'nonsense')).toBe(0)
+  })
+
+  it('sinks an unknown or blank name to the oldest end', () => {
+    expect(cmp('', 'FY25 ZTM')).toBeLessThan(0)
+    expect(cmp('FY2025 Q3', '')).toBeGreaterThan(0)
+  })
+
+  describe('unparseable deadlines', () => {
+    // A record whose deadline is present but malformed maps to NaN, which is
+    // not the same as being absent from the map. Returning NaN from a
+    // comparator is outside Array.prototype.sort's contract and leaves the
+    // row's position up to the engine, so NaN has to reach the same sentinel
+    // an unknown name does.
+    const withBad = new Map([
+      ['bad-deadline', Number.NaN],
+      ['also-bad', Number.NaN],
+      ['FY25 ZTM', Date.parse('2025-09-30T00:00:00Z')],
+    ])
+    const cmpBad = datacallNameComparator(withBad)
+
+    it('never returns NaN', () => {
+      expect(cmpBad('bad-deadline', 'FY25 ZTM')).not.toBeNaN()
+      expect(cmpBad('FY25 ZTM', 'bad-deadline')).not.toBeNaN()
+      expect(cmpBad('bad-deadline', 'also-bad')).not.toBeNaN()
+    })
+
+    it('sinks a malformed deadline to the oldest end', () => {
+      expect(cmpBad('bad-deadline', 'FY25 ZTM')).toBeLessThan(0)
+      expect(cmpBad('FY25 ZTM', 'bad-deadline')).toBeGreaterThan(0)
+    })
+
+    it('treats two malformed deadlines as equal', () => {
+      expect(cmpBad('bad-deadline', 'also-bad')).toBe(0)
+    })
+  })
+})

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -1,0 +1,90 @@
+import type { datacall } from '@/types'
+import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
+
+/**
+ * Sort comparator for the Data Call column. Cell values are call NAMES (so
+ * the quick filter can match them), but names do not sort chronologically
+ * ("FY2025 Q3" string-sorts near "FY25 ZTM" by accident only), so ordering
+ * goes through each call's deadline. A name with no known deadline, or one
+ * whose deadline failed to parse, sinks to the oldest end rather than
+ * interleaving (mirrors sortDatacallsByDeadline's bad-value handling).
+ * Duplicate call names collapse to one deadline (last-write-wins in the map);
+ * the admin call-name grammar keeps names unique in practice.
+ * @param {Map<string, number>} deadlineByName - Call name -> deadline epoch ms.
+ * @returns {(a: string, b: string) => number} Ascending-by-deadline comparator.
+ */
+export function datacallNameComparator(
+  deadlineByName: Map<string, number>
+): (a: string, b: string) => number {
+  // A name absent from the map and a name mapped to NaN (empty or malformed
+  // deadline on a real record) both have to land on the same finite sentinel.
+  // Returning NaN from a comparator is outside Array.prototype.sort's contract
+  // and leaves the row's position engine-dependent.
+  const key = (name: string): number => {
+    const value = deadlineByName.get(name)
+    return value === undefined || Number.isNaN(value) ? -Infinity : value
+  }
+  return (a, b) => {
+    const av = key(a)
+    const bv = key(b)
+    if (av === bv) return 0
+    return av - bv
+  }
+}
+
+/**
+ * The data call a dashboard row is displaying. One source of truth shared by
+ * the Data Call column, the past-call row styling, and the Pillar Scores
+ * modal, so a cell and the modal it opens can never disagree about which call
+ * a row is on.
+ *
+ * Resolution order: the call chosen by most-recently-updated in
+ * buildDashboardMaps; else the newest-by-deadline call the system has scores
+ * in; else a call that is actually in the current view.
+ *
+ * That last rung matters. activeDataCallId collapses to the newest call
+ * whenever more than one call is toggled on, and selecting a year toggles all
+ * of its calls, so for any multi-call year it points at the open call rather
+ * than anything on screen. Naming it would label a row in a historical view
+ * with the current call, and hand the Pillar Scores modal an id the row has no
+ * score for, which sends the modal down its own fallback and lets the column
+ * and the modal name different calls. Preferring the newest call in view keeps
+ * the label inside what the user is looking at.
+ * @param {number} fismasystemid - The row's system id.
+ * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
+ * @param {datacall[]} datacalls - All known data calls.
+ * @param {number} activeDataCallId - The dashboard's active call id.
+ * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.
+ *   Omit to keep the pre-existing activeDataCallId-only behavior.
+ * @returns {number} The resolved data call id.
+ */
+export function resolveRowCallId(
+  fismasystemid: number,
+  chosenCallMap: Record<number, number>,
+  systemCallMap: Record<number, number[]>,
+  datacalls: datacall[],
+  activeDataCallId: number,
+  activeDatacallIds?: number[]
+): number {
+  const chosen = chosenCallMap[fismasystemid]
+  if (chosen != null) return chosen
+
+  const scored = sortDatacallsByDeadline(
+    (systemCallMap[fismasystemid] ?? [])
+      .map((id) => datacalls.find((d) => d.datacallid === id))
+      .filter((d): d is datacall => Boolean(d))
+  )[0]?.datacallid
+  if (scored != null) return scored
+
+  if (activeDatacallIds?.length) {
+    if (activeDatacallIds.includes(activeDataCallId)) return activeDataCallId
+    const newestInView = sortDatacallsByDeadline(
+      activeDatacallIds
+        .map((id) => datacalls.find((d) => d.datacallid === id))
+        .filter((d): d is datacall => Boolean(d))
+    )[0]?.datacallid
+    if (newestInView != null) return newestInView
+  }
+  return activeDataCallId
+}

--- a/src/views/Home/aggregateScores.test.ts
+++ b/src/views/Home/aggregateScores.test.ts
@@ -36,6 +36,96 @@ describe('buildDashboardMaps', () => {
     expect(systemCallMap[2]).toEqual([3])
   })
 
+  it('includes a system present only in progress (no score row)', () => {
+    // A never-started system in the current call: /scores/progress returns a row
+    // (40 expected, 0 updated) but there is no aggregate score row yet. It must
+    // still land in progressMap so the "Not updated only" facet can see it -
+    // keying off scores alone dropped these systems entirely.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[agg(1, 80)], []], // system 7 has no score row in either call
+        [[prog(1, 40, '2025-09-01'), prog(7, 0, null)], []]
+      )
+    expect(scoreMap[7]).toBeUndefined() // no fake score
+    expect(progressMap[7].questionsexpected).toBe(40)
+    expect(progressMap[7].questionsupdated).toBe(0)
+    // systemCallMap is score-derived: a never-started system lists no calls, so
+    // export provenance and the call picker don't treat it as having real data.
+    expect(systemCallMap[7]).toEqual([])
+    expect(chosenCallMap[7]).toBe(38)
+  })
+
+  it('keeps the newest call for a never-started system present in multiple calls', () => {
+    // System 7 is never-started in BOTH calls with no score anywhere, so every
+    // idx ties at -1. With no scored call to prefer, the tie-break leaves the
+    // newest-first fallback intact (idxs[0] = 38) and systemCallMap stays empty.
+    const { scoreMap, progressMap, systemCallMap, chosenCallMap } =
+      buildDashboardMaps(
+        CALL_IDS,
+        [[], []],
+        [[prog(7, 0, null)], [prog(7, 0, null)]]
+      )
+    expect(scoreMap[7]).toBeUndefined()
+    expect(progressMap[7].questionsupdated).toBe(0)
+    expect(chosenCallMap[7]).toBe(38) // newest-first fallback
+    expect(systemCallMap[7]).toEqual([])
+  })
+
+  it('keeps a scored call as chosen when a never-started progress row exists in another call', () => {
+    // System 1 is scored + completed in the newer call 38, and has a
+    // never-started progress row (0 updated, null lastupdated) in the older call
+    // 3. The union adds call 3 to its idxs, but that never-started row must not
+    // win `chosen` and blank the real score, and systemCallMap must stay
+    // score-derived ([38], not the union [38, 3]).
+    const { scoreMap, chosenCallMap, systemCallMap } = buildDashboardMaps(
+      CALL_IDS,
+      [[agg(1, 88)], []], // score only in call 38
+      [[prog(1, 40, '2025-09-01')], [prog(1, 0, null)]]
+    )
+    expect(scoreMap[1].score).toBe(88) // scored call kept
+    expect(chosenCallMap[1]).toBe(38)
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
+  it('keeps the score when the older scored call has no progress rows', () => {
+    // Score only in the older call 3, but its /scores/progress fetch failed, so
+    // call 3 has no progress row -> lastUpdatedMs -1, tying with call 38's
+    // never-started row. Without the score-preference tie-break, chosen lands on
+    // 38 and the real score is lost.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], []]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
+  })
+
+  it('keeps the score when the scored call row has a null lastupdatedat', () => {
+    // Score in the older call 3, whose progress row has a null lastupdatedat (an
+    // imported call carries no edit events) -> -1, tying with call 38's
+    // never-started row. The tie-break must still keep the scored call.
+    const { scoreMap, chosenCallMap } = buildDashboardMaps(
+      [38, 3],
+      [[], [agg(1, 88)]],
+      [[prog(1, 0, null)], [prog(1, 12, null)]]
+    )
+    expect(chosenCallMap[1]).toBe(3)
+    expect(scoreMap[1]?.score).toBe(88)
+  })
+
+  it('lists a call once for a system in both its scores and progress', () => {
+    // System 1 appears in the score AND progress list for call 38; its call list
+    // must not double-count that call (the union is deduped per call index).
+    const { systemCallMap } = buildDashboardMaps(
+      [38],
+      [[agg(1, 80)]],
+      [[prog(1, 40, '2025-09-01')]]
+    )
+    expect(systemCallMap[1]).toEqual([38])
+  })
+
   it('shows the call a multi-call system most recently updated, not the newest', () => {
     // System 1 is in both calls; it completed the OLDER call (3) recently and
     // never touched the newer call (38). Expect the older call's score/progress.

--- a/src/views/Home/aggregateScores.ts
+++ b/src/views/Home/aggregateScores.ts
@@ -50,16 +50,32 @@ export function buildDashboardMaps(
     return m
   })
 
-  // The call indices each system appears in (scores drive the table), newest
-  // first since callIds is newest first.
+  // Two per-call, newest-first index lists (callIds is newest first):
+  //   systemIdxs - union of score AND progress rows. Drives row membership,
+  //     progressMap, and the rank, so a never-started system (progress row, no
+  //     score) is included instead of dropped.
+  //   scoreIdxs  - score rows only. Drives systemCallMap, whose consumers
+  //     (export provenance, the #467 call picker in FismaTable) mean "calls this
+  //     system has a real score in". Feeding them the union would list
+  //     progress-only calls, disabling export and firing the picker spuriously.
+  // Per call index keeps both deduped.
   const systemIdxs = new Map<number, number[]>()
-  scoreByCall.forEach((m, idx) => {
-    for (const sys of m.keys()) {
+  const scoreIdxs = new Map<number, number[]>()
+  for (let idx = 0; idx < callIds.length; idx++) {
+    const sysIds = new Set<number>()
+    for (const sys of scoreByCall[idx]?.keys() ?? []) {
+      sysIds.add(sys)
+      const arr = scoreIdxs.get(sys)
+      if (arr) arr.push(idx)
+      else scoreIdxs.set(sys, [idx])
+    }
+    for (const sys of progressByCall[idx]?.keys() ?? []) sysIds.add(sys)
+    for (const sys of sysIds) {
       const arr = systemIdxs.get(sys)
       if (arr) arr.push(idx)
       else systemIdxs.set(sys, [idx])
     }
-  })
+  }
 
   const scoreMap: Record<number, SystemScoreEntry> = {}
   const progressMap: Record<number, ScoreProgress> = {}
@@ -67,15 +83,28 @@ export function buildDashboardMaps(
   const chosenCallMap: Record<number, number> = {}
 
   for (const [sys, idxs] of systemIdxs) {
-    // Choose the call this system most recently updated; ties and
-    // never-updated systems keep the newest call (idxs[0]).
+    // Choose the call this system most recently updated; ties/never-updated keep
+    // the newest (idxs[0]). Break ties toward a call the system actually has a
+    // score in: lastUpdatedMs returns -1 for a null OR missing progress row (a
+    // failed /scores/progress fetch, or an imported call with no edit events),
+    // so a scored call can tie at -1 with a never-started one. Without the
+    // score-preference the newer (progress-only) call would win and the real
+    // score would never land in scoreMap - the system would read as unscored.
+    // The tie-break only covers the -1 tie; a scoreless call winning outright
+    // (strict >) is prevented only by the backend invariant "scoreless => null
+    // lastupdatedat" (edits create scores). If that ever changes - e.g. a
+    // non-answer event bumps lastupdatedat - a scoreless call could out-`>` a
+    // scored one and this is where the score would be blanked.
     let chosen = idxs[0]
-    let bestT = lastUpdatedMs(progressByCall[chosen]?.get(sys))
+    let bestT = -Infinity
+    let bestHasScore = false
     for (const idx of idxs) {
       const t = lastUpdatedMs(progressByCall[idx]?.get(sys))
-      if (t > bestT) {
+      const hasScore = scoreByCall[idx]?.has(sys) ?? false
+      if (t > bestT || (t === bestT && hasScore && !bestHasScore)) {
         bestT = t
         chosen = idx
+        bestHasScore = hasScore
       }
     }
 
@@ -85,7 +114,8 @@ export function buildDashboardMaps(
     }
     const progress = progressByCall[chosen]?.get(sys)
     if (progress) progressMap[sys] = progress
-    systemCallMap[sys] = idxs.map((idx) => callIds[idx])
+    // Score-derived (see scoreIdxs): a never-started system lists no calls here.
+    systemCallMap[sys] = (scoreIdxs.get(sys) ?? []).map((idx) => callIds[idx])
     chosenCallMap[sys] = callIds[chosen]
   }
 

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -54,6 +54,16 @@ const opdivOptions: OpDiv[] = [
   },
 ]
 
+// Full label source (incl. the non-assignable OpDiv 99, e.g. a parent/inactive
+// division), so the modal can label a grant to it even though it is absent from
+// opdivOptions. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
+// fallback.
+const opdivLabelMap: Record<number, { code: string; name: string }> = {
+  1: { code: 'AAA', name: 'Division A' },
+  2: { code: 'BBB', name: 'Division B' },
+  99: { code: 'ZZZ', name: 'Parent Division' },
+}
+
 function renderModal(
   overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
 ) {
@@ -64,6 +74,9 @@ function renderModal(
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerGrantIds={[1, 2]}
       onChanged={jest.fn()}
       {...overrides}
     />
@@ -75,9 +88,9 @@ beforeEach(() => {
   mockedNavigate.mockReset()
 })
 
-// The most important test: verifies the scopedIds filter strips out-of-scope
-// grants before the PUT so an OPDIV_ADMIN never triggers a backend 403.
-test('PUT body excludes grants the target user holds outside the caller scope', async () => {
+// Scoped caller (OPDIV_ADMIN, enforceCallerScope=true): the save strips
+// out-of-scope grants before the PUT so the backend scope gate never 403s.
+test('scoped caller: PUT body excludes grants the target holds outside caller scope', async () => {
   // Target user holds [1, 2, 99]. OpDiv 99 is absent from opdivOptions
   // (out of caller scope), so only [1, 2] must reach the batch endpoint.
   mock
@@ -85,7 +98,7 @@ test('PUT body excludes grants the target user holds outside the caller scope', 
     .reply(200, { data: [1, 2, 99] })
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
-  renderModal()
+  renderModal({ enforceCallerScope: true })
   await waitFor(() => expect(mock.history.get).toHaveLength(1))
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
@@ -95,6 +108,137 @@ test('PUT body excludes grants the target user holds outside the caller scope', 
   expect(body.opdiv_ids).toHaveLength(2)
   expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2]))
   expect(body.opdiv_ids).not.toContain(99)
+})
+
+// Unscoped caller (OWNER/HHS_ADMIN, enforceCallerScope=false): the save must
+// PRESERVE the target's non-assignable grants. Omitting 99 would read as a
+// revocation to the backend and silently drop the grant.
+test('unscoped caller: PUT body preserves grants outside the assignable set', async () => {
+  mock
+    .onGet(`/users/${USER_ID}/assignedopdivs`)
+    .reply(200, { data: [1, 2, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  renderModal({ enforceCallerScope: false })
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 2, 99]))
+  expect(body.opdiv_ids).toHaveLength(3)
+})
+
+// Scoped caller whose OWN grant (99) is to an OpDiv since re-parented or
+// deactivated: 99 is in callerGrantIds (the backend still sees IsAssignedOpDiv
+// = true) but absent from opdivOptions (parent/inactive is filtered out). The
+// save must PRESERVE 99 - filtering on the narrower assignable set would strip
+// it from the PUT and the backend's toRemove gate (pure grant membership) would
+// then silently revoke the target's grant. The save boundary is the caller's
+// raw scope, not the dropdown's assignable set.
+test('scoped caller: preserves a caller-held grant that is no longer assignable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
+  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 99]))
+  expect(body.opdiv_ids).toHaveLength(2)
+})
+
+// A grant to a non-assignable OpDiv (99, absent from opdivOptions) still chips
+// with a readable label from opdivLabelMap - never a blank chip.
+test('labels a grant to a non-assignable OpDiv from the full label map', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal()
+
+  // The chip renders the label map entry, not a blank chip or a raw id.
+  expect(await screen.findByText('ZZZ - Parent Division')).toBeInTheDocument()
+})
+
+// A grant to an OpDiv missing from the label map falls back to "OpDiv #{id}"
+// rather than an empty chip.
+test('falls back to "OpDiv #{id}" for a grant missing from the label map', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [77] })
+
+  renderModal()
+
+  expect(await screen.findByText('OpDiv #77')).toBeInTheDocument()
+})
+
+// A non-assignable grant (99) resolves as a chip but must NOT be offered in the
+// dropdown - filterOptions narrows the selectable set to the assignable OpDivs
+// so it can't be re-selected.
+test('dropdown excludes a non-assignable grant even though it chips', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal()
+  // The grant chips (so the fetch has resolved and options are settled).
+  await screen.findByText('ZZZ - Parent Division')
+
+  // Open the dropdown.
+  await userEvent.click(screen.getByRole('combobox'))
+
+  // Assignable OpDivs are offered...
+  expect(await screen.findByRole('option', { name: /AAA/ })).toBeInTheDocument()
+  // ...but the non-assignable grant is filtered out of the selectable options.
+  expect(screen.queryByRole('option', { name: /ZZZ/ })).not.toBeInTheDocument()
+})
+
+// A grant outside the caller's own backend scope (99 here is held by the target
+// via another admin, not by this caller) is stripped on save regardless, so a
+// delete would be a silent no-op: it renders WITHOUT a delete affordance, while
+// an in-scope chip keeps it.
+test('scoped caller: a chip outside the caller scope is not deletable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+
+  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 2] })
+
+  const inScope = (await screen.findByText('AAA - Division A')).closest(
+    '.MuiChip-root'
+  ) as HTMLElement
+  const outOfScope = screen
+    .getByText('ZZZ - Parent Division')
+    .closest('.MuiChip-root') as HTMLElement
+
+  expect(inScope.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
+  expect(outOfScope.querySelector('.MuiChip-deleteIcon')).toBeNull()
+})
+
+// A caller-held grant that is merely non-assignable now (99 in callerGrantIds
+// but absent from opdivOptions, e.g. re-parented/deactivated) stays deletable:
+// removing it is a real, permitted revocation, unlike an out-of-scope grant.
+test('scoped caller: a caller-held but non-assignable chip stays deletable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+
+  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
+
+  const heldNonAssignable = (
+    await screen.findByText('ZZZ - Parent Division')
+  ).closest('.MuiChip-root') as HTMLElement
+
+  expect(heldNonAssignable.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
+})
+
+// An unscoped caller's removal really revokes, so their out-of-scope chip must
+// keep the delete affordance.
+test('unscoped caller: an out-of-scope grant chip stays deletable', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
+
+  renderModal({ enforceCallerScope: false })
+
+  const outOfScope = (await screen.findByText('ZZZ - Parent Division')).closest(
+    '.MuiChip-root'
+  ) as HTMLElement
+
+  expect(outOfScope.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
 })
 
 test('success: modal closes and onChanged fires after save', async () => {
@@ -236,6 +380,9 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerGrantIds={[1, 2]}
       onChanged={jest.fn()}
     />
   )
@@ -246,6 +393,9 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       userid={USER_ID}
       userName="Test User"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerGrantIds={[1, 2]}
       onChanged={jest.fn()}
     />
   )
@@ -295,6 +445,9 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       userid={USER_ID_B}
       userName="Test User B"
       opdivOptions={opdivOptions}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerGrantIds={[1, 2]}
       onChanged={onChanged}
     />
   )

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Chip,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -10,7 +11,7 @@ import { Button as CmsButton } from '@cmsgov/design-system'
 import { GridRowId } from '@mui/x-data-grid'
 import Checkbox from '@mui/material/Checkbox'
 import TextField from '@mui/material/TextField'
-import Autocomplete from '@mui/material/Autocomplete'
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
@@ -24,9 +25,37 @@ type Props = {
   /**
    * Assignable OpDivs, already scoped by the caller (children only, active,
    * and - for an OPDIV_ADMIN actor - limited to their own OpDivs). The modal
-   * does not re-scope; it renders exactly what it is given.
+   * does not re-scope; it renders exactly what it is given. Drives the dropdown.
    */
   opdivOptions: OpDiv[]
+  /**
+   * Full label source (all OpDivs, incl. parent/inactive), keyed by opdiv_id.
+   * Separate from opdivOptions so a grant to a non-assignable OpDiv still
+   * resolves to a readable chip instead of a blank one. Ids missing here fall
+   * back to "OpDiv #{id}".
+   */
+  opdivLabelMap: Record<number, { code: string; name: string }>
+  /**
+   * True when the caller is scope-limited (an OPDIV_ADMIN): the save must drop
+   * grants outside the caller's own scope, since the backend rejects a desired
+   * set containing an ID the caller doesn't hold. False for unscoped admins
+   * (OWNER/HHS_ADMIN), whose save must PRESERVE the target's out-of-scope
+   * grants - omitting them reads as a revocation.
+   */
+  enforceCallerScope: boolean
+  /**
+   * The caller's RAW own-grant ids - the backend's true add/remove scope
+   * (IsAssignedOpDiv), unfiltered by parent/active. This is the save-time
+   * preserve boundary and MUST be a superset of the dropdown's assignable set:
+   * opdivOptions is additionally narrowed to !is_parent && active, so a grant
+   * the caller holds to an OpDiv that was later re-parented or deactivated is
+   * absent from opdivOptions but still in the caller's backend scope. Filtering
+   * the save on the narrower opdivOptions would strip such a grant from the PUT
+   * and the backend would then revoke it (its toRemove gate is pure grant
+   * membership) - the same silent-revocation this modal exists to prevent.
+   * Only consulted when enforceCallerScope is true.
+   */
+  callerGrantIds: number[]
   /**
    * Fired after a successful save so the caller can refresh the user's row
    * (grants + derived identity_provider) against post-mutation server state.
@@ -40,6 +69,9 @@ export default function OpDivGrantModal({
   userid,
   userName,
   opdivOptions,
+  opdivLabelMap,
+  enforceCallerScope,
+  callerGrantIds,
   onChanged,
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
@@ -47,23 +79,44 @@ export default function OpDivGrantModal({
   const [loading, setLoading] = React.useState(false)
   const [fetchFailed, setFetchFailed] = React.useState(false)
 
-  const opdivMap = React.useMemo(() => {
-    const map: Record<number, { code: string; name: string }> = {}
-    for (const od of opdivOptions) {
-      map[od.opdiv_id] = { code: od.code, name: od.name }
-    }
-    return map
-  }, [opdivOptions])
-
-  const sortedOptionIds = React.useMemo(
-    () =>
-      opdivOptions
-        .map((od) => od.opdiv_id)
-        .sort((a, b) =>
-          (opdivMap[a]?.code || '').localeCompare(opdivMap[b]?.code || '')
-        ),
-    [opdivOptions, opdivMap]
+  // The assignable set drives the dropdown (what may be newly selected).
+  const assignableIds = React.useMemo(
+    () => new Set(opdivOptions.map((od) => od.opdiv_id)),
+    [opdivOptions]
   )
+
+  // The caller's raw backend scope (IsAssignedOpDiv). Superset of assignableIds
+  // - it also covers grants to OpDivs since re-parented/deactivated. Gates the
+  // scoped save and the chip lock, so both agree with what the backend will act
+  // on (see the callerGrantIds prop docs).
+  const callerScope = React.useMemo(
+    () => new Set(callerGrantIds),
+    [callerGrantIds]
+  )
+
+  // Label from the full map (assignable or not), with an identifiable fallback
+  // so a grant to an OpDiv missing from the map never chips blank.
+  const optionLabel = React.useCallback(
+    (opdivId: number) => {
+      const od = opdivLabelMap[opdivId]
+      return od ? `${od.code} - ${od.name}` : `OpDiv #${opdivId}`
+    },
+    [opdivLabelMap]
+  )
+
+  // Options = assignable + currently-granted, so a chip for a grant to a
+  // non-assignable OpDiv still resolves against the options (no MUI "value not
+  // in options" warning, no blank chip). filterOptions below narrows the
+  // DROPDOWN back to the assignable set so those grants are not re-selectable.
+  const sortedOptionIds = React.useMemo(() => {
+    const ids = new Set<number>(assignableIds)
+    for (const id of localOpDivs) ids.add(id)
+    return Array.from(ids).sort((a, b) =>
+      optionLabel(a).localeCompare(optionLabel(b))
+    )
+  }, [assignableIds, localOpDivs, optionLabel])
+
+  const baseFilter = React.useMemo(() => createFilterOptions<number>(), [])
 
   const handleError = React.useCallback((error: unknown) => {
     if (isAuthHandled(error)) return
@@ -100,20 +153,22 @@ export default function OpDivGrantModal({
     }
   }, [open, userid, handleError])
 
-  const optionLabel = (opdivId: number) => {
-    const od = opdivMap[opdivId]
-    return od ? `${od.code} - ${od.name}` : ''
-  }
-
   const handleSave = () => {
     setSaving(true)
-    // An OPDIV_ADMIN's scope is already encoded in sortedOptionIds (only their
-    // own OpDivs appear as options). Filter localOpDivs to that set so the
-    // batch request never includes out-of-scope IDs the target user holds from
-    // another admin — the backend scope gate rejects any desired set that
-    // contains an ID the caller doesn't hold, even if they didn't add it.
-    const scopedIds = localOpDivs.filter((id) => sortedOptionIds.includes(id))
-    setUserOpDivs(String(userid), scopedIds)
+    // Scoped caller (OPDIV_ADMIN): keep only grants within the caller's own
+    // backend scope (callerScope), so the batch request never includes ids the
+    // target holds from another admin - the backend rejects a desired set
+    // containing an id the caller doesn't hold. callerScope (not assignableIds)
+    // is used deliberately: a caller-held grant to a now parent/inactive OpDiv
+    // is absent from assignableIds but still in the caller's backend scope, so
+    // filtering on assignableIds would drop it from the PUT and the backend
+    // would revoke it. Unscoped caller (OWNER/HHS_ADMIN): send every grant
+    // as-is, since omitting the target's non-assignable grants would revoke
+    // them.
+    const idsToSave = enforceCallerScope
+      ? localOpDivs.filter((id) => callerScope.has(id))
+      : localOpDivs
+    setUserOpDivs(String(userid), idsToSave)
       .then(() => {
         notify('Saved', 'success')
         onChanged?.(String(userid))
@@ -140,11 +195,37 @@ export default function OpDivGrantModal({
         <Autocomplete
           multiple
           disableCloseOnSelect
-          limitTags={3}
           options={sortedOptionIds}
           disabled={loading || fetchFailed}
           disableClearable
           getOptionLabel={optionLabel}
+          // Keep the dropdown scoped to the assignable set even though options
+          // also carries current non-assignable grants (for chip resolution).
+          filterOptions={(options, params) =>
+            baseFilter(options, params).filter((o) => assignableIds.has(o))
+          }
+          // Lock (drop the delete button on) only chips outside the caller's
+          // backend scope for a scoped caller: those are grants from another
+          // admin that the save strips regardless, so a delete would be a
+          // silent no-op. A caller-held grant (incl. one to a now
+          // parent/inactive OpDiv) stays deletable - removing it is a real,
+          // permitted revocation. Unscoped callers keep delete on everything.
+          // No limitTags collapse - surfacing every grant, including the
+          // non-assignable ones, is the point of this fix.
+          renderTags={(value, getTagProps) =>
+            value.map((option, index) => {
+              const { key, onDelete, ...tagProps } = getTagProps({ index })
+              const locked = enforceCallerScope && !callerScope.has(option)
+              return (
+                <Chip
+                  {...tagProps}
+                  key={key}
+                  label={optionLabel(option)}
+                  onDelete={locked ? undefined : onDelete}
+                />
+              )
+            })
+          }
           renderOption={(props, option, { selected }) => (
             <li {...props} key={option}>
               <Checkbox style={{ marginRight: 8 }} checked={selected} />

--- a/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
+++ b/src/views/QuestionnairePage/ConfirmSummaryDialog.tsx
@@ -1,0 +1,129 @@
+import { useId } from 'react'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import Link from '@mui/material/Link'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import Typography from '@mui/material/Typography'
+import CloseIcon from '@mui/icons-material/Close'
+import { Button as CmsButton } from '@cmsgov/design-system'
+import type { ConfirmSummary, ConfirmSummaryEntry } from './confirmState'
+
+type Props = {
+  /** null keeps the dialog closed. */
+  summary: ConfirmSummary | null
+  onClose: () => void
+  /** Navigate to the entry's question (the parent owns routing). */
+  onJump: (entry: ConfirmSummaryEntry) => void
+}
+
+/**
+ * The end-of-questionnaire summary shown by Complete on an open data call:
+ * one "are you sure" moment instead of 40 per-question dialogs. Lists
+ * carried-forward answers awaiting confirmation and unanswered questions as
+ * jump links; when neither remains it is the success state (which also
+ * retires the old silent loop back to question 1).
+ */
+const ConfirmSummaryDialog = ({ summary, onClose, onJump }: Props) => {
+  const titleId = useId()
+  const descId = useId()
+  if (!summary) return null
+
+  const outstanding = summary.unconfirmed.length + summary.unanswered.length
+  const complete = outstanding === 0
+
+  const entryList = (entries: ConfirmSummaryEntry[]) => (
+    <List dense sx={{ pt: 0 }}>
+      {entries.map((entry) => (
+        <ListItem key={entry.functionid} sx={{ py: 0.25 }}>
+          <Link
+            component="button"
+            type="button"
+            onClick={() => onJump(entry)}
+            sx={{ textAlign: 'left' }}
+          >
+            {entry.pillarName} — {entry.functionName}
+          </Link>
+        </ListItem>
+      ))}
+    </List>
+  )
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby={titleId}
+      aria-describedby={summary.hasStatusData ? descId : undefined}
+    >
+      <DialogTitle id={titleId}>
+        {complete ? 'Questionnaire complete' : 'Before you finish'}
+      </DialogTitle>
+      <Box position="absolute" top={0} right={0}>
+        <IconButton onClick={onClose} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent>
+        {/* The headline count reads scores.status; without status data (the
+            backend not yet serving it) the count would be a lie built from
+            absence, so it is omitted and only row-presence facts render. */}
+        {summary.hasStatusData && (
+          <Typography id={descId} sx={{ mb: 1 }}>
+            {summary.updated} of {summary.total} answers counted as updated for
+            this data call.
+          </Typography>
+        )}
+        {complete ? (
+          <Alert severity="success" icon={false}>
+            Every question is answered
+            {summary.hasStatusData ? ' and counted as updated' : ''}. You are
+            done — no further action is needed.
+          </Alert>
+        ) : (
+          <>
+            {summary.unconfirmed.length > 0 && (
+              <Box sx={{ mb: 1.5 }}>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Carried forward — needs confirmation (
+                  {summary.unconfirmed.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These answers were carried over from the previous data call
+                  and do not count as updated until you confirm them. Open each
+                  question and select “Confirm this answer is still accurate,”
+                  or update the answer.
+                </Typography>
+                {entryList(summary.unconfirmed)}
+              </Box>
+            )}
+            {summary.unanswered.length > 0 && (
+              <Box>
+                <Typography component="h3" sx={{ fontWeight: 700 }}>
+                  Unanswered ({summary.unanswered.length})
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                  These questions have no answer yet. Open each question, select
+                  an answer, and continue with Next or Complete to save it.
+                </Typography>
+                {entryList(summary.unanswered)}
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <CmsButton onClick={onClose}>Close</CmsButton>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmSummaryDialog

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1296,10 +1296,50 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
       />
     )
     expand()
-    expect(screen.getByText(/1 of 2 checks passed/)).toBeInTheDocument()
+    // SecurityHub's feed is failure-only, so a "pass" is the absence of a
+    // finding, not an observed pass — the summary must not claim otherwise.
+    expect(
+      screen.getByText(/1 of 2 checks reported no findings/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/1 of 2 checks passed/)).not.toBeInTheDocument()
     // Feed chips are labeled by the SecurityHub finding code.
     expect(screen.getByText('IAM.1').textContent).toContain('✓')
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
+    // The chip still reads ✓, but neither its accessible name nor its hover may
+    // say "Passed".
+    expect(
+      screen.getByRole('img', { name: /^IAM\.1 — .* — No finding reported$/ })
+    ).toBeInTheDocument()
+  })
+
+  it('withholds an inferred SecurityHub pass from the control rollup', () => {
+    // A control whose only evidence is an inferred SecurityHub pass must not
+    // read as satisfied — that would assert the control is met on the strength
+    // of a check that may never have run on a partially scanned system.
+    const sechubOnly = rollupControls({
+      sechub_passing: [
+        { id: 'IAM.1', nist_controls: 'AC-3', description: 'x', level: 1 },
+      ],
+    })
+    expect(sechubOnly).toHaveLength(0)
+
+    // Kion and Hardenize report real passes, so theirs still count.
+    const kion = rollupControls({
+      kion_passing: [
+        { id: 'iam-user-inactive', nist_controls: 'AC-3', description: 'x' },
+      ],
+    })
+    expect(kion).toHaveLength(1)
+    expect(kion[0].state).toBe('satisfied')
+
+    // A SecurityHub *failure* is still real evidence and must survive.
+    const sechubFailing = rollupControls({
+      findings: {
+        sechub: [{ id: 'IAM.10', nist_controls: 'IA-2', description: 'y' }],
+      },
+    })
+    expect(sechubFailing).toHaveLength(1)
+    expect(sechubFailing[0].state).toBe('failing')
   })
 
   it('renders SecurityHub as a chip block even with only failing findings', () => {
@@ -1328,6 +1368,38 @@ describe('FeedCheckBlock (feed pass/fail checks)', () => {
     expect(screen.getByText('IAM.10').textContent).toContain('✗')
     // Title lives in the hover now, not as body text.
     expect(screen.queryByText('MFA should be enabled')).not.toBeInTheDocument()
+  })
+
+  it('words the collapse toggle as "no findings" for an inferred-pass source', () => {
+    // The summary and the chips avoid claiming a pass, but the collapse toggle is
+    // its own label — with 1,493 SecurityHub rows upstream, blocks routinely spill
+    // past the collapse threshold, so this is where the unsupported claim would
+    // survive.
+    const passing = Array.from({ length: 9 }, (_, i) => ({
+      id: `SEC.${i}`,
+      nist_controls: 'SC-7',
+      level: 1,
+    }))
+    render(
+      <InsightsPanel
+        payload={
+          {
+            suggested_score: 2,
+            has_sechub_data: true,
+            sechub_passing: passing,
+          } as unknown as InsightPayload
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /details/i }))
+    expect(
+      screen.getByRole('button', {
+        name: /Show all 9 checks with no findings/i,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Show all 9 passing checks/i })
+    ).not.toBeInTheDocument()
   })
 
   it('collapses the passing bulk behind a toggle, keeps failing chips at the top, and expands on click', () => {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -399,6 +399,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
       ...s,
       passing: asFindingArray(raw),
       hasPassing: Array.isArray(raw),
+      inferredPass: INFERRED_PASS_SOURCES.has(s.key),
     }
   })
   const anyFeedBlock = feedSources.some((s) => s.hasPassing)
@@ -610,6 +611,7 @@ function InsightsPanelInner({ payload, questionId }: Props) {
                   passing={s.passing}
                   failing={s.failing}
                   hasPassing={s.hasPassing}
+                  inferredPass={s.inferredPass}
                   resetKey={questionId}
                 />
               ) : null
@@ -925,9 +927,13 @@ function ControlChip({
 function CheckTooltip({
   finding,
   pass,
+  inferredPass = false,
 }: {
   finding: InsightFinding
   pass: boolean
+  // See INFERRED_PASS_SOURCES: this source reports only failures, so a "pass" is
+  // the absence of a finding and must not be worded as an observed pass.
+  inferredPass?: boolean
 }) {
   const slug = asText(finding?.id) ?? asText(finding?.title)
   // The chip label now carries the check name (its code/slug), so the hover leads
@@ -955,7 +961,7 @@ function CheckTooltip({
     nist ? `Control: ${nist}` : undefined,
     level != null ? `Level ${level}` : undefined,
     severity ? severity.toUpperCase() : undefined,
-    pass ? 'Passed' : 'Failed',
+    pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
   ]
     .filter(Boolean)
     .join(' · ')
@@ -1030,12 +1036,17 @@ function FeedCheckBlock({
   passing,
   failing,
   hasPassing,
+  inferredPass = false,
   resetKey,
 }: {
   label: string
   passing: InsightFinding[]
   failing: InsightFinding[]
   hasPassing: boolean
+  // See INFERRED_PASS_SOURCES: this source's passing entries mean "no finding
+  // reported", which the summary and each chip's hover must say rather than
+  // claiming the checks were observed to pass.
+  inferredPass?: boolean
   resetKey?: string | number
 }) {
   const [showAllPassing, setShowAllPassing] = React.useState(false)
@@ -1062,9 +1073,11 @@ function FeedCheckBlock({
   }
   const passed = passing.length
   const total = passing.length + failing.length
-  const summary = hasPassing
-    ? `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
-    : `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+  const summary = !hasPassing
+    ? `${failing.length} finding${failing.length === 1 ? '' : 's'}`
+    : inferredPass
+      ? `${passed} of ${total} check${total === 1 ? '' : 's'} reported no findings`
+      : `${passed} of ${total} check${total === 1 ? '' : 's'} passed`
   // Collapse the passing bulk once it spills past a couple of rows (mainly
   // Hardenize, which can carry 30+ passing checks). Failing chips (findings) are
   // always shown AND rendered first, so problems stay at the top and visible even
@@ -1090,7 +1103,7 @@ function FeedCheckBlock({
     const ariaLabel = [
       slug,
       desc,
-      pass ? 'Passed' : 'Failed',
+      pass ? (inferredPass ? 'No finding reported' : 'Passed') : 'Failed',
       remediation ? `How to fix: ${remediation}` : undefined,
     ]
       .filter(Boolean)
@@ -1100,7 +1113,9 @@ function FeedCheckBlock({
         key={key}
         id={slug ?? nist ?? '—'}
         variant={pass ? 'satisfied' : 'failing'}
-        tooltip={<CheckTooltip finding={f} pass={pass} />}
+        tooltip={
+          <CheckTooltip finding={f} pass={pass} inferredPass={inferredPass} />
+        }
         ariaLabel={ariaLabel || undefined}
       />
     )
@@ -1143,7 +1158,11 @@ function FeedCheckBlock({
         >
           {showAllPassing
             ? 'Show fewer'
-            : `Show all ${passing.length} passing checks`}
+            : // Matches the summary wording: for an inferred-pass source these
+              // are checks with no finding reported, not checks observed to pass.
+              `Show all ${passing.length} ${
+                inferredPass ? 'checks with no findings' : 'passing checks'
+              }`}
         </Link>
       )}
     </Box>
@@ -1265,6 +1284,20 @@ const CONTROL_RANK: Record<ControlRollupState, number> = {
 // appears here even though CFACTS never assessed it, and why a conflicted control
 // can net to failing. The payload is opaque, so every value is coerced and
 // guarded; a malformed element is skipped, never thrown.
+// Sources whose "passing" entries are inferred from the absence of a finding
+// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
+// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
+// as "mapped control with no active failure". That cannot distinguish "evaluated
+// and passed" from "never scanned", so on a partially scanned system it would
+// otherwise assert controls are met on the strength of checks that never ran.
+// Consequently these entries still render as ✓ chips (the check is not failing)
+// but are read as an absence of findings, and are withheld from the control
+// rollup rather than counted as affirmative `satisfied` evidence.
+//
+// Remove a source from this set once its feed emits real passes; nothing else
+// needs to change. Used by both the feed blocks and rollupControls below.
+const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
+
 export function rollupControls(
   payload: Partial<InsightPayload>
 ): ControlRollup[] {
@@ -1336,18 +1369,25 @@ export function rollupControls(
   }
   for (const src of ['kion', 'sechub', 'hardenize'] as const) {
     const label = SRC_LABEL[src]
-    arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach((f) => {
-      const o = finding(f)
-      add(
-        o?.nist_controls,
-        label,
-        'satisfied',
-        asText(o?.id) ?? asText(o?.title),
-        // Kion puts the sentence in `description`, SecurityHub in `title` —
-        // same fallback CheckTooltip uses, so both hovers read alike.
-        asText(o?.description) ?? asText(o?.title)
+    // An inferred pass is the absence of a finding, not evidence the control is
+    // met — counting it as `satisfied` would flip a control from "not assessed"
+    // to green on the strength of a check that may never have run.
+    if (!INFERRED_PASS_SOURCES.has(src)) {
+      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
+        (f) => {
+          const o = finding(f)
+          add(
+            o?.nist_controls,
+            label,
+            'satisfied',
+            asText(o?.id) ?? asText(o?.title),
+            // Kion puts the sentence in `description`, SecurityHub in `title` —
+            // same fallback CheckTooltip uses, so both hovers read alike.
+            asText(o?.description) ?? asText(o?.title)
+          )
+        }
       )
-    })
+    }
     arr(findings[src]).forEach((f) => {
       const o = finding(f)
       add(

--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -1,0 +1,322 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// Cross-navigation coverage for ui#610: the questionnaire header needs a link
+// back to System Info and a Pillar Scores button, alongside the existing
+// Compare Datacalls button.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+// draftStore uses crypto.subtle (unavailable in jsdom); stub to no-ops.
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+// notify() reaches notistack's standalone enqueueSnackbar, which needs a
+// mounted provider; keep isAuthHandled real so the error path is exercised as
+// written (same pattern as QuestionnairePage.test).
+const notifyMock = jest.fn()
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return {
+    ...actual,
+    notify: (...args: unknown[]) => notifyMock(...args),
+  }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const QUESTIONS = [
+  {
+    questionid: 900,
+    question: 'Question for Imperial Identity Verification',
+    notesprompt: 'Notes',
+    pillar: { pillar: 'Identity' },
+    function: {
+      functionid: 7006,
+      function: 'Imperial Identity Verification',
+      description: 'Imperial Identity Verification description',
+      datacenterenvironment: 'Imperial-Fleet',
+    },
+  },
+]
+
+const OPTIONS_7006 = [
+  { functionoptionid: 100, description: 'Baseline', score: 1 },
+  { functionoptionid: 101, description: 'Advanced', score: 2 },
+]
+
+const AGGREGATE = [
+  {
+    datacallid: 5,
+    fismasystemid: 1002,
+    systemscore: 3.75,
+    pillarscores: [{ pillarid: 1, pillar: 'Identity', score: 3.5 }],
+  },
+]
+
+function makeCtx(role: userData['role'] | undefined) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    latestDataCallId: 5,
+    latestDatacall: 'Audit Fields Smoke Cycle',
+    latestDeadline: '2099-12-31T23:59:59Z',
+    selectedDatacall: {
+      datacallid: 5,
+      datacall: 'Audit Fields Smoke Cycle',
+      datecreated: '',
+      deadline: '2099-12-31T23:59:59Z',
+    },
+    datacalls: [
+      {
+        datacallid: 5,
+        datacall: 'Audit Fields Smoke Cycle',
+        datecreated: '',
+        deadline: '2099-12-31T23:59:59Z',
+      },
+    ],
+    activeDatacallIds: [5],
+    fismaSystems: [
+      {
+        fismasystemid: 1002,
+        fismaacronym: 'SSD-EX',
+        fismaname: 'Super Star Destroyer Executor Command Systems',
+        datacenterenvironment: 'Imperial-Fleet',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCtx = makeCtx('OWNER')
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/scores/aggregate'))
+      return Promise.resolve({ data: { data: AGGREGATE } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('/options')) return Promise.resolve({ data: { data: [] } })
+    if (url.includes('insights')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+// Data-router harness matching the app's createHashRouter, per the note in
+// QuestionnairePage.deeplink.test: a plain MemoryRouter hands the component the
+// unstable useNavigate and re-runs the fetch effect on the canonical redirect.
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> },
+      { path: '/systems/:fismasystemid', element: <div>system detail</div> },
+    ],
+    { initialEntries: ['/questionnaire/ssd-ex'] }
+  )
+  const { unmount } = render(<RouterProvider router={router} />)
+  return { router, unmount }
+}
+
+const aggregateCalls = () =>
+  mockGet.mock.calls
+    .map((c) => c[0] as string)
+    .filter((u) => typeof u === 'string' && u.includes('/scores/aggregate'))
+
+it('navigates to the system detail page keyed on fismasystemid', async () => {
+  const { router } = renderPage()
+  const button = await screen.findByRole('link', { name: 'System Info' })
+  await userEvent.click(button)
+  // The questionnaire route carries the acronym; the detail route is keyed on
+  // the id, so this proves the acronym was resolved to 1002 before linking.
+  expect(router.state.location.pathname).toBe('/systems/1002')
+})
+
+it('suppresses System Info when the role fails the system-access gate', async () => {
+  mockCtx = makeCtx(undefined)
+  renderPage()
+  // Compare Datacalls is ungated, so its presence proves the header rendered
+  // and only the gated button is missing.
+  await screen.findByRole('button', { name: 'Compare Datacalls' })
+  expect(
+    screen.queryByRole('link', { name: 'System Info' })
+  ).not.toBeInTheDocument()
+})
+
+it('fetches the pillar aggregate for this system and opens the modal', async () => {
+  renderPage()
+  const button = await screen.findByRole('button', { name: 'Pillar Scores' })
+  expect(aggregateCalls()).toHaveLength(0)
+  await userEvent.click(button)
+
+  await waitFor(() =>
+    expect(
+      aggregateCalls().some(
+        (u) =>
+          u.includes('fismasystemid=1002') && u.includes('include_pillars=true')
+      )
+    ).toBe(true)
+  )
+  // Acronym in the title comes from the resolved system, not the lowercased
+  // URL param, so it matches the dashboard's casing.
+  expect(
+    await screen.findByText(
+      /Super Star Destroyer Executor Command Systems \(SSD-EX\) - Pillar Scores/
+    )
+  ).toBeInTheDocument()
+})
+
+it('keeps the modal closed when the aggregate fetch fails', async () => {
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/scores/aggregate'))
+      return Promise.reject(new Error('boom'))
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  renderPage()
+  await userEvent.click(
+    await screen.findByRole('button', { name: 'Pillar Scores' })
+  )
+
+  await waitFor(() => expect(aggregateCalls()).not.toHaveLength(0))
+  // An empty modal would read as "this system has no scores"; nothing opens and
+  // the user is told instead.
+  await waitFor(() =>
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.stringContaining('error occurred'),
+      'error'
+    )
+  )
+  expect(screen.queryByText(/- Pillar Scores/)).not.toBeInTheDocument()
+})
+
+it('offers a way back from the no-questionnaire state', async () => {
+  // A decommissioned or out-of-scope system joins to zero functions, and the
+  // #609 button makes that state reachable from System Info. Without the link
+  // here the trip is one-way (#640 review).
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  renderPage()
+  expect(
+    await screen.findByText(/No questionnaire is available for this system/i)
+  ).toBeInTheDocument()
+  expect(
+    await screen.findByRole('link', { name: 'System Info' })
+  ).toHaveAttribute('href', '/systems/1002')
+})
+
+it('flushes a pending draft when the page unmounts mid-debounce', async () => {
+  const { saveDraft } = require('./draftStore') as {
+    saveDraft: jest.Mock
+  }
+  // Real options so the answer/notes panel renders rather than staying in its
+  // loading state.
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  await userEvent.type(notesField, 'Imperial posture note')
+  // Nothing written yet: the save is debounced 1s and no timer has fired.
+  expect(saveDraft).not.toHaveBeenCalled()
+
+  // Leaving for System Info (or the Dashboard breadcrumb, or browser back)
+  // unmounts the page. beforeunload does not fire on in-app navigation and the
+  // debounce cleanup cancels its own timer, so without the unmount flush this
+  // edit was silently dropped.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(1)
+  const [userid, system, questionId, datacallID, draft] =
+    saveDraft.mock.calls[0]
+  expect({ userid, system, datacallID }).toEqual({
+    userid: '1',
+    system: 1002,
+    datacallID: 5,
+  })
+  expect(questionId).toBe(7006)
+  expect(draft.notes).toBe('Imperial posture note')
+})
+
+it('does not lose a newer edit made while an earlier save is in flight', async () => {
+  // Regression for the identity-clear race (#640 review): edit A's debounced
+  // save starts; edit B replaces the pending payload under the SAME generation
+  // (saveGenRef only moves on explicit clears); save A's completion must not
+  // clear B's payload, or an unmount before B's own debounce flushes nothing.
+  const { saveDraft } = require('./draftStore') as { saveDraft: jest.Mock }
+  let resolveSaveA!: (saved: boolean) => void
+  saveDraft.mockImplementationOnce(
+    () => new Promise<boolean>((resolve) => (resolveSaveA = resolve))
+  )
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.includes('/options'))
+      return Promise.resolve({ data: { data: OPTIONS_7006 } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+
+  const { unmount } = renderPage()
+  const notesField = await screen.findByLabelText('Justification notes')
+
+  // Edit A; let its 1s debounce fire so saveDraft(A) is genuinely in flight.
+  await userEvent.type(notesField, 'A')
+  await waitFor(() => expect(saveDraft).toHaveBeenCalledTimes(1), {
+    timeout: 3000,
+  })
+  expect(saveDraft.mock.calls[0][4].notes).toBe('A')
+
+  // Edit B while A remains unresolved.
+  await userEvent.type(notesField, 'B')
+
+  // A resolves successfully. Identity check must leave B's payload pending.
+  await act(async () => {
+    resolveSaveA(true)
+  })
+
+  // Leave before B's own debounce fires.
+  unmount()
+
+  expect(saveDraft).toHaveBeenCalledTimes(2)
+  expect(saveDraft.mock.calls[1][4].notes).toBe('AB')
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+  configure as rtlConfigure,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Routes as AppRoutes } from '@/router/constants'
@@ -939,8 +946,12 @@ describe('QuestionnairePage justification integration', () => {
     const complete = screen.getByRole('button', { name: 'Complete' })
     expect(complete).toBeDisabled()
 
-    // Accepting the required review is a current-call action, so the answer
-    // persists even though the text equals the seeded prior response.
+    // Accepting the required review must land even though the text equals
+    // the seeded prior response — via the confirm endpoint, since the old
+    // identical-body answer PUT was silently discarded by the backend's
+    // no-op guard. Insert alone performs no write (like the
+    // insights-suggestion card's Insert); the resolved review lands on the
+    // next navigation, so the two adjacent Insert buttons behave alike.
     fireEvent.click(
       screen.getByRole('button', {
         name: 'Insert previous ISSO response into current response',
@@ -948,18 +959,17 @@ describe('QuestionnairePage justification integration', () => {
     )
     expect(response).toHaveValue(PRIOR_RESPONSE)
     expect(complete).toBeEnabled()
+    expect(axios.put).not.toHaveBeenCalled()
 
     fireEvent.click(complete)
 
     await waitFor(() =>
-      expect(axios.put).toHaveBeenCalledWith('scores/5001', {
-        fismasystemid: 1002,
-        notes: PRIOR_RESPONSE,
-        functionoptionid: 100,
-        datacallid: 6,
-        notes_is_ai_summary: false,
-      })
+      expect(axios.put).toHaveBeenCalledWith('scores/5001/confirm')
     )
+    // The unchanged answer body must NOT be re-PUT — that path re-stamps
+    // nothing server-side and would clear notes_is_ai_summary on a real
+    // change-detection miss.
+    expect(axios.put).not.toHaveBeenCalledWith('scores/5001', expect.anything())
   })
 
   it('shows the insights panel, option badges, and suggestion for a CMS data call', async () => {
@@ -1076,5 +1086,319 @@ describe('QuestionnairePage justification integration', () => {
     expect(
       screen.queryByRole('textbox', { name: 'Current response' })
     ).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Carried-forward confirmation: badge, inline Confirm, the #413
+// browse-is-write-free guard, and the Complete summary.
+// ---------------------------------------------------------------------------
+
+describe('carried-forward confirmation', () => {
+  // CI runners execute this suite ~3x slower than a dev machine, and these
+  // tests each begin by awaiting a full page load — RTL's default 1s
+  // findBy/waitFor timeout flaked there while the question was still
+  // loading. Raise the async ceiling for this block only; passing tests are
+  // unaffected (they resolve as soon as the DOM settles).
+  beforeAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 4000 })
+    jest.setTimeout(15000)
+  })
+  afterAll(() => {
+    rtlConfigure({ asyncUtilTimeout: 1000 })
+    jest.setTimeout(5000)
+  })
+
+  const OPTIONS_7001 = [
+    { functionoptionid: 200, description: 'Baseline', score: 1 },
+    { functionoptionid: 201, description: 'Advanced', score: 2 },
+  ]
+
+  // A row copied by the FY2026 rollover: status not_started, no edit event.
+  const carried7006 = (status: 'not_started' | 'done' = 'not_started') => ({
+    scoreid: 6001,
+    fismasystemid: 1002,
+    notes: 'carried justification',
+    functionoptionid: 100,
+    datacallid: 5,
+    status,
+    functionoption: {
+      functionoptionid: 100,
+      functionid: 7006,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+    last_edited_at: null,
+    last_edited_by: null,
+  })
+
+  const done7001 = () => ({
+    scoreid: 6002,
+    fismasystemid: 1002,
+    notes: 'answered this cycle',
+    functionoptionid: 200,
+    datacallid: 5,
+    status: 'done',
+    functionoption: {
+      functionoptionid: 200,
+      functionid: 7001,
+      score: 1,
+      optionname: 'Baseline',
+      description: 'Baseline',
+    },
+  })
+
+  const DEVICES_LINK =
+    '/questionnaire/ssd-ex/FY2026_Q1/devices/imperial-device-management'
+
+  // Serves a mutable scores list and, like the real backend, flips the
+  // targeted row to done when the confirm endpoint is hit — so the refetch
+  // after a confirm returns the confirmed row instead of resurrecting the
+  // original fixture.
+  function installScoreMocks(scores: Array<{ scoreid: number }>) {
+    let rows = scores
+    axios.get.mockImplementation((url: string) => {
+      if (url.includes('/questions'))
+        return Promise.resolve({ data: { data: QUESTIONS } })
+      if (url.startsWith('scores'))
+        return Promise.resolve({ data: { data: rows } })
+      if (url.includes('functions/7006/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7006 } })
+      if (url.includes('functions/7001/options'))
+        return Promise.resolve({ data: { data: OPTIONS_7001 } })
+      return Promise.resolve({ data: { data: [] } })
+    })
+    axios.post.mockResolvedValue({ data: {} })
+    axios.put.mockImplementation((url: string) => {
+      const confirm = /^scores\/(\d+)\/confirm$/.exec(url)
+      if (confirm) {
+        rows = rows.map((row) =>
+          row.scoreid === Number(confirm[1]) ? { ...row, status: 'done' } : row
+        )
+      }
+      return Promise.resolve({ data: { data: {} } })
+    })
+  }
+
+  it('badges an unconfirmed carried-forward answer in the question view and sidebar, and confirms it with one dedicated PUT', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    // Question-view badge (role="status" so the flip below is announced).
+    const badge = await screen.findByText('Carried forward — not yet confirmed')
+    expect(badge).toBeInTheDocument()
+    // Sidebar marker for the same fact, on the carried question only.
+    expect(screen.getAllByText('Not yet confirmed')).toHaveLength(1)
+
+    // The explicit act: exactly one confirm PUT, no answer PUT/POST.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    )
+    await waitFor(() =>
+      expect(axios.put).toHaveBeenCalledWith('scores/6001/confirm')
+    )
+    expect(axios.put).toHaveBeenCalledTimes(1)
+    expect(saveScorePosts()).toHaveLength(0)
+
+    // Feedback is the badge swapping to its confirmed state.
+    expect(
+      await screen.findByText('Updated this data call')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps Next write-free on an untouched carried-forward question (#413)', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByText('Carried forward — not yet confirmed')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+
+    // Navigation happened (the next question's options load)...
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7001/options')
+        )
+      ).toBe(true)
+    )
+    // ...and no write of any kind was issued.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+  })
+
+  it('yields the Confirm button to the edit path the moment the question is dirty', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    await screen.findByRole('button', {
+      name: 'Confirm this answer is still accurate',
+    })
+    fireEvent.click(screen.getByRole('radio', { name: /Advanced/ }))
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+    // The badge still shows — the row is still unconfirmed until saved.
+    expect(
+      screen.getByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+  })
+
+  it('shows the badge but no Confirm button to a read-only admin', async () => {
+    installScoreMocks([carried7006()])
+    setMockCtx(
+      makeCtx({
+        userInfo: {
+          userid: 'u-2',
+          email: 'auditor@hhs.gov',
+          fullname: 'Read Only',
+          role: 'HHS_READONLY_ADMIN',
+        } as userData,
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText('Carried forward — not yet confirmed')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders no carried-forward treatment on a closed data call', async () => {
+    installScoreMocks([carried7006()])
+    const pastDeadline = '2001-01-01T00:00:00Z'
+    // OWNER stays writable past the deadline (isReadOnly false), isolating
+    // the open-call gate as the only thing hiding the treatment.
+    setMockCtx(
+      makeCtx({
+        latestDeadline: pastDeadline,
+        selectedDatacall: {
+          datacallid: 5,
+          datacall: 'FY2026 Q1',
+          datecreated: '',
+          deadline: pastDeadline,
+        },
+        datacalls: [
+          {
+            datacallid: 5,
+            datacall: 'FY2026 Q1',
+            datecreated: '',
+            deadline: pastDeadline,
+          },
+        ],
+      })
+    )
+
+    renderAt(DEEP_LINK)
+
+    await waitFor(() =>
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    )
+    expect(
+      screen.queryByText('Carried forward — not yet confirmed')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('Complete summarizes unconfirmed and unanswered questions with working jump links', async () => {
+    // Devices (7001) is the last question; it has no row at all. Identity
+    // (7006) carries an unconfirmed answer.
+    installScoreMocks([carried7006()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    // The summary reads a freshly-awaited scores fetch, then opens.
+    expect(await screen.findByText('Before you finish')).toBeInTheDocument()
+    expect(
+      screen.getByText('0 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Carried forward — needs confirmation (1)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Unanswered (1)')).toBeInTheDocument()
+
+    // No loop back to question 1: Complete opened the summary instead of
+    // silently navigating.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
+
+    // The jump link navigates to the listed question.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Identity — Imperial Identity Verification',
+      })
+    )
+    await waitFor(() =>
+      expect(
+        axios.get.mock.calls.some(
+          (c: unknown[]) =>
+            typeof c[0] === 'string' &&
+            (c[0] as string).includes('functions/7006/options')
+        )
+      ).toBe(true)
+    )
+    expect(screen.queryByText('Before you finish')).not.toBeInTheDocument()
+  })
+
+  it('Complete shows the success state and stops looping when everything is updated', async () => {
+    installScoreMocks([carried7006('done'), done7001()])
+
+    renderAt(DEVICES_LINK)
+
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    fireEvent.click(complete)
+
+    expect(
+      await screen.findByText('Questionnaire complete')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('2 of 2 answers counted as updated for this data call.')
+    ).toBeInTheDocument()
+    // No writes fired: everything was already done, and Complete must not
+    // manufacture one.
+    expect(axios.put).not.toHaveBeenCalled()
+    expect(saveScorePosts()).toHaveLength(0)
+    // And no silent wrap-around to the first question.
+    expect(
+      axios.get.mock.calls.some(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          (c[0] as string).includes('functions/7006/options')
+      )
+    ).toBe(false)
   })
 })

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -150,6 +150,7 @@ const SSD_EX = {
   fismaacronym: 'SSD-EX',
   fismaname: 'Super Star Destroyer Executor Command Systems',
   datacenterenvironment: 'Imperial-Fleet',
+  opdiv_id: 9,
 }
 
 function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
@@ -771,9 +772,11 @@ test('the questionId effect reads live scores via ref and seeds the answer at mo
 
 // ---------------------------------------------------------------------------
 // 4. ZTMF Insights justification-field wiring (#527/#529).
-//    - HHS data calls render the review-aware JustificationField but hide the
-//      CMS-internal insights layer (panel, option badges, suggestion).
-//    - CMS data calls render both the JustificationField and the insights layer.
+//    - The insights layer (panel, option badges, suggestion) is gated on the
+//      SYSTEM's OpDiv (opdivs.insights_enabled), not the viewed call's name:
+//      an enabled OpDiv keeps its insights inside the unified HHS-named cycle
+//      (the FY2026 regression), and a disabled OpDiv never sees the layer.
+//    - The review-aware JustificationField renders regardless of OpDiv.
 //    - A carried-forward prior response blocks submission until reviewed, and
 //      the initial insights lookup blocks submission until it settles.
 //    - A question with no justification context keeps the plain notes field.
@@ -841,17 +844,46 @@ const HHS_ZTM = {
 const HHS_DEEP_LINK =
   '/questionnaire/ssd-ex/FY25_ZTM/identity/imperial-identity-verification'
 
+// SSD-EX (opdiv_id 9) belongs to the insights-enabled OpDiv; 2 is a disabled
+// OpDiv for the negative case.
+const OPDIV_ROWS = [
+  {
+    opdiv_id: 9,
+    code: 'CMS',
+    name: 'Centers for Medicare & Medicaid Services',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+    insights_enabled: true,
+  },
+  {
+    opdiv_id: 2,
+    code: 'ACF',
+    name: 'Administration for Children and Families',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+    insights_enabled: false,
+  },
+]
+
 describe('QuestionnairePage justification integration', () => {
   type InsightsResponse = { data: { data: unknown[] } }
 
   function installMocks({
     insightRows = [INSIGHT_ROW] as unknown[],
     insightsResponse,
+    opdivRows = OPDIV_ROWS as unknown[],
+    opdivsResponse,
   }: {
     insightRows?: unknown[]
     insightsResponse?: Promise<InsightsResponse>
+    opdivRows?: unknown[]
+    opdivsResponse?: Promise<InsightsResponse>
   } = {}) {
     axios.get.mockImplementation((url: string) => {
+      if (url === '/opdivs')
+        return opdivsResponse ?? Promise.resolve({ data: { data: opdivRows } })
       if (url === 'insights') {
         return (
           insightsResponse ?? Promise.resolve({ data: { data: insightRows } })
@@ -869,7 +901,7 @@ describe('QuestionnairePage justification integration', () => {
     axios.put.mockResolvedValue({ data: {} })
   }
 
-  it('renders the justification field but hides the insights layer for an HHS data call, and persists an accepted prior response', async () => {
+  it('keeps the insights layer on an HHS-named call for an insights-enabled OpDiv, and persists an accepted prior response', async () => {
     installMocks()
     setMockCtx(
       makeCtx({
@@ -893,14 +925,16 @@ describe('QuestionnairePage justification integration', () => {
     // The FIPS baseline is a federal-wide concept and must appear for HHS too.
     expect(await screen.findByText('Low baseline')).toBeInTheDocument()
 
-    // The CMS-internal insights layer is suppressed for HHS calls.
-    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    // The insights layer follows the system's OpDiv, not the call name: an
+    // insights-enabled OpDiv keeps its panel inside the HHS-named cycle (the
+    // FY2026 single-call regression this gate change fixes).
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
     expect(
-      screen.queryByText('ZTMF Insights option badge')
-    ).not.toBeInTheDocument()
+      (await screen.findAllByText('ZTMF Insights option badge')).length
+    ).toBeGreaterThan(0)
     expect(
-      screen.queryByText('Suggested justification')
-    ).not.toBeInTheDocument()
+      await screen.findByText('Suggested justification')
+    ).toBeInTheDocument()
 
     const complete = screen.getByRole('button', { name: 'Complete' })
     expect(complete).toBeDisabled()
@@ -944,6 +978,58 @@ describe('QuestionnairePage justification integration', () => {
     expect(
       await screen.findByText("Last year's response — FY2025 Q1")
     ).toBeInTheDocument()
+  })
+
+  it('hides the insights layer when the system belongs to an insights-disabled OpDiv', async () => {
+    installMocks({
+      opdivRows: [{ ...OPDIV_ROWS[0], insights_enabled: false }, OPDIV_ROWS[1]],
+    })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    // The justification review context still renders...
+    expect(await screen.findByText('Review required')).toBeInTheDocument()
+    // ...and the federal-wide FIPS baseline treatment stays.
+    expect(await screen.findByText('Low baseline')).toBeInTheDocument()
+    // ...but every insights surface is suppressed, regardless of call name.
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('ZTMF Insights option badge')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Suggested justification')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps the gate closed and submission blocked until the OpDiv lookup settles', async () => {
+    let resolveOpdivs: ((value: InsightsResponse) => void) | null = null
+    const opdivsResponse = new Promise<InsightsResponse>((resolve) => {
+      resolveOpdivs = resolve
+    })
+    installMocks({ opdivsResponse })
+    setMockCtx(makeCtx())
+
+    renderAt(DEEP_LINK)
+
+    // Insights rows resolved instantly, but the OpDiv capability list has
+    // not - the gate stays closed and the page still reads as pending, so
+    // the panel cannot pop in after the user has already advanced.
+    const complete = await screen.findByRole('button', { name: 'Complete' })
+    expect(
+      await screen.findByText('Checking for prior responses…')
+    ).toBeInTheDocument()
+    expect(complete).toBeDisabled()
+    expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveOpdivs?.({ data: { data: OPDIV_ROWS } })
+    })
+
+    expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Checking for prior responses…')
+    ).not.toBeInTheDocument()
   })
 
   it('blocks submission until the initial insights lookup settles', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import Typography from '@mui/material/Typography'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
@@ -63,6 +65,15 @@ import {
   shouldPersistResponse,
   needsNotesUpdateForChoiceChange,
 } from './saveGuard'
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+  type ConfirmSummary,
+  type ConfirmSummaryEntry,
+} from './confirmState'
+import ConfirmSummaryDialog from './ConfirmSummaryDialog'
 import { saveDraft, loadDraft, clearDraft } from './draftStore'
 import { deriveScoreSelection, shouldReseedAnswer } from './scoreSelection'
 import {
@@ -243,10 +254,14 @@ export default function QuestionnarePage() {
   // strictly required for the selection to update, but it is retained as a clean
   // reset of the subtree when a re-seed changes the answer out of band.
   const [radioKey, setRadioKey] = React.useState(0)
+  // Returns the fresh map alongside committing it to state, so a caller that
+  // must reason over the authoritative data in the same tick (the Complete
+  // summary) does not have to read a not-yet-rendered state value. undefined
+  // on failure — callers fall back to the state they already had.
   const fetchQuestionScores = async (
     systemId: number | string | undefined,
     setQuestionScores: (scores: questionScoreMap) => void
-  ) => {
+  ): Promise<questionScoreMap | undefined> => {
     try {
       const response = await axiosInstance.get(
         `scores?datacallid=${datacallID}&fismasystemid=${systemId}&include=functionoption`
@@ -258,9 +273,11 @@ export default function QuestionnarePage() {
         }))
       )
       setQuestionScores(hashTable)
+      return hashTable
     } catch (error) {
-      if (isAuthHandled(error)) return
+      if (isAuthHandled(error)) return undefined
       console.error('Error fetching question scores:', error)
+      return undefined
     }
   }
   const handleChoiceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -599,6 +616,131 @@ export default function QuestionnarePage() {
     priorReviewNeedsSave,
   }
 
+  // Carried-forward confirmation state, read from scores.status — the same
+  // persisted fact the Data Call Progress fraction counts. Open call only:
+  // historical rows are legitimately not_started forever. Read-only sessions
+  // see the badges but never the Confirm button.
+  const isOpenCall = !isPastDeadline
+  const scoreByFunction = React.useMemo(
+    () => buildScoreByFunction(questionScores),
+    [questionScores]
+  )
+  // The saved row backing the current question. Keyed by initQuestionChoice
+  // (the seeded answer), not selectQuestionOption, so flipping the radio does
+  // not detach the badge from the row it describes.
+  const currentSavedScore =
+    initQuestionChoice !== -1 ? questionScores[initQuestionChoice] : undefined
+  const currentCarryState = carryForwardState(currentSavedScore, isOpenCall)
+  const showConfirmButton = canConfirmCarryForward({
+    state: currentCarryState,
+    // Any deviation from the seeded answer/notes: the edit is the explicit
+    // act, and Next saves it (flipping status server-side), so the button
+    // yields to avoid two visible paths to the same write.
+    dirty: selectQuestionOption !== initQuestionChoice || notes !== initNotes,
+    isReadOnly,
+    priorReviewBlocked:
+      priorReviewState === 'pending' || priorReviewState === 'initializing',
+  })
+  const [confirming, setConfirming] = React.useState(false)
+  // The Complete-time summary dialog. null = closed.
+  const [confirmSummary, setConfirmSummary] =
+    React.useState<ConfirmSummary | null>(null)
+
+  // The explicit act behind "Confirm this answer is still accurate": flips
+  // the row's status to done via the confirm endpoint — the ordinary PUT
+  // cannot express agreement, its no-op guard (correctly) drops an unchanged
+  // body (#412/#413). Shared with saveResponse's resolved-review path.
+  const confirmScoreById = async (id: number): Promise<boolean> => {
+    try {
+      await axiosInstance.put(`scores/${id}/confirm`)
+      notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
+      clearCurrentDraft()
+      setPriorReview((current) =>
+        current.contextId === priorReviewContextId
+          ? { ...current, needsSave: false }
+          : current
+      )
+      // Flip the badge immediately (role="status" announces the change);
+      // the refetch then brings the authoritative row, audit fields included.
+      setQuestionScores((prev) => {
+        const entry = Object.entries(prev).find(([, s]) => s.scoreid === id)
+        if (!entry) return prev
+        return { ...prev, [entry[0]]: { ...entry[1], status: 'done' } }
+      })
+      fetchQuestionScores(system, setQuestionScores)
+      return true
+    } catch (error) {
+      if (isAuthHandled(error)) return false
+      console.error('Error confirming score:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error', { autoHideDuration: 2500 })
+      return false
+    }
+  }
+
+  const handleConfirmClick = async () => {
+    if (!currentSavedScore || confirming) return
+    setConfirming(true)
+    try {
+      await confirmScoreById(currentSavedScore.scoreid)
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  // Complete on the open call: save the current question as Next always has,
+  // then show one end-of-questionnaire summary instead of silently looping
+  // back to question 1. Built from a freshly-awaited scores fetch so the
+  // just-saved answer counts; falls back to the on-screen map on failure.
+  const handleCompleteClick = async () => {
+    saveGenRef.current++
+    if (!isReadOnly) {
+      await saveResponse()
+    }
+    const fresh = await fetchQuestionScores(system, setQuestionScores)
+    if (fresh) {
+      // Re-seed the current question's saved state from the fresh map. The
+      // old Complete re-seeded implicitly by navigating to question 1; this
+      // one stays put, and without a re-seed a just-POSTed answer would
+      // still read as unsaved (scoreid 0) — a second Complete would POST a
+      // duplicate row and double-weight the question in the pillar average.
+      const sel = deriveScoreSelection(
+        optionsRef.current.map((o) => Number(o.value)),
+        fresh
+      )
+      setInitQuestionChoice(sel.choice)
+      setInitNotes(sel.notes)
+      setScoreId(sel.scoreid)
+    }
+    setConfirmSummary(
+      buildConfirmSummary(
+        categories,
+        fresh ? buildScoreByFunction(fresh) : scoreByFunction,
+        isOpenCall
+      )
+    )
+  }
+
+  // Jump link from the Complete summary: same slug navigation + list-click
+  // path the sidebar uses, so the datacall context rides along (#501).
+  const jumpToSummaryEntry = (entry: ConfirmSummaryEntry) => {
+    setConfirmSummary(null)
+    // Already on this question (e.g. the last question is itself unanswered):
+    // just close the dialog. handleListItemClick would set loading for a
+    // questionId change that never fires, stranding the spinner.
+    if (entry.functionid === questionId) return
+    const q = questions[entry.functionid]
+    if (q) {
+      navigate(
+        `/${RouteNames.QUESTIONNAIRE}/${fismaacronym?.toLowerCase()}/${datacall}/${toSlug(q.pillar)}/${toSlug(q.function)}`,
+        {
+          state: { fismasystemid: system, ...datacallStateRef.current },
+          replace: true,
+        }
+      )
+    }
+    handleListItemClick(entry.functionid)
+  }
+
   const saveResponse = async () => {
     // Resolving a required carried-forward review is itself a current-call
     // action, even when the final text is byte-for-byte identical to the
@@ -607,7 +749,6 @@ export default function QuestionnarePage() {
     const resolvedPriorReview =
       priorReviewNeedsSave && selectQuestionOption >= 0
     if (
-      !resolvedPriorReview &&
       !shouldPersistResponse({
         selectQuestionOption,
         initQuestionChoice,
@@ -615,6 +756,14 @@ export default function QuestionnarePage() {
         initNotes,
       })
     ) {
+      // Nothing changed on the answer fields. A resolved required review is
+      // still an affirmative act that must land — the ordinary PUT's no-op
+      // guard would silently drop an identical body, so route it through the
+      // confirm endpoint.
+      if (resolvedPriorReview && scoreid) {
+        await confirmScoreById(scoreid)
+        return
+      }
       clearCurrentDraft()
       return
     }
@@ -1238,11 +1387,17 @@ export default function QuestionnarePage() {
         : undefined
     if (priorReview.contextId === priorReviewContextId) return
 
+    // "Untouched this cycle": prefer the persisted scores.status so this gate
+    // and the progress count cannot diverge; fall back to the older
+    // no-edit-event proxy for a backend that does not serve status yet.
+    const untouchedThisCycle = currentScore?.status
+      ? currentScore.status === 'not_started'
+      : !currentScore?.last_edited_at
     const isUnreviewedCarryForward =
       !isReadOnly &&
       !!currentPriorResponse &&
       !!currentScore &&
-      !currentScore.last_edited_at &&
+      untouchedThisCycle &&
       draftStatus !== 'restored' &&
       notes.trim() === currentPriorResponse.text.trim()
     setPriorReview({
@@ -1434,6 +1589,14 @@ export default function QuestionnarePage() {
                       const text = addSpace(func.function.function)
                       const customFontSize =
                         text.length > 33 ? '0.9rem' : '1rem'
+                      // Sidebar confirmation marker: same classification the
+                      // question view's badge reads. Text-bearing, not
+                      // color-only (508); rendered as ListItemText secondary
+                      // so it is part of the button's accessible name.
+                      const sidebarCarryState = carryForwardState(
+                        scoreByFunction[func.function.functionid],
+                        isOpenCall
+                      )
                       // TODO: refactor this code such that it's going to be a single component instead of being rerendered everytime
                       return (
                         <ListItem
@@ -1475,6 +1638,20 @@ export default function QuestionnarePage() {
                           >
                             <ListItemText
                               primary={`${text}`}
+                              secondary={
+                                sidebarCarryState === 'unconfirmed'
+                                  ? 'Not yet confirmed'
+                                  : sidebarCarryState === 'updated'
+                                    ? 'Updated'
+                                    : undefined
+                              }
+                              secondaryTypographyProps={{
+                                fontSize: '0.75rem',
+                                color:
+                                  sidebarCarryState === 'unconfirmed'
+                                    ? 'warning.dark'
+                                    : 'success.dark',
+                              }}
                               sx={{ fontSize: customFontSize }}
                             />
                           </ListItemButton>
@@ -1624,6 +1801,55 @@ export default function QuestionnarePage() {
                       </Typography>
                     )}
                   </Box>
+                  {/* Carried-forward confirmation strip, in the same zone
+                      where the prior-response flow surfaces its "review
+                      before continuing" message, so every system shares one
+                      review area. The chip is a role="status" live region, so
+                      confirming — which swaps its label in place — is
+                      announced (508). The button yields the moment the
+                      question is dirty (the edit is the explicit act; Next
+                      saves it), and Next itself never writes on an untouched
+                      question (#413). */}
+                  {currentCarryState !== 'none' && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        flexWrap: 'wrap',
+                        gap: 1,
+                        mt: 1.5,
+                      }}
+                    >
+                      <Chip
+                        role="status"
+                        size="small"
+                        variant="outlined"
+                        color={
+                          currentCarryState === 'unconfirmed'
+                            ? 'warning'
+                            : 'success'
+                        }
+                        label={
+                          currentCarryState === 'unconfirmed'
+                            ? 'Carried forward — not yet confirmed'
+                            : 'Updated this data call'
+                        }
+                      />
+                      {showConfirmButton && (
+                        <Button
+                          variant="outlined"
+                          color="success"
+                          size="small"
+                          startIcon={<CheckCircleOutlineIcon />}
+                          onClick={handleConfirmClick}
+                          disabled={confirming}
+                          sx={{ textTransform: 'none' }}
+                        >
+                          Confirm this answer is still accurate
+                        </Button>
+                      )}
+                    </Box>
+                  )}
                   <Box
                     position="relative"
                     display="flex"
@@ -1675,12 +1901,21 @@ export default function QuestionnarePage() {
                     </CmsButton>
                     <CmsButton
                       onClick={() => {
-                        saveGenRef.current++
-                        const id =
+                        const isLastQuestion =
                           selectedIndex ===
                           stepFunctionId[stepFunctionId.length - 1]
-                            ? stepFunctionId[0]
-                            : stepFunctionId[functionIdIdx[selectedIndex] + 1]
+                        // Complete on the open call summarizes instead of
+                        // silently wrapping to question 1. A closed call
+                        // keeps the wrap-around — harmless paging for a
+                        // historical viewer.
+                        if (isLastQuestion && isOpenCall) {
+                          void handleCompleteClick()
+                          return
+                        }
+                        saveGenRef.current++
+                        const id = isLastQuestion
+                          ? stepFunctionId[0]
+                          : stepFunctionId[functionIdIdx[selectedIndex] + 1]
 
                         if (questions[id]) {
                           const q = questions[id]
@@ -1763,6 +1998,11 @@ export default function QuestionnarePage() {
             open={openAlert}
             onClose={() => setOpenAlert(false)}
             confirmClick={handleConfirmReturn}
+          />
+          <ConfirmSummaryDialog
+            summary={confirmSummary}
+            onClose={() => setConfirmSummary(null)}
+            onJump={jumpToSummaryEntry}
           />
         </Grid>
       </Container>

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -37,7 +37,7 @@ import {
   NOTES_UPDATE_REQUIRED_MSG,
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
-import { parseDatacallName } from '@/utils/datacallGrouping'
+import { fetchOpDivs } from '@/utils/opdivs'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
@@ -273,13 +273,14 @@ export default function QuestionnarePage() {
     // (per-option warn styling, divider, above-baseline badge/notice) that a flat
     // ChoiceList can't express.
     //
-    // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights layer.
-    // Always pass insight so the FIPS baseline markers (a federal-wide concept)
-    // render for all systems including HHS. showInsightBadges suppresses the
-    // CMS-specific option chips (suggested + prior-answer) for HHS calls while
-    // leaving the baseline treatment intact. The Insights panel, suggestion,
-    // and per-option insight badges are each separately gated (showInsights /
-    // showInsightSuggestion / showInsightBadges) — all derive from showCmsInsights.
+    // Systems whose OpDiv has insights disabled do not surface the internal
+    // ZTMF Insights layer. Always pass insight so the FIPS baseline markers (a
+    // federal-wide concept) render for every system regardless of OpDiv.
+    // showInsightBadges suppresses the insights option chips (suggested +
+    // prior-answer) for disabled OpDivs while leaving the baseline treatment
+    // intact. The Insights panel, suggestion, and per-option insight badges are
+    // each separately gated (showInsights / showInsightSuggestion /
+    // showInsightBadges) — all derive from showCmsInsights.
     return (
       <QuestionRadioGroup
         options={options}
@@ -322,6 +323,38 @@ export default function QuestionnarePage() {
   const [decommissionedSystems, setDecommissionedSystems] = React.useState<
     FismaSystemType[] | null
   >(null)
+  // OpDivs whose systems surface the internal ZTMF Insights layer
+  // (opdivs.insights_enabled - CMS today). Fetched once per page mount. The
+  // insights gate keys on the SYSTEM's OpDiv, not the viewed data call's
+  // name: the FY23-25 era used call tenant (CMS-named vs ZTM-named calls) as
+  // a proxy, which broke when FY2026 unified every OpDiv into one HHS-named
+  // call and silently hid the insights layer for every insights-enabled
+  // system. null = not loaded yet; the gate stays closed until it resolves,
+  // so the panel can appear late but never flashes for a disabled OpDiv.
+  const [insightsOpdivIds, setInsightsOpdivIds] =
+    React.useState<Set<number> | null>(null)
+  React.useEffect(() => {
+    const controller = new AbortController()
+    // includeInactive: the backend serves insights rows for any
+    // insights-enabled OpDiv regardless of its active flag, so the UI gate
+    // must see inactive rows too or the two would diverge.
+    fetchOpDivs(true, controller.signal)
+      .then((rows) =>
+        setInsightsOpdivIds(
+          new Set(
+            rows
+              .filter((o) => o.insights_enabled === true)
+              .map((o) => o.opdiv_id)
+          )
+        )
+      )
+      .catch(() => {
+        // Insights are additive and optional; a failed lookup leaves the
+        // gate closed rather than surfacing an error.
+        if (!controller.signal.aborted) setInsightsOpdivIds(new Set())
+      })
+    return () => controller.abort()
+  }, [])
   const resolvedDecommissioned = React.useMemo(
     () => resolveSystemIdByAcronym(decommissionedSystems ?? [], fismaacronym),
     [decommissionedSystems, fismaacronym]
@@ -494,20 +527,29 @@ export default function QuestionnarePage() {
   // rendered and the page is unchanged.
   const currentDatabaseQuestionId =
     questionId != null ? questions[questionId]?.questionid : undefined
+  // Pending until BOTH lookups settle: the per-system insights rows and the
+  // per-OpDiv capability list the gate below keys on. Without the second
+  // condition a fast /insights response could enable Next/Complete before
+  // /opdivs resolves, letting the panel pop in after the user advanced.
   const insightsPending =
     !!system &&
-    (insightsLoadState.system !== system || !insightsLoadState.settled)
+    (insightsLoadState.system !== system ||
+      !insightsLoadState.settled ||
+      insightsOpdivIds === null)
   const currentInsight =
     insightsLoadState.system === system && currentDatabaseQuestionId != null
       ? insightsByQuestion.get(currentDatabaseQuestionId)
       : undefined
-  // HHS OpDiv data calls do not surface the CMS-internal ZTMF Insights UI
-  // (panel, suggestion). The carried-forward prior-response review still
-  // applies so a copied answer is affirmatively reviewed.
-  const isHhsDatacall =
-    parseDatacallName(datacall.replaceAll('_', ' ')).tenant === 'HHS'
-  // Single source of truth for all CMS-internal insight UI gates.
-  const showCmsInsights = !isHhsDatacall
+  // ZTMF Insights are a per-OpDiv capability (opdivs.insights_enabled), so
+  // the gate keys on the SYSTEM's OpDiv. Gating on the viewed call's tenant
+  // (the FY23-25 behavior) hid the layer for every system once FY2026 merged
+  // all OpDivs into a single HHS-named call. The carried-forward
+  // prior-response review is deliberately NOT gated here, so a copied answer
+  // is affirmatively reviewed for every system regardless of OpDiv.
+  const systemOpdivId = systemInfo?.opdiv_id
+  // Single source of truth for all internal insight UI gates.
+  const showCmsInsights =
+    systemOpdivId != null && (insightsOpdivIds?.has(systemOpdivId) ?? false)
   const showInsights = Boolean(currentInsight) && showCmsInsights
   const currentSuggestion = showCmsInsights
     ? buildInsightJustification(currentInsight)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -21,11 +21,12 @@ import {
   QuestionScores,
   Insight,
   InsightPayload,
+  ScoreAggregate,
 } from '@/types'
 import { Container } from '@mui/system'
 import { styled } from '@mui/material/styles'
 import axiosInstance from '@/axiosConfig'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, Link as RouterLink } from 'react-router-dom'
 import { RouteNames } from '@/router/constants'
 import { ArrowIcon } from '@cmsgov/design-system'
 import {
@@ -44,9 +45,10 @@ import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import ScoreDiffModal from '@/components/ScoreDiffModal/ScoreDiffModal'
+import PillarScoresModal from '@/components/PillarScoresModal/PillarScoresModal'
 import AISummaryBadge from '@/components/AISummaryBadge/AISummaryBadge'
 import { useContextProp } from '../Title/Context'
-import { isAdmin, isReadOnlyAdmin } from '@/utils/userRoles'
+import { isAdmin, isReadOnlyAdmin, hasSystemAccess } from '@/utils/userRoles'
 import LastEditedFooter from './LastEditedFooter'
 import InsightsPanel from './InsightsPanel/InsightsPanel'
 import QuestionRadioGroup from './QuestionRadioGroup'
@@ -130,6 +132,12 @@ export default function QuestionnarePage() {
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const [diffModalOpen, setDiffModalOpen] = React.useState(false)
+  // PillarScoresModal takes its rows as a prop rather than fetching (unlike
+  // ScoreDiffModal), so the header button fetches before opening (ui#610).
+  const [pillarScores, setPillarScores] = React.useState<{
+    open: boolean
+    scores: ScoreAggregate[]
+  }>({ open: false, scores: [] })
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
   const [questionScores, setQuestionScores] = React.useState<questionScoreMap>(
@@ -201,6 +209,20 @@ export default function QuestionnarePage() {
   // Incremented on every explicit draft clear so in-flight debounced saves
   // that fire after a clear don't resurrect the just-removed draft.
   const saveGenRef = React.useRef(0)
+  // Mirrors the payload the debounced draft save would write, so unmount can
+  // flush it. The debounce cleanup cancels its own pending timer, and a route
+  // change away from this page (System Info, the Dashboard breadcrumb, browser
+  // back) tears the component down without firing beforeunload, so an edit made
+  // inside the 1s window was dropped. Carries the generation so a flush cannot
+  // resurrect a draft clearCurrentDraft deleted after the timer was scheduled.
+  const pendingDraftRef = React.useRef<{
+    userid: string
+    system: number
+    questionId: number
+    datacallID: number
+    draft: { selectQuestionOption: number; notes: string }
+    gen: number
+  } | null>(null)
   const unsavedRef = React.useRef({
     selectQuestionOption,
     initQuestionChoice,
@@ -443,6 +465,23 @@ export default function QuestionnarePage() {
       void clearDraft(userInfo.userid, system, questionId, datacallID)
     }
     setDraftStatus('idle')
+  }
+
+  // Same aggregate call the dashboard's Pillar Scores action makes. Not cached:
+  // the dashboard memoizes across many rows, this page is one system and one
+  // click. On failure nothing opens and the user is told, rather than opening an
+  // empty modal that reads as "this system has no scores".
+  const handleOpenPillarScores = async () => {
+    try {
+      const res = await axiosInstance.get(
+        `/scores/aggregate?fismasystemid=${system}&include_pillars=true`
+      )
+      setPillarScores({ open: true, scores: res.data?.data ?? [] })
+    } catch (error) {
+      if (isAuthHandled(error)) return
+      console.error('Error fetching pillar scores:', error)
+      notify(ERROR_MESSAGES.tryAgain, 'error')
+    }
   }
 
   // Keep insight, review, and card state scoped to one system x data call x
@@ -983,10 +1022,12 @@ export default function QuestionnarePage() {
       datacallID <= 0 ||
       loadingQuestion
     ) {
+      pendingDraftRef.current = null
       if (draftStatusRef.current !== 'idle') setDraftStatus('idle')
       return
     }
     if (selectQuestionOption === initQuestionChoice && notes === initNotes) {
+      pendingDraftRef.current = null
       saveGenRef.current++
       // Skip clearDraft when a draft was just restored from storage — the draft
       // values matching the server state does not mean the user reverted manually.
@@ -1003,17 +1044,35 @@ export default function QuestionnarePage() {
       return
     }
     const currentGen = saveGenRef.current
+    const pending = {
+      userid: userInfo.userid,
+      system,
+      questionId,
+      datacallID,
+      draft: { selectQuestionOption, notes },
+      gen: currentGen,
+    }
+    pendingDraftRef.current = pending
     const timer = setTimeout(() => {
       if (saveGenRef.current !== currentGen) return
       saveDraft(
-        userInfo.userid,
-        system,
-        questionId,
-        datacallID,
-        { selectQuestionOption, notes },
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft,
         () => saveGenRef.current === currentGen
       ).then((saved) => {
         if (saveGenRef.current !== currentGen) return
+        // Clear by identity, not generation: a newer edit re-runs this effect
+        // and replaces the ref with a NEW object under the SAME generation
+        // (saveGenRef only moves on explicit clears), so a generation check
+        // here would let the older save's completion discard the newer edit's
+        // payload while its own debounce is still pending — and an unmount in
+        // that window would then flush nothing (#640 review). Gated on `saved`
+        // so a failed write stays in the ref for the unmount flush to retry.
+        if (saved && pendingDraftRef.current === pending)
+          pendingDraftRef.current = null
         if (saved) {
           if (draftStatusRef.current !== 'restored') setDraftStatus('saved')
         } else {
@@ -1034,6 +1093,32 @@ export default function QuestionnarePage() {
     loadingQuestion,
     userInfo.userid,
   ])
+
+  // Flush a pending draft on unmount. beforeunload below covers tab close and
+  // hard refresh, but it does not fire on in-app navigation, and the debounce
+  // cleanup cancels the timer that would have written the draft. Mount-once so
+  // the cleanup runs on unmount only, never on a dep change (flushing on every
+  // dep change would defeat the debounce and write on each keystroke).
+  // saveDraft takes primitives and touches no component state, so the write
+  // completes after this component is gone.
+  React.useEffect(() => {
+    return () => {
+      const pending = pendingDraftRef.current
+      // Reading the live generation is the point of this guard, not a staleness
+      // bug: it must reflect any clearCurrentDraft that ran after the timer was
+      // scheduled, so a flush cannot resurrect a just-deleted draft. Copying it
+      // into the effect body would freeze it at its mount value.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      if (!pending || saveGenRef.current !== pending.gen) return
+      void saveDraft(
+        pending.userid,
+        pending.system,
+        pending.questionId,
+        pending.datacallID,
+        pending.draft
+      )
+    }
+  }, [])
 
   // Warn before tab close or hard refresh when the active question has edits
   // that haven't been committed to the backend yet.
@@ -1170,10 +1255,41 @@ export default function QuestionnarePage() {
       </>
     )
   }
+  // Cross-navigation back to this system's detail page (ui#610). A real router
+  // link rather than onClick + navigate, so open-in-new-tab and copy-link work.
+  // Gated on the same hasSystemAccess check the dashboard puts on its own System
+  // Details action. Every current role passes it (delegates included), so in
+  // practice this only suppresses the link while userInfo is unloaded or carries
+  // an unrecognized role - but it is the gate that moves if system-detail access
+  // ever narrows.
+  const systemInfoLink = hasSystemAccess(userInfo) ? (
+    <Button
+      variant="outlined"
+      size="small"
+      component={RouterLink}
+      to={`/systems/${system}`}
+      sx={{ whiteSpace: 'nowrap' }}
+    >
+      System Info
+    </Button>
+  ) : null
   if (noQuestions) {
     return (
       <>
-        <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
+          {/* Without this the flow System Info -> Questionnaire -> "no
+              questionnaire available" is one-way, which the #609 button makes
+              reachable for any out-of-scope or decommissioned system (#640
+              review). */}
+          {systemInfoLink}
+        </Box>
         <Container maxWidth={false} disableGutters>
           <Alert severity="info" sx={{ mt: 2 }}>
             No questionnaire is available for this system. This typically
@@ -1193,6 +1309,14 @@ export default function QuestionnarePage() {
     notes,
     initNotes,
   })
+  // The data call both header modals present as "current". Prefer the call this
+  // questionnaire actually resolved (datacallID covers every entry path,
+  // including URL deep links where no route state exists); fall back to the
+  // route/selected/latest chain during the pre-fetch window.
+  const viewedDataCallId =
+    datacallID > 0
+      ? datacallID
+      : routeDatacallId ?? selectedDatacall?.datacallid ?? latestDataCallId
   return (
     <>
       <Box
@@ -1203,14 +1327,25 @@ export default function QuestionnarePage() {
         }}
       >
         <BreadCrumbs segmentLabels={breadcrumbSegmentLabels} />
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => setDiffModalOpen(true)}
-          sx={{ whiteSpace: 'nowrap' }}
-        >
-          Compare Datacalls
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {systemInfoLink}
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleOpenPillarScores}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Pillar Scores
+          </Button>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setDiffModalOpen(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            Compare Datacalls
+          </Button>
+        </Box>
       </Box>
       {isPastDeadline && !isReadOnly && (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -1589,23 +1724,26 @@ export default function QuestionnarePage() {
           />
         </Grid>
       </Container>
-      {/* Seeds the "To" picker default in ScoreDiffModal. Prefer the call this
-          questionnaire actually resolved (datacallID covers every entry path,
-          including URL deep links where no route state exists); fall back to
-          the route/selected/latest chain during the pre-fetch window. */}
       <ScoreDiffModal
         open={diffModalOpen}
         onClose={() => setDiffModalOpen(false)}
         fismasystemid={system ?? 0}
         systemName={systemName}
         systemAcronym={fismaacronym ?? ''}
-        selectedDataCallId={
-          datacallID > 0
-            ? datacallID
-            : routeDatacallId ??
-              selectedDatacall?.datacallid ??
-              latestDataCallId
+        selectedDataCallId={viewedDataCallId}
+      />
+      {/* Same modal the dashboard's Pillar Scores action opens. The acronym
+          comes from the resolved system rather than the lowercased URL param so
+          the title matches the dashboard's casing. */}
+      <PillarScoresModal
+        open={pillarScores.open}
+        onClose={() => setPillarScores((prev) => ({ ...prev, open: false }))}
+        systemName={systemName}
+        systemAcronym={
+          systemInfo?.fismaacronym ?? fismaacronym?.toUpperCase() ?? ''
         }
+        scores={pillarScores.scores}
+        selectedDataCallId={viewedDataCallId}
       />
     </>
   )

--- a/src/views/QuestionnairePage/confirmState.test.ts
+++ b/src/views/QuestionnairePage/confirmState.test.ts
@@ -1,0 +1,204 @@
+import {
+  carryForwardState,
+  canConfirmCarryForward,
+  buildScoreByFunction,
+  buildConfirmSummary,
+} from './confirmState'
+import type { QuestionScores, FismaQuestion, ScoreStatus } from '@/types'
+
+const score = (over: Partial<QuestionScores> = {}): QuestionScores => ({
+  scoreid: 1,
+  fismasystemid: 10,
+  datecalculated: 0,
+  notes: 'carried notes',
+  functionoptionid: 100,
+  datacallid: 5,
+  ...over,
+})
+
+const question = (
+  functionid: number,
+  name = `fn-${functionid}`
+): FismaQuestion => ({
+  questionid: functionid + 1000,
+  question: `Q ${functionid}`,
+  notesprompt: '',
+  pillar: { pillar: 'Devices', pillarid: 1, order: 1 },
+  function: {
+    functionid,
+    function: name,
+    description: '',
+    datacenterenvironment: 'Hybrid',
+  },
+})
+
+describe('carryForwardState', () => {
+  it('classifies a not_started row on the open call as unconfirmed', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), true)).toBe(
+      'unconfirmed'
+    )
+  })
+
+  it('classifies a done row on the open call as updated', () => {
+    expect(carryForwardState(score({ status: 'done' }), true)).toBe('updated')
+  })
+
+  it('renders nothing on a past call — historical rows are legitimately not_started forever', () => {
+    expect(carryForwardState(score({ status: 'not_started' }), false)).toBe(
+      'none'
+    )
+    expect(carryForwardState(score({ status: 'done' }), false)).toBe('none')
+  })
+
+  it('renders nothing when the backend does not serve status (pre-deploy degrade)', () => {
+    expect(carryForwardState(score(), true)).toBe('none')
+  })
+
+  it('renders nothing without an answer row', () => {
+    expect(carryForwardState(undefined, true)).toBe('none')
+  })
+})
+
+describe('canConfirmCarryForward', () => {
+  const confirmable = {
+    state: 'unconfirmed' as const,
+    dirty: false,
+    isReadOnly: false,
+    priorReviewBlocked: false,
+  }
+
+  it('allows confirming an untouched carried-forward answer', () => {
+    expect(canConfirmCarryForward(confirmable)).toBe(true)
+  })
+
+  it('hides while dirty — the edit is the explicit act and Next saves it', () => {
+    expect(canConfirmCarryForward({ ...confirmable, dirty: true })).toBe(false)
+  })
+
+  it('hides for read-only sessions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, isReadOnly: true })).toBe(
+      false
+    )
+  })
+
+  it('hides while the CMS prior-response review blanks the field', () => {
+    expect(
+      canConfirmCarryForward({ ...confirmable, priorReviewBlocked: true })
+    ).toBe(false)
+  })
+
+  it('hides for updated and stateless questions', () => {
+    expect(canConfirmCarryForward({ ...confirmable, state: 'updated' })).toBe(
+      false
+    )
+    expect(canConfirmCarryForward({ ...confirmable, state: 'none' })).toBe(
+      false
+    )
+  })
+})
+
+describe('buildScoreByFunction', () => {
+  it('re-keys rows by their owning functionid', () => {
+    const byFunction = buildScoreByFunction({
+      100: score({
+        functionoptionid: 100,
+        functionoption: {
+          functionoptionid: 100,
+          functionid: 7,
+          score: 2,
+          optionname: 'Defined',
+          description: '',
+        },
+      }),
+    })
+    expect(byFunction[7]?.functionoptionid).toBe(100)
+  })
+
+  it('skips rows without functionoption — they cannot be attributed to a question', () => {
+    expect(buildScoreByFunction({ 100: score() })).toEqual({})
+  })
+})
+
+describe('buildConfirmSummary', () => {
+  const withStatus = (
+    functionid: number,
+    status?: ScoreStatus
+  ): QuestionScores =>
+    score({
+      scoreid: functionid,
+      status,
+      functionoption: {
+        functionoptionid: functionid * 10,
+        functionid,
+        score: 1,
+        optionname: 'Traditional',
+        description: '',
+      },
+    })
+
+  const categories = [
+    { name: 'Devices', steps: [question(1), question(2)] },
+    { name: 'Networks', steps: [question(3), question(4)] },
+  ]
+
+  it('buckets unconfirmed, updated, and unanswered in sidebar order', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1, 'not_started'),
+        2: withStatus(2, 'done'),
+        3: withStatus(3, 'not_started'),
+        // 4 has no row at all.
+      },
+      true
+    )
+    expect(summary.total).toBe(4)
+    expect(summary.updated).toBe(1)
+    expect(summary.unconfirmed.map((e) => e.functionid)).toEqual([1, 3])
+    expect(summary.unconfirmed[0]).toEqual({
+      functionid: 1,
+      functionName: 'fn-1',
+      pillarName: 'Devices',
+    })
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(true)
+  })
+
+  it('keeps the unanswered list but flags missing status data pre-deploy', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      {
+        1: withStatus(1),
+        2: withStatus(2),
+        3: withStatus(3),
+      },
+      true
+    )
+    // Answered rows without status land in no bucket: not unconfirmed (that
+    // would badge everything) and not updated (that would claim knowledge the
+    // backend has not served).
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.updated).toBe(0)
+    expect(summary.unanswered.map((e) => e.functionid)).toEqual([4])
+    expect(summary.hasStatusData).toBe(false)
+  })
+
+  it('lists nothing as unconfirmed on a past call', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 1: withStatus(1, 'not_started') },
+      false
+    )
+    expect(summary.unconfirmed).toEqual([])
+  })
+
+  it('ignores score rows whose function is not in the questionnaire (inapplicable after an environment change)', () => {
+    const summary = buildConfirmSummary(
+      categories,
+      { 99: withStatus(99, 'not_started') },
+      true
+    )
+    expect(summary.unconfirmed).toEqual([])
+    expect(summary.total).toBe(4)
+  })
+})

--- a/src/views/QuestionnairePage/confirmState.ts
+++ b/src/views/QuestionnairePage/confirmState.ts
@@ -1,0 +1,134 @@
+import type { QuestionScores, ScoreStatus, FismaQuestion } from '@/types'
+
+/**
+ * Carried-forward confirmation state, derived from the persisted
+ * scores.status column — the same fact the Data Call Progress fraction
+ * counts — so the badge, Confirm button, sidebar markers, and Complete
+ * summary can never disagree with the number the user is shown. Pure, so the
+ * classification rules live in one place (mirrors saveGuard.ts).
+ */
+
+/**
+ * The per-question classification every piece of confirmation UI reads.
+ * 'none' covers: no answer row, a closed call (historical rows are
+ * legitimately not_started forever), or a backend that does not serve status
+ * yet (degrade to no badges rather than badging everything).
+ */
+export type CarryForwardState = 'unconfirmed' | 'updated' | 'none'
+
+export const carryForwardState = (
+  score: QuestionScores | undefined,
+  isOpenCall: boolean
+): CarryForwardState => {
+  if (!isOpenCall || !score?.status) return 'none'
+  return score.status === 'not_started' ? 'unconfirmed' : 'updated'
+}
+
+/**
+ * Whether the inline Confirm button renders. It is the explicit act for an
+ * untouched carried-forward answer, so it hides whenever another act owns the
+ * write: dirty edits (Next saves those), a pending prior-response review (the
+ * field is blanked; same condition that disables Next), or a read-only
+ * session.
+ */
+export const canConfirmCarryForward = (s: {
+  state: CarryForwardState
+  dirty: boolean
+  isReadOnly: boolean
+  priorReviewBlocked: boolean
+}): boolean =>
+  s.state === 'unconfirmed' &&
+  !s.dirty &&
+  !s.isReadOnly &&
+  !s.priorReviewBlocked
+
+/**
+ * Re-key the score map (keyed by functionoptionid) by owning functionid, so
+ * the sidebar and Complete summary can look up a question's answer row
+ * directly. Rows without functionoption cannot be attributed and are skipped.
+ */
+export const buildScoreByFunction = (scores: {
+  [key: number]: QuestionScores
+}): Record<number, QuestionScores> => {
+  const byFunction: Record<number, QuestionScores> = {}
+  for (const score of Object.values(scores)) {
+    const functionid = score.functionoption?.functionid
+    if (functionid != null) byFunction[functionid] = score
+  }
+  return byFunction
+}
+
+export type ConfirmSummaryEntry = {
+  functionid: number
+  functionName: string
+  pillarName: string
+}
+
+export type ConfirmSummary = {
+  /** Total questions in the questionnaire (the summary's denominator). */
+  total: number
+  /** Questions whose answer counts as updated this cycle (status = 'done'). */
+  updated: number
+  /** Carried-forward answers still awaiting confirmation, in sidebar order. */
+  unconfirmed: ConfirmSummaryEntry[]
+  /** Questions with no answer row at all, in sidebar order. */
+  unanswered: ConfirmSummaryEntry[]
+  /**
+   * True when at least one row carries status. False = the backend does not
+   * serve it, so the updated count and unconfirmed list would be lies built
+   * from absence — callers must render neither. The unanswered list stays
+   * valid (derived from row presence, not status).
+   */
+  hasStatusData: boolean
+}
+
+/**
+ * Build the Complete-time summary from the sidebar's own category list, so
+ * entries come out in sidebar order with sidebar names, ready for the same
+ * slug-based navigation.
+ */
+export const buildConfirmSummary = (
+  categories: { name: string; steps: FismaQuestion[] }[],
+  scoreByFunction: Record<number, QuestionScores>,
+  isOpenCall: boolean
+): ConfirmSummary => {
+  const summary: ConfirmSummary = {
+    total: 0,
+    updated: 0,
+    unconfirmed: [],
+    unanswered: [],
+    hasStatusData: Object.values(scoreByFunction).some((s) => s.status != null),
+  }
+  for (const pillar of categories) {
+    for (const step of pillar.steps) {
+      summary.total++
+      const functionid = step.function.functionid
+      const score = scoreByFunction[functionid]
+      if (!score) {
+        summary.unanswered.push({
+          functionid,
+          functionName: step.function.function,
+          pillarName: pillar.name,
+        })
+        continue
+      }
+      switch (carryForwardState(score, isOpenCall)) {
+        case 'unconfirmed':
+          summary.unconfirmed.push({
+            functionid,
+            functionName: step.function.function,
+            pillarName: pillar.name,
+          })
+          break
+        case 'updated':
+          summary.updated++
+          break
+        // 'none' (no status served): answered, but neither confirmable nor
+        // countable as updated — deliberately absent from every bucket.
+      }
+    }
+  }
+  return summary
+}
+
+export type { ScoreStatus }

--- a/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react'
+import StatisticsBlocks from './StatisticsBlocks'
+import type { FismaSystemType, SystemScoreEntry } from '@/types'
+
+// StatisticsBlocks reads the full active-system list from the outlet context and
+// the selection-scoped score map from props. The bug in ztmf-ui#633 was the
+// average dividing by the whole context list; these tests pin the denominator to
+// the systems that actually have a score.
+let mockFismaSystems: FismaSystemType[] = []
+jest.mock('../Title/Context', () => ({
+  __esModule: true,
+  useContextProp: () => ({ fismaSystems: mockFismaSystems }),
+}))
+
+const sys = (id: number, acronym: string): FismaSystemType =>
+  ({ fismasystemid: id, fismaacronym: acronym }) as FismaSystemType
+
+const score = (
+  n: number,
+  tier?: SystemScoreEntry['tier']
+): SystemScoreEntry => ({
+  score: n,
+  tier,
+})
+
+// Read the big numeral out of a tile located by its label. The high/low tiles
+// fold an acronym into the label element, so callers pass a regex for those.
+const tileValue = (label: string | RegExp): string => {
+  const tile = screen.getByText(label).closest('.MuiPaper-root')
+  const numeral = tile?.querySelector('h2')
+  return (numeral?.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
+  afterEach(() => {
+    mockFismaSystems = []
+  })
+
+  it('averages only over systems with a score, not the full active list', () => {
+    // Three active systems, only two answered the selected call. The average must
+    // be (2 + 5) / 2 = 3.5, NOT (2 + 5) / 3 = 2.33 (the old diluted denominator).
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2, 'Traditional'),
+      2: score(5, 'Optimal'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Average System Score')).toBe('3.5')
+  })
+
+  it('shows the Scored / Total ratio scoped to the selection', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(2),
+      2: score(5),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('2 / 3')
+  })
+
+  it('keeps the average between the lowest and highest displayed scores', () => {
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(1.5, 'Traditional'),
+      2: score(3, 'Initial'),
+      3: score(4.82, 'Advanced'),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    const avg = Number(tileValue('Average System Score'))
+    const low = Number(tileValue(/Lowest System Score/))
+    const high = Number(tileValue(/Highest System Score/))
+    expect(low).toBeLessThanOrEqual(avg)
+    expect(avg).toBeLessThanOrEqual(high)
+    expect(low).toBe(1.5)
+    expect(high).toBe(4.82)
+  })
+
+  it('handles a selection no system participated in without going below scale', () => {
+    // No scored systems: average is 0 (guarded), ratio is 0 / N, and the lowest
+    // tile falls back to 0.00 rather than rendering Infinity.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    render(<StatisticsBlocks scores={{}} />)
+
+    expect(tileValue('Average System Score')).toBe('0')
+    expect(tileValue('Scored / Total Systems')).toBe('0 / 2')
+    expect(tileValue('Lowest System Score:')).toBe('0.00')
+  })
+
+  it('formats large totals with thousands separators', () => {
+    mockFismaSystems = Array.from({ length: 1342 }, (_, i) =>
+      sys(i + 1, `S${i}`)
+    )
+    const scores: Record<number, SystemScoreEntry> = {
+      1: score(3.44),
+    }
+    render(<StatisticsBlocks scores={scores} />)
+
+    expect(tileValue('Scored / Total Systems')).toBe('1 / 1,342')
+  })
+})

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -26,6 +26,7 @@ export default function StatisticsBlocks({
 }) {
   const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
+  const [answeredSystems, setAnsweredSystems] = useState<number>(0)
   const [avgSystemScore, setAvgSystemScore] = useState<number>(0)
   const [maxSystemAcronym, setMaxSystemAcronym] = useState<string>('')
   const [maxSystemScore, setMaxSystemScore] = useState<number>(0)
@@ -40,7 +41,12 @@ export default function StatisticsBlocks({
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    const totalCount = fismaSystems.length
+    // Count only the systems that actually contribute a score. The `scores` map
+    // is already scoped to the selected data call(s), so systems with no answers
+    // in the selection must not inflate the denominator (that dragged the average
+    // below the scale minimum — see ztmf-ui#633). Counted inside the loop so the
+    // numerator and denominator always cover the same systems.
+    let scoredCount: number = 0
     let maxScore: number = 0
     let maxScoreSystem: string = ''
     let maxScoreTier: ScoreTier | undefined
@@ -62,16 +68,18 @@ export default function StatisticsBlocks({
           minScoreTier = entry.tier
         }
         totalScores += entry.score
+        scoredCount += 1
       }
     }
-    if (totalCount === 0) {
+    if (scoredCount === 0) {
       setAvgSystemScore(0)
       setMinSystemScore(0)
     } else {
-      setAvgSystemScore(Number((totalScores / totalCount).toFixed(2)))
+      setAvgSystemScore(Number((totalScores / scoredCount).toFixed(2)))
       setMinSystemScore(minScore)
     }
-    setTotalSystems(totalCount)
+    setAnsweredSystems(scoredCount)
+    setTotalSystems(fismaSystems.length)
     setMaxSystemScore(maxScore)
     setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
@@ -99,14 +107,14 @@ export default function StatisticsBlocks({
       }}
     >
       <StatisticsPaper variant="outlined">
-        <Typography variant="h2" sx={{ color: '#004297', fontSize: '56px' }}>
-          {totalSystems}
+        <Typography variant="h2" sx={{ color: '#004297', fontSize: '44px' }}>
+          {answeredSystems.toLocaleString()} / {totalSystems.toLocaleString()}
         </Typography>
         <Typography
           variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
-          Total Systems
+          Scored / Total Systems
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">

--- a/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.test.tsx
@@ -137,6 +137,30 @@ test('setting the boolean to Unknown emits null (the clear signal)', async () =>
   expect(onFieldChange).toHaveBeenCalledWith('hva', null)
 })
 
+test('ISSO Name renders as an editable control with its override guidance', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  expect(screen.getByRole('textbox', { name: 'ISSO Name' })).toBeEnabled()
+  // The guidance is what tells an admin that a typed name is a permanent
+  // override and that clearing returns the derived name.
+  expect(
+    screen.getByText(/overrides the name from the ISSO's user account/i)
+  ).toBeInTheDocument()
+})
+
+test('clearing ISSO Name emits the empty-string clear signal', async () => {
+  mock.onGet('/systemattributes').reply(200, { data: [] })
+  const user = userEvent.setup()
+  const { onFieldChange } = renderEditView({ isso_name: 'Conan Antonio Motti' })
+
+  await user.clear(screen.getByRole('textbox', { name: 'ISSO Name' }))
+
+  // '' clears the stored override via blankToNil, restoring the name the
+  // backend derives from the ISSO user record; null would leave it unchanged.
+  expect(onFieldChange).toHaveBeenCalledWith('isso_name', '')
+})
+
 test('cloud dependents are hidden while cloud_system is No', () => {
   mock.onGet('/systemattributes').reply(200, { data: [] })
   renderEditView({ cloud_system: false })

--- a/src/views/SystemDetailPage/SystemDetailEditView.tsx
+++ b/src/views/SystemDetailPage/SystemDetailEditView.tsx
@@ -662,8 +662,8 @@ export default function SystemDetailEditView(props: SystemDetailEditViewProps) {
       </Grid>
 
       {/* Extended Metadata — full width, 3-col grid. Standard system
-          attributes editable across all OpDivs. isso_name is display-only
-          (backend-resolved), so it renders disabled. */}
+          attributes editable across all OpDivs. A field marked read-only in
+          fieldConfig renders disabled. */}
       <Grid item xs={12}>
         <Card variant="outlined">
           <CardHeader

--- a/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import SystemDetailHeader from './SystemDetailHeader'
+
+// Cross-navigation coverage for ui#609: System Info needs a link to the
+// system's questionnaire. The questionnaire route is keyed on :fismaacronym
+// while this page is routed by :fismasystemid, so the acronym is passed in.
+
+const BASE_PROPS = {
+  systemName: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  canEdit: false,
+  isEditing: false,
+  isSaving: false,
+  isFormValid: true,
+  onEdit: jest.fn(),
+  onSave: jest.fn(),
+  onCancel: jest.fn(),
+}
+
+// Data-router harness so the component gets the same useNavigate the app does,
+// and so the resulting pathname is assertable off router.state.
+function renderHeader(props: Partial<typeof BASE_PROPS> = {}) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/systems/:fismasystemid',
+        element: <SystemDetailHeader {...BASE_PROPS} {...props} />,
+      },
+      {
+        path: '/questionnaire/:fismaacronym',
+        element: <div>questionnaire</div>,
+      },
+      { path: '/', element: <div>dashboard</div> },
+    ],
+    { initialEntries: ['/systems/1002'] }
+  )
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+it('renders Questionnaire as a link, not a bare button', () => {
+  renderHeader()
+  // An anchor (CmsButton href) rather than onClick + navigate, so
+  // open-in-new-tab and copy-link work (#640 review).
+  const link = screen.getByRole('link', { name: 'Questionnaire' })
+  expect(link).toBeInTheDocument()
+  expect(link.tagName).toBe('A')
+})
+
+it('targets the questionnaire keyed on the lowercased acronym', () => {
+  renderHeader()
+  // Lowercased to match the URL shape the dashboard's own questionnaire action
+  // builds (FismaTable openQuestionnaire), so both entry points share one link.
+  // Bare acronym with no trailing segments: the omitted datacall is what makes
+  // QuestionnairePage resolve the cycle itself, and pinning one from here would
+  // fix the wrong call.
+  expect(
+    screen.getByRole('link', { name: 'Questionnaire' }).getAttribute('href')
+  ).toBe('/questionnaire/ssd-ex')
+})
+
+it('shows Questionnaire alongside Edit for an editor', () => {
+  renderHeader({ canEdit: true })
+  expect(
+    screen.getByRole('link', { name: 'Questionnaire' })
+  ).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+})
+
+it('hides Questionnaire while editing so a dirty form keeps Save/Cancel only', () => {
+  renderHeader({ canEdit: true, isEditing: true })
+  expect(
+    screen.queryByRole('link', { name: 'Questionnaire' })
+  ).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+})

--- a/src/views/SystemDetailPage/SystemDetailHeader.tsx
+++ b/src/views/SystemDetailPage/SystemDetailHeader.tsx
@@ -1,10 +1,13 @@
 import { Box, Typography, IconButton } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { Button as CmsButton } from '@cmsgov/design-system'
-import { useNavigate } from 'react-router-dom'
+import { useHref, useNavigate } from 'react-router-dom'
 
 interface SystemDetailHeaderProps {
   systemName: string
+  /** Drives the Questionnaire link; the questionnaire route is keyed on the
+   * acronym, not the fismasystemid this page is routed by (ui#609). */
+  fismaacronym: string
   /** Admins edit the whole form; an assigned ISSO gets the same Edit button
    * but only the target-maturity card unlocks for them (ztmf#398). */
   canEdit: boolean
@@ -18,6 +21,7 @@ interface SystemDetailHeaderProps {
 
 export default function SystemDetailHeader({
   systemName,
+  fismaacronym,
   canEdit,
   isEditing,
   isSaving,
@@ -27,6 +31,14 @@ export default function SystemDetailHeader({
   onCancel,
 }: SystemDetailHeaderProps) {
   const navigate = useNavigate()
+  // Rendered as an <a> via CmsButton's href so open-in-new-tab and copy-link
+  // work. CmsButton has no polymorphic `component` prop, so react-router's Link
+  // cannot be composed in; useHref resolves the path the same way Link would
+  // (under the app's hash router it yields `#/questionnaire/<acronym>`) instead
+  // of hand-writing the fragment. (#640 review)
+  const questionnaireHref = useHref(
+    `/questionnaire/${fismaacronym.toLowerCase()}`
+  )
 
   return (
     <Box
@@ -61,11 +73,22 @@ export default function SystemDetailHeader({
             </CmsButton>
           </>
         ) : (
-          canEdit && (
-            <CmsButton variation="solid" onClick={onEdit}>
-              Edit
-            </CmsButton>
-          )
+          <>
+            {/* Cross-navigation to this system's questionnaire (ui#609). The
+                target carries no route state: QuestionnairePage falls back to
+                the selected/latest data call when location.state has no
+                datacallid, which is the right default arriving from here, and it
+                keeps the link plainly shareable. Rendered only outside edit mode
+                so a dirty form keeps Save/Cancel as its only actions. A
+                decommissioned system links too and the questionnaire's own
+                "no questionnaire is available" alert explains the outcome. */}
+            <CmsButton href={questionnaireHref}>Questionnaire</CmsButton>
+            {canEdit && (
+              <CmsButton variation="solid" onClick={onEdit}>
+                Edit
+              </CmsButton>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -1,0 +1,269 @@
+// Role coverage for the ISSO Name control on the System Details page, plus the
+// two write signals it can send. The page-level isAdmin gate is the only gate
+// on the field: the whole edit surface (the Edit button and the edit view) is
+// admin-only, so the write-admin tiers get the control and every other tier
+// never reaches an editable form at all. A typed name is a permanent override
+// of the name derived from the ISSO user record; the empty string clears the
+// override.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+import MockAdapter from 'axios-mock-adapter'
+import SystemDetailPage from './SystemDetailPage'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, UserRole, userData } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+
+const SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Super Star Destroyer Executor Command Systems',
+  fismaacronym: 'SSD-EX',
+  fismauid: 'UID-42',
+  component: 'CMS',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: 'admiral.piett@executor.empire',
+  datacallcontact: 'captain.needa@executor.empire',
+  opdiv_id: 1,
+  decommissioned: false,
+  // Both enrichment (ZTMF Insights) and the delegates roster are gated off in
+  // this fixture so the page's only network reads are opdivs and the
+  // system-attribute vocabulary.
+  sdl_sync_enabled: false,
+  isso_name: 'Conan Antonio Motti',
+  hva: null,
+  fips: null,
+  system_type: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+const WRITE_ADMIN_ROLES: UserRole[] = [
+  'OWNER',
+  'HHS_ADMIN',
+  'OPDIV_ADMIN',
+  'ADMIN',
+]
+
+const NON_WRITE_ROLES: UserRole[] = [
+  'HHS_READONLY_ADMIN',
+  'OPDIV_READONLY_ADMIN',
+  'READONLY_ADMIN',
+  'ISSO',
+  'ISSM',
+  'SYSTEM_DELEGATE',
+]
+
+beforeEach(() => {
+  mock.reset()
+  mock
+    .onGet('/opdivs')
+    .reply(200, {
+      data: [
+        {
+          opdiv_id: 1,
+          code: 'CMS',
+          name: 'CMS',
+          active: true,
+          system_delegate_enabled: false,
+        },
+      ],
+    })
+    .onGet('/systemattributes')
+    .reply(200, { data: [] })
+})
+
+/**
+ * Renders the page for a system owned by the given role, on the route the
+ * page reads :fismasystemid from.
+ */
+function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
+  mockCtx = {
+    fismaSystems: [system],
+    setFismaSystems: jest.fn(),
+    userInfo: {
+      userid: '1',
+      email: 'grand.moff@deathstar.empire',
+      fullname: 'Grand Moff Tarkin',
+      role,
+    } as userData,
+    datacenterEnvironments: [],
+    // The page refetches after a save instead of echoing its draft, so both of
+    // these have to be present or the save path throws.
+    fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
+    showDecommissioned: false,
+  }
+  return renderWithProviders(
+    <Routes>
+      <Route path="/systems/:fismasystemid" element={<SystemDetailPage />} />
+    </Routes>,
+    { initialEntries: ['/systems/42'] }
+  )
+}
+
+/**
+ * The page-level Edit buttons currently on screen. The target-maturity card
+ * renders its own Edit button in view mode (for admins and for an assigned
+ * ISSO/ISSM), so match the header button by its CMS design-system class to keep
+ * the two apart: only the header one opens the system form.
+ */
+function pageEditButtons(): HTMLElement[] {
+  return screen
+    .queryAllByRole('button', { name: 'Edit' })
+    .filter((button) => button.classList.contains('ds-c-button'))
+}
+
+/** Captures the body of the page's full-system PUT. */
+function captureSave() {
+  const captured: { body?: Record<string, unknown> } = {}
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    captured.body = JSON.parse(config.data)
+    return [200, {}]
+  })
+  return captured
+}
+
+test.each(WRITE_ADMIN_ROLES)(
+  'ISSO Name is an editable control for %s',
+  async (role) => {
+    const user = userEvent.setup()
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    await user.click(pageEditButtons()[0])
+
+    expect(
+      await screen.findByRole('textbox', { name: 'ISSO Name' })
+    ).toBeEnabled()
+  }
+)
+
+test.each(NON_WRITE_ROLES)(
+  '%s gets no system-form edit affordance and no ISSO Name control',
+  async (role) => {
+    renderPage(role)
+
+    await screen.findByText('System Identity')
+    expect(pageEditButtons()).toHaveLength(0)
+    // The read view is the only view these tiers reach, and it renders every
+    // field as text, so there is no control to disable.
+    expect(
+      screen.queryByRole('textbox', { name: 'ISSO Name' })
+    ).not.toBeInTheDocument()
+  }
+)
+
+test('an edited ISSO Name is sent in the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  expect(captured.body).toHaveProperty('isso_name', 'Firmus Piett')
+})
+
+test('clearing ISSO Name sends the empty-string clear signal', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // '' clears the stored override via blankToNil so the name derived from the
+  // ISSO user record applies again; null would read as "leave unchanged".
+  expect(captured.body).toHaveProperty('isso_name', '')
+})
+
+// The saved value of isso_name is resolved by the backend, so the draft the
+// page sent is not the truth once the field was cleared. Echoing the draft into
+// shared state would render the cleared field as empty instead of the derived
+// name, so the page has to refetch and must not write the draft.
+test('clearing ISSO Name refetches instead of echoing the draft', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await user.clear(await screen.findByRole('textbox', { name: 'ISSO Name' }))
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(false)
+  )
+  expect(mockCtx.setFismaSystems).not.toHaveBeenCalled()
+})
+
+// A save must not silently change which systems the dashboard lists, so the
+// refetch carries the caller's current decommissioned view mode.
+test('the post-save refetch preserves the decommissioned view mode', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+  mockCtx.showDecommissioned = true
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  const input = await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.clear(input)
+  await user.type(input, 'Firmus Piett')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  await waitFor(() =>
+    expect(mockCtx.fetchFismaSystems).toHaveBeenCalledWith(true)
+  )
+})
+
+test('an untouched ISSO Name is omitted from the save payload', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage('OPDIV_ADMIN')
+
+  await screen.findByText('System Identity')
+  await user.click(pageEditButtons()[0])
+  await screen.findByRole('textbox', { name: 'ISSO Name' })
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // The detail page shows the resolved name, so sending it back unedited would
+  // persist a derived name as an override on any unrelated save.
+  expect(captured.body).not.toHaveProperty('isso_name')
+})

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -45,8 +45,14 @@ import SystemDelegatesSection from './SystemDelegatesSection'
 
 export default function SystemDetailPage() {
   const { fismasystemid } = useParams<{ fismasystemid: string }>()
-  const { fismaSystems, setFismaSystems, userInfo, datacenterEnvironments } =
-    useContextProp()
+  const {
+    fismaSystems,
+    setFismaSystems,
+    userInfo,
+    datacenterEnvironments,
+    fetchFismaSystems,
+    showDecommissioned,
+  } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
   const systemId = fismasystemid ? Number(fismasystemid) : NaN
@@ -331,6 +337,16 @@ export default function SystemDetailPage() {
 
   const handleSave = async () => {
     if (!editedSystem) return
+    // The extended-metadata payload is a diff against the loaded system, and
+    // buildExtendedDiff treats a missing baseline as "every field is unset",
+    // which sends all of them. editedSystem outlives the system it was seeded
+    // from, so saving without a baseline would persist values the user never
+    // touched, including an ISSO name the backend derived rather than stored.
+    // Refuse the save rather than writing a payload built from no baseline.
+    if (!system) {
+      notify(STATUS_MESSAGES.notSaved, 'error', { autoHideDuration: 1500 })
+      return
+    }
     setIsSaving(true)
     try {
       // Full-system PUT. The page-level Edit button is gated on isAdmin,
@@ -362,11 +378,18 @@ export default function SystemDetailPage() {
       )
 
       notify(STATUS_MESSAGES.saved, 'success', { autoHideDuration: 1500 })
-      setFismaSystems((prev) =>
-        prev.map((s) =>
-          s.fismasystemid !== editedSystem.fismasystemid ? s : editedSystem
-        )
-      )
+      // Refetch rather than echoing the local draft into state. The PUT returns
+      // no body, and the saved value of a field the backend resolves is not the
+      // value that was sent: clearing isso_name stores NULL, and the list read
+      // then resolves the name from the ISSO's user record. Echoing the draft
+      // would show the cleared field as empty until the next fetch.
+      //
+      // The caller's decommissioned view mode is preserved so saving does not
+      // change which systems the dashboard lists. That mode can exclude the
+      // system just saved, so clearing triedFetch lets the single-system
+      // fallback re-add it.
+      triedFetch.current = false
+      await fetchFismaSystems(showDecommissioned)
     } catch (error) {
       if (isAuthHandled(error)) return
       const parsed = parseApiError(error)

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -612,6 +612,7 @@ export default function SystemDetailPage() {
 
       <SystemDetailHeader
         systemName={system.fismaname}
+        fismaacronym={system.fismaacronym}
         canEdit={isAdmin}
         isEditing={isEditing}
         isSaving={isSaving}

--- a/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailReadView.test.tsx
@@ -83,14 +83,12 @@ describe('extended metadata formatting', () => {
     expect(screen.getByText('IaaS, PaaS')).toBeInTheDocument()
   })
 
-  test('applies the legacy field custom boolean labels', () => {
-    // legacy is a funding disposition; its label is "Not Funded for
-    // Remediation", so true reads "Not funded" rather than a double-negative
-    // "Yes".
+  test('renders the legacy field with default Yes/No labels', () => {
+    // legacy is a plain legacy-system flag labeled "Legacy System", so true
+    // reads as the default "Yes".
     renderWithExtended({ legacy: true })
-    expect(screen.getByText('Not Funded for Remediation')).toBeInTheDocument()
-    expect(screen.getByText('Not funded')).toBeInTheDocument()
-    expect(screen.queryByText('Yes')).not.toBeInTheDocument()
+    expect(screen.getByText('Legacy System')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
   })
 
   test('hides the extended card when only an empty array is present', () => {

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -11,11 +11,12 @@ export interface FieldConfig {
   required: boolean
   type: FieldType
   // Display-only: rendered but never editable and excluded from the write
-  // payload. Used for values the backend resolves/owns (e.g. isso_name).
+  // payload. For a value whose only writer is the backend.
   readOnly?: boolean
-  // Short guidance shown under the control while editing. For terms of art
-  // whose label alone is ambiguous or easily misread. Rendered only when set;
-  // there is no backend dependency, the copy lives here.
+  // Short guidance shown under the control while editing. For a label that is
+  // ambiguous or easily misread on its own, or a value whose write semantics
+  // need saying at the point of edit. Rendered only when set; there is no
+  // backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
   // its read-view text). For a field whose label reads ambiguously against a
@@ -108,17 +109,20 @@ export const fieldConfigs: FieldConfig[] = [
     type: 'email',
   },
 
-  // Extended Metadata section. Standard system attributes editable by any
-  // write admin across all OpDivs. isso_name is the exception: the backend
-  // resolves it (from the ISSO user record for CMS, from the import for HHS),
-  // so it is display-only here and the edit form still edits issoemail.
+  // Extended Metadata section. The system attributes below are writable only by
+  // an unscoped admin; the backend restores the stored values over anything an
+  // OpDiv-scoped admin sends for them. isso_name is the exception, writable by
+  // any write admin: a stored value overrides the name the backend derives from
+  // the ISSO user record, and the empty string clears it so the derived name
+  // applies again.
   {
     key: 'isso_name',
     label: 'ISSO Name',
     section: 'extended',
     required: false,
     type: 'text',
-    readOnly: true,
+    helpText:
+      "A name entered here overrides the name from the ISSO's user account. Clear the field to show that name again.",
   },
   {
     key: 'hva',
@@ -204,10 +208,9 @@ export function getFieldsBySection(section: FieldSection): FieldConfig[] {
 }
 
 // Single source of truth for the extended metadata write list. Derived from the
-// `extended` section above (excluding read-only fields like isso_name) so a
-// field added to fieldConfig can't silently render-but-not-save, and a
-// display-only field can't silently be written (the modal/detail PUT loops
-// consume this).
+// `extended` section above (excluding read-only fields) so a field added to
+// fieldConfig can't silently render-but-not-save, and a display-only field
+// can't silently be written (the modal/detail PUT loops consume this).
 export const EXTENDED_METADATA_KEYS: (keyof FismaSystemType)[] = fieldConfigs
   .filter((f) => f.section === 'extended' && !f.readOnly)
   .map((f) => f.key)

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -18,8 +18,9 @@ export interface FieldConfig {
   // there is no backend dependency, the copy lives here.
   helpText?: string
   // Overrides the Yes/No labels on a `boolean` field's tri-state control (and
-  // its read-view text). For a negatively-phrased label where Yes/No would read
-  // as a double negative. Unknown stays Unknown.
+  // its read-view text). For a field whose label reads ambiguously against a
+  // plain Yes/No (e.g. a negatively-phrased label where "No" is a double
+  // negative). Unknown stays Unknown.
   booleanLabels?: { true: string; false: string }
 }
 
@@ -191,15 +192,10 @@ export const fieldConfigs: FieldConfig[] = [
   },
   {
     key: 'legacy',
-    label: 'Not Funded for Remediation',
+    label: 'Legacy System',
     section: 'extended',
     required: false,
     type: 'boolean',
-    booleanLabels: { true: 'Not funded', false: 'Funded' },
-    helpText:
-      'HHS has not committed funding to remediate known gaps on this system. ' +
-      "This is a funding disposition, not a judgement about the system's age " +
-      'or technology.',
   },
 ]
 

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -43,6 +43,13 @@ jest.mock('@/utils/notify', () => ({
   isAuthHandled: jest.fn(),
 }))
 
+// Cross-tab logout signal (#606); mock so the test can assert it fires on
+// sign-out without constructing a real BroadcastChannel.
+jest.mock('@/utils/sessionSync', () => ({
+  __esModule: true,
+  broadcastLogout: jest.fn(),
+}))
+
 // Heavy children the logout affordance does not depend on. Stubbing them keeps
 // the test focused on the header menu and avoids their own asset/network deps.
 jest.mock('@/components/EmailModal/EmailModal', () => ({
@@ -86,6 +93,7 @@ import axiosInstance from '@/axiosConfig'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
 import { notify } from '@/utils/notify'
+import { broadcastLogout } from '@/utils/sessionSync'
 import Title from './Title'
 
 const mockedUseLoaderData = useLoaderData as jest.Mock
@@ -95,6 +103,7 @@ const mockedPost = axiosInstance.post as jest.Mock
 const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
 const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
 const mockedNotify = notify as jest.Mock
+const mockedBroadcastLogout = broadcastLogout as jest.Mock
 
 function makeUser(role: UserRole): userData {
   return {
@@ -200,6 +209,8 @@ describe('Title logout affordance', () => {
     // Toast fires immediately (before the await), covering the click-to-
     // reload gap with visible feedback.
     expect(mockedNotify).toHaveBeenCalledWith('Signing out...', 'info')
+    // Every other open tab is signalled to tear down too.
+    expect(mockedBroadcastLogout).toHaveBeenCalled()
   })
 
   it('still redirects to sign-in when the logout request fails', async () => {
@@ -218,6 +229,8 @@ describe('Title logout affordance', () => {
       expect(window.location.reload as jest.Mock).toHaveBeenCalled()
     )
     expect(window.location.hash).toBe(Routes.SIGNIN)
+    // Broadcast is independent of the POST result (best-effort).
+    expect(mockedBroadcastLogout).toHaveBeenCalled()
     errSpy.mockRestore()
   })
 })

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -34,6 +34,7 @@ import type { AuthLoaderData } from '@/router/authLoader'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
 import { notify } from '@/utils/notify'
+import { broadcastLogout } from '@/utils/sessionSync'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import LoginPage from '../LoginPage/LoginPage'
@@ -274,6 +275,9 @@ export default function Title() {
     } catch (error) {
       console.error('Error logging out:', error)
     }
+    // Best-effort and independent of the POST result, matching the "even if
+    // the request fails we still drop to sign-in" contract above.
+    broadcastLogout()
     window.location.hash = Routes.SIGNIN
     window.location.reload()
   }

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -35,6 +35,7 @@ import {
   hasAdminRead,
   hasUnscopedRead,
   isOpDivTier,
+  isUnscopedWriteAdmin,
   selectableRoles,
 } from '@/utils/userRoles'
 import { fetchOpDivs } from '@/utils/opdivs'
@@ -181,6 +182,12 @@ export default function UserTable() {
   const [opdivOptions, setOpDivOptions] = useState<OpDiv[]>([])
   // opdiv_id -> code, for rendering the OpDivs membership column.
   const [opdivCodeMap, setOpDivCodeMap] = useState<Record<number, string>>({})
+  // opdiv_id -> { code, name }, a full label source (incl. parent/inactive) so
+  // the grant modal can label grants to non-assignable OpDivs, which are absent
+  // from its scoped options list.
+  const [opdivLabelMap, setOpDivLabelMap] = useState<
+    Record<number, { code: string; name: string }>
+  >({})
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older
@@ -570,10 +577,13 @@ export default function UserTable() {
       try {
         const all = await fetchOpDivs(true)
         const codeMap: Record<number, string> = {}
+        const labelMap: Record<number, { code: string; name: string }> = {}
         all.forEach((od) => {
           codeMap[od.opdiv_id] = od.code
+          labelMap[od.opdiv_id] = { code: od.code, name: od.name }
         })
         setOpDivCodeMap(codeMap)
+        setOpDivLabelMap(labelMap)
 
         let assignable = all.filter((od) => !od.is_parent && od.active)
         if (isOpDivTier(userInfo)) {
@@ -585,6 +595,7 @@ export default function UserTable() {
         // Non-fatal: the grant modal simply shows no options if this fails.
         setOpDivOptions([])
         setOpDivCodeMap({})
+        setOpDivLabelMap({})
       }
     }
     loadOpDivs()
@@ -924,6 +935,17 @@ export default function UserTable() {
         userid={opdivModalUserId}
         userName={opdivModalUserName}
         opdivOptions={opdivOptions}
+        opdivLabelMap={opdivLabelMap}
+        // Scoped callers (every admin except an unscoped write admin) must not
+        // silently revoke the target's out-of-scope grants on save, so gate the
+        // save-time filter for them. Unscoped write admins (OWNER/HHS_ADMIN)
+        // send the grant set as-is. This is the inverse of the backend's
+        // unscoped-write branch, the predicate it actually decides on.
+        enforceCallerScope={!isUnscopedWriteAdmin(userInfo)}
+        // The caller's RAW grants (unfiltered by parent/active) - the save-time
+        // preserve boundary. Wider than opdivOptions so a caller-held grant to a
+        // since re-parented/deactivated OpDiv is preserved, not silently revoked.
+        callerGrantIds={userInfo.assignedopdivids ?? []}
         onChanged={refreshUserRow}
       />
       <ConfirmDialog


### PR DESCRIPTION
Automated nightly sync of `main` into `impl` — **main wins every overlap**.

This branch is `impl` with `main` merged in using `-X theirs`, so the result is deterministic: main's version wins any conflict, and impl-only files that don't conflict are preserved. There should be nothing to hand-resolve.

⚠️ **Merge this with a MERGE COMMIT, not squash.** `main` and `impl` share no squash ancestry; squashing here would leave them diverged and every future nightly sync would re-conflict. A merge commit re-establishes shared ancestry and closes the gap.

- Review the net change, then merge (merge commit). Merging pushes to `impl` and triggers the impl deploy (orchestration-impl).
- To smoke-test the merged result in the impl environment first, run **Manual Deploy to IMPL** with `--ref automation/sync-main-to-impl`.

_Opened by the nightly-impl-sync workflow._
