### PR TITLE
Let select-all reach systems with no score rows

### DIFF
--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -53,10 +53,20 @@ beforeEach(() => {
   mockAxiosGet.mockResolvedValue(blobResponse)
 })
 
-function renderFooter(selectedRows: number[]) {
+function renderFooter(
+  selectedRows: number[],
+  extra: {
+    systemCallMap?: Record<number, number[]>
+    chosenCallMap?: Record<number, number>
+  } = {}
+) {
   return render(
     <MemoryRouter>
-      <CustomFooterSaveComponent {...baseProps} selectedRows={selectedRows} />
+      <CustomFooterSaveComponent
+        {...baseProps}
+        {...extra}
+        selectedRows={selectedRows}
+      />
     </MemoryRouter>
   )
 }
@@ -96,5 +106,29 @@ describe('CustomFooterSaveComponent download button', () => {
     // Must NOT be a bare export URL (no fsids = download everything)
     expect(calledUrl).not.toMatch(/\/export$/)
     expect(calledUrl).not.toMatch(/\/export\?$/)
+  })
+
+  it('targets a not-started system displayed call, not the active call', () => {
+    // A not-started system has no score-derived call (empty systemCallMap), but
+    // the dashboard shows it against call 7 (a past-year view). The export must
+    // target 7, not the active call 42 - otherwise a past-year export silently
+    // hits the wrong call once the backend starts returning rows for it.
+    renderFooter([3], { systemCallMap: {}, chosenCallMap: { 3: 7 } })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).not.toContain('/datacalls/42/export')
+    expect(calledUrl).toContain('fsids=3')
+  })
+
+  it('disables export when selected rows display different calls', () => {
+    // Two never-started rows shown against different calls have no single
+    // export target, so the button stays disabled rather than guessing.
+    renderFooter([3, 4], { systemCallMap: {}, chosenCallMap: { 3: 7, 4: 9 } })
+    expect(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    ).toBeDisabled()
   })
 })

--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -131,4 +131,34 @@ describe('CustomFooterSaveComponent download button', () => {
       screen.getByRole('button', { name: /download selected system answers/i })
     ).toBeDisabled()
   })
