### PR TITLE
fix(#668): say what makes a carried-forward answer count

### DIFF
--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -108,6 +108,17 @@ describe('JustificationField', () => {
     ).toBeInTheDocument()
   })
 
+  it('names both ways to satisfy the pending review', () => {
+    // "Review the previous response" alone left users guessing what action
+    // clears the gate; the message must name the two that do.
+    render(<Harness />)
+    expect(
+      screen.getByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
+    ).toBeInTheDocument()
+  })
+
   it('copies the previous response into the submitted field after acceptance', () => {
     render(<Harness />)
     fireEvent.click(
@@ -120,7 +131,9 @@ describe('JustificationField', () => {
     ).toHaveValue(insight.last_score_notes)
     expect(screen.getByText('Added to response')).toBeInTheDocument()
     expect(
-      screen.queryByText('Review the previous response before continuing.')
+      screen.queryByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
     ).not.toBeInTheDocument()
   })
 

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -610,7 +610,7 @@ export default function JustificationField({
         >
           {priorInitializing
             ? 'Checking the previous response…'
-            : 'Review the previous response before continuing.'}
+            : 'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'}
         </Typography>
       )}
     </Box>

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1152,13 +1152,29 @@ describe('carried-forward confirmation', () => {
   const DEVICES_LINK =
     '/questionnaire/ssd-ex/FY2026_Q1/devices/imperial-device-management'
 
+  // The guidance sentence, asserted by exact text so a copy change has to be
+  // deliberate.
+  const HELPER_COPY =
+    'Review the carried-forward answer and confirm it, or write a new justification, before continuing.'
+
   // Serves a mutable scores list and, like the real backend, flips the
   // targeted row to done when the confirm endpoint is hit — so the refetch
   // after a confirm returns the confirmed row instead of resurrecting the
-  // original fixture.
-  function installScoreMocks(scores: Array<{ scoreid: number }>) {
+  // original fixture. Insights/OpDiv rows default to empty (the non-CMS
+  // variant); pass them to exercise the prior-response card.
+  function installScoreMocks(
+    scores: Array<{ scoreid: number }>,
+    {
+      insightRows = [] as unknown[],
+      opdivRows = [] as unknown[],
+    }: { insightRows?: unknown[]; opdivRows?: unknown[] } = {}
+  ) {
     let rows = scores
     axios.get.mockImplementation((url: string) => {
+      if (url === '/opdivs')
+        return Promise.resolve({ data: { data: opdivRows } })
+      if (url === 'insights')
+        return Promise.resolve({ data: { data: insightRows } })
       if (url.includes('/questions'))
         return Promise.resolve({ data: { data: QUESTIONS } })
       if (url.startsWith('scores'))
@@ -1284,6 +1300,62 @@ describe('carried-forward confirmation', () => {
         name: 'Confirm this answer is still accurate',
       })
     ).not.toBeInTheDocument()
+    // No action to take, so no instruction to take it.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
+  })
+
+  it('states what makes the carried answer count, and describes the Confirm button with it', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    expect(await screen.findByText(HELPER_COPY)).toBeInTheDocument()
+    // The reason is announced with the action, not as a second live region.
+    expect(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).toHaveAccessibleDescription(HELPER_COPY)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    )
+
+    // Confirmed: the instruction retires with the button.
+    expect(
+      await screen.findByText('Updated this data call')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
+  })
+
+  it('leaves the guidance to the prior-response card when one is shown', async () => {
+    // The insights variant blanks the field and explains itself through the
+    // card's own review message; a second sentence here would duplicate it.
+    installScoreMocks([carried7006()], {
+      insightRows: [
+        {
+          fismasystemid: 1002,
+          questionid: 900,
+          synced_at: '2026-07-14T00:00:00Z',
+          payload: {
+            last_score_notes: 'carried justification',
+            last_datacall: 'FY2025 Q1',
+          },
+        },
+      ],
+      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
+    })
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
   })
 
   it('renders no carried-forward treatment on a closed data call', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1257,7 +1257,7 @@ describe('carried-forward confirmation', () => {
     expect(saveScorePosts()).toHaveLength(0)
   })
 
-  it('yields the Confirm button to the edit path the moment the question is dirty', async () => {
+  it('yields the Confirm button and its guidance to the edit path the moment the question is dirty', async () => {
     installScoreMocks([carried7006()])
 
     renderAt(DEEP_LINK)
@@ -1265,16 +1265,59 @@ describe('carried-forward confirmation', () => {
     await screen.findByRole('button', {
       name: 'Confirm this answer is still accurate',
     })
+    expect(screen.getByText(HELPER_COPY)).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('radio', { name: /Advanced/ }))
+
     expect(
       screen.queryByRole('button', {
         name: 'Confirm this answer is still accurate',
       })
     ).not.toBeInTheDocument()
+    // The guidance retires with the button: once the user is editing, telling
+    // them to write a new justification describes what they are already doing.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
     // The badge still shows — the row is still unconfirmed until saved.
     expect(
       screen.getByText('Carried forward — not yet confirmed')
     ).toBeInTheDocument()
+  })
+
+  it('keeps the guidance off a resolved prior-response card, where the button returns', async () => {
+    // Pins !currentPriorResponse: a resolved review unblocks the button, so
+    // that term is the only thing keeping the strip quiet on insights
+    // questions, where the card owns the explanation.
+    installScoreMocks([carried7006()], {
+      insightRows: [
+        {
+          fismasystemid: 1002,
+          questionid: 900,
+          synced_at: '2026-07-14T00:00:00Z',
+          payload: {
+            last_score_notes: 'carried justification',
+            last_datacall: 'FY2025 Q1',
+          },
+        },
+      ],
+      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
+    })
+
+    renderAt(DEEP_LINK)
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+
+    // The review is resolved, so the Confirm button is offered...
+    expect(
+      await screen.findByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).toBeInTheDocument()
+    // ...but the card owns the explanation on this variant.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
   })
 
   it('shows the badge but no Confirm button to a read-only admin', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -645,11 +645,11 @@ export default function QuestionnarePage() {
     priorReviewBlocked:
       priorReviewState === 'pending' || priorReviewState === 'initializing',
   })
-  // Guidance under the review strip, for the variant that has no
-  // prior-response card of its own: that card carries its own review message,
-  // and two guidance lines on one question is worse than none.
-  const showCarryForwardHelper =
-    currentCarryState === 'unconfirmed' && !currentPriorResponse && !isReadOnly
+  // Derived from the button so the sentence and the action it describes cannot
+  // drift apart. !currentPriorResponse suppresses it on insights questions,
+  // where the card owns the explanation — a resolved review unblocks the
+  // button, so nothing else would.
+  const showCarryForwardHelper = showConfirmButton && !currentPriorResponse
   const [confirming, setConfirming] = React.useState(false)
   // The Complete-time summary dialog. null = closed.
   const [confirmSummary, setConfirmSummary] =
@@ -1778,17 +1778,11 @@ export default function QuestionnarePage() {
                       />
                     </>
                   )}
-                  {/* Directly under the field, styled to match the
-                      prior-response flow's own review message, so both variants
-                      put their instruction in the same place and voice. The
-                      verb differs — "confirm" rather than "insert", since there
-                      is no card to insert from here; the answer is pre-filled.
-                      So does the ending: "before continuing" is advisory on
-                      purpose, because Next is NOT blocked on this variant (only
-                      the prior-response review gates it), so wording that
-                      implied a hard gate would teach the wrong model. Plain
-                      text, not a live region: the chip below owns the
-                      announcement. */}
+                  {/* Sits where the prior-response flow puts its own review
+                      message, so both variants instruct in the same place.
+                      "before continuing" is advisory on purpose: Next is not
+                      blocked on this variant. Plain text, not a live region —
+                      the chip below owns the announcement. */}
                   {showCarryForwardHelper && (
                     <Typography
                       id={CARRY_FORWARD_HELPER_ID}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -116,6 +116,10 @@ const CssTextField = styled(TextField)({
     },
   },
 })
+// Ties the carried-forward guidance line to the Confirm button it explains, so
+// a screen reader hears the reason with the action.
+const CARRY_FORWARD_HELPER_ID = 'carried-forward-confirm-helper'
+
 const addSpace = (str: string) => {
   for (let i = 0; i < str.length; i++) {
     if (
@@ -641,6 +645,11 @@ export default function QuestionnarePage() {
     priorReviewBlocked:
       priorReviewState === 'pending' || priorReviewState === 'initializing',
   })
+  // Guidance under the review strip, for the variant that has no
+  // prior-response card of its own: that card carries its own review message,
+  // and two guidance lines on one question is worse than none.
+  const showCarryForwardHelper =
+    currentCarryState === 'unconfirmed' && !currentPriorResponse && !isReadOnly
   const [confirming, setConfirming] = React.useState(false)
   // The Complete-time summary dialog. null = closed.
   const [confirmSummary, setConfirmSummary] =
@@ -1769,6 +1778,26 @@ export default function QuestionnarePage() {
                       />
                     </>
                   )}
+                  {/* Directly under the field, styled to match the
+                      prior-response flow's own review message, so both variants
+                      put their instruction in the same place and voice. The
+                      verb differs — "confirm" rather than "insert", since there
+                      is no card to insert from here; the answer is pre-filled.
+                      So does the ending: "before continuing" is advisory on
+                      purpose, because Next is NOT blocked on this variant (only
+                      the prior-response review gates it), so wording that
+                      implied a hard gate would teach the wrong model. Plain
+                      text, not a live region: the chip below owns the
+                      announcement. */}
+                  {showCarryForwardHelper && (
+                    <Typography
+                      id={CARRY_FORWARD_HELPER_ID}
+                      sx={{ mt: 0.5, fontSize: 12, color: '#8a4b00' }}
+                    >
+                      Review the carried-forward answer and confirm it, or write
+                      a new justification, before continuing.
+                    </Typography>
+                  )}
                   <Box
                     sx={{
                       display: 'flex',
@@ -1843,6 +1872,11 @@ export default function QuestionnarePage() {
                           startIcon={<CheckCircleOutlineIcon />}
                           onClick={handleConfirmClick}
                           disabled={confirming}
+                          aria-describedby={
+                            showCarryForwardHelper
+                              ? CARRY_FORWARD_HELPER_ID
+                              : undefined
+                          }
                           sx={{ textTransform: 'none' }}
                         >
                           Confirm this answer is still accurate


### PR DESCRIPTION
Closes #668

## Problem

A pre-filled answer looks complete, so nothing on the page told users that leaving it untouched keeps it out of the data call's count. The two questionnaire variants failed differently, and both misled:

- **Carried-forward questions without a prior-response card** showed a state chip and a Confirm button but no instruction — no indication that skipping the button leaves the answer uncounted.
- **CMS / ZTMF Insights questions** did gate on review, but the message ("Review the previous response before continuing.") never named the actions that clear the gate. Worse, users who reasonably tried writing their own justification found Next still disabled with no explanation: typing never resolves the review, because only the card's **Insert into response** and **Dismiss** buttons call `onPriorReview` (`JustificationField.tsx:534`, `:545`).

## Changes

Copy only, positioned and styled identically in both variants — directly under the justification field, so the instruction lives in one place regardless of which flow the system gets.

**CMS / Insights** (`JustificationField.tsx`):

> Review the previous response and insert it, or dismiss it and write a new justification, to continue.

Both branches are accurate: Insert and Dismiss each unlock Next. Keeps `id="previous-response-review-message"` (the textarea's `aria-describedby` target), `role="status"`, and the "Checking the previous response…" initializing branch untouched.

**Carried-forward without a prior-response card** (`QuestionnairePage.tsx`):

> Review the carried-forward answer and confirm it, or write a new justification, before continuing.

The verb and the ending differ from the CMS string on purpose, because the behavior differs. There is no card to insert from — the answer is pre-filled into the field — so it says "confirm" rather than "insert". And Next is **not** blocked on this variant, so the line ends "before continuing": it reads as guidance on what to do next rather than a claim that the user is stopped, which is what a "to continue" ending would wrongly imply. Both variants stay one sentence in the same position and voice, so they read as one system.

Suppressed when a prior-response card is present (that card carries its own message — two guidance lines on one question is worse than none) and for read-only sessions (no action to take). Rendered as plain text rather than a second live region, since the state chip already owns the announcement, and tied to the Confirm button with `aria-describedby` so the reason is announced with the action.

## No behavior change

Next remains enabled and write-free on an unconfirmed carried-forward answer (#413's guarantee that browsing never stamps a viewer as an editor), and the CMS pending-review gate is untouched — it still disables Next until Insert or Dismiss. This PR adds no gating and changes no save path.

## Acceptance criteria

- [x] On a carried-forward question without a prior-response card, the page states in plain language that the answer needs to be confirmed or updated before moving on. Advisory rather than absolute: Next is not blocked on this variant, so the copy must not imply a hard gate (AC amended on #668 from an earlier "to count for this data call" phrasing, which read as a stronger claim than the behavior supports)
- [x] That guidance disappears once the answer is confirmed or edited, together with the Confirm button
- [x] It does not appear on questions that already show a prior-response review card, nor on any question that is not carried-forward-unconfirmed
- [x] The CMS / Insights pending-review message names both accepted actions (insert the prior response, or dismiss it and write your own)
- [x] A screen reader reaching the Confirm button hears why it exists; no dangling `aria-describedby` when the helper is not rendered; the static sentence is not announced twice
- [x] No behavior change: Next remains enabled and write-free on an unconfirmed non-CMS question, and the CMS gate still disables Next until Insert or Dismiss
- [x] The existing test pin on the old message string is updated so its negative assertion cannot pass vacuously; new tests cover the helper's presence, absence, and accessible description
- [x] Full suite, lint, and typecheck clean

## Testing

New coverage:
- `JustificationField.test.tsx` — the pending-review message names both actions (positive assertion; the pre-existing negative assertion was updated so it can no longer pass vacuously against a string that had been replaced)
- `QuestionnairePage.test.tsx` — the helper renders for an unconfirmed carried answer and the Confirm button carries it as its accessible description; the helper retires with the button after confirming; it is absent for read-only sessions; and it is absent when a prior-response card is showing (that path asserts the CMS message instead)

Results: 271 questionnaire tests, 802 full suite, lint clean, no new type errors.

Manual, against dev (~38.8k `not_started` rows in FY2026 ZTM): non-CMS systems (**SPS**, **NGSC**) show the helper under the field and it clears on Confirm; CMS systems (**ACO-OS**, **ABR**) show the new gate message, and Next stays disabled until Insert or Dismiss, then enables — including the previously confusing path where a user writes their own justification first.

## Follow-up

#669 covers the sidebar half of this feedback (hidden scrollbar, selection that never follows navigation, no sense of remaining work). Independent of this PR.
