### PR TITLE
Code freeze batch 2 (frontend): select-all for unscored systems, isso_name contract, user-grid edit-gate coverage

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,18 @@ export type FismaSystemType = {
   // Extended metadata fields, typed and canonicalized by the backend.
   // Enum strings carry a canonical value or null; the tri-state booleans are
   // true / false / null = Unknown; cloud_service_model is a decomposed list.
+  //
+  // isso_name is asymmetric between read and write, and that asymmetry is the
+  // contract. A read may return either the stored override or a name the backend
+  // resolved from the ISSO's user record, and the payload does not say which. A
+  // write always stores. So echoing back a value the user did not edit converts a
+  // resolved name into a permanent stored override for that system, silently, and
+  // no server-side rule rejects it.
+  //
+  // The guarantee therefore lives in this client, by decision rather than by
+  // accident: send only the fields the user changed. buildExtendedDiff does that,
+  // and it needs a real baseline to work. Any move toward sending the whole
+  // object reintroduces the bug with every existing test still green.
   isso_name?: string | null
   hva?: boolean | null
   fips?: string | null

--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -53,10 +53,20 @@ beforeEach(() => {
   mockAxiosGet.mockResolvedValue(blobResponse)
 })
 
-function renderFooter(selectedRows: number[]) {
+function renderFooter(
+  selectedRows: number[],
+  extra: {
+    systemCallMap?: Record<number, number[]>
+    chosenCallMap?: Record<number, number>
+  } = {}
+) {
   return render(
     <MemoryRouter>
-      <CustomFooterSaveComponent {...baseProps} selectedRows={selectedRows} />
+      <CustomFooterSaveComponent
+        {...baseProps}
+        {...extra}
+        selectedRows={selectedRows}
+      />
     </MemoryRouter>
   )
 }
@@ -96,5 +106,29 @@ describe('CustomFooterSaveComponent download button', () => {
     // Must NOT be a bare export URL (no fsids = download everything)
     expect(calledUrl).not.toMatch(/\/export$/)
     expect(calledUrl).not.toMatch(/\/export\?$/)
+  })
+
+  it('targets a not-started system displayed call, not the active call', () => {
+    // A not-started system has no score-derived call (empty systemCallMap), but
+    // the dashboard shows it against call 7 (a past-year view). The export must
+    // target 7, not the active call 42 - otherwise a past-year export silently
+    // hits the wrong call once the backend starts returning rows for it.
+    renderFooter([3], { systemCallMap: {}, chosenCallMap: { 3: 7 } })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).not.toContain('/datacalls/42/export')
+    expect(calledUrl).toContain('fsids=3')
+  })
+
+  it('disables export when selected rows display different calls', () => {
+    // Two never-started rows shown against different calls have no single
+    // export target, so the button stays disabled rather than guessing.
+    renderFooter([3, 4], { systemCallMap: {}, chosenCallMap: { 3: 7, 4: 9 } })
+    expect(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    ).toBeDisabled()
   })
 })

--- a/src/views/FismaTable/FismaTable.test.tsx
+++ b/src/views/FismaTable/FismaTable.test.tsx
@@ -131,4 +131,34 @@ describe('CustomFooterSaveComponent download button', () => {
       screen.getByRole('button', { name: /download selected system answers/i })
     ).toBeDisabled()
   })