+
+  it('targets a scored system score-derived call', () => {
+    // A scored system resolves through systemCallMap (calls it has scores in),
+    // not the chosen-call fallback. Pins that the not-started fallback did not
+    // displace the original path.
+    renderFooter([1], { systemCallMap: { 1: [7] } })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).toContain('fsids=1')
+  })
+
+  it('exports a mixed scored + not-started selection sharing one call', () => {
+    // Scored system 1 has a score in call 7; not-started system 3 is displayed
+    // against call 7. They share one target, so export goes to call 7 with both
+    // ids rather than disabling or splitting.
+    renderFooter([1, 3], {
+      systemCallMap: { 1: [7] },
+      chosenCallMap: { 3: 7 },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).toContain('fsids=1')
+    expect(calledUrl).toContain('fsids=3')
+  })
 })

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -111,8 +111,8 @@ export function CustomFooterSaveComponent(
   // scores), so it would otherwise contribute nothing and let an
   // all-never-started selection fall through to the active call - wrong in a
   // past-year view. The dashboard still shows such a row against one chosen
-  // call (chosenCallMap, which buildDashboardMaps fills for every row), so fall
-  // back to that per row before the global active-call default.
+  // call (chosenCallMap, which buildDashboardMaps fills for every selectable
+  // row), so fall back to that per row before the global active-call default.
   const selectedCallIds = new Set<number>()
   const callMap = props.systemCallMap ?? {}
   const chosenMap = props.chosenCallMap ?? {}

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -50,7 +50,9 @@ import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresMo
 import { FismaTableProps } from '@/types'
 import type { ScoreAggregate, SystemScoreEntry, datacall } from '@/types'
 import { hasSystemAccess } from '@/utils/userRoles'
-import { TIERS } from '@/utils/tierStyles'
+import { ScoreCell } from './scoreColumn'
+import { scoreSortValue } from './scoreHelpers'
+import { isSystemSelectable } from './rowSelection'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
 import { resolveRowCallId, datacallNameComparator } from './rowCall'
@@ -848,38 +850,10 @@ export default function FismaTable({
       align: 'center',
       headerAlign: 'center',
       hideable: false,
-      valueGetter: (value) => {
-        const entry = scores[value.row.fismasystemid]
-        if (!entry || !entry.score) {
-          return 0
-        }
-        return entry.score.toFixed(2)
-      },
-      renderCell: (params) => {
-        const entry = scores[params.row.fismasystemid]
-        const score = entry?.score ?? 0
-        // Tier comes from the backend on /scores/aggregate; do not derive
-        // it from the numeric score. Cells without a tier render with no
-        // background fill so a transient deploy mismatch reads as
-        // "unknown" rather than a misleading color.
-        const backgroundColor = entry?.tier
-          ? TIERS[entry.tier]?.cell.backgroundColor ?? 'transparent'
-          : 'transparent'
-        return (
-          <Box
-            sx={{
-              border: 1,
-              p: 1,
-              px: 4,
-              borderRadius: 2,
-              borderColor: 'darkgray',
-              backgroundColor,
-            }}
-          >
-            {score.toFixed(2)}
-          </Box>
-        )
-      },
+      valueGetter: (value) => scoreSortValue(scores[value.row.fismasystemid]),
+      renderCell: (params) => (
+        <ScoreCell entry={scores[params.row.fismasystemid]} />
+      ),
     },
     {
       // Which call the row is displaying (ui#639), named plainly so a
@@ -1037,7 +1011,7 @@ export default function FismaTable({
       <DataGrid
         rows={filteredRows}
         isRowSelectable={(params: GridRowParams) =>
-          params.row.fismasystemid in scores
+          isSystemSelectable(params.row.fismasystemid, scores, progress)
         }
         // De-emphasize rows displaying a closed call while the open call is
         // in view (ui#639). Only in that mixed view: between calls, or on a

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -77,6 +77,7 @@ declare module '@mui/x-data-grid' {
     activeDataCallId: number
     scores: Record<number, SystemScoreEntry>
     systemCallMap?: Record<number, number[]>
+    chosenCallMap?: Record<number, number>
   }
   interface ToolbarPropsOverrides {
     filters: DashboardFilterState
@@ -105,10 +106,24 @@ export function CustomFooterSaveComponent(
   // rows' own call(s): if they all share one call, export that; an empty
   // provenance falls back to the active call; a selection that spans more than
   // one call has no single export target, so the button is disabled.
+  //
+  // A not-started system has no score-derived call (systemCallMap keys off
+  // scores), so it would otherwise contribute nothing and let an
+  // all-never-started selection fall through to the active call - wrong in a
+  // past-year view. The dashboard still shows such a row against one chosen
+  // call (chosenCallMap, which buildDashboardMaps fills for every row), so fall
+  // back to that per row before the global active-call default.
   const selectedCallIds = new Set<number>()
   const callMap = props.systemCallMap ?? {}
+  const chosenMap = props.chosenCallMap ?? {}
   for (const id of props.selectedRows ?? []) {
-    for (const cid of callMap[id as number] ?? []) selectedCallIds.add(cid)
+    const scoreCalls = callMap[id as number] ?? []
+    if (scoreCalls.length > 0) {
+      for (const cid of scoreCalls) selectedCallIds.add(cid)
+    } else {
+      const chosen = chosenMap[id as number]
+      if (chosen != null) selectedCallIds.add(chosen)
+    }
   }
   const exportCallId =
     selectedCallIds.size === 1
@@ -1038,6 +1053,7 @@ export default function FismaTable({
             activeDataCallId,
             scores,
             systemCallMap,
+            chosenCallMap,
           },
           toolbar: {
             filters,

--- a/src/views/FismaTable/rowSelection.test.ts
+++ b/src/views/FismaTable/rowSelection.test.ts
@@ -1,0 +1,37 @@
+import type { ScoreProgress, SystemScoreEntry } from '@/types'
+import { isSystemSelectable } from './rowSelection'
+
+const scores: Record<number, SystemScoreEntry> = { 1: { score: 3.5 } }
+const progress: Record<number, ScoreProgress> = {
+  2: {
+    fismasystemid: 2,
+    questionsexpected: 40,
+    questionsanswered: 0,
+    questionsupdated: 0,
+    lastupdatedat: null,
+    updatedsincestart: false,
+  },
+}
+
+describe('isSystemSelectable', () => {
+  it('selects a system that has a score row', () => {
+    expect(isSystemSelectable(1, scores, progress)).toBe(true)
+  })
+
+  it('selects a not-started system present only in progress', () => {
+    // The bug: a system with a progress row (40 expected / 0 updated) but no
+    // score row was unselectable, dropping exactly the not-started systems.
+    expect(isSystemSelectable(2, scores, progress)).toBe(true)
+  })
+
+  it('does not select a system absent from both maps', () => {
+    expect(isSystemSelectable(99, scores, progress)).toBe(false)
+  })
+
+  it('still selects a scored system when progress is missing entirely', () => {
+    // A failed /scores/progress fetch resolves to an empty map; the union with
+    // scores keeps scored rows selectable rather than disabling every checkbox.
+    expect(isSystemSelectable(1, scores, undefined)).toBe(true)
+    expect(isSystemSelectable(2, scores, undefined)).toBe(false)
+  })
+})

--- a/src/views/FismaTable/rowSelection.ts
+++ b/src/views/FismaTable/rowSelection.ts
@@ -1,0 +1,25 @@
+import type { ScoreProgress, SystemScoreEntry } from '@/types'
+
+/**
+ * Whether a dashboard row can be selected for the answers export.
+ *
+ * A system is selectable if it appears in the viewed data calls at all: with a
+ * score row or with a questionnaire-progress row. Keying off scores alone hid
+ * not-started systems (a progress row of 40 expected / 0 updated but no score
+ * yet), which are exactly the ones an OpDiv admin most needs to select, and
+ * left their checkbox permanently unchecked with no visible reason. The union
+ * with scores keeps scored rows selectable even if the progress fetch fails and
+ * resolves to an empty map; a not-started system exists only in progress, so it
+ * still needs that fetch to have succeeded to be selectable.
+ * @param {number} fismasystemid - The row's system id.
+ * @param {Record<number, SystemScoreEntry>} scores - Per-system score entries.
+ * @param {Record<number, ScoreProgress>} [progress] - Per-system progress rows.
+ * @returns {boolean} True when the row can be selected.
+ */
+export function isSystemSelectable(
+  fismasystemid: number,
+  scores: Record<number, SystemScoreEntry>,
+  progress?: Record<number, ScoreProgress>
+): boolean {
+  return fismasystemid in scores || fismasystemid in (progress ?? {})
+}

--- a/src/views/FismaTable/scoreColumn.test.tsx
+++ b/src/views/FismaTable/scoreColumn.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import type { SystemScoreEntry } from '@/types'
+import { ScoreCell } from './scoreColumn'
+import { scoreSortValue } from './scoreHelpers'
+
+describe('scoreSortValue', () => {
+  it('sorts a never-assessed system below a genuine zero', () => {
+    // The whole point of the column fix: "no score row" and "assessed at 0.00"
+    // must not collapse to the same value.
+    expect(scoreSortValue(undefined)).toBeLessThan(scoreSortValue({ score: 0 }))
+  })
+
+  it('returns the numeric score for an assessed system', () => {
+    expect(scoreSortValue({ score: 3.5 })).toBe(3.5)
+    expect(scoreSortValue({ score: 0 })).toBe(0)
+  })
+})
+
+describe('ScoreCell', () => {
+  it('reads "Not scored" for a system with no score row', () => {
+    render(<ScoreCell entry={undefined} />)
+    expect(screen.getByText('Not scored')).toBeInTheDocument()
+    // Never the shared 0.00 that hid these systems.
+    expect(screen.queryByText('0.00')).not.toBeInTheDocument()
+  })
+
+  it('renders a real 0.00 for a system genuinely assessed at zero', () => {
+    render(<ScoreCell entry={{ score: 0 }} />)
+    expect(screen.getByText('0.00')).toBeInTheDocument()
+    expect(screen.queryByText('Not scored')).not.toBeInTheDocument()
+  })
+
+  it('renders the two-decimal score for an assessed system', () => {
+    const entry: SystemScoreEntry = { score: 3.5 }
+    render(<ScoreCell entry={entry} />)
+    expect(screen.getByText('3.50')).toBeInTheDocument()
+  })
+})

--- a/src/views/FismaTable/scoreColumn.tsx
+++ b/src/views/FismaTable/scoreColumn.tsx
@@ -1,0 +1,38 @@
+import { Box } from '@mui/material'
+import type { SystemScoreEntry } from '@/types'
+import { TIERS } from '@/utils/tierStyles'
+
+/**
+ * The Zero Trust Score cell. A system with no aggregate row reads "Not scored"
+ * so it is distinguishable from a system genuinely assessed at 0.00, which the
+ * old shared 0.00 rendering hid. A scored cell keeps the tier-colored badge.
+ * @param {object} props - Component props.
+ * @param {SystemScoreEntry} [props.entry] - The system's score entry, if any.
+ * @returns {JSX.Element} The rendered cell.
+ */
+export function ScoreCell({ entry }: { entry?: SystemScoreEntry }) {
+  if (!entry) {
+    return <Box sx={{ color: 'text.secondary' }}>Not scored</Box>
+  }
+  const score = entry.score ?? 0
+  // Tier comes from the backend on /scores/aggregate; do not derive it from the
+  // numeric score. A cell without a tier renders with no fill so a transient
+  // deploy mismatch reads as "unknown" rather than a misleading color.
+  const backgroundColor = entry.tier
+    ? TIERS[entry.tier]?.cell.backgroundColor ?? 'transparent'
+    : 'transparent'
+  return (
+    <Box
+      sx={{
+        border: 1,
+        p: 1,
+        px: 4,
+        borderRadius: 2,
+        borderColor: 'darkgray',
+        backgroundColor,
+      }}
+    >
+      {score.toFixed(2)}
+    </Box>
+  )
+}

--- a/src/views/FismaTable/scoreHelpers.ts
+++ b/src/views/FismaTable/scoreHelpers.ts
@@ -1,0 +1,13 @@
+import type { SystemScoreEntry } from '@/types'
+
+/**
+ * Sort key for the Zero Trust Score column. A system with no aggregate row has
+ * never been assessed, so it sorts below a genuine zero and the two never
+ * interleave; a scored system sorts by its numeric score.
+ * @param {SystemScoreEntry | undefined} entry - The system's score entry, if any.
+ * @returns {number} The numeric sort key (-1 when never assessed).
+ */
+export function scoreSortValue(entry: SystemScoreEntry | undefined): number {
+  if (!entry) return -1
+  return entry.score ?? 0
+}


### PR DESCRIPTION
## Summary

Closes #678 (frontend half). Backend half tracked in CMS-Enterprise/ztmf#526; this PR is sequenced to merge together with it.

On the Home dashboard, select-all could not reach systems with no score rows in the viewed data calls, and their checkbox could not be ticked manually either. Nothing signaled the skip, so anything driven by the selection silently omitted exactly the not-started systems that most need attention. Compounding it, the Zero Trust Score column rendered 0.00 both for a genuine zero-score row and for a system with no row at all, so two rows that looked identical behaved differently.

Root cause: `FismaTable` gated row selection on membership in the scores map (built from `/scores/aggregate`), so a system only counted if it had a score row. A not-started system has a `/scores/progress` row (40 expected, 0 updated) but no score yet, so it was never selectable. The Score column's `valueGetter` returned 0 for a missing entry, rendering it identically to a genuine zero.

Since #655, `progressMap` already includes these not-started systems and passes them to `FismaTable` as progress, so the fix needs no new fetch.

## Changes

* **`rowSelection.ts` (new):** `isSystemSelectable(id, scores, progress)` gates selection on membership in scores OR progress, so any system present in the viewed calls is selectable. The union (not progress alone) keeps scored rows selectable if `/scores/progress` fails and resolves to an empty map.
* **`scoreColumn.tsx` / `scoreHelpers.ts` (new):** `ScoreCell` renders "Not scored" for a system with no aggregate row, distinct from a real 0.00, keeping the tier-colored badge for scored cells. `scoreSortValue` sorts a never-assessed system below a genuine zero so the two never interleave.
* **`FismaTable.tsx`:** wired in the three helpers; the inline score `valueGetter`/`renderCell` collapse to one-liners and the now-unused `TIERS` import moved into `scoreColumn.tsx`. The score `valueGetter` now returns a number (was a mixed string/number), which is correct for the `type: 'number'` column; a side effect is that quick-filter text matches the raw value ("3.5") rather than the formatted "3.50".
* **`FismaTable.tsx` (export footer):** the export call target now falls back to a row's displayed call (`chosenCallMap`, which `buildDashboardMaps` fills for every row) before the global active-call default. A not-started system has no score-derived call, so an all-never-started selection previously fell through to the active call, which is the wrong call in a past-year view. This becomes a live correctness bug the moment ztmf#526 makes those systems return export rows, so it is fixed here rather than deferred. `systemCallMap` stays score-derived (the #467 call picker and export button depend on it); only the footer's per-row fallback changed.

## Acceptance criteria

* [x] Select-all and the per-row checkbox can select not-started systems (present in progress, no score row).
* [x] A never-assessed system reads "Not scored", not 0.00; a genuine zero score system still reads 0.00.
* [x] "Not scored" sorts below a real zero rather than interleaving.
* [x] Scored rows stay selectable if the progress fetch fails.
* [x] An export of only never-started systems targets the call those rows are displayed against, not the active call (correct in a past-year view).
* [ ] Export file actually contains not-started systems: backend-owned. `FindAnswers` inner-joins on scores, so the file gains those rows only once CMS-Enterprise/ztmf#526 lands. This PR is sequenced to merge with it.

## Testing

* **`rowSelection.test.ts` (4):** scored selectable, not-started selectable (the bug fix), absent-from-both not selectable, and the failed-progress-fetch fallback.
* **`scoreColumn.test.tsx` (5):** "Not scored" vs real 0.00, and sort ordering (never-assessed below zero).
* **`FismaTable.test.tsx` (5):** footer export targeting, including the not-started displayed-call fallback and the multi-call disable guard.
* Full `FismaTable` + Home suites green (99 passed); `tsc --noEmit` and `eslint` clean.
* Behavior-only; no visual change beyond the Score column's "Not scored" badge.
