### PR TITLE
Adjust required fields for system edit form to allow saving with blank values 

### DIFF
--- a/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
@@ -1,0 +1,180 @@
+// A blank Component, Data Call Contact, or ISSO Email must not block editing an
+// unrelated field on a system onboarded without those values; the four fields
+// the backend needs on every record still gate the save.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+import MockAdapter from 'axios-mock-adapter'
+import SystemDetailPage from './SystemDetailPage'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, userData } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+
+// The four required fields are present; Component, Data Call Contact, and ISSO
+// Email were never collected.
+const NON_CMS_SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Rebel Alliance Fleet Command',
+  fismaacronym: 'RAFC',
+  fismauid: 'UID-42',
+  component: '',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: '',
+  datacallcontact: '',
+  opdiv_id: 1,
+  decommissioned: false,
+  sdl_sync_enabled: false,
+  isso_name: '',
+  hva: null,
+  fips: null,
+  system_type: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+beforeEach(() => {
+  mock.reset()
+  mock
+    .onGet('/opdivs')
+    .reply(200, {
+      data: [
+        {
+          opdiv_id: 1,
+          code: 'CMS',
+          name: 'CMS',
+          active: true,
+          system_delegate_enabled: false,
+        },
+      ],
+    })
+    .onGet('/systemattributes')
+    .reply(200, { data: [] })
+})
+
+function renderPage(system: FismaSystemType = NON_CMS_SYSTEM) {
+  mockCtx = {
+    fismaSystems: [system],
+    setFismaSystems: jest.fn(),
+    userInfo: {
+      userid: '1',
+      email: 'mon.mothma@rebellion.org',
+      fullname: 'Mon Mothma',
+      role: 'OPDIV_ADMIN',
+    } as userData,
+    datacenterEnvironments: [],
+    fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
+    showDecommissioned: false,
+  }
+  return renderWithProviders(
+    <Routes>
+      <Route path="/systems/:fismasystemid" element={<SystemDetailPage />} />
+    </Routes>,
+    { initialEntries: ['/systems/42'] }
+  )
+}
+
+/** The header Edit button (matched by the CMS design-system class). */
+function pageEditButton(): HTMLElement {
+  return screen
+    .queryAllByRole('button', { name: 'Edit' })
+    .filter((button) => button.classList.contains('ds-c-button'))[0]
+}
+
+/** Captures the body of the page's full-system PUT. */
+function captureSave() {
+  const captured: { body?: Record<string, unknown> } = {}
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    captured.body = JSON.parse(config.data)
+    return [200, {}]
+  })
+  return captured
+}
+
+async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
+  await screen.findByText('System Identity')
+  await user.click(pageEditButton())
+  await screen.findByRole('textbox', { name: 'ISSO Name' })
+}
+
+test('Save is enabled for a system with no Component, Data Call Contact, or ISSO Email', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  )
+})
+
+test('editing one field on such a system saves without filling the blank fields', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  const isso = screen.getByRole('textbox', { name: 'ISSO Name' })
+  await user.type(isso, 'General Dodonna')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // The blank fields are sent as-is, not demanded.
+  expect(captured.body).toHaveProperty('isso_name', 'General Dodonna')
+  expect(captured.body).toHaveProperty('component', '')
+  expect(captured.body).toHaveProperty('issoemail', '')
+  expect(captured.body).toHaveProperty('datacallcontact', '')
+})
+
+test('clearing a hard-required field (FISMA Name) still blocks the save', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  await user.clear(screen.getByRole('textbox', { name: 'FISMA Name' }))
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  )
+})
+
+test('a malformed value typed into ISSO Email still blocks the save', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  // Optional-to-edit is not unvalidated: a present value must be a valid address.
+  await user.type(
+    screen.getByRole('textbox', { name: 'ISSO Email' }),
+    'not-an-email'
+  )
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  )
+})

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -135,24 +135,21 @@ export default function SystemDetailPage() {
   const [showReactivateForm, setShowReactivateForm] = useState(false)
   const [reactivatedByName, setReactivatedByName] = useState('')
 
+  // Only the fields required to edit gate the save; keep aligned with the
+  // required fields in fieldConfig.ts. component, datacallcontact, and issoemail
+  // are absent so a blank stored value cannot freeze an unrelated edit.
   const [formValid, setFormValid] = useState<FormValidType>({
-    issoemail: false,
-    datacallcontact: false,
     fismaname: false,
     fismaacronym: false,
     datacenterenvironment: false,
-    component: false,
     fismauid: false,
   })
 
   const [formValidErrorText, setFormValidErrorText] =
     useState<FormValidHelperText>({
-      issoemail: TEXTFIELD_HELPER_TEXT,
-      datacallcontact: TEXTFIELD_HELPER_TEXT,
       fismaname: TEXTFIELD_HELPER_TEXT,
       fismaacronym: TEXTFIELD_HELPER_TEXT,
       datacenterenvironment: TEXTFIELD_HELPER_TEXT,
-      component: TEXTFIELD_HELPER_TEXT,
       fismauid: TEXTFIELD_HELPER_TEXT,
     })
 
@@ -164,12 +161,9 @@ export default function SystemDetailPage() {
         sdl_sync_enabled: system.sdl_sync_enabled ?? false,
       })
       setFormValid({
-        issoemail: (system.issoemail?.length ?? 0) > 0,
-        datacallcontact: (system.datacallcontact?.length ?? 0) > 0,
         fismaname: (system.fismaname?.length ?? 0) > 0,
         fismaacronym: (system.fismaacronym?.length ?? 0) > 0,
         datacenterenvironment: (system.datacenterenvironment?.length ?? 0) > 0,
-        component: (system.component?.length ?? 0) > 0,
         fismauid: (system.fismauid?.length ?? 0) > 0,
       })
       setDecommissionDate(getTodayISO())

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -8,6 +8,9 @@ export interface FieldConfig {
   key: keyof FismaSystemType
   label: string
   section: FieldSection
+  // Required to edit, not to create: true blocks the save while the field is
+  // blank. Create-only requirements stay false here and are enforced in the
+  // add-system modal.
   required: boolean
   type: FieldType
   // Display-only: rendered but never editable and excluded from the write
@@ -58,8 +61,9 @@ export const fieldConfigs: FieldConfig[] = [
   {
     key: 'component',
     label: 'Component',
+    // A CMS concept with no OpDiv equivalent, so unset on most non-CMS systems.
     section: 'identity',
-    required: true,
+    required: false,
     type: 'text',
   },
   {
@@ -97,15 +101,19 @@ export const fieldConfigs: FieldConfig[] = [
   {
     key: 'issoemail',
     label: 'ISSO Email',
+    // Required to create, not to edit: a system loaded without an ISSO must not
+    // be frozen. A typed value is still format-checked.
     section: 'contacts',
-    required: true,
+    required: false,
     type: 'email',
   },
   {
     key: 'datacallcontact',
     label: 'Data Call Contact',
+    // Not collected at onboarding, so unset on nearly every non-CMS system. A
+    // typed value is still format-checked.
     section: 'contacts',
-    required: true,
+    required: false,
     type: 'email',
   },
 


### PR DESCRIPTION
Summary

Closes #667.

The system edit form re-validated the entire record against its create-time required-field rules on every single-field edit. Systems onboarded outside CMS arrive without a Component, Data Call Contact, or ISSO Email, so those blank stored values failed validation and froze the whole record: an OPDIV admin could not change the ISSO without first backfilling fields the system was never given. This blocked edits on every non-CMS system.

Root cause: the required-field rules live in two places that both have to agree before Save enables. fieldConfig.ts drives the edit view's rendering (error state, which validator runs), and a separate hardcoded formValid object in SystemDetailPage.tsx is the actual save gate (Object.values(formValid).every(...)). component, datacallcontact, and issoemail were required in both, so a blank value in any of them disabled Save regardless of what the user actually edited.

The distinction the fix encodes: required-to-create is not the same as required-to-edit. A system already exists by the time it reaches this form, so a value it was onboarded without must not freeze an unrelated edit.

Changes

- fieldConfig.ts: set component, datacallcontact, and issoemail to required: false. The two email fields switch to the optional validator (blank is valid, a typed value is still format-checked) and lose the required styling. Documented the required flag as "required to edit, not to create."
- SystemDetailPage.tsx: drop the same three keys from the formValid save gate (initial state and edit-mode seed), so a blank stored value no longer disables Save. The four fields the backend needs on every record stay required.

Acceptance criteria

- [x] fismaname, fismaacronym, fismauiemain required to edit.
- [x] component and datacallcontact no longer block the save; they stay on the form, editable, saved,
and displayed.
- [x] A missing stored issoemail no longer blocks an edit, but a typed value is still format-checked.
- [x] Creating a system still requires modal is a separate hardcoded surface,used in production only in create mode, and is untouched).
- [x] Editing an unrelated field on a ut backfilling the blank fields.

Testing

- New SystemDetailPage.requiredFields.e with all three fields blank; editingone field saves without filling the blanks; clearing a hard-required field still blocks; a malformed ISSO Email still blocks (optional is n
- Full SystemDetailPage suite green (79 passed), tsc --noEmit and eslint clean.
- Behavior-only fix; no visual change r rendering as required.