### PR TITLE
docs(types): record the isso_name read/write asymmetry on the field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,18 @@ export type FismaSystemType = {
   // Extended metadata fields, typed and canonicalized by the backend.
   // Enum strings carry a canonical value or null; the tri-state booleans are
   // true / false / null = Unknown; cloud_service_model is a decomposed list.
+  //
+  // isso_name is asymmetric between read and write, and that asymmetry is the
+  // contract. A read may return either the stored override or a name the backend
+  // resolved from the ISSO's user record, and the payload does not say which. A
+  // write always stores. So echoing back a value the user did not edit converts a
+  // resolved name into a permanent stored override for that system, silently, and
+  // no server-side rule rejects it.
+  //
+  // The guarantee therefore lives in this client, by decision rather than by
+  // accident: send only the fields the user changed. buildExtendedDiff does that,
+  // and it needs a real baseline to work. Any move toward sending the whole
+  // object reintroduces the bug with every existing test still green.
   isso_name?: string | null
   hva?: boolean | null
   fips?: string | null


### PR DESCRIPTION
Records the decision on the ISSO Name field contract, taken on CMS-Enterprise/ztmf-misc#262. Comment-only, `+12/-0`, no behaviour change.

## Why

`isso_name` is asymmetric between read and write. A read may return either the stored override or a name the backend resolved from the ISSO's user record, and the payload does not say which. A write always stores. So echoing back a value the user did not edit converts a resolved name into a permanent stored override for that system, silently, and no server-side rule rejects it.

The decision was to keep one field and let the client hold the guarantee, rather than splitting the API into stored and resolved fields. That makes the dirty-diff part of the data model rather than a UI convenience, and a decision recorded only in a closed issue thread is a decision nobody will find.

## Why on the type rather than only at `buildExtendedDiff`

`buildExtendedDiff` already documents the omission rule and is what enforces it. But the realistic failure is a well-intentioned refactor toward "just send the whole object" that never opens the diff helper. Someone reaching for this field starts at its declaration, so the constraint belongs there too.

The rule for anyone following on is one line: send only the fields the user changed, and always pass a real baseline. A missing baseline defeats it just as thoroughly as sending everything, because every field then counts as changed.

## Scope note

This holds while `ztmf-ui` is the only writer of the field. A script, integration, or second client would not inherit the dirty-diff and the guarantee would evaporate on its first write. That is the condition that would reopen the separate-field question, and it is recorded on the epic rather than here.

## Verification

`tsc --noEmit` clean. `eslint ./src` 0 errors, with the 2 pre-existing warnings in a file this does not touch. No test changes, since nothing executable changed.
