### PR TITLE
Code freeze batch: approved frontend fixes (OpDiv scope, system edit required fields, confirm guidance)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -334,9 +334,8 @@ export type ScoreProgress = {
   questionsexpected: number
   // Distinct applicable questions with an answer at all, any status (ztmf#437).
   // The completion signal a closed call needs: imported/carried answers are
-  // answered but never "updated this cycle". Optional so the UI degrades to the
-  // prior score-presence proxy until the backend field is deployed.
-  questionsanswered?: number
+  // answered but never "updated this cycle".
+  questionsanswered: number
   questionsupdated: number
   lastupdatedat?: string | null
   updatedsincestart: boolean

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -931,7 +931,6 @@ export default function FismaTable({
         <ProgressCell
           entry={progress?.[params.row.fismasystemid]}
           isCurrentCall={isRowCurrentCall(params.row.fismasystemid)}
-          hasScore={Boolean(scores[params.row.fismasystemid])}
         />
       ),
     },

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -102,6 +102,25 @@ describe('progressSortValue', () => {
       progressSortValue(pastComplete, false)
     )
   })
+
+  it('returns a usable rank for a past-call row missing the answered count', () => {
+    // The type requires the field, so absence can only be reached at runtime
+    // against a response that omits it, and the cast is how the test expresses
+    // that. Without coalescing this returned NaN, which compares equal to every
+    // other rank and drops the row at an arbitrary position instead of ranking
+    // it. Zero is the honest rank: nothing recorded as answered.
+    const missingAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    const rank = progressSortValue(missingAnswered, false)
+    expect(Number.isNaN(rank)).toBe(false)
+    expect(rank).toBe(0)
+    // Ranks with the genuinely unanswered rather than above a partial call.
+    expect(rank).toBeLessThan(
+      progressSortValue({ ...untouchedEntry, questionsanswered: 10 }, false)
+    )
+  })
 })
 
 describe('progressTooltip', () => {
@@ -201,6 +220,22 @@ describe('ProgressCell', () => {
     expect(screen.getByText('0/41')).toBeInTheDocument()
     expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('renders 0/total on a past call when the answered count is missing', () => {
+    // Reachable only at runtime against a response that omits the field, which
+    // the cast expresses. The fraction interpolates the value directly and React
+    // drops undefined, so without coalescing this rendered a bare "/41" beside a
+    // warning chip. This is the one input where retiring the score-presence
+    // proxy changes what a reader sees, so it is pinned here.
+    const missingAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    render(<ProgressCell entry={missingAnswered} isCurrentCall={false} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -307,18 +307,40 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
   })
 
-  it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
-    // The field is now required on ScoreProgress, so absence can no longer be
-    // expressed through the type. It remains reachable at runtime against a
-    // backend that predates the field, which is exactly what the cell's
-    // fallback guards, so the cast is deliberate: it exercises the runtime
-    // path the type alone can no longer describe.
+  it('reads Not started on the current call when the answered count is absent', () => {
+    // The field is required on ScoreProgress, so absence is reachable only at
+    // runtime against a response that omits it, and the cast is how the test
+    // expresses that. Both branches now coalesce, so this reads as nothing
+    // answered rather than falling back to the retired "Not updated" wording.
     const withoutAnswered = {
       ...untouchedEntry,
       questionsanswered: undefined,
     } as unknown as ScoreProgress
     render(<ProgressCell entry={withoutAnswered} isCurrentCall={true} />)
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
+    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+  })
+
+  it('no longer renders the retired Not updated wording in any state', () => {
+    // The label had one emit site, so this is the guard against it coming back
+    // through a future conditional rather than a restatement of the cases above.
+    for (const entry of [
+      updatedEntry,
+      untouchedEntry,
+      { ...untouchedEntry, questionsanswered: 41 },
+      {
+        ...untouchedEntry,
+        questionsanswered: undefined,
+      } as unknown as ScoreProgress,
+    ]) {
+      for (const isCurrentCall of [true, false]) {
+        const { unmount } = render(
+          <ProgressCell entry={entry} isCurrentCall={isCurrentCall} />
+        )
+        expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
+        unmount()
+      }
+    }
   })
 
   it('describes the carried-forward state in the tooltip', () => {

--- a/src/views/FismaTable/progressColumn.test.tsx
+++ b/src/views/FismaTable/progressColumn.test.tsx
@@ -6,6 +6,7 @@ import { progressSortValue, progressTooltip } from './progressHelpers'
 const updatedEntry: ScoreProgress = {
   fismasystemid: 1,
   questionsexpected: 41,
+  questionsanswered: 12,
   questionsupdated: 12,
   lastupdatedat: '2026-07-01T15:30:00Z',
   updatedsincestart: true,
@@ -14,6 +15,7 @@ const updatedEntry: ScoreProgress = {
 const untouchedEntry: ScoreProgress = {
   fismasystemid: 2,
   questionsexpected: 41,
+  questionsanswered: 0,
   questionsupdated: 0,
   lastupdatedat: null,
   updatedsincestart: false,
@@ -52,6 +54,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -69,6 +72,7 @@ describe('progressSortValue', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -127,6 +131,7 @@ describe('progressTooltip', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -157,12 +162,14 @@ describe('ProgressCell', () => {
     expect(screen.getByText('Updated')).toBeInTheDocument()
   })
 
-  it('renders the fraction and a Not updated chip for a carried-over system', () => {
-    // A pre-populated questionnaire has answers but no edits this cycle -
-    // the whole point of ztmf#299 is that this renders as NOT updated.
+  it('renders the fraction and a laggard chip for an unstarted system', () => {
+    // No answers and no edits this cycle, so the cell shows the honest
+    // fraction alongside the warning chip. The fixture carries zero answers,
+    // which is the "Not started" half of the wording split; the carried-answers
+    // half is covered below.
     render(<ProgressCell entry={untouchedEntry} />)
     expect(screen.getByText('0/41')).toBeInTheDocument()
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
   })
 
   it('renders an em-dash when progress data is missing', () => {
@@ -176,6 +183,7 @@ describe('ProgressCell', () => {
     const empty: ScoreProgress = {
       fismasystemid: 3,
       questionsexpected: 0,
+      questionsanswered: 0,
       questionsupdated: 0,
       updatedsincestart: false,
     }
@@ -185,49 +193,25 @@ describe('ProgressCell', () => {
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
 
-  it('renders a neutral Complete chip for a scored past-call system', () => {
-    // ztmf#537: a past call reads 0 updates this cycle for everyone. A system
-    // with a score for that call was completed - show a neutral Complete chip,
-    // never the orange "0/40 Not updated" laggard chip.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={true}
-      />
-    )
-    expect(screen.getByText('Complete')).toBeInTheDocument()
+  it('renders 0/total + Incomplete for a fully-unanswered past call', () => {
+    // ztmf#537 kept a past call off the orange laggard chip; ztmf-ui#578
+    // retires the score-presence proxy, so a past call nobody answered reads
+    // an honest 0/41 with the neutral-warning Incomplete chip instead.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={false} />)
+    expect(screen.getByText('0/41')).toBeInTheDocument()
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
     expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
-    expect(screen.queryByText('0/41')).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
   })
 
   it('keeps the current-cycle chip for the same entry on the active call', () => {
-    // Same untouched entry, but on the current call it is a genuine laggard.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={true}
-        hasScore={true}
-      />
-    )
+    // Same untouched entry, but on the current call it is a genuine laggard,
+    // so it wears the warning chip rather than the past-call Incomplete one.
+    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
     expect(screen.getByText('0/41')).toBeInTheDocument()
-    expect(screen.getByText('Not updated')).toBeInTheDocument()
+    expect(screen.getByText('Not started')).toBeInTheDocument()
     expect(screen.queryByText('Complete')).not.toBeInTheDocument()
-  })
-
-  it('renders an em-dash for a past-call system with no score', () => {
-    // Defensive: a past-call row must never show the orange laggard chip even
-    // without a score to prove completion.
-    render(
-      <ProgressCell
-        entry={untouchedEntry}
-        isCurrentCall={false}
-        hasScore={false}
-      />
-    )
-    expect(screen.getByLabelText('No progress data')).toBeInTheDocument()
-    expect(screen.queryByText('Not updated')).not.toBeInTheDocument()
-    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+    expect(screen.queryByText('Incomplete')).not.toBeInTheDocument()
   })
 
   it('renders Complete for a fully-answered past call even with zero updates', () => {
@@ -238,7 +222,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 41 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('Complete')).toBeInTheDocument()
@@ -253,7 +236,6 @@ describe('ProgressCell', () => {
       <ProgressCell
         entry={{ ...untouchedEntry, questionsanswered: 10 }}
         isCurrentCall={false}
-        hasScore={true}
       />
     )
     expect(screen.getByText('10/41')).toBeInTheDocument()
@@ -291,9 +273,16 @@ describe('ProgressCell', () => {
   })
 
   it('keeps the legacy Not updated wording when questionsanswered is absent', () => {
-    // ztmf#437 may not be deployed everywhere; without the field the split
-    // would be a guess, so the cell keeps saying what it always said.
-    render(<ProgressCell entry={untouchedEntry} isCurrentCall={true} />)
+    // The field is now required on ScoreProgress, so absence can no longer be
+    // expressed through the type. It remains reachable at runtime against a
+    // backend that predates the field, which is exactly what the cell's
+    // fallback guards, so the cast is deliberate: it exercises the runtime
+    // path the type alone can no longer describe.
+    const withoutAnswered = {
+      ...untouchedEntry,
+      questionsanswered: undefined,
+    } as unknown as ScoreProgress
+    render(<ProgressCell entry={withoutAnswered} isCurrentCall={true} />)
     expect(screen.getByText('Not updated')).toBeInTheDocument()
   })
 

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -63,7 +63,12 @@ export function ProgressCell({
   // fully-answered past call is a neutral "Complete"; a partially-answered
   // one shows an honest answered/total with an "Incomplete" chip.
   if (!isCurrentCall) {
-    const answered = entry.questionsanswered
+    // Coalesce so a response that omits the count renders an honest 0/N rather
+    // than a bare "/N": the fraction interpolates the value directly, and React
+    // drops undefined from the output. The current-call branch below keeps its
+    // own null check because it has a distinct legacy wording to fall back to;
+    // here zero and missing describe the same state to the reader.
+    const answered = entry.questionsanswered ?? 0
     if (answered >= entry.questionsexpected) {
       return (
         <Tooltip title={progressTooltip(entry, { completed: true })}>

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -14,9 +14,10 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * "Updated this cycle" only has meaning for the current/active data call. For a
  * past call nobody has touched anything this cycle, so questionsupdated is 0 for
  * every system - showing "0/40 Not updated" wrongly reads a completed historical
- * call as missing (ztmf#537). A past call with a score for that system was
- * completed, so it gets a neutral "Complete" chip instead of the current-cycle
- * fraction and Updated/Not-updated chip.
+ * call as missing (ztmf#537). A past call is judged on how much of it was
+ * answered instead: fully answered reads as a neutral "Complete" chip, and
+ * partially answered keeps the answered/total fraction with an "Incomplete"
+ * chip, rather than the current-cycle Updated/Not-updated framing.
  *
  * States:
  *   - past call (isCurrentCall false), fully answered: neutral "Complete" chip;

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -66,9 +66,8 @@ export function ProgressCell({
   if (!isCurrentCall) {
     // Coalesce so a response that omits the count renders an honest 0/N rather
     // than a bare "/N": the fraction interpolates the value directly, and React
-    // drops undefined from the output. The current-call branch below keeps its
-    // own null check because it has a distinct legacy wording to fall back to;
-    // here zero and missing describe the same state to the reader.
+    // drops undefined from the output. Zero and missing describe the same state
+    // to the reader.
     const answered = entry.questionsanswered ?? 0
     if (answered >= entry.questionsexpected) {
       return (

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -19,9 +19,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * fraction and Updated/Not-updated chip.
  *
  * States:
- *   - past call (isCurrentCall false) with a score: neutral "Complete" chip -
- *     the score is the completion signal (ScoreProgress has no "total answered"
- *     field); the orange laggard chip never appears off the active call;
+ *   - past call (isCurrentCall false), fully answered: neutral "Complete" chip;
+ *     partially answered: answered/total fraction with an "Incomplete" chip.
+ *     The orange laggard chip never appears off the active call;
  *   - a system with no applicable questionnaire (0/0) renders a neutral
  *     "N/A" chip, not an orange "Not updated" one - it is not a laggard,
  *     there is nothing to nudge;
@@ -35,19 +35,14 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  * @param {boolean} [props.isCurrentCall=true] - Whether the row's displayed call
  *   is the current/active one. Defaults true so callers without call context
  *   keep the original current-cycle rendering.
- * @param {boolean} [props.hasScore=false] - Whether the system has a score for
- *   the displayed call. Used only for a past call, where a score means the call
- *   was completed.
  * @returns {JSX.Element} The progress cell.
  */
 export function ProgressCell({
   entry,
   isCurrentCall = true,
-  hasScore = false,
 }: {
   entry: ScoreProgress | undefined
   isCurrentCall?: boolean
-  hasScore?: boolean
 }) {
   if (!entry) {
     return <span aria-label="No progress data">—</span>
@@ -62,24 +57,12 @@ export function ProgressCell({
   // A past data call is closed: "updated this cycle" is meaningless, so never
   // show the orange laggard chip here. But completion is answered/total, NOT
   // updated/total - imported and carried-over answers are answered yet never
-  // "updated this cycle", so gating on updates (or on mere score presence)
-  // would either drop them or, worse, mask a partially-answered historical
-  // call as done. Prefer QuestionsAnswered (ztmf#437): a fully-answered past
-  // call is a neutral "Complete"; a partially-answered one shows an honest
-  // answered/total with an "Incomplete" chip. Until the backend field ships,
-  // fall back to the prior score-presence proxy.
+  // "updated this cycle", so gating on updates would either drop them or,
+  // worse, mask a partially-answered historical call as done (ztmf#437): a
+  // fully-answered past call is a neutral "Complete"; a partially-answered
+  // one shows an honest answered/total with an "Incomplete" chip.
   if (!isCurrentCall) {
     const answered = entry.questionsanswered
-    if (answered == null) {
-      if (!hasScore) {
-        return <span aria-label="No progress data">—</span>
-      }
-      return (
-        <Tooltip title={progressTooltip(entry, { completed: true })}>
-          <Chip size="small" label="Complete" variant="outlined" />
-        </Tooltip>
-      )
-    }
     if (answered >= entry.questionsexpected) {
       return (
         <Tooltip title={progressTooltip(entry, { completed: true })}>

--- a/src/views/FismaTable/progressColumn.tsx
+++ b/src/views/FismaTable/progressColumn.tsx
@@ -28,8 +28,9 @@ import { hasNoQuestionnaire, progressTooltip } from './progressHelpers'
  *     there is nothing to nudge;
  *   - current call, any genuine edit: "Updated" (green);
  *   - current call, zero updates: "Awaiting confirmation" (carried answers
- *     exist) or "Not started" (none do), both warning-colored laggards;
- *     legacy "Not updated" when questionsanswered is not served.
+ *     exist) or "Not started" (none do), both warning-colored laggards. A
+ *     response omitting the answered count reads as "Not started", the same
+ *     way the past-call branch treats it as zero.
  * @param {object} props - Component props.
  * @param {ScoreProgress | undefined} props.entry - The system's progress row;
  *   undefined renders an em-dash (progress fetch failed or not covered).
@@ -96,16 +97,16 @@ export function ProgressCell({
   // Zero updates splits two materially different states: carried-forward
   // answers awaiting confirmation vs no answers at all — a blanket "Not
   // updated" read as data loss to ISSOs who had just reviewed everything.
-  // questionsanswered may be absent until ztmf#437 is deployed everywhere;
-  // keep the legacy wording then rather than guessing.
-  const answered = entry.questionsanswered
+  // Coalesce as the past-call branch does, so both branches read the count the
+  // same way rather than one trusting the type and the other guarding against
+  // it. A response that omits the count describes a system with nothing
+  // recorded as answered, which is what "Not started" already says.
+  const answered = entry.questionsanswered ?? 0
   const label = updated
     ? 'Updated'
-    : answered == null
-      ? 'Not updated'
-      : answered > 0
-        ? 'Awaiting confirmation'
-        : 'Not started'
+    : answered > 0
+      ? 'Awaiting confirmation'
+      : 'Not started'
   return (
     <Tooltip title={progressTooltip(entry)}>
       <Box

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -29,9 +29,7 @@ export function hasNoQuestionnaire(entry: ScoreProgress | undefined): boolean {
  * For a PAST call the "-1 needs a nudge" ranking is wrong - a closed call has no
  * updates to chase, so ranking by questionsupdated would sort every historical
  * row to the laggard top, contradicting its own Complete/Incomplete chip. Past
- * calls are ranked by completion (answered/total) instead, never -1. Prefer
- * QuestionsAnswered (ztmf#437); without it, a past-call row with progress is
- * treated as complete (1) so it never ranks as urgent.
+ * calls are ranked by completion (answered/total, ztmf#437) instead, never -1.
  * @param {ScoreProgress | undefined} entry - The system's progress row.
  * @param {boolean} [isCurrentCall=true] - Whether the row's displayed call is
  *   the current/active one. Past calls sort by completion, not updates.
@@ -44,9 +42,10 @@ export function progressSortValue(
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
   if (!isCurrentCall) {
-    const answered = entry.questionsanswered
-    if (answered == null) return 1
-    return Math.min(Math.max(answered, 0) / entry.questionsexpected, 1)
+    return Math.min(
+      Math.max(entry.questionsanswered, 0) / entry.questionsexpected,
+      1
+    )
   }
   if (entry.questionsupdated <= 0) return -1
   return entry.questionsupdated / entry.questionsexpected

--- a/src/views/FismaTable/progressHelpers.ts
+++ b/src/views/FismaTable/progressHelpers.ts
@@ -42,8 +42,14 @@ export function progressSortValue(
   if (!entry) return 2
   if (entry.questionsexpected <= 0) return 1.5
   if (!isCurrentCall) {
+    // Coalesce before the arithmetic. The type says the field is always served,
+    // but a response that omits it would otherwise produce NaN here, and a NaN
+    // sort key compares equal to every other row, so the row lands in an
+    // arbitrary position rather than anywhere meaningful. Treating a missing
+    // count as zero ranks it with the genuinely unanswered, which is the
+    // honest reading and matches what the cell renders.
     return Math.min(
-      Math.max(entry.questionsanswered, 0) / entry.questionsexpected,
+      Math.max(entry.questionsanswered ?? 0, 0) / entry.questionsexpected,
       1
     )
   }

--- a/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.test.tsx
@@ -31,11 +31,13 @@ const mock = new MockAdapter(axiosInstance)
 
 const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const USER_ID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const CALLER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 
-// Represents the caller's grantable scope (children, active, and — for an
-// OPDIV_ADMIN — limited to their own OpDivs). OpDiv 99 is intentionally absent
-// so scope-filter tests can verify it is stripped from the PUT body.
-const opdivOptions: OpDiv[] = [
+// The full assignable universe: active, non-parent OpDivs, NOT narrowed to the
+// caller. The modal narrows this against the caller's fresh grants itself. 99 is
+// intentionally absent (parent/inactive) so it can only ever appear as a
+// current grant, never as a selectable option.
+const assignableOpDivs: OpDiv[] = [
   {
     opdiv_id: 1,
     code: 'AAA',
@@ -56,13 +58,20 @@ const opdivOptions: OpDiv[] = [
 
 // Full label source (incl. the non-assignable OpDiv 99, e.g. a parent/inactive
 // division), so the modal can label a grant to it even though it is absent from
-// opdivOptions. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
+// assignableOpDivs. Id 77 is intentionally absent to exercise the "OpDiv #{id}"
 // fallback.
 const opdivLabelMap: Record<number, { code: string; name: string }> = {
   1: { code: 'AAA', name: 'Division A' },
   2: { code: 'BBB', name: 'Division B' },
   99: { code: 'ZZZ', name: 'Parent Division' },
 }
+
+// The acting caller's own current grants, served fresh by the modal's on-open
+// fetch. Mutable so a test can change it between two opens (the staleness case).
+let callerGrants: number[] = [1, 2]
+// Status the caller-scope fetch returns; non-200 exercises the failure paths
+// (500 = generic error guard, 401 = auth redirect).
+let callerFetchStatus = 200
 
 function renderModal(
   overrides: Partial<React.ComponentProps<typeof OpDivGrantModal>> = {}
@@ -73,19 +82,37 @@ function renderModal(
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
       {...overrides}
     />
   )
 }
 
+// Waits for the modal's on-open fetches to settle (Save enabled = not loading).
+// Fetch-count-agnostic, so it survives the extra caller-scope fetch.
+const waitForReady = () =>
+  waitFor(() =>
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled()
+  )
+
 beforeEach(() => {
   mock.reset()
   mockedNavigate.mockReset()
+  callerGrants = [1, 2]
+  callerFetchStatus = 200
+  // The caller-scope fetch is read at request time, so mutating callerGrants
+  // (or callerFetchStatus) between opens changes what the next open sees.
+  mock
+    .onGet(`/users/${CALLER_ID}/assignedopdivs`)
+    .reply(() =>
+      callerFetchStatus === 200
+        ? [200, { data: callerGrants }]
+        : [callerFetchStatus, {}]
+    )
 })
 
 // Scoped caller (OPDIV_ADMIN, enforceCallerScope=true): the save strips
@@ -99,7 +126,7 @@ test('scoped caller: PUT body excludes grants the target holds outside caller sc
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
   renderModal({ enforceCallerScope: true })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -120,7 +147,7 @@ test('unscoped caller: PUT body preserves grants outside the assignable set', as
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
   renderModal({ enforceCallerScope: false })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -141,8 +168,9 @@ test('scoped caller: preserves a caller-held grant that is no longer assignable'
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  callerGrants = [1, 99]
+  renderModal()
+  await waitForReady()
 
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -150,6 +178,123 @@ test('scoped caller: preserves a caller-held grant that is no longer assignable'
   const body = JSON.parse(mock.history.put[0].data)
   expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 99]))
   expect(body.opdiv_ids).toHaveLength(2)
+})
+
+// The staleness AC: an OPDIV_ADMIN whose OWN grants change mid-session gets the
+// current scope on the NEXT open, no reload. First open the caller does not hold
+// 99; between opens they gain it; the second open must preserve the target's
+// grant to 99, not strip it (which the backend would then revoke). Fetching the
+// caller's scope fresh on each open is what makes the second open see the newer
+// set - a session-cached scope would still be missing 99.
+test('scoped caller: a mid-session scope change is picked up on the next open', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
+  mock.onPut(`/users/${USER_ID}/opdivs`).reply(204)
+
+  const modal = (open: boolean) => (
+    <OpDivGrantModal
+      open={open}
+      handleClose={jest.fn()}
+      userid={USER_ID}
+      userName="Test User"
+      assignableOpDivs={assignableOpDivs}
+      opdivLabelMap={opdivLabelMap}
+      enforceCallerScope={true}
+      callerUserId={CALLER_ID}
+      onChanged={jest.fn()}
+    />
+  )
+
+  // First open: caller does not hold 99 yet.
+  callerGrants = [1]
+  const { rerender } = renderWithProviders(modal(true))
+  await waitForReady()
+
+  // Close, the caller gains 99, then reopen.
+  rerender(modal(false))
+  callerGrants = [1, 99]
+  rerender(modal(true))
+  await waitForReady()
+
+  await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+  await waitFor(() => expect(mock.history.put).toHaveLength(1))
+  const body = JSON.parse(mock.history.put[0].data)
+  // The second open used the fresher scope, so 99 survives.
+  expect(body.opdiv_ids).toEqual(expect.arrayContaining([1, 99]))
+  expect(body.opdiv_ids).toHaveLength(2)
+})
+
+// The data-integrity guard: if the caller-scope fetch fails, the modal must
+// block the save. Filtering the target's grants against an empty fallback scope
+// would strip - and the backend then revoke - grants the caller actually holds.
+test('scoped caller: a caller-scope fetch failure disables the modal and blocks save', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerFetchStatus = 500
+
+  renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  expect(screen.getByRole('combobox')).toBeDisabled()
+  expect(mock.history.put).toHaveLength(0)
+})
+
+// A scoped caller whose own grants were all revoked mid-session has an empty
+// (but successfully fetched) scope. Save must be blocked so it can't PUT an
+// empty desired set - distinct from the fetch-failure guard: the picker is
+// enabled (load succeeded), only Save is blocked.
+test('scoped caller: an empty caller scope blocks save without a fetch error', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerGrants = []
+
+  renderModal()
+
+  // Picker enabled proves the load finished (not a loading/fetchFailed state)...
+  await waitFor(() => expect(screen.getByRole('combobox')).toBeEnabled())
+  // ...but Save stays disabled because the caller has no scope to grant from.
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+  expect(mock.history.put).toHaveLength(0)
+})
+
+// Both fetches failing surfaces exactly one error toast, not one per fetch.
+test('surfaces a single error snackbar when both fetches fail', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(500)
+  callerFetchStatus = 500
+
+  renderModal()
+
+  await screen.findByText(ERROR_MESSAGES.tryAgain)
+  expect(screen.getAllByText(ERROR_MESSAGES.tryAgain)).toHaveLength(1)
+})
+
+// A 401 on the caller-scope fetch (target ok) redirects to sign-in via the auth
+// interceptor and suppresses the generic error toast, same as a 401 on the
+// target fetch.
+test('a 401 on the caller-scope fetch redirects to sign-in without a generic toast', async () => {
+  mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 2] })
+  callerFetchStatus = 401
+
+  renderModal()
+
+  await waitFor(() => {
+    expect(mockedNavigate).toHaveBeenCalledWith(Routes.SIGNIN, {
+      replace: true,
+      state: { message: ERROR_MESSAGES.expired, reason: 'EXPIRED' },
+    })
+  })
+  expect(screen.queryByText(ERROR_MESSAGES.tryAgain)).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+})
+
+// Self-row: an admin opening the modal on their own row (userid === callerUserId)
+// hits the same endpoint for both fetches, so it must fire a single request.
+test('self-row: caller opening their own row fires a single grants fetch', async () => {
+  renderModal({ userid: CALLER_ID })
+  await waitForReady()
+
+  const selfGets = mock.history.get.filter(
+    (g) => g.url === `/users/${CALLER_ID}/assignedopdivs`
+  )
+  expect(selfGets).toHaveLength(1)
 })
 
 // A grant to a non-assignable OpDiv (99, absent from opdivOptions) still chips
@@ -180,8 +325,9 @@ test('dropdown excludes a non-assignable grant even though it chips', async () =
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [99] })
 
   renderModal()
-  // The grant chips (so the fetch has resolved and options are settled).
-  await screen.findByText('ZZZ - Parent Division')
+  // Wait for both fetches so the picker is enabled and the assignable set is
+  // narrowed against the caller's fresh scope.
+  await waitForReady()
 
   // Open the dropdown.
   await userEvent.click(screen.getByRole('combobox'))
@@ -199,11 +345,13 @@ test('dropdown excludes a non-assignable grant even though it chips', async () =
 test('scoped caller: a chip outside the caller scope is not deletable', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 2] })
+  // Caller holds [1, 2]; 99 is held by the target via another admin.
+  renderModal()
+  await waitForReady()
 
-  const inScope = (await screen.findByText('AAA - Division A')).closest(
-    '.MuiChip-root'
-  ) as HTMLElement
+  const inScope = screen
+    .getByText('AAA - Division A')
+    .closest('.MuiChip-root') as HTMLElement
   const outOfScope = screen
     .getByText('ZZZ - Parent Division')
     .closest('.MuiChip-root') as HTMLElement
@@ -218,11 +366,13 @@ test('scoped caller: a chip outside the caller scope is not deletable', async ()
 test('scoped caller: a caller-held but non-assignable chip stays deletable', async () => {
   mock.onGet(`/users/${USER_ID}/assignedopdivs`).reply(200, { data: [1, 99] })
 
-  renderModal({ enforceCallerScope: true, callerGrantIds: [1, 99] })
+  callerGrants = [1, 99]
+  renderModal()
+  await waitForReady()
 
-  const heldNonAssignable = (
-    await screen.findByText('ZZZ - Parent Division')
-  ).closest('.MuiChip-root') as HTMLElement
+  const heldNonAssignable = screen
+    .getByText('ZZZ - Parent Division')
+    .closest('.MuiChip-root') as HTMLElement
 
   expect(heldNonAssignable.querySelector('.MuiChip-deleteIcon')).not.toBeNull()
 })
@@ -249,7 +399,7 @@ test('success: modal closes and onChanged fires after save', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -266,7 +416,7 @@ test('modal stays open on save error and does not call onChanged', async () => {
   const onChanged = jest.fn()
   renderModal({ handleClose, onChanged })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.tryAgain)).toBeInTheDocument()
@@ -281,7 +431,7 @@ test('403 shows the permission snackbar and does not close the modal', async () 
   const handleClose = jest.fn()
   renderModal({ handleClose })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   expect(await screen.findByText(ERROR_MESSAGES.permission)).toBeInTheDocument()
@@ -293,7 +443,7 @@ test('401 redirects to sign-in without firing a generic error snackbar', async (
   mock.onPut(`/users/${USER_ID}/opdivs`).reply(401)
 
   renderModal()
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
   await waitFor(() => {
@@ -313,7 +463,7 @@ test('save button is disabled while the request is in flight', async () => {
   renderModal()
   const saveButton = screen.getByRole('button', { name: /^save$/i })
 
-  await waitFor(() => expect(mock.history.get).toHaveLength(1))
+  await waitForReady()
   await userEvent.click(saveButton)
 
   expect(saveButton).toBeDisabled()
@@ -379,10 +529,10 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
     />
   )
@@ -392,10 +542,10 @@ test('closing after a fetch failure resets error state so Save re-enables on reo
       handleClose={jest.fn()}
       userid={USER_ID}
       userName="Test User"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={jest.fn()}
     />
   )
@@ -444,16 +594,16 @@ test('stale fetch from a prior user is discarded when userid changes', async () 
       handleClose={jest.fn()}
       userid={USER_ID_B}
       userName="Test User B"
-      opdivOptions={opdivOptions}
+      assignableOpDivs={assignableOpDivs}
       opdivLabelMap={opdivLabelMap}
       enforceCallerScope={true}
-      callerGrantIds={[1, 2]}
+      callerUserId={CALLER_ID}
       onChanged={onChanged}
     />
   )
 
-  // Both GETs have been sent; user B's has already resolved.
-  await waitFor(() => expect(mock.history.get).toHaveLength(2))
+  // User B's fetches have resolved (Save enabled); user A's is still pending.
+  await waitForReady()
 
   // Release user A's stale fetch — the cancelled flag should swallow the result.
   resolveUserA()

--- a/src/views/OpDivGrantModal/OpDivGrantModal.tsx
+++ b/src/views/OpDivGrantModal/OpDivGrantModal.tsx
@@ -23,14 +23,16 @@ type Props = {
   userid: GridRowId
   userName: string
   /**
-   * Assignable OpDivs, already scoped by the caller (children only, active,
-   * and - for an OPDIV_ADMIN actor - limited to their own OpDivs). The modal
-   * does not re-scope; it renders exactly what it is given. Drives the dropdown.
+   * All assignable OpDivs (active, non-parent) - the full universe BEFORE any
+   * caller-scope narrowing. For a scoped caller the modal narrows this to the
+   * caller's own current grants itself, fetched fresh on open, so the dropdown
+   * reflects a mid-session change to the caller's grants rather than the
+   * session-old userInfo. Drives the dropdown.
    */
-  opdivOptions: OpDiv[]
+  assignableOpDivs: OpDiv[]
   /**
    * Full label source (all OpDivs, incl. parent/inactive), keyed by opdiv_id.
-   * Separate from opdivOptions so a grant to a non-assignable OpDiv still
+   * Separate from assignableOpDivs so a grant to a non-assignable OpDiv still
    * resolves to a readable chip instead of a blank one. Ids missing here fall
    * back to "OpDiv #{id}".
    */
@@ -44,18 +46,16 @@ type Props = {
    */
   enforceCallerScope: boolean
   /**
-   * The caller's RAW own-grant ids - the backend's true add/remove scope
-   * (IsAssignedOpDiv), unfiltered by parent/active. This is the save-time
-   * preserve boundary and MUST be a superset of the dropdown's assignable set:
-   * opdivOptions is additionally narrowed to !is_parent && active, so a grant
-   * the caller holds to an OpDiv that was later re-parented or deactivated is
-   * absent from opdivOptions but still in the caller's backend scope. Filtering
-   * the save on the narrower opdivOptions would strip such a grant from the PUT
-   * and the backend would then revoke it (its toRemove gate is pure grant
-   * membership) - the same silent-revocation this modal exists to prevent.
-   * Only consulted when enforceCallerScope is true.
+   * The acting admin's own user id. When enforceCallerScope is true the modal
+   * fetches this user's CURRENT OpDiv grants on open - the backend's true
+   * add/remove scope (IsAssignedOpDiv) - and uses that fresh set as BOTH the
+   * dropdown's assignable narrowing and the save-time preserve boundary. Read
+   * from a fresh fetch rather than the session userInfo, whose assignedopdivids
+   * is loaded once and never refreshed, so a mid-session grant change to the
+   * caller can't silently revoke a target's grant on save. Only fetched when
+   * enforceCallerScope is true.
    */
-  callerGrantIds: number[]
+  callerUserId: string
   /**
    * Fired after a successful save so the caller can refresh the user's row
    * (grants + derived identity_provider) against post-mutation server state.
@@ -68,31 +68,46 @@ export default function OpDivGrantModal({
   handleClose,
   userid,
   userName,
-  opdivOptions,
+  assignableOpDivs,
   opdivLabelMap,
   enforceCallerScope,
-  callerGrantIds,
+  callerUserId,
   onChanged,
 }: Props) {
   const [localOpDivs, setLocalOpDivs] = React.useState<number[]>([])
+  // The caller's own current grants, fetched fresh on open (scoped callers
+  // only). The backend's true add/remove scope (IsAssignedOpDiv), used for both
+  // the dropdown narrowing and the save-time preserve boundary.
+  const [callerGrantIds, setCallerGrantIds] = React.useState<number[]>([])
   const [saving, setSaving] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
   const [fetchFailed, setFetchFailed] = React.useState(false)
 
-  // The assignable set drives the dropdown (what may be newly selected).
-  const assignableIds = React.useMemo(
-    () => new Set(opdivOptions.map((od) => od.opdiv_id)),
-    [opdivOptions]
-  )
-
   // The caller's raw backend scope (IsAssignedOpDiv). Superset of assignableIds
   // - it also covers grants to OpDivs since re-parented/deactivated. Gates the
-  // scoped save and the chip lock, so both agree with what the backend will act
-  // on (see the callerGrantIds prop docs).
+  // scoped save and the chip lock, so both agree with what the backend acts on.
   const callerScope = React.useMemo(
     () => new Set(callerGrantIds),
     [callerGrantIds]
   )
+
+  // A scoped caller with no grants of their own has nothing they may grant, and
+  // a save would PUT an empty desired set. That is a no-op under the backend's
+  // grant-membership toRemove gate (nothing the caller doesn't hold is removed),
+  // but block it anyway: it avoids a pointless request and keeps the frontend
+  // safe if that gate ever changes. (During loading callerScope is empty too,
+  // but Save is already disabled by `loading`, so this only bites post-fetch.)
+  const callerHasNoScope = enforceCallerScope && callerScope.size === 0
+
+  // The dropdown's assignable set: all active/non-parent OpDivs, narrowed to the
+  // caller's own fresh scope for a scoped caller so it never offers an OpDiv the
+  // backend would 403 on. Kept a subset of callerScope, which is what keeps the
+  // save from stripping a legitimately-held grant.
+  const assignableIds = React.useMemo(() => {
+    const full = assignableOpDivs.map((od) => od.opdiv_id)
+    if (!enforceCallerScope) return new Set(full)
+    return new Set(full.filter((id) => callerScope.has(id)))
+  }, [assignableOpDivs, enforceCallerScope, callerScope])
 
   // Label from the full map (assignable or not), with an identifiable fallback
   // so a grant to an OpDiv missing from the map never chips blank.
@@ -130,13 +145,44 @@ export default function OpDivGrantModal({
       setLoading(true)
       setFetchFailed(false)
       setLocalOpDivs([])
-      fetchUserOpDivs(String(userid))
-        .then((grants) => {
-          if (!cancelled) setLocalOpDivs(grants)
-        })
-        .catch((error) => {
-          if (!cancelled) {
-            handleError(error)
+      setCallerGrantIds([])
+      // Fetch the target's grants and, for a scoped caller, the caller's own
+      // current grants. Fetching the caller's scope fresh (rather than reading
+      // the session-old userInfo) is what closes the staleness gap: an admin
+      // whose own grants changed mid-session gets the current scope on open.
+      // A seconds-wide open-to-save TOCTOU remains by design - a concurrent
+      // change to the caller's OWN grants during an active edit isn't caught
+      // until the next open. That's unclosable client-side (a save-time refetch
+      // only narrows it) and the backend's grant-membership gate is the final
+      // authority; don't move this to save-time to chase it.
+      // When the caller opens the modal on their OWN row the two are the same
+      // request, so reuse the one promise instead of an identical second GET.
+      const targetPromise = fetchUserOpDivs(String(userid))
+      const callerScopePromise = !enforceCallerScope
+        ? Promise.resolve<number[]>([])
+        : callerUserId === String(userid)
+          ? targetPromise
+          : fetchUserOpDivs(callerUserId)
+      Promise.allSettled([targetPromise, callerScopePromise])
+        .then(([targetRes, callerRes]) => {
+          if (cancelled) return
+          if (targetRes.status === 'fulfilled') setLocalOpDivs(targetRes.value)
+          if (callerRes.status === 'fulfilled')
+            setCallerGrantIds(callerRes.value)
+          // Either fetch failing blocks the save: a missing target list, or
+          // (worse) a missing caller scope, could revoke grants - fetchFailed
+          // disables the picker and Save so the empty fallback scope is never
+          // acted on. Surface a single error; a second identical toast when both
+          // fail adds nothing, and any 401 redirect is handled by the axios
+          // interceptor regardless of which reason we pass here.
+          const failure =
+            targetRes.status === 'rejected'
+              ? targetRes.reason
+              : callerRes.status === 'rejected'
+                ? callerRes.reason
+                : null
+          if (failure) {
+            handleError(failure)
             setFetchFailed(true)
           }
         })
@@ -150,8 +196,9 @@ export default function OpDivGrantModal({
       setFetchFailed(false)
       setLoading(false)
       setLocalOpDivs([])
+      setCallerGrantIds([])
     }
-  }, [open, userid, handleError])
+  }, [open, userid, callerUserId, enforceCallerScope, handleError])
 
   const handleSave = () => {
     setSaving(true)
@@ -251,7 +298,7 @@ export default function OpDivGrantModal({
         </CmsButton>
         <CmsButton
           onClick={handleSave}
-          disabled={saving || loading || fetchFailed}
+          disabled={saving || loading || fetchFailed || callerHasNoScope}
         >
           Save
         </CmsButton>

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.test.tsx
@@ -108,6 +108,17 @@ describe('JustificationField', () => {
     ).toBeInTheDocument()
   })
 
+  it('names both ways to satisfy the pending review', () => {
+    // "Review the previous response" alone left users guessing what action
+    // clears the gate; the message must name the two that do.
+    render(<Harness />)
+    expect(
+      screen.getByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
+    ).toBeInTheDocument()
+  })
+
   it('copies the previous response into the submitted field after acceptance', () => {
     render(<Harness />)
     fireEvent.click(
@@ -120,7 +131,9 @@ describe('JustificationField', () => {
     ).toHaveValue(insight.last_score_notes)
     expect(screen.getByText('Added to response')).toBeInTheDocument()
     expect(
-      screen.queryByText('Review the previous response before continuing.')
+      screen.queryByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
     ).not.toBeInTheDocument()
   })
 

--- a/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
+++ b/src/views/QuestionnairePage/JustificationField/JustificationField.tsx
@@ -610,7 +610,7 @@ export default function JustificationField({
         >
           {priorInitializing
             ? 'Checking the previous response…'
-            : 'Review the previous response before continuing.'}
+            : 'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'}
         </Typography>
       )}
     </Box>

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1152,13 +1152,29 @@ describe('carried-forward confirmation', () => {
   const DEVICES_LINK =
     '/questionnaire/ssd-ex/FY2026_Q1/devices/imperial-device-management'
 
+  // The guidance sentence, asserted by exact text so a copy change has to be
+  // deliberate.
+  const HELPER_COPY =
+    'Review the carried-forward answer and confirm it, or write a new justification, before continuing.'
+
   // Serves a mutable scores list and, like the real backend, flips the
   // targeted row to done when the confirm endpoint is hit — so the refetch
   // after a confirm returns the confirmed row instead of resurrecting the
-  // original fixture.
-  function installScoreMocks(scores: Array<{ scoreid: number }>) {
+  // original fixture. Insights/OpDiv rows default to empty (the non-CMS
+  // variant); pass them to exercise the prior-response card.
+  function installScoreMocks(
+    scores: Array<{ scoreid: number }>,
+    {
+      insightRows = [] as unknown[],
+      opdivRows = [] as unknown[],
+    }: { insightRows?: unknown[]; opdivRows?: unknown[] } = {}
+  ) {
     let rows = scores
     axios.get.mockImplementation((url: string) => {
+      if (url === '/opdivs')
+        return Promise.resolve({ data: { data: opdivRows } })
+      if (url === 'insights')
+        return Promise.resolve({ data: { data: insightRows } })
       if (url.includes('/questions'))
         return Promise.resolve({ data: { data: QUESTIONS } })
       if (url.startsWith('scores'))
@@ -1284,6 +1300,62 @@ describe('carried-forward confirmation', () => {
         name: 'Confirm this answer is still accurate',
       })
     ).not.toBeInTheDocument()
+    // No action to take, so no instruction to take it.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
+  })
+
+  it('states what makes the carried answer count, and describes the Confirm button with it', async () => {
+    installScoreMocks([carried7006()])
+
+    renderAt(DEEP_LINK)
+
+    expect(await screen.findByText(HELPER_COPY)).toBeInTheDocument()
+    // The reason is announced with the action, not as a second live region.
+    expect(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).toHaveAccessibleDescription(HELPER_COPY)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    )
+
+    // Confirmed: the instruction retires with the button.
+    expect(
+      await screen.findByText('Updated this data call')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
+  })
+
+  it('leaves the guidance to the prior-response card when one is shown', async () => {
+    // The insights variant blanks the field and explains itself through the
+    // card's own review message; a second sentence here would duplicate it.
+    installScoreMocks([carried7006()], {
+      insightRows: [
+        {
+          fismasystemid: 1002,
+          questionid: 900,
+          synced_at: '2026-07-14T00:00:00Z',
+          payload: {
+            last_score_notes: 'carried justification',
+            last_datacall: 'FY2025 Q1',
+          },
+        },
+      ],
+      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
+    })
+
+    renderAt(DEEP_LINK)
+
+    expect(
+      await screen.findByText(
+        'Review the previous response and insert it, or dismiss it and write a new justification, to continue.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
   })
 
   it('renders no carried-forward treatment on a closed data call', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -1257,7 +1257,7 @@ describe('carried-forward confirmation', () => {
     expect(saveScorePosts()).toHaveLength(0)
   })
 
-  it('yields the Confirm button to the edit path the moment the question is dirty', async () => {
+  it('yields the Confirm button and its guidance to the edit path the moment the question is dirty', async () => {
     installScoreMocks([carried7006()])
 
     renderAt(DEEP_LINK)
@@ -1265,16 +1265,59 @@ describe('carried-forward confirmation', () => {
     await screen.findByRole('button', {
       name: 'Confirm this answer is still accurate',
     })
+    expect(screen.getByText(HELPER_COPY)).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('radio', { name: /Advanced/ }))
+
     expect(
       screen.queryByRole('button', {
         name: 'Confirm this answer is still accurate',
       })
     ).not.toBeInTheDocument()
+    // The guidance retires with the button: once the user is editing, telling
+    // them to write a new justification describes what they are already doing.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
     // The badge still shows — the row is still unconfirmed until saved.
     expect(
       screen.getByText('Carried forward — not yet confirmed')
     ).toBeInTheDocument()
+  })
+
+  it('keeps the guidance off a resolved prior-response card, where the button returns', async () => {
+    // Pins !currentPriorResponse: a resolved review unblocks the button, so
+    // that term is the only thing keeping the strip quiet on insights
+    // questions, where the card owns the explanation.
+    installScoreMocks([carried7006()], {
+      insightRows: [
+        {
+          fismasystemid: 1002,
+          questionid: 900,
+          synced_at: '2026-07-14T00:00:00Z',
+          payload: {
+            last_score_notes: 'carried justification',
+            last_datacall: 'FY2025 Q1',
+          },
+        },
+      ],
+      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
+    })
+
+    renderAt(DEEP_LINK)
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Insert previous ISSO response into current response',
+      })
+    )
+
+    // The review is resolved, so the Confirm button is offered...
+    expect(
+      await screen.findByRole('button', {
+        name: 'Confirm this answer is still accurate',
+      })
+    ).toBeInTheDocument()
+    // ...but the card owns the explanation on this variant.
+    expect(screen.queryByText(HELPER_COPY)).not.toBeInTheDocument()
   })
 
   it('shows the badge but no Confirm button to a read-only admin', async () => {

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -645,11 +645,11 @@ export default function QuestionnarePage() {
     priorReviewBlocked:
       priorReviewState === 'pending' || priorReviewState === 'initializing',
   })
-  // Guidance under the review strip, for the variant that has no
-  // prior-response card of its own: that card carries its own review message,
-  // and two guidance lines on one question is worse than none.
-  const showCarryForwardHelper =
-    currentCarryState === 'unconfirmed' && !currentPriorResponse && !isReadOnly
+  // Derived from the button so the sentence and the action it describes cannot
+  // drift apart. !currentPriorResponse suppresses it on insights questions,
+  // where the card owns the explanation — a resolved review unblocks the
+  // button, so nothing else would.
+  const showCarryForwardHelper = showConfirmButton && !currentPriorResponse
   const [confirming, setConfirming] = React.useState(false)
   // The Complete-time summary dialog. null = closed.
   const [confirmSummary, setConfirmSummary] =
@@ -1778,17 +1778,11 @@ export default function QuestionnarePage() {
                       />
                     </>
                   )}
-                  {/* Directly under the field, styled to match the
-                      prior-response flow's own review message, so both variants
-                      put their instruction in the same place and voice. The
-                      verb differs — "confirm" rather than "insert", since there
-                      is no card to insert from here; the answer is pre-filled.
-                      So does the ending: "before continuing" is advisory on
-                      purpose, because Next is NOT blocked on this variant (only
-                      the prior-response review gates it), so wording that
-                      implied a hard gate would teach the wrong model. Plain
-                      text, not a live region: the chip below owns the
-                      announcement. */}
+                  {/* Sits where the prior-response flow puts its own review
+                      message, so both variants instruct in the same place.
+                      "before continuing" is advisory on purpose: Next is not
+                      blocked on this variant. Plain text, not a live region —
+                      the chip below owns the announcement. */}
                   {showCarryForwardHelper && (
                     <Typography
                       id={CARRY_FORWARD_HELPER_ID}

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -116,6 +116,10 @@ const CssTextField = styled(TextField)({
     },
   },
 })
+// Ties the carried-forward guidance line to the Confirm button it explains, so
+// a screen reader hears the reason with the action.
+const CARRY_FORWARD_HELPER_ID = 'carried-forward-confirm-helper'
+
 const addSpace = (str: string) => {
   for (let i = 0; i < str.length; i++) {
     if (
@@ -641,6 +645,11 @@ export default function QuestionnarePage() {
     priorReviewBlocked:
       priorReviewState === 'pending' || priorReviewState === 'initializing',
   })
+  // Guidance under the review strip, for the variant that has no
+  // prior-response card of its own: that card carries its own review message,
+  // and two guidance lines on one question is worse than none.
+  const showCarryForwardHelper =
+    currentCarryState === 'unconfirmed' && !currentPriorResponse && !isReadOnly
   const [confirming, setConfirming] = React.useState(false)
   // The Complete-time summary dialog. null = closed.
   const [confirmSummary, setConfirmSummary] =
@@ -1769,6 +1778,26 @@ export default function QuestionnarePage() {
                       />
                     </>
                   )}
+                  {/* Directly under the field, styled to match the
+                      prior-response flow's own review message, so both variants
+                      put their instruction in the same place and voice. The
+                      verb differs — "confirm" rather than "insert", since there
+                      is no card to insert from here; the answer is pre-filled.
+                      So does the ending: "before continuing" is advisory on
+                      purpose, because Next is NOT blocked on this variant (only
+                      the prior-response review gates it), so wording that
+                      implied a hard gate would teach the wrong model. Plain
+                      text, not a live region: the chip below owns the
+                      announcement. */}
+                  {showCarryForwardHelper && (
+                    <Typography
+                      id={CARRY_FORWARD_HELPER_ID}
+                      sx={{ mt: 0.5, fontSize: 12, color: '#8a4b00' }}
+                    >
+                      Review the carried-forward answer and confirm it, or write
+                      a new justification, before continuing.
+                    </Typography>
+                  )}
                   <Box
                     sx={{
                       display: 'flex',
@@ -1843,6 +1872,11 @@ export default function QuestionnarePage() {
                           startIcon={<CheckCircleOutlineIcon />}
                           onClick={handleConfirmClick}
                           disabled={confirming}
+                          aria-describedby={
+                            showCarryForwardHelper
+                              ? CARRY_FORWARD_HELPER_ID
+                              : undefined
+                          }
                           sx={{ textTransform: 'none' }}
                         >
                           Confirm this answer is still accurate

--- a/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
@@ -1,0 +1,180 @@
+// A blank Component, Data Call Contact, or ISSO Email must not block editing an
+// unrelated field on a system onboarded without those values; the four fields
+// the backend needs on every record still gate the save.
+
+// axiosConfig reads import.meta.env at module load and throws under @swc/jest.
+// Swap in a bare axios instance the MockAdapter can drive.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+// The page reads its shared state via useContextProp (useOutletContext).
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Route, Routes } from 'react-router-dom'
+import MockAdapter from 'axios-mock-adapter'
+import SystemDetailPage from './SystemDetailPage'
+import axiosInstance from '@/axiosConfig'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import type { FismaSystemType, userData } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+
+// The four required fields are present; Component, Data Call Contact, and ISSO
+// Email were never collected.
+const NON_CMS_SYSTEM = {
+  fismasystemid: 42,
+  fismaname: 'Rebel Alliance Fleet Command',
+  fismaacronym: 'RAFC',
+  fismauid: 'UID-42',
+  component: '',
+  datacenterenvironment: 'CMS-Cloud-AWS',
+  issoemail: '',
+  datacallcontact: '',
+  opdiv_id: 1,
+  decommissioned: false,
+  sdl_sync_enabled: false,
+  isso_name: '',
+  hva: null,
+  fips: null,
+  system_type: null,
+  cloud_system: null,
+  cloud_service_model: null,
+  cloud_vendor: null,
+  system_operator: null,
+  goco_coco_gogo: null,
+  system_owner: null,
+  system_owner_email: null,
+  legacy: null,
+} as unknown as FismaSystemType
+
+beforeEach(() => {
+  mock.reset()
+  mock
+    .onGet('/opdivs')
+    .reply(200, {
+      data: [
+        {
+          opdiv_id: 1,
+          code: 'CMS',
+          name: 'CMS',
+          active: true,
+          system_delegate_enabled: false,
+        },
+      ],
+    })
+    .onGet('/systemattributes')
+    .reply(200, { data: [] })
+})
+
+function renderPage(system: FismaSystemType = NON_CMS_SYSTEM) {
+  mockCtx = {
+    fismaSystems: [system],
+    setFismaSystems: jest.fn(),
+    userInfo: {
+      userid: '1',
+      email: 'mon.mothma@rebellion.org',
+      fullname: 'Mon Mothma',
+      role: 'OPDIV_ADMIN',
+    } as userData,
+    datacenterEnvironments: [],
+    fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
+    showDecommissioned: false,
+  }
+  return renderWithProviders(
+    <Routes>
+      <Route path="/systems/:fismasystemid" element={<SystemDetailPage />} />
+    </Routes>,
+    { initialEntries: ['/systems/42'] }
+  )
+}
+
+/** The header Edit button (matched by the CMS design-system class). */
+function pageEditButton(): HTMLElement {
+  return screen
+    .queryAllByRole('button', { name: 'Edit' })
+    .filter((button) => button.classList.contains('ds-c-button'))[0]
+}
+
+/** Captures the body of the page's full-system PUT. */
+function captureSave() {
+  const captured: { body?: Record<string, unknown> } = {}
+  mock.onPut(/fismasystems\/42$/).reply((config) => {
+    captured.body = JSON.parse(config.data)
+    return [200, {}]
+  })
+  return captured
+}
+
+async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
+  await screen.findByText('System Identity')
+  await user.click(pageEditButton())
+  await screen.findByRole('textbox', { name: 'ISSO Name' })
+}
+
+test('Save is enabled for a system with no Component, Data Call Contact, or ISSO Email', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  )
+})
+
+test('editing one field on such a system saves without filling the blank fields', async () => {
+  const captured = captureSave()
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  const isso = screen.getByRole('textbox', { name: 'ISSO Name' })
+  await user.type(isso, 'General Dodonna')
+  await user.click(screen.getByRole('button', { name: 'Save' }))
+
+  await waitFor(() => expect(captured.body).toBeDefined())
+  // The blank fields are sent as-is, not demanded.
+  expect(captured.body).toHaveProperty('isso_name', 'General Dodonna')
+  expect(captured.body).toHaveProperty('component', '')
+  expect(captured.body).toHaveProperty('issoemail', '')
+  expect(captured.body).toHaveProperty('datacallcontact', '')
+})
+
+test('clearing a hard-required field (FISMA Name) still blocks the save', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  await user.clear(screen.getByRole('textbox', { name: 'FISMA Name' }))
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  )
+})
+
+test('a malformed value typed into ISSO Email still blocks the save', async () => {
+  const user = userEvent.setup()
+  renderPage()
+
+  await enterEditMode(user)
+  // Optional-to-edit is not unvalidated: a present value must be a valid address.
+  await user.type(
+    screen.getByRole('textbox', { name: 'ISSO Email' }),
+    'not-an-email'
+  )
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  )
+})

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -135,24 +135,21 @@ export default function SystemDetailPage() {
   const [showReactivateForm, setShowReactivateForm] = useState(false)
   const [reactivatedByName, setReactivatedByName] = useState('')
 
+  // Only the fields required to edit gate the save; keep aligned with the
+  // required fields in fieldConfig.ts. component, datacallcontact, and issoemail
+  // are absent so a blank stored value cannot freeze an unrelated edit.
   const [formValid, setFormValid] = useState<FormValidType>({
-    issoemail: false,
-    datacallcontact: false,
     fismaname: false,
     fismaacronym: false,
     datacenterenvironment: false,
-    component: false,
     fismauid: false,
   })
 
   const [formValidErrorText, setFormValidErrorText] =
     useState<FormValidHelperText>({
-      issoemail: TEXTFIELD_HELPER_TEXT,
-      datacallcontact: TEXTFIELD_HELPER_TEXT,
       fismaname: TEXTFIELD_HELPER_TEXT,
       fismaacronym: TEXTFIELD_HELPER_TEXT,
       datacenterenvironment: TEXTFIELD_HELPER_TEXT,
-      component: TEXTFIELD_HELPER_TEXT,
       fismauid: TEXTFIELD_HELPER_TEXT,
     })
 
@@ -164,12 +161,9 @@ export default function SystemDetailPage() {
         sdl_sync_enabled: system.sdl_sync_enabled ?? false,
       })
       setFormValid({
-        issoemail: (system.issoemail?.length ?? 0) > 0,
-        datacallcontact: (system.datacallcontact?.length ?? 0) > 0,
         fismaname: (system.fismaname?.length ?? 0) > 0,
         fismaacronym: (system.fismaacronym?.length ?? 0) > 0,
         datacenterenvironment: (system.datacenterenvironment?.length ?? 0) > 0,
-        component: (system.component?.length ?? 0) > 0,
         fismauid: (system.fismauid?.length ?? 0) > 0,
       })
       setDecommissionDate(getTodayISO())

--- a/src/views/SystemDetailPage/fieldConfig.ts
+++ b/src/views/SystemDetailPage/fieldConfig.ts
@@ -8,6 +8,9 @@ export interface FieldConfig {
   key: keyof FismaSystemType
   label: string
   section: FieldSection
+  // Required to edit, not to create: true blocks the save while the field is
+  // blank. Create-only requirements stay false here and are enforced in the
+  // add-system modal.
   required: boolean
   type: FieldType
   // Display-only: rendered but never editable and excluded from the write
@@ -58,8 +61,9 @@ export const fieldConfigs: FieldConfig[] = [
   {
     key: 'component',
     label: 'Component',
+    // A CMS concept with no OpDiv equivalent, so unset on most non-CMS systems.
     section: 'identity',
-    required: true,
+    required: false,
     type: 'text',
   },
   {
@@ -97,15 +101,19 @@ export const fieldConfigs: FieldConfig[] = [
   {
     key: 'issoemail',
     label: 'ISSO Email',
+    // Required to create, not to edit: a system loaded without an ISSO must not
+    // be frozen. A typed value is still format-checked.
     section: 'contacts',
-    required: true,
+    required: false,
     type: 'email',
   },
   {
     key: 'datacallcontact',
     label: 'Data Call Contact',
+    // Not collected at onboarding, so unset on nearly every non-CMS system. A
+    // typed value is still format-checked.
     section: 'contacts',
-    required: true,
+    required: false,
     type: 'email',
   },
 

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -188,6 +188,10 @@ export default function UserTable() {
   const [opdivLabelMap, setOpDivLabelMap] = useState<
     Record<number, { code: string; name: string }>
   >({})
+  // All assignable OpDivs (active, non-parent), NOT narrowed to the caller's
+  // scope. The grant modal narrows this against the caller's fresh grants
+  // itself, so it isn't fed the session-old scope that opdivOptions carries.
+  const [allAssignableOpDivs, setAllAssignableOpDivs] = useState<OpDiv[]>([])
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older
@@ -585,7 +589,13 @@ export default function UserTable() {
         setOpDivCodeMap(codeMap)
         setOpDivLabelMap(labelMap)
 
-        let assignable = all.filter((od) => !od.is_parent && od.active)
+        const activeNonParent = all.filter((od) => !od.is_parent && od.active)
+        setAllAssignableOpDivs(activeNonParent)
+
+        // opdivOptions stays caller-narrowed for the inline EditOpDivCell. The
+        // grant modal does NOT use this; it narrows the full set against the
+        // caller's fresh scope itself, so it isn't fed this session-old value.
+        let assignable = activeNonParent
         if (isOpDivTier(userInfo)) {
           const own = new Set(userInfo.assignedopdivids ?? [])
           assignable = assignable.filter((od) => own.has(od.opdiv_id))
@@ -594,6 +604,7 @@ export default function UserTable() {
       } catch {
         // Non-fatal: the grant modal simply shows no options if this fails.
         setOpDivOptions([])
+        setAllAssignableOpDivs([])
         setOpDivCodeMap({})
         setOpDivLabelMap({})
       }
@@ -934,7 +945,7 @@ export default function UserTable() {
         handleClose={handleCloseOpDivModal}
         userid={opdivModalUserId}
         userName={opdivModalUserName}
-        opdivOptions={opdivOptions}
+        assignableOpDivs={allAssignableOpDivs}
         opdivLabelMap={opdivLabelMap}
         // Scoped callers (every admin except an unscoped write admin) must not
         // silently revoke the target's out-of-scope grants on save, so gate the
@@ -942,10 +953,11 @@ export default function UserTable() {
         // send the grant set as-is. This is the inverse of the backend's
         // unscoped-write branch, the predicate it actually decides on.
         enforceCallerScope={!isUnscopedWriteAdmin(userInfo)}
-        // The caller's RAW grants (unfiltered by parent/active) - the save-time
-        // preserve boundary. Wider than opdivOptions so a caller-held grant to a
-        // since re-parented/deactivated OpDiv is preserved, not silently revoked.
-        callerGrantIds={userInfo.assignedopdivids ?? []}
+        // The acting admin's own id. The modal fetches this user's CURRENT
+        // grants on open for its scope, rather than reading the session-old
+        // userInfo.assignedopdivids, so a mid-session grant change can't
+        // silently revoke a target's grant on save.
+        callerUserId={userInfo.userid}
         onChanged={refreshUserRow}
       />
       <ConfirmDialog


### PR DESCRIPTION
Frontend release train for the code freeze. **The queue is complete: every approved frontend PR is in, and this is now open for review and merge.** The backend counterpart is CMS-Enterprise/ztmf#521.

Closes #643
Closes #667
Closes #668
Closes #578

## What is in it

Approved PRs only, cherry-picked in the order they cleared review so each commit's entry point is auditable. Original authorship is preserved on every commit.

| Source | Author | Change | Closes |
| --- | --- | --- | --- |
| #650 | @tarratsco | Fresh caller scope in the Assign OpDivs modal | #643 |
| #670 | @tarratsco | Required fields on the system edit form allow saving with blank values | #667 |
| #671 | @costacalvin | State what makes a carried-forward answer count | #668 |
| #654 | @voidspooks, with follow-on commits from @jsos3-cms | Retire the hasScore score-presence proxy from ProgressCell, coalesce the answered count on the past-call branch, and retire the legacy wording fallback | #578 |

The first three touch disjoint files (`OpDivGrantModal` and `UserTable`, `SystemDetailPage`, `QuestionnairePage` and `JustificationField`), so their ordering is for readability rather than to avoid conflicts. Verified that reordering produces a byte-identical tree. #654 touches `FismaTable` and `types.ts`, also disjoint from the other three, and appending it was a fast-forward.

#654 carries five commits rather than one: @voidspooks' retirement, then a docblock correction, the past-call coalescing, the wording-fallback retirement, and a fix for a comment that the retirement made self-contradicting. @danielbowne reviewed the retirement decision and asked for that last fix specifically before merge.

## Disposition of everything else

Recorded in full, because four approved PRs sitting open alongside this batch invites the question of whether something was missed. Nothing was: every approved frontend PR is in.

**The four source PRs stay open and will close without merging.** #650, #670, #671, and #654 are all folded in here. That is why their `Closes` keywords are declared on this PR instead: a PR that closes unmerged never fires its own. After this merges, confirm each of #643, #667, #668, and #578 actually closed rather than assuming, since exactly this pattern left two issues open after an earlier combined PR.

**#646** is @voidspooks' fork original that #654 rehomes. Held as a draft so it cannot merge as a duplicate. It closes once this merges, pointing at #654.

**#584** is a dependency bump with no approval, so it stays out. It joins only if it gets one.

**#672 is deliberately absent from the `Closes` list above, and that is not an omission.** Its second half is resolved here, by the coalescing and wording-retirement commits in #654. Its first half, validating the response instead of casting it, is not: that is the app-wide casting pattern at 72 `axiosInstance` call sites and it belongs with **#619**. So #672 needs a manual close naming #619 for the remaining half, rather than an auto-close that would drop it. @danielbowne asked for that pointer explicitly.

**#619** stays open and is where the validation half lands. Nothing here changes it.

**ztmf#521** is the backend counterpart batch, tracked separately. No dependency in either direction.

## Verification on the combined branch

`tsc --noEmit` clean. `eslint ./src` 0 errors, with 2 pre-existing warnings in a file none of these PRs touch. Full jest suite **815 passed, 0 failed**, 3 skipped, across 58 suites. Every commit is signed.

The point of verifying the combination rather than trusting the individual PRs is that three green PRs can still interact once stacked. They do not here, but that is a result rather than an assumption.

## How this branch is maintained

Additions are appended, never reordered. Appending keeps the push a fast-forward, avoids re-hashing other contributors' commits, and keeps the "what joined when" history intact. Each addition gets a comment recording which PR joined and the verification result at that point.

Two things worth knowing while this stays open:

Any push dismisses an approval on this PR, so approvals are best collected now that the batch is final rather than per addition.

**A skipped check is not a pass.** While this was a draft both the Snyk job and the `ui` deploy were gated on `draft == false` and reported `skipping`, which reads as green at a glance. The runs that count are the ones from after the conversion. Older `skipping` entries stay visible on the checks tab because check-runs attach to the commit, so expect duplicate names with different results.

Noted for next time: the conversion did fire a fresh run here, and on ztmf#521 as well. The concern that marking ready would not spawn a run for an already-seen head did not materialise in either repo today, so the empty-commit workaround was not needed.

## After merge

The source PRs will close without merging, so their own `Closes` keywords will not fire. That is why all four tracking issues are declared on this PR instead. Any issue not listed here needs closing by hand, which currently means #672 and #646.



