### PR TITLE
test(users): pin the cell-level edit gates for the user grid

### DIFF
--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -42,6 +42,7 @@ import { fetchOpDivs } from '@/utils/opdivs'
 import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
+import { isUserCellEditable } from './cellEditGuards'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
@@ -845,28 +846,14 @@ export default function UserTable() {
           rows={rows}
           apiRef={apiRef}
           columns={columns}
-          // Cell-level edit gates (defense-in-depth; server enforces the same rules):
-          // - role: locked on existing rows whose current role is outside this
-          //   admin's assignable tier, preventing unauthorized role changes.
-          // - opdivs / identity_provider: locked to new rows only — existing
-          //   users' OpDiv memberships and derived IdP are managed via the
-          //   Assign OpDivs action, not inline editing.
-          isCellEditable={(params) => {
-            if (params.field === 'role') {
-              return (
-                params.row.isNew ||
-                !params.row.role ||
-                assignableRoles.includes(params.row.role)
-              )
-            }
-            if (params.field === 'opdivs') {
-              return !!params.row.isNew
-            }
-            if (params.field === 'identity_provider') {
-              return !!params.row.isNew && showIdpSelector
-            }
-            return true
-          }}
+          // Cell-level edit gates live in cellEditGuards so they can be tested
+          // without the grid. See that file for what each field allows and why.
+          isCellEditable={(params) =>
+            isUserCellEditable(params.field, params.row, {
+              assignableRoles,
+              showIdpSelector,
+            })
+          }
           editMode="row"
           getRowId={(row) => row.userid}
           initialState={{

--- a/src/views/UserTable/cellEditGuards.test.ts
+++ b/src/views/UserTable/cellEditGuards.test.ts
@@ -1,0 +1,83 @@
+import { isUserCellEditable } from './cellEditGuards'
+
+const ctx = { assignableRoles: ['ISSO', 'ISSM'], showIdpSelector: true }
+
+describe('isUserCellEditable', () => {
+  describe('opdivs', () => {
+    // This is the gate that makes the discard unreachable. processRowUpdate
+    // writes grants only on the create path, so an editable cell on an existing
+    // row would commit, report success, and drop the change. If this assertion
+    // ever fails, that bug is live again and the UI will claim it saved.
+    it('is not editable on an existing user', () => {
+      expect(isUserCellEditable('opdivs', { isNew: false }, ctx)).toBe(false)
+    })
+
+    it('is not editable when isNew is absent rather than false', () => {
+      expect(isUserCellEditable('opdivs', {}, ctx)).toBe(false)
+    })
+
+    it('is editable on a new row, which is the path that persists grants', () => {
+      expect(isUserCellEditable('opdivs', { isNew: true }, ctx)).toBe(true)
+    })
+  })
+
+  describe('identity_provider', () => {
+    it('is not editable on an existing user', () => {
+      expect(
+        isUserCellEditable('identity_provider', { isNew: false }, ctx)
+      ).toBe(false)
+    })
+
+    it('is editable on a new row when the IdP column applies', () => {
+      expect(
+        isUserCellEditable('identity_provider', { isNew: true }, ctx)
+      ).toBe(true)
+    })
+
+    it('stays locked on a new row when the IdP column does not apply', () => {
+      expect(
+        isUserCellEditable(
+          'identity_provider',
+          { isNew: true },
+          {
+            ...ctx,
+            showIdpSelector: false,
+          }
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('role', () => {
+    it('is editable when the current role is inside the assignable tier', () => {
+      expect(
+        isUserCellEditable('role', { isNew: false, role: 'ISSO' }, ctx)
+      ).toBe(true)
+    })
+
+    it('is locked when the current role is outside the assignable tier', () => {
+      // An admin who cannot grant OWNER must not be able to edit an OWNER's
+      // role, since the edit control would otherwise offer a downgrade.
+      expect(
+        isUserCellEditable('role', { isNew: false, role: 'OWNER' }, ctx)
+      ).toBe(false)
+    })
+
+    it('is editable on a row with no role yet', () => {
+      expect(
+        isUserCellEditable('role', { isNew: false, role: null }, ctx)
+      ).toBe(true)
+    })
+
+    it('is editable on a new row regardless of assignable tier', () => {
+      expect(
+        isUserCellEditable('role', { isNew: true, role: 'OWNER' }, ctx)
+      ).toBe(true)
+    })
+  })
+
+  it('leaves other fields to the column definition', () => {
+    expect(isUserCellEditable('email', { isNew: false }, ctx)).toBe(true)
+    expect(isUserCellEditable('fullname', { isNew: false }, ctx)).toBe(true)
+  })
+})

--- a/src/views/UserTable/cellEditGuards.ts
+++ b/src/views/UserTable/cellEditGuards.ts
@@ -1,0 +1,58 @@
+/**
+ * Cell-level edit gates for the user grid, extracted so they can be tested
+ * without standing up the grid. Defense in depth: the server enforces the same
+ * rules, and these only decide whether a cell can enter edit mode.
+ *
+ * The opdivs gate is the load-bearing one. `processRowUpdate` writes OpDiv
+ * grants only on the create path, so if an existing user's cell could be
+ * edited the commit would report success and discard the change. Nothing else
+ * prevents that, which is why this predicate is worth pinning.
+ */
+
+/** The row fields these gates read. */
+export type EditableRow = {
+  isNew?: boolean
+  role?: string | null
+}
+
+/** Caller context the gates depend on. */
+export type EditGuardContext = {
+  /** Roles this admin may assign, from selectableRoles(callerRole). */
+  assignableRoles: string[]
+  /** Whether the IdP column is offered at all for this caller. */
+  showIdpSelector: boolean
+}
+
+/**
+ * Whether a given cell may enter edit mode.
+ *
+ * - `role`: editable on a new row, on a row with no role yet, or when the
+ *   row's current role is inside the caller's assignable tier. Prevents an
+ *   admin editing a role they could not otherwise grant.
+ * - `opdivs`: new rows only. Existing users' memberships are changed through
+ *   the Assign OpDivs action, which is the only path that persists them.
+ * - `identity_provider`: new rows only, and only when the IdP column applies
+ *   to this caller at all.
+ * - anything else: editable, subject to the column's own `editable` flag.
+ *
+ * @param field - The column field key.
+ * @param row - The row being edited.
+ * @param ctx - Caller context (assignable roles, IdP visibility).
+ * @returns True when the cell may enter edit mode.
+ */
+export function isUserCellEditable(
+  field: string,
+  row: EditableRow,
+  ctx: EditGuardContext
+): boolean {
+  if (field === 'role') {
+    return !!row.isNew || !row.role || ctx.assignableRoles.includes(row.role)
+  }
+  if (field === 'opdivs') {
+    return !!row.isNew
+  }
+  if (field === 'identity_provider') {
+    return !!row.isNew && ctx.showIdpSelector
+  }
+  return true
+}


### PR DESCRIPTION
Covers the case behind #651, which is being closed as not reproducible. Behaviour-preserving: the predicate is extracted unchanged and the call site passes the same inputs.

## Why

#651 reported that an admin could inline-edit an existing user's OpDivs cell, have the commit report success, and lose the change. That does not reproduce: `isCellEditable` has gated the `opdivs` field to new rows only since #432 merged on 2026-06-29. I filed the issue from the column definition, which declares `editable: isAdmin`, and missed the gate 180 lines below it.

The write-path asymmetry behind the report is real, though. `processRowUpdate` writes grants only on the `newRow.isNew` branch, so there is no path that persists them for an existing user, and the existing-user path still sets the saved message and optimistically updates the row. **The gate is the only thing keeping that unreachable**, and nothing tested it:

- `isCellEditable` appeared exactly once in the repo, in the implementation.
- `src/views/UserTable/` has no test file at all, so there was no harness to notice a change to it.

So a refactor that reorganised the grid props could have removed the gate and restored a write that lies about having saved, with the entire suite still green. That is the gap this closes.

## What changed

`cellEditGuards.ts` holds the predicate, extracted with no behaviour change, following the pattern this repo already uses for `saveGuard.ts`, `confirmState.ts`, and `rowSelection.ts`: a pure function with its own test rather than logic embedded in a component. The grid now calls it with the same `assignableRoles` and `showIdpSelector` it computed before.

`cellEditGuards.test.ts` covers all four branches, 11 tests: `opdivs` and `identity_provider` locked on existing rows, `role` locked when the current role is outside the caller's assignable tier, and everything else deferred to the column definition. It includes the `isNew` absent case, not just `isNew: false`, since the field is optional.

One small type improvement falls out: the `role` branch previously returned `params.row.isNew || ...`, so its value was truthy rather than boolean. The helper returns a real boolean. Same behaviour through MUI, which reads it for truthiness.

## Verification

The two `opdivs` assertions were checked against a deliberately broken guard: flipping the branch to `return true` fails exactly those two and passes the other nine, and restoring it passes all 11. Verified by running it rather than assumed, since a test that survives the bug it names is worthless.

`tsc --noEmit` clean, `eslint ./src` 0 errors with the 2 pre-existing warnings in an untouched file, full suite **826 passed, 0 failed** (up 11).

## Not addressed here

Whether the inline OpDivs editor should eventually persist rather than be gated off is a product question, not this. The gate reflects a deliberate decision that memberships are managed through the Assign OpDivs action, which is the only path with the caller-scope narrowing and preserve boundary from #642 and #650. This just makes that decision enforceable.