+
+  it('targets a scored system score-derived call', () => {
+    // A scored system resolves through systemCallMap (calls it has scores in),
+    // not the chosen-call fallback. Pins that the not-started fallback did not
+    // displace the original path.
+    renderFooter([1], { systemCallMap: { 1: [7] } })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).toContain('fsids=1')
+  })
+
+  it('exports a mixed scored + not-started selection sharing one call', () => {
+    // Scored system 1 has a score in call 7; not-started system 3 is displayed
+    // against call 7. They share one target, so export goes to call 7 with both
+    // ids rather than disabling or splitting.
+    renderFooter([1, 3], {
+      systemCallMap: { 1: [7] },
+      chosenCallMap: { 3: 7 },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: /download selected system answers/i })
+    )
+    const calledUrl: string = mockAxiosGet.mock.calls[0][0]
+    expect(calledUrl).toContain('/datacalls/7/export')
+    expect(calledUrl).toContain('fsids=1')
+    expect(calledUrl).toContain('fsids=3')
+  })
 })

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -111,8 +111,8 @@ export function CustomFooterSaveComponent(
   // scores), so it would otherwise contribute nothing and let an
   // all-never-started selection fall through to the active call - wrong in a
   // past-year view. The dashboard still shows such a row against one chosen
-  // call (chosenCallMap, which buildDashboardMaps fills for every row), so fall
-  // back to that per row before the global active-call default.
+  // call (chosenCallMap, which buildDashboardMaps fills for every selectable
+  // row), so fall back to that per row before the global active-call default.
   const selectedCallIds = new Set<number>()
   const callMap = props.systemCallMap ?? {}
   const chosenMap = props.chosenCallMap ?? {}

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -50,7 +50,9 @@ import PillarScoresModal from '../../components/PillarScoresModal/PillarScoresMo
 import { FismaTableProps } from '@/types'
 import type { ScoreAggregate, SystemScoreEntry, datacall } from '@/types'
 import { hasSystemAccess } from '@/utils/userRoles'
-import { TIERS } from '@/utils/tierStyles'
+import { ScoreCell } from './scoreColumn'
+import { scoreSortValue } from './scoreHelpers'
+import { isSystemSelectable } from './rowSelection'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
 import { resolveRowCallId, datacallNameComparator } from './rowCall'
@@ -848,38 +850,10 @@ export default function FismaTable({
       align: 'center',
       headerAlign: 'center',
       hideable: false,
-      valueGetter: (value) => {
-        const entry = scores[value.row.fismasystemid]
-        if (!entry || !entry.score) {
-          return 0
-        }
-        return entry.score.toFixed(2)
-      },
-      renderCell: (params) => {
-        const entry = scores[params.row.fismasystemid]
-        const score = entry?.score ?? 0
-        // Tier comes from the backend on /scores/aggregate; do not derive
-        // it from the numeric score. Cells without a tier render with no
-        // background fill so a transient deploy mismatch reads as
-        // "unknown" rather than a misleading color.
-        const backgroundColor = entry?.tier
-          ? TIERS[entry.tier]?.cell.backgroundColor ?? 'transparent'
-          : 'transparent'
-        return (
-          <Box
-            sx={{
-              border: 1,
-              p: 1,
-              px: 4,
-              borderRadius: 2,
-              borderColor: 'darkgray',
-              backgroundColor,
-            }}
-          >
-            {score.toFixed(2)}
-          </Box>
-        )
-      },
+      valueGetter: (value) => scoreSortValue(scores[value.row.fismasystemid]),
+      renderCell: (params) => (
+        <ScoreCell entry={scores[params.row.fismasystemid]} />
+      ),
     },
     {
       // Which call the row is displaying (ui#639), named plainly so a
@@ -1037,7 +1011,7 @@ export default function FismaTable({
       <DataGrid
         rows={filteredRows}
         isRowSelectable={(params: GridRowParams) =>
-          params.row.fismasystemid in scores
+          isSystemSelectable(params.row.fismasystemid, scores, progress)
         }
         // De-emphasize rows displaying a closed call while the open call is
         // in view (ui#639). Only in that mixed view: between calls, or on a

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -77,6 +77,7 @@ declare module '@mui/x-data-grid' {
     activeDataCallId: number
     scores: Record<number, SystemScoreEntry>
     systemCallMap?: Record<number, number[]>
+    chosenCallMap?: Record<number, number>
   }
   interface ToolbarPropsOverrides {
     filters: DashboardFilterState
@@ -105,10 +106,24 @@ export function CustomFooterSaveComponent(
   // rows' own call(s): if they all share one call, export that; an empty
   // provenance falls back to the active call; a selection that spans more than
   // one call has no single export target, so the button is disabled.
+  //
+  // A not-started system has no score-derived call (systemCallMap keys off
+  // scores), so it would otherwise contribute nothing and let an
+  // all-never-started selection fall through to the active call - wrong in a
+  // past-year view. The dashboard still shows such a row against one chosen
+  // call (chosenCallMap, which buildDashboardMaps fills for every row), so fall
+  // back to that per row before the global active-call default.
   const selectedCallIds = new Set<number>()
   const callMap = props.systemCallMap ?? {}
+  const chosenMap = props.chosenCallMap ?? {}
   for (const id of props.selectedRows ?? []) {
-    for (const cid of callMap[id as number] ?? []) selectedCallIds.add(cid)
+    const scoreCalls = callMap[id as number] ?? []
+    if (scoreCalls.length > 0) {
+      for (const cid of scoreCalls) selectedCallIds.add(cid)
+    } else {
+      const chosen = chosenMap[id as number]
+      if (chosen != null) selectedCallIds.add(chosen)
+    }
   }
   const exportCallId =
     selectedCallIds.size === 1
@@ -1038,6 +1053,7 @@ export default function FismaTable({
             activeDataCallId,
             scores,
             systemCallMap,
+            chosenCallMap,
           },
           toolbar: {
             filters,

--- a/src/views/FismaTable/rowSelection.test.ts
+++ b/src/views/FismaTable/rowSelection.test.ts
@@ -1,0 +1,37 @@
+import type { ScoreProgress, SystemScoreEntry } from '@/types'
+import { isSystemSelectable } from './rowSelection'
+
+const scores: Record<number, SystemScoreEntry> = { 1: { score: 3.5 } }
+const progress: Record<number, ScoreProgress> = {
+  2: {
+    fismasystemid: 2,
+    questionsexpected: 40,
+    questionsanswered: 0,
+    questionsupdated: 0,
+    lastupdatedat: null,
+    updatedsincestart: false,
+  },
+}
+
+describe('isSystemSelectable', () => {
+  it('selects a system that has a score row', () => {
+    expect(isSystemSelectable(1, scores, progress)).toBe(true)
+  })
+
+  it('selects a not-started system present only in progress', () => {
+    // The bug: a system with a progress row (40 expected / 0 updated) but no
+    // score row was unselectable, dropping exactly the not-started systems.
+    expect(isSystemSelectable(2, scores, progress)).toBe(true)
+  })
+
+  it('does not select a system absent from both maps', () => {
+    expect(isSystemSelectable(99, scores, progress)).toBe(false)
+  })
+
+  it('still selects a scored system when progress is missing entirely', () => {
+    // A failed /scores/progress fetch resolves to an empty map; the union with
+    // scores keeps scored rows selectable rather than disabling every checkbox.
+    expect(isSystemSelectable(1, scores, undefined)).toBe(true)
+    expect(isSystemSelectable(2, scores, undefined)).toBe(false)
+  })
+})

--- a/src/views/FismaTable/rowSelection.ts
+++ b/src/views/FismaTable/rowSelection.ts
@@ -1,0 +1,25 @@
+import type { ScoreProgress, SystemScoreEntry } from '@/types'
+
+/**
+ * Whether a dashboard row can be selected for the answers export.
+ *
+ * A system is selectable if it appears in the viewed data calls at all: with a
+ * score row or with a questionnaire-progress row. Keying off scores alone hid
+ * not-started systems (a progress row of 40 expected / 0 updated but no score
+ * yet), which are exactly the ones an OpDiv admin most needs to select, and
+ * left their checkbox permanently unchecked with no visible reason. The union
+ * with scores keeps scored rows selectable even if the progress fetch fails and
+ * resolves to an empty map; a not-started system exists only in progress, so it
+ * still needs that fetch to have succeeded to be selectable.
+ * @param {number} fismasystemid - The row's system id.
+ * @param {Record<number, SystemScoreEntry>} scores - Per-system score entries.
+ * @param {Record<number, ScoreProgress>} [progress] - Per-system progress rows.
+ * @returns {boolean} True when the row can be selected.
+ */
+export function isSystemSelectable(
+  fismasystemid: number,
+  scores: Record<number, SystemScoreEntry>,
+  progress?: Record<number, ScoreProgress>
+): boolean {
+  return fismasystemid in scores || fismasystemid in (progress ?? {})
+}

--- a/src/views/FismaTable/scoreColumn.test.tsx
+++ b/src/views/FismaTable/scoreColumn.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import type { SystemScoreEntry } from '@/types'
+import { ScoreCell } from './scoreColumn'
+import { scoreSortValue } from './scoreHelpers'
+
+describe('scoreSortValue', () => {
+  it('sorts a never-assessed system below a genuine zero', () => {
+    // The whole point of the column fix: "no score row" and "assessed at 0.00"
+    // must not collapse to the same value.
+    expect(scoreSortValue(undefined)).toBeLessThan(scoreSortValue({ score: 0 }))
+  })
+
+  it('returns the numeric score for an assessed system', () => {
+    expect(scoreSortValue({ score: 3.5 })).toBe(3.5)
+    expect(scoreSortValue({ score: 0 })).toBe(0)
+  })
+})
+
+describe('ScoreCell', () => {
+  it('reads "Not scored" for a system with no score row', () => {
+    render(<ScoreCell entry={undefined} />)
+    expect(screen.getByText('Not scored')).toBeInTheDocument()
+    // Never the shared 0.00 that hid these systems.
+    expect(screen.queryByText('0.00')).not.toBeInTheDocument()
+  })
+
+  it('renders a real 0.00 for a system genuinely assessed at zero', () => {
+    render(<ScoreCell entry={{ score: 0 }} />)
+    expect(screen.getByText('0.00')).toBeInTheDocument()
+    expect(screen.queryByText('Not scored')).not.toBeInTheDocument()
+  })
+
+  it('renders the two-decimal score for an assessed system', () => {
+    const entry: SystemScoreEntry = { score: 3.5 }
+    render(<ScoreCell entry={entry} />)
+    expect(screen.getByText('3.50')).toBeInTheDocument()
+  })
+})

--- a/src/views/FismaTable/scoreColumn.tsx
+++ b/src/views/FismaTable/scoreColumn.tsx
@@ -1,0 +1,38 @@
+import { Box } from '@mui/material'
+import type { SystemScoreEntry } from '@/types'
+import { TIERS } from '@/utils/tierStyles'
+
+/**
+ * The Zero Trust Score cell. A system with no aggregate row reads "Not scored"
+ * so it is distinguishable from a system genuinely assessed at 0.00, which the
+ * old shared 0.00 rendering hid. A scored cell keeps the tier-colored badge.
+ * @param {object} props - Component props.
+ * @param {SystemScoreEntry} [props.entry] - The system's score entry, if any.
+ * @returns {JSX.Element} The rendered cell.
+ */
+export function ScoreCell({ entry }: { entry?: SystemScoreEntry }) {
+  if (!entry) {
+    return <Box sx={{ color: 'text.secondary' }}>Not scored</Box>
+  }
+  const score = entry.score ?? 0
+  // Tier comes from the backend on /scores/aggregate; do not derive it from the
+  // numeric score. A cell without a tier renders with no fill so a transient
+  // deploy mismatch reads as "unknown" rather than a misleading color.
+  const backgroundColor = entry.tier
+    ? TIERS[entry.tier]?.cell.backgroundColor ?? 'transparent'
+    : 'transparent'
+  return (
+    <Box
+      sx={{
+        border: 1,
+        p: 1,
+        px: 4,
+        borderRadius: 2,
+        borderColor: 'darkgray',
+        backgroundColor,
+      }}
+    >
+      {score.toFixed(2)}
+    </Box>
+  )
+}

--- a/src/views/FismaTable/scoreHelpers.ts
+++ b/src/views/FismaTable/scoreHelpers.ts
@@ -1,0 +1,13 @@
+import type { SystemScoreEntry } from '@/types'
+
+/**
+ * Sort key for the Zero Trust Score column. A system with no aggregate row has
+ * never been assessed, so it sorts below a genuine zero and the two never
+ * interleave; a scored system sorts by its numeric score.
+ * @param {SystemScoreEntry | undefined} entry - The system's score entry, if any.
+ * @returns {number} The numeric sort key (-1 when never assessed).
+ */
+export function scoreSortValue(entry: SystemScoreEntry | undefined): number {
+  if (!entry) return -1
+  return entry.score ?? 0
+}

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -42,6 +42,7 @@ import { fetchOpDivs } from '@/utils/opdivs'
 import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
+import { isUserCellEditable } from './cellEditGuards'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
@@ -845,28 +846,14 @@ export default function UserTable() {
           rows={rows}
           apiRef={apiRef}
           columns={columns}
-          // Cell-level edit gates (defense-in-depth; server enforces the same rules):
-          // - role: locked on existing rows whose current role is outside this
-          //   admin's assignable tier, preventing unauthorized role changes.
-          // - opdivs / identity_provider: locked to new rows only — existing
-          //   users' OpDiv memberships and derived IdP are managed via the
-          //   Assign OpDivs action, not inline editing.
-          isCellEditable={(params) => {
-            if (params.field === 'role') {
-              return (
-                params.row.isNew ||
-                !params.row.role ||
-                assignableRoles.includes(params.row.role)
-              )
-            }
-            if (params.field === 'opdivs') {
-              return !!params.row.isNew
-            }
-            if (params.field === 'identity_provider') {
-              return !!params.row.isNew && showIdpSelector
-            }
-            return true
-          }}
+          // Cell-level edit gates live in cellEditGuards so they can be tested
+          // without the grid. See that file for what each field allows and why.
+          isCellEditable={(params) =>
+            isUserCellEditable(params.field, params.row, {
+              assignableRoles,
+              showIdpSelector,
+            })
+          }
           editMode="row"
           getRowId={(row) => row.userid}
           initialState={{

--- a/src/views/UserTable/cellEditGuards.test.ts
+++ b/src/views/UserTable/cellEditGuards.test.ts
@@ -1,0 +1,83 @@
+import { isUserCellEditable } from './cellEditGuards'
+
+const ctx = { assignableRoles: ['ISSO', 'ISSM'], showIdpSelector: true }
+
+describe('isUserCellEditable', () => {
+  describe('opdivs', () => {
+    // This is the gate that makes the discard unreachable. processRowUpdate
+    // writes grants only on the create path, so an editable cell on an existing
+    // row would commit, report success, and drop the change. If this assertion
+    // ever fails, that bug is live again and the UI will claim it saved.
+    it('is not editable on an existing user', () => {
+      expect(isUserCellEditable('opdivs', { isNew: false }, ctx)).toBe(false)
+    })
+
+    it('is not editable when isNew is absent rather than false', () => {
+      expect(isUserCellEditable('opdivs', {}, ctx)).toBe(false)
+    })
+
+    it('is editable on a new row, which is the path that persists grants', () => {
+      expect(isUserCellEditable('opdivs', { isNew: true }, ctx)).toBe(true)
+    })
+  })
+
+  describe('identity_provider', () => {
+    it('is not editable on an existing user', () => {
+      expect(
+        isUserCellEditable('identity_provider', { isNew: false }, ctx)
+      ).toBe(false)
+    })
+
+    it('is editable on a new row when the IdP column applies', () => {
+      expect(
+        isUserCellEditable('identity_provider', { isNew: true }, ctx)
+      ).toBe(true)
+    })
+
+    it('stays locked on a new row when the IdP column does not apply', () => {
+      expect(
+        isUserCellEditable(
+          'identity_provider',
+          { isNew: true },
+          {
+            ...ctx,
+            showIdpSelector: false,
+          }
+        )
+      ).toBe(false)
+    })
+  })
+
+  describe('role', () => {
+    it('is editable when the current role is inside the assignable tier', () => {
+      expect(
+        isUserCellEditable('role', { isNew: false, role: 'ISSO' }, ctx)
+      ).toBe(true)
+    })
+
+    it('is locked when the current role is outside the assignable tier', () => {
+      // An admin who cannot grant OWNER must not be able to edit an OWNER's
+      // role, since the edit control would otherwise offer a downgrade.
+      expect(
+        isUserCellEditable('role', { isNew: false, role: 'OWNER' }, ctx)
+      ).toBe(false)
+    })
+
+    it('is editable on a row with no role yet', () => {
+      expect(
+        isUserCellEditable('role', { isNew: false, role: null }, ctx)
+      ).toBe(true)
+    })
+
+    it('is editable on a new row regardless of assignable tier', () => {
+      expect(
+        isUserCellEditable('role', { isNew: true, role: 'OWNER' }, ctx)
+      ).toBe(true)
+    })
+  })
+
+  it('leaves other fields to the column definition', () => {
+    expect(isUserCellEditable('email', { isNew: false }, ctx)).toBe(true)
+    expect(isUserCellEditable('fullname', { isNew: false }, ctx)).toBe(true)
+  })
+})

--- a/src/views/UserTable/cellEditGuards.ts
+++ b/src/views/UserTable/cellEditGuards.ts
@@ -1,0 +1,58 @@
+/**
+ * Cell-level edit gates for the user grid, extracted so they can be tested
+ * without standing up the grid. Defense in depth: the server enforces the same
+ * rules, and these only decide whether a cell can enter edit mode.
+ *
+ * The opdivs gate is the load-bearing one. `processRowUpdate` writes OpDiv
+ * grants only on the create path, so if an existing user's cell could be
+ * edited the commit would report success and discard the change. Nothing else
+ * prevents that, which is why this predicate is worth pinning.
+ */
+
+/** The row fields these gates read. */
+export type EditableRow = {
+  isNew?: boolean
+  role?: string | null
+}
+
+/** Caller context the gates depend on. */
+export type EditGuardContext = {
+  /** Roles this admin may assign, from selectableRoles(callerRole). */
+  assignableRoles: string[]
+  /** Whether the IdP column is offered at all for this caller. */
+  showIdpSelector: boolean
+}
+
+/**
+ * Whether a given cell may enter edit mode.
+ *
+ * - `role`: editable on a new row, on a row with no role yet, or when the
+ *   row's current role is inside the caller's assignable tier. Prevents an
+ *   admin editing a role they could not otherwise grant.
+ * - `opdivs`: new rows only. Existing users' memberships are changed through
+ *   the Assign OpDivs action, which is the only path that persists them.
+ * - `identity_provider`: new rows only, and only when the IdP column applies
+ *   to this caller at all.
+ * - anything else: editable, subject to the column's own `editable` flag.
+ *
+ * @param field - The column field key.
+ * @param row - The row being edited.
+ * @param ctx - Caller context (assignable roles, IdP visibility).
+ * @returns True when the cell may enter edit mode.
+ */
+export function isUserCellEditable(
+  field: string,
+  row: EditableRow,
+  ctx: EditGuardContext
+): boolean {
+  if (field === 'role') {
+    return !!row.isNew || !row.role || ctx.assignableRoles.includes(row.role)
+  }
+  if (field === 'opdivs') {
+    return !!row.isNew
+  }
+  if (field === 'identity_provider') {
+    return !!row.isNew && ctx.showIdpSelector
+  }
+  return true
+}


### PR DESCRIPTION
Frontend release train for the code freeze. Approved PRs only, cherry-picked so each contributor's authorship and signature survive. Backend counterpart is CMS-Enterprise/ztmf#529, **which must merge first** — see below.

Closes #678

## What is in it

| Source | Author | Change | Closes |
| --- | --- | --- | --- |
| #679 | @tarratsco | Let select-all reach systems with no score rows; "Not scored" distinct from a real 0.00; export targets a row's displayed call | #678 |
| #680 | @jsos3-cms | Record the `isso_name` read/write asymmetry on the field | — |
| #681 | @jsos3-cms | Pin the cell-level edit gates for the user grid | — |

All three touch disjoint areas: `FismaTable`, `types.ts`, and `UserTable`. Ordering is by approval and carries no conflict risk.

#680 and #681 declare no closing issue because both record decisions on issues already closed: #680 captures the Option B outcome from CMS-Enterprise/ztmf-misc#262, and #681 adds the coverage that made #651 safe to close as not reproducible.

## Verification on the combined branch

`tsc --noEmit` clean. `eslint ./src` 0 errors, with the 2 pre-existing warnings in a file none of these touch. Full jest suite **839 passed, 0 failed**, 3 skipped across 61 suites.

Verified as a combination rather than trusting the parts. That matters more than usual here: #679 rewrites the Score column's `valueGetter` and #681 extracts a predicate out of a different grid, so a shared-fixture or shared-import interaction would only show up once stacked. It does not, but that is a result.

## Merge order, and this one is a correctness constraint

**ztmf#529 merges first, and this follows at least five minutes later.**

Not just deploy courtesy. #679 makes a never-started system's checkbox selectable and the export button clickable for such a selection. Until the backend's export change is live, that download silently produces a header-row-only file. The author disclosed exactly this in an unchecked acceptance criterion on #679, so it is a known and accepted window rather than a hidden one, but it is why the order is not interchangeable.

Landing them the other way round is not unsafe in the crash sense; it just turns "this cannot be done yet" into "this appeared to work and gave you nothing", which is the worse of the two.

## Deploy note

Opened ready rather than draft-then-ready on purpose. That transition fired two dev deploys two minutes apart on the backend side earlier today, and the second failed on an ECS stabilise timeout after racing the first. The frontend lane is a shared bucket rather than ECS, where the same race yields a served `index.html` referencing a bundle the other deploy already deleted, so a single run matters here too. If the deploy fails, let it settle and re-run **one**; do not push again in parallel.

## What is not in it

- #584 is a dependency bump with no approval.
- #676 is the nightly `main -> impl` sync, on a different base and not feature work.
