### PR TITLE
Last Seen column in the user management grid

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -371,6 +371,11 @@ export type users = {
   deleted?: boolean
   isNew?: boolean
   identity_provider?: 'okta' | 'entra'
+  // Most recent recorded activity (incl. sign-ins), list endpoint only.
+  // null = no activity recorded since tracking began (2026-08-06), which for
+  // older accounts is NOT the same as "never signed in" - keep any empty-state
+  // wording neutral. /users/current always returns null for this field.
+  last_seen?: string | null
 }
 
 export type datacall = {

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import InsightsPanel, {
   OptionInsightBadges,
-  severityStyle,
-  rollupControls,
   ISSO_DETERMINATION_DISCLAIMER,
 } from './InsightsPanel'
+import { severityStyle, rollupControls } from './controlRollup'
 import type { InsightPayload } from '@/types'
 import CONFIG from '@/utils/config'
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -14,6 +14,15 @@ import {
   asImpactLevel,
   FIPS_GOLD,
 } from '../fipsBaseline'
+import {
+  asText,
+  severityStyle,
+  rollupControls,
+  INFERRED_PASS_SOURCES,
+  type ControlRollup,
+  type ControlRollupState,
+  type ControlEvidence,
+} from './controlRollup'
 
 type Props = {
   payload: InsightPayload
@@ -1169,17 +1178,6 @@ function FeedCheckBlock({
   )
 }
 
-// Coerce an opaque payload value to renderable text. The payload is untrusted
-// JSON, so a field the type declares as a string could arrive as an object or
-// array; rendering that directly throws "Objects are not valid as a React
-// child" and (via the error boundary) blanks the whole panel. Coercing to a
-// string degrades gracefully instead. Returns undefined for nullish/empty so
-// existing truthiness guards still hide the element.
-function asText(v: unknown): string | undefined {
-  if (v == null || v === '') return undefined
-  return typeof v === 'string' ? v : String(v)
-}
-
 // Hardenize instance `detail` is inconsistent — a stringified JSON object
 // ({"Error message":"..."}), plain text ("Dangling DNS record: ..."), or empty
 // ({}). Surface something readable: JSON objects → their values joined; plain
@@ -1197,17 +1195,6 @@ function formatHardenizeDetail(detail?: string): string | undefined {
     /* not JSON — fall through to raw text */
   }
   return t
-}
-
-// Severity → chip color. error/high/critical = red, warning/medium = amber,
-// everything else (low, powerup, unknown) = neutral.
-export function severityStyle(sev?: string): { bg: string; fg: string } {
-  const s = (sev ?? '').toLowerCase()
-  if (s === 'error' || s === 'high' || s === 'critical')
-    return { bg: '#fdecec', fg: '#b02a37' }
-  if (s === 'warning' || s === 'warn' || s === 'medium')
-    return { bg: '#fff4e5', fg: '#b26a00' }
-  return { bg: '#f0f0f0', fg: '#666' }
 }
 
 // TEMPORARY stopgap severity glossary shown on hover when a finding has no
@@ -1233,182 +1220,6 @@ const SEVERITY_HELP: Record<string, string> = {
 }
 function severityHelp(sev?: string): string | undefined {
   return SEVERITY_HELP[(sev ?? '').toLowerCase()]
-}
-
-// The state of one control in the ARS Controls rollup. `unsatisfied` = CFACTS says
-// the control applies here but nothing has confirmed it satisfied (may be
-// unassessed) — informational, not an alarm.
-export type ControlRollupState = 'satisfied' | 'unsatisfied' | 'failing'
-
-// One piece of evidence behind a control's state: which source spoke to it, the
-// specific check (when the evidence is a finding-source check rather than a CFACTS
-// coverage flag), and what that evidence said.
-export type ControlEvidence = {
-  source: string
-  check?: string
-  state: ControlRollupState
-  // The check's human sentence, carried alongside the slug. A control chip is
-  // labeled with the control id, so without this its hover would name the check
-  // only by slug (`account-without-compliant-password-policy`) and the reader
-  // would have to decode it — the check chips have shown this sentence since
-  // they were introduced.
-  description?: string
-}
-
-// A control after the cross-source rollup: its net (weakest-link) state, whether
-// its sources disagree, and the full evidence list so the UI can name every source
-// and show how a conflict resolved.
-export type ControlRollup = {
-  id: string
-  state: ControlRollupState
-  conflict: boolean
-  evidence: ControlEvidence[]
-}
-
-// Weakest-link precedence for a control's NET state: failing beats satisfied beats
-// unsatisfied. So a control is failing if ANY source fails it, else satisfied if
-// ANY source passes it, else unsatisfied. Matches the zero-trust scoring principle
-// (lowest signal wins).
-const CONTROL_RANK: Record<ControlRollupState, number> = {
-  failing: 3,
-  satisfied: 2,
-  unsatisfied: 1,
-}
-
-// The ARS Controls total is the UNION of every ARS control any evidence source
-// touches — CFACTS applicable/failing controls PLUS the NIST control each Kion,
-// SecurityHub, and Hardenize check maps to. Each control keeps its full evidence
-// list, nets to a weakest-link state, and is flagged `conflict` when at least one
-// source passes it AND at least one source fails it (e.g. SC-12: Kion passes
-// key-rotation but fails cross-account-access). This is why a control Kion passes
-// appears here even though CFACTS never assessed it, and why a conflicted control
-// can net to failing. The payload is opaque, so every value is coerced and
-// guarded; a malformed element is skipped, never thrown.
-// Sources whose "passing" entries are inferred from the absence of a finding
-// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
-// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
-// as "mapped control with no active failure". That cannot distinguish "evaluated
-// and passed" from "never scanned", so on a partially scanned system it would
-// otherwise assert controls are met on the strength of checks that never ran.
-// Consequently these entries still render as ✓ chips (the check is not failing)
-// but are read as an absence of findings, and are withheld from the control
-// rollup rather than counted as affirmative `satisfied` evidence.
-//
-// Remove a source from this set once its feed emits real passes; nothing else
-// needs to change. Used by both the feed blocks and rollupControls below.
-const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
-
-export function rollupControls(
-  payload: Partial<InsightPayload>
-): ControlRollup[] {
-  const map = new Map<string, ControlEvidence[]>()
-  const add = (
-    raw: unknown,
-    source: string,
-    state: ControlRollupState,
-    check?: string,
-    description?: string
-  ) => {
-    const text = asText(raw)
-    if (!text) return
-    // One check can map to several controls, e.g. "AC-2, AC-3".
-    for (const part of text.split(',')) {
-      const id = part.trim()
-      if (!id) continue
-      const list = map.get(id) ?? []
-      list.push({
-        source,
-        state,
-        check,
-        // A title-only finding (no id, no description) resolves both the check
-        // and the sentence to that same title. Drop the duplicate rather than
-        // printing it twice in the hover and announcing it twice to AT.
-        description: description === check ? undefined : description,
-      })
-      map.set(id, list)
-    }
-  }
-  const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
-  const finding = (f: unknown) =>
-    f && typeof f === 'object'
-      ? (f as {
-          nist_controls?: unknown
-          id?: unknown
-          title?: unknown
-          description?: unknown
-        })
-      : null
-  // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
-  // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
-  // control catalog, not a source — CFACTS is the source of this coverage. These
-  // arrays are plain control-id strings (unlike nist_controls, which may arrive as
-  // an array and needs asText coercion), so filter to strings: a non-string
-  // element would otherwise coerce to a junk chip ("42", "[object Object]").
-  const isStr = (v: unknown): v is string => typeof v === 'string'
-  // ars_not_satisfied is a SUPERSET of ars_failing — a failing control appears in
-  // both. Subtract the failing ids so the control isn't listed twice in the hover
-  // (once "not assessed", once "failed"); the net state is failing either way.
-  const arsFailingIds = new Set(arr(payload.ars_failing_controls).filter(isStr))
-  arr(payload.ars_satisfied_controls)
-    .filter(isStr)
-    .forEach((c) => add(c, 'CFACTS', 'satisfied'))
-  arr(payload.ars_not_satisfied_controls)
-    .filter(isStr)
-    .filter((c) => !arsFailingIds.has(c))
-    .forEach((c) => add(c, 'CFACTS', 'unsatisfied'))
-  arr(payload.ars_failing_controls)
-    .filter(isStr)
-    .forEach((c) => add(c, 'CFACTS', 'failing'))
-  // Finding-source checks: a passing check satisfies its control, a failing one (a
-  // finding) fails it. Carry the check id/title so the hover can name it.
-  const findings = (payload.findings ?? {}) as Record<string, unknown>
-  const SRC_LABEL: Record<string, string> = {
-    kion: 'Kion',
-    sechub: 'SecurityHub',
-    hardenize: 'Hardenize',
-  }
-  for (const src of ['kion', 'sechub', 'hardenize'] as const) {
-    const label = SRC_LABEL[src]
-    // An inferred pass is the absence of a finding, not evidence the control is
-    // met — counting it as `satisfied` would flip a control from "not assessed"
-    // to green on the strength of a check that may never have run.
-    if (!INFERRED_PASS_SOURCES.has(src)) {
-      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
-        (f) => {
-          const o = finding(f)
-          add(
-            o?.nist_controls,
-            label,
-            'satisfied',
-            asText(o?.id) ?? asText(o?.title),
-            // Kion puts the sentence in `description`, SecurityHub in `title` —
-            // same fallback CheckTooltip uses, so both hovers read alike.
-            asText(o?.description) ?? asText(o?.title)
-          )
-        }
-      )
-    }
-    arr(findings[src]).forEach((f) => {
-      const o = finding(f)
-      add(
-        o?.nist_controls,
-        label,
-        'failing',
-        asText(o?.id) ?? asText(o?.title),
-        asText(o?.description) ?? asText(o?.title)
-      )
-    })
-  }
-  return [...map.entries()].map(([id, evidence]) => {
-    const state = evidence.reduce<ControlRollupState>(
-      (net, e) => (CONTROL_RANK[e.state] > CONTROL_RANK[net] ? e.state : net),
-      'unsatisfied'
-    )
-    const conflict =
-      evidence.some((e) => e.state === 'satisfied') &&
-      evidence.some((e) => e.state === 'failing')
-    return { id, state, conflict, evidence }
-  })
 }
 
 // Plain-text words for a control's net state and each evidence line — shared by the

--- a/src/views/QuestionnairePage/InsightsPanel/controlRollup.ts
+++ b/src/views/QuestionnairePage/InsightsPanel/controlRollup.ts
@@ -1,0 +1,205 @@
+/**
+ * Non-component logic shared by the Insights panel and its tests: payload text
+ * coercion, severity chip styling, and the cross-source ARS control rollup.
+ * Lives in its own module (not InsightsPanel.tsx) so the panel file only
+ * exports components and Vite fast refresh keeps working.
+ */
+import type { InsightPayload } from '@/types'
+
+// Coerce an opaque payload value to renderable text. The payload is untrusted
+// JSON, so a field the type declares as a string could arrive as an object or
+// array; rendering that directly throws "Objects are not valid as a React
+// child" and (via the error boundary) blanks the whole panel. Coercing to a
+// string degrades gracefully instead. Returns undefined for nullish/empty so
+// existing truthiness guards still hide the element.
+export function asText(v: unknown): string | undefined {
+  if (v == null || v === '') return undefined
+  return typeof v === 'string' ? v : String(v)
+}
+
+// Severity → chip color. error/high/critical = red, warning/medium = amber,
+// everything else (low, powerup, unknown) = neutral.
+export function severityStyle(sev?: string): { bg: string; fg: string } {
+  const s = (sev ?? '').toLowerCase()
+  if (s === 'error' || s === 'high' || s === 'critical')
+    return { bg: '#fdecec', fg: '#b02a37' }
+  if (s === 'warning' || s === 'warn' || s === 'medium')
+    return { bg: '#fff4e5', fg: '#b26a00' }
+  return { bg: '#f0f0f0', fg: '#666' }
+}
+
+// The state of one control in the ARS Controls rollup. `unsatisfied` = CFACTS says
+// the control applies here but nothing has confirmed it satisfied (may be
+// unassessed) — informational, not an alarm.
+export type ControlRollupState = 'satisfied' | 'unsatisfied' | 'failing'
+
+// One piece of evidence behind a control's state: which source spoke to it, the
+// specific check (when the evidence is a finding-source check rather than a CFACTS
+// coverage flag), and what that evidence said.
+export type ControlEvidence = {
+  source: string
+  check?: string
+  state: ControlRollupState
+  // The check's human sentence, carried alongside the slug. A control chip is
+  // labeled with the control id, so without this its hover would name the check
+  // only by slug (`account-without-compliant-password-policy`) and the reader
+  // would have to decode it — the check chips have shown this sentence since
+  // they were introduced.
+  description?: string
+}
+
+// A control after the cross-source rollup: its net (weakest-link) state, whether
+// its sources disagree, and the full evidence list so the UI can name every source
+// and show how a conflict resolved.
+export type ControlRollup = {
+  id: string
+  state: ControlRollupState
+  conflict: boolean
+  evidence: ControlEvidence[]
+}
+
+// Weakest-link precedence for a control's NET state: failing beats satisfied beats
+// unsatisfied. So a control is failing if ANY source fails it, else satisfied if
+// ANY source passes it, else unsatisfied. Matches the zero-trust scoring principle
+// (lowest signal wins).
+const CONTROL_RANK: Record<ControlRollupState, number> = {
+  failing: 3,
+  satisfied: 2,
+  unsatisfied: 1,
+}
+
+// Sources whose "passing" entries are inferred from the absence of a finding
+// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
+// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
+// as "mapped control with no active failure". That cannot distinguish "evaluated
+// and passed" from "never scanned", so on a partially scanned system it would
+// otherwise assert controls are met on the strength of checks that never ran.
+// Consequently these entries still render as ✓ chips (the check is not failing)
+// but are read as an absence of findings, and are withheld from the control
+// rollup rather than counted as affirmative `satisfied` evidence.
+//
+// Remove a source from this set once its feed emits real passes; nothing else
+// needs to change. Used by both the panel's feed blocks and rollupControls below.
+export const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
+
+// The ARS Controls total is the UNION of every ARS control any evidence source
+// touches — CFACTS applicable/failing controls PLUS the NIST control each Kion,
+// SecurityHub, and Hardenize check maps to. Each control keeps its full evidence
+// list, nets to a weakest-link state, and is flagged `conflict` when at least one
+// source passes it AND at least one source fails it (e.g. SC-12: Kion passes
+// key-rotation but fails cross-account-access). This is why a control Kion passes
+// appears here even though CFACTS never assessed it, and why a conflicted control
+// can net to failing. The payload is opaque, so every value is coerced and
+// guarded; a malformed element is skipped, never thrown.
+export function rollupControls(
+  payload: Partial<InsightPayload>
+): ControlRollup[] {
+  const map = new Map<string, ControlEvidence[]>()
+  const add = (
+    raw: unknown,
+    source: string,
+    state: ControlRollupState,
+    check?: string,
+    description?: string
+  ) => {
+    const text = asText(raw)
+    if (!text) return
+    // One check can map to several controls, e.g. "AC-2, AC-3".
+    for (const part of text.split(',')) {
+      const id = part.trim()
+      if (!id) continue
+      const list = map.get(id) ?? []
+      list.push({
+        source,
+        state,
+        check,
+        // A title-only finding (no id, no description) resolves both the check
+        // and the sentence to that same title. Drop the duplicate rather than
+        // printing it twice in the hover and announcing it twice to AT.
+        description: description === check ? undefined : description,
+      })
+      map.set(id, list)
+    }
+  }
+  const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
+  const finding = (f: unknown) =>
+    f && typeof f === 'object'
+      ? (f as {
+          nist_controls?: unknown
+          id?: unknown
+          title?: unknown
+          description?: unknown
+        })
+      : null
+  // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
+  // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
+  // control catalog, not a source — CFACTS is the source of this coverage. These
+  // arrays are plain control-id strings (unlike nist_controls, which may arrive as
+  // an array and needs asText coercion), so filter to strings: a non-string
+  // element would otherwise coerce to a junk chip ("42", "[object Object]").
+  const isStr = (v: unknown): v is string => typeof v === 'string'
+  // ars_not_satisfied is a SUPERSET of ars_failing — a failing control appears in
+  // both. Subtract the failing ids so the control isn't listed twice in the hover
+  // (once "not assessed", once "failed"); the net state is failing either way.
+  const arsFailingIds = new Set(arr(payload.ars_failing_controls).filter(isStr))
+  arr(payload.ars_satisfied_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'satisfied'))
+  arr(payload.ars_not_satisfied_controls)
+    .filter(isStr)
+    .filter((c) => !arsFailingIds.has(c))
+    .forEach((c) => add(c, 'CFACTS', 'unsatisfied'))
+  arr(payload.ars_failing_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'failing'))
+  // Finding-source checks: a passing check satisfies its control, a failing one (a
+  // finding) fails it. Carry the check id/title so the hover can name it.
+  const findings = (payload.findings ?? {}) as Record<string, unknown>
+  const SRC_LABEL: Record<string, string> = {
+    kion: 'Kion',
+    sechub: 'SecurityHub',
+    hardenize: 'Hardenize',
+  }
+  for (const src of ['kion', 'sechub', 'hardenize'] as const) {
+    const label = SRC_LABEL[src]
+    // An inferred pass is the absence of a finding, not evidence the control is
+    // met — counting it as `satisfied` would flip a control from "not assessed"
+    // to green on the strength of a check that may never have run.
+    if (!INFERRED_PASS_SOURCES.has(src)) {
+      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
+        (f) => {
+          const o = finding(f)
+          add(
+            o?.nist_controls,
+            label,
+            'satisfied',
+            asText(o?.id) ?? asText(o?.title),
+            // Kion puts the sentence in `description`, SecurityHub in `title` —
+            // same fallback CheckTooltip uses, so both hovers read alike.
+            asText(o?.description) ?? asText(o?.title)
+          )
+        }
+      )
+    }
+    arr(findings[src]).forEach((f) => {
+      const o = finding(f)
+      add(
+        o?.nist_controls,
+        label,
+        'failing',
+        asText(o?.id) ?? asText(o?.title),
+        asText(o?.description) ?? asText(o?.title)
+      )
+    })
+  }
+  return [...map.entries()].map(([id, evidence]) => {
+    const state = evidence.reduce<ControlRollupState>(
+      (net, e) => (CONTROL_RANK[e.state] > CONTROL_RANK[net] ? e.state : net),
+      'unsatisfied'
+    )
+    const conflict =
+      evidence.some((e) => e.state === 'satisfied') &&
+      evidence.some((e) => e.state === 'failing')
+    return { id, state, conflict, evidence }
+  })
+}

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -24,4 +24,13 @@ describe('LastSeenCell', () => {
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent('2026')
   })
+
+  it('carries the absolute timestamp in the accessible name (tooltip is hover-only)', () => {
+    render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
+    const el = screen.getByText('3 days ago')
+    expect(el).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/^3 days ago \(.*2026.*\)$/)
+    )
+  })
 })

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LastSeenCell from './LastSeenCell'
+import { LAST_SEEN_EMPTY_LABEL } from './lastSeen'
+
+describe('LastSeenCell', () => {
+  const now = new Date('2026-08-07T12:00:00Z')
+
+  it('renders the neutral empty state for null (never blank)', () => {
+    render(<LastSeenCell value={null} now={now} />)
+    expect(screen.getByText(LAST_SEEN_EMPTY_LABEL)).toBeInTheDocument()
+  })
+
+  it('renders relative time for a recorded timestamp', () => {
+    render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
+    expect(screen.getByText('3 days ago')).toBeInTheDocument()
+  })
+
+  it('exposes the absolute timestamp as a tooltip on hover', async () => {
+    const user = userEvent.setup()
+    const value = new Date('2026-08-04T12:00:00Z')
+    render(<LastSeenCell value={value} now={now} />)
+    await user.hover(screen.getByText('3 days ago'))
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip).toHaveTextContent('2026')
+  })
+})

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -13,24 +13,25 @@ describe('LastSeenCell', () => {
 
   it('renders relative time for a recorded timestamp', () => {
     render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
-    expect(screen.getByText('3 days ago')).toBeInTheDocument()
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument()
   })
 
   it('exposes the absolute timestamp as a tooltip on hover', async () => {
     const user = userEvent.setup()
     const value = new Date('2026-08-04T12:00:00Z')
     render(<LastSeenCell value={value} now={now} />)
-    await user.hover(screen.getByText('3 days ago'))
+    await user.hover(screen.getByText(/3 days ago/))
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent('2026')
   })
 
-  it('carries the absolute timestamp in the accessible name (tooltip is hover-only)', () => {
+  it('carries the absolute timestamp in a visually hidden span (tooltip is hover-only)', () => {
     render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
-    const el = screen.getByText('3 days ago')
-    expect(el).toHaveAttribute(
-      'aria-label',
-      expect.stringMatching(/^3 days ago \(.*2026.*\)$/)
-    )
+    // Full spoken text = relative phrase plus the parenthesized absolute.
+    const cell = screen.getByText(/3 days ago/)
+    expect(cell).toHaveTextContent(/3 days ago \(.*2026.*\)/)
+    // The absolute part is present for AT but visually clipped, not displayed.
+    const hidden = screen.getByText(/\(.*2026.*\)/)
+    expect(hidden).toHaveStyle({ position: 'absolute', width: '1px' })
   })
 })

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -30,10 +30,15 @@ export default function LastSeenCell({ value, now }: Props) {
       </Typography>
     )
   }
+  const absolute = formatLastSeenAbsolute(value)
+  const relative = formatLastSeenRelative(value, now ?? new Date())
   return (
-    <Tooltip title={formatLastSeenAbsolute(value)} placement="top">
-      <Typography variant="body2">
-        {formatLastSeenRelative(value, now ?? new Date())}
+    <Tooltip title={absolute} placement="top">
+      {/* The tooltip is hover-only, so the absolute timestamp rides in the
+          accessible name too - a screen reader hears both, not just the
+          relative phrase (508). */}
+      <Typography variant="body2" aria-label={`${relative} (${absolute})`}>
+        {relative}
       </Typography>
     </Tooltip>
   )

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -1,0 +1,40 @@
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import {
+  LAST_SEEN_EMPTY_LABEL,
+  formatLastSeenAbsolute,
+  formatLastSeenRelative,
+} from './lastSeen'
+
+type Props = {
+  value: Date | null
+  /** Injectable clock for tests; defaults to the real current time. */
+  now?: Date
+}
+
+/**
+ * View cell for the "Last seen" column: relative time with the absolute
+ * timestamp on hover, or a neutral empty state for rows with no recorded
+ * activity (deliberately not blank, so "never seen" is a visible, scannable
+ * state rather than an ambiguous hole in the grid).
+ */
+export default function LastSeenCell({ value, now }: Props) {
+  if (!value) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ fontStyle: 'italic' }}
+      >
+        {LAST_SEEN_EMPTY_LABEL}
+      </Typography>
+    )
+  }
+  return (
+    <Tooltip title={formatLastSeenAbsolute(value)} placement="top">
+      <Typography variant="body2">
+        {formatLastSeenRelative(value, now ?? new Date())}
+      </Typography>
+    </Tooltip>
+  )
+}

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -1,5 +1,7 @@
+import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import { visuallyHidden } from '@mui/utils'
 import {
   LAST_SEEN_EMPTY_LABEL,
   formatLastSeenAbsolute,
@@ -34,11 +36,13 @@ export default function LastSeenCell({ value, now }: Props) {
   const relative = formatLastSeenRelative(value, now ?? new Date())
   return (
     <Tooltip title={absolute} placement="top">
-      {/* The tooltip is hover-only, so the absolute timestamp rides in the
-          accessible name too - a screen reader hears both, not just the
-          relative phrase (508). */}
-      <Typography variant="body2" aria-label={`${relative} (${absolute})`}>
+      <Typography variant="body2">
         {relative}
+        {/* The tooltip is hover-only, so the absolute timestamp also rides
+            along visually hidden - a screen reader hears both, not just the
+            relative phrase (508). A hidden span rather than aria-label
+            because ARIA-in-HTML doesn't permit aria-label on a paragraph. */}
+        <Box component="span" sx={visuallyHidden}>{` (${absolute})`}</Box>
       </Typography>
     </Tooltip>
   )

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -23,7 +23,6 @@ import {
   GridRowEditStopReasons,
   GridToolbarQuickFilter,
   GridFilterModel,
-  GridSortItem,
   useGridApiRef,
 } from '@mui/x-data-grid'
 import { Chip, FormControlLabel, Switch, Typography } from '@mui/material'
@@ -58,7 +57,7 @@ import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import LastSeenCell from './LastSeenCell'
 import {
-  compareLastSeen,
+  lastSeenSortComparator,
   parseLastSeen,
   hasNoActivityFilter,
   withNoActivityFilter,
@@ -765,14 +764,9 @@ export default function UserTable() {
       valueGetter: (params) => parseLastSeen(params.row.last_seen),
       // Direction-aware so never-active rows sort last under BOTH asc and
       // desc; see compareLastSeen for how it pre-compensates the grid's
-      // negation on desc.
-      sortComparator: (v1, v2, cellParams1) => {
-        const direction =
-          (cellParams1.api.getSortModel() as GridSortItem[]).find(
-            (item) => item.field === cellParams1.field
-          )?.sort ?? 'asc'
-        return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
-      },
+      // negation on desc, and lastSeenSortComparator for the live-direction
+      // read (and the TODO for the v7 getSortComparator migration).
+      sortComparator: lastSeenSortComparator,
       renderCell: (params) => <LastSeenCell value={params.value ?? null} />,
     },
     {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -22,6 +22,8 @@ import {
   GridRenderEditCellParams,
   GridRowEditStopReasons,
   GridToolbarQuickFilter,
+  GridFilterModel,
+  GridSortItem,
   useGridApiRef,
 } from '@mui/x-data-grid'
 import { Chip, FormControlLabel, Switch, Typography } from '@mui/material'
@@ -54,6 +56,8 @@ import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
+import LastSeenCell from './LastSeenCell'
+import { compareLastSeen, parseLastSeen } from './lastSeen'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
   setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void
@@ -63,11 +67,20 @@ interface EditToolbarProps {
   isAdmin?: boolean
   showDeleted: boolean
   setShowDeleted: (value: boolean) => void
+  noActivityOnly: boolean
+  setNoActivityOnly: (value: boolean) => void
 }
 
 function EditToolbar(props: EditToolbarProps) {
-  const { setRows, setRowModesModel, isAdmin, showDeleted, setShowDeleted } =
-    props
+  const {
+    setRows,
+    setRowModesModel,
+    isAdmin,
+    showDeleted,
+    setShowDeleted,
+    noActivityOnly,
+    setNoActivityOnly,
+  } = props
   const addUserRow = () => {
     const userid = Math.floor(Math.random() * 1000) + 1
     setRows((oldRows) => [
@@ -103,6 +116,23 @@ function EditToolbar(props: EditToolbarProps) {
         }}
       />
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={noActivityOnly}
+              onChange={(e) => setNoActivityOnly(e.target.checked)}
+              sx={{
+                '& .MuiSwitch-switchBase.Mui-checked': {
+                  color: '#004297',
+                },
+                '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                  backgroundColor: '#004297',
+                },
+              }}
+            />
+          }
+          label="No Activity Only"
+        />
         <FormControlLabel
           control={
             <Switch
@@ -174,6 +204,28 @@ export default function UserTable() {
     assignedfismasystems: [],
   })
   const [showDeleted, setShowDeleted] = useState<boolean>(false)
+  // Controlled so the "No Activity Only" toolbar switch can inject/remove an
+  // isEmpty filter on last_seen while quick-filter text (which also lives in
+  // this model) keeps working. The switch state is DERIVED from the model, so
+  // removing the filter via the column filter panel un-checks the switch too.
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({ items: [] })
+  const noActivityOnly = filterModel.items.some(
+    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
+  )
+  const setNoActivityOnly = (value: boolean) => {
+    setFilterModel((prev) => ({
+      ...prev,
+      items: value
+        ? [
+            ...prev.items.filter((item) => item.field !== 'last_seen'),
+            { id: 'no-activity', field: 'last_seen', operator: 'isEmpty' },
+          ]
+        : prev.items.filter(
+            (item) =>
+              !(item.field === 'last_seen' && item.operator === 'isEmpty')
+          ),
+    }))
+  }
   const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
   const [pendingRestoreRow, setPendingRestoreRow] = useState<users | null>(null)
   const [assignModalUserName, setAssignModalUserName] = useState<string>('')
@@ -708,6 +760,27 @@ export default function UserTable() {
       renderCell: (params) => params.row.identity_provider || '—',
     },
     {
+      field: 'last_seen',
+      headerName: 'Last Seen',
+      flex: 0.75,
+      type: 'dateTime',
+      // valueGetter (not just renderCell) so sorting, the isEmpty filter
+      // operator, and the toolbar's No Activity switch all see a real
+      // Date-or-null instead of the raw ISO string.
+      valueGetter: (params) => parseLastSeen(params.row.last_seen),
+      // Direction-aware so never-active rows sort last under BOTH asc and
+      // desc; see compareLastSeen for how it pre-compensates the grid's
+      // negation on desc.
+      sortComparator: (v1, v2, cellParams1) => {
+        const direction =
+          (cellParams1.api.getSortModel() as GridSortItem[]).find(
+            (item) => item.field === cellParams1.field
+          )?.sort ?? 'asc'
+        return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
+      },
+      renderCell: (params) => <LastSeenCell value={params.value ?? null} />,
+    },
+    {
       field: 'actions',
       type: 'actions',
       headerName: 'Actions',
@@ -861,6 +934,8 @@ export default function UserTable() {
               sortModel: [{ field: 'role', sort: 'asc' }],
             },
           }}
+          filterModel={filterModel}
+          onFilterModelChange={setFilterModel}
           rowModesModel={rowModesModel}
           onRowModesModelChange={handleRowModesModelChange}
           onProcessRowUpdateError={handleProcessRowUpdateError}
@@ -876,6 +951,8 @@ export default function UserTable() {
               isAdmin,
               showDeleted,
               setShowDeleted,
+              noActivityOnly,
+              setNoActivityOnly,
             },
             filterPanel: {
               sx: {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -57,7 +57,12 @@ import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import LastSeenCell from './LastSeenCell'
-import { compareLastSeen, parseLastSeen } from './lastSeen'
+import {
+  compareLastSeen,
+  parseLastSeen,
+  hasNoActivityFilter,
+  withNoActivityFilter,
+} from './lastSeen'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
   setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void
@@ -208,23 +213,13 @@ export default function UserTable() {
   // isEmpty filter on last_seen while quick-filter text (which also lives in
   // this model) keeps working. The switch state is DERIVED from the model, so
   // removing the filter via the column filter panel un-checks the switch too.
+  // The toggle logic lives in lastSeen.ts (withNoActivityFilter) because the
+  // community grid's single-filter-item limit makes it subtle enough to pin
+  // with tests.
   const [filterModel, setFilterModel] = useState<GridFilterModel>({ items: [] })
-  const noActivityOnly = filterModel.items.some(
-    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
-  )
+  const noActivityOnly = hasNoActivityFilter(filterModel)
   const setNoActivityOnly = (value: boolean) => {
-    setFilterModel((prev) => ({
-      ...prev,
-      items: value
-        ? [
-            ...prev.items.filter((item) => item.field !== 'last_seen'),
-            { id: 'no-activity', field: 'last_seen', operator: 'isEmpty' },
-          ]
-        : prev.items.filter(
-            (item) =>
-              !(item.field === 'last_seen' && item.operator === 'isEmpty')
-          ),
-    }))
+    setFilterModel((prev) => withNoActivityFilter(prev, value))
   }
   const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
   const [pendingRestoreRow, setPendingRestoreRow] = useState<users | null>(null)

--- a/src/views/UserTable/lastSeen.test.ts
+++ b/src/views/UserTable/lastSeen.test.ts
@@ -1,9 +1,12 @@
 import {
   LAST_SEEN_EMPTY_LABEL,
+  NO_ACTIVITY_FILTER_ITEM,
   compareLastSeen,
   formatLastSeenAbsolute,
   formatLastSeenRelative,
+  hasNoActivityFilter,
   parseLastSeen,
+  withNoActivityFilter,
 } from './lastSeen'
 
 describe('parseLastSeen', () => {
@@ -87,6 +90,58 @@ describe('compareLastSeen', () => {
     // Desc mirrors the grid: it negates the comparator's result.
     const desc = [...rows].sort((a, b) => -compareLastSeen(a, b, 'desc'))
     expect(desc).toEqual([newer, older, null, null])
+  })
+})
+
+describe('withNoActivityFilter / hasNoActivityFilter', () => {
+  it('turning ON injects the isEmpty item and reports active', () => {
+    const next = withNoActivityFilter({ items: [] }, true)
+    expect(next.items).toEqual([NO_ACTIVITY_FILTER_ITEM])
+    expect(hasNoActivityFilter(next)).toBe(true)
+  })
+
+  // The community DataGrid keeps only ONE column-filter item
+  // (disableMultipleColumnsFiltering is hard-set) and silently discards the
+  // rest. An implementation that APPENDS after an existing panel filter puts
+  // the no-activity item at index 1, where the grid throws it away and the
+  // toggle does nothing - so ON must replace the items outright.
+  it('turning ON replaces a pre-existing column filter instead of appending', () => {
+    const withPanelFilter = {
+      items: [{ id: 1, field: 'role', operator: 'is', value: 'ISSO' }],
+    }
+    const next = withNoActivityFilter(withPanelFilter, true)
+    expect(next.items).toEqual([NO_ACTIVITY_FILTER_ITEM])
+  })
+
+  it('preserves quick-filter text across both transitions', () => {
+    const quick = { items: [], quickFilterValues: ['skywalker'] }
+    const on = withNoActivityFilter(quick, true)
+    expect(on.quickFilterValues).toEqual(['skywalker'])
+    const off = withNoActivityFilter(on, false)
+    expect(off.quickFilterValues).toEqual(['skywalker'])
+    expect(off.items).toEqual([])
+  })
+
+  it('turning OFF removes only the no-activity item', () => {
+    const model = {
+      items: [
+        { id: 1, field: 'role', operator: 'is', value: 'ISSO' },
+        NO_ACTIVITY_FILTER_ITEM,
+      ],
+    }
+    const off = withNoActivityFilter(model, false)
+    expect(off.items).toEqual([
+      { id: 1, field: 'role', operator: 'is', value: 'ISSO' },
+    ])
+    expect(hasNoActivityFilter(off)).toBe(false)
+  })
+
+  it('hasNoActivityFilter is false for an unrelated last_seen filter', () => {
+    expect(
+      hasNoActivityFilter({
+        items: [{ id: 2, field: 'last_seen', operator: 'after', value: 'x' }],
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/views/UserTable/lastSeen.test.ts
+++ b/src/views/UserTable/lastSeen.test.ts
@@ -1,0 +1,102 @@
+import {
+  LAST_SEEN_EMPTY_LABEL,
+  compareLastSeen,
+  formatLastSeenAbsolute,
+  formatLastSeenRelative,
+  parseLastSeen,
+} from './lastSeen'
+
+describe('parseLastSeen', () => {
+  it('parses a backend ISO timestamp (microseconds + Z)', () => {
+    const d = parseLastSeen('2026-08-04T11:52:20.090616Z')
+    expect(d).toBeInstanceOf(Date)
+    expect(d!.toISOString()).toBe('2026-08-04T11:52:20.090Z')
+  })
+
+  it('returns null for null, undefined, and empty string', () => {
+    expect(parseLastSeen(null)).toBeNull()
+    expect(parseLastSeen(undefined)).toBeNull()
+    expect(parseLastSeen('')).toBeNull()
+  })
+
+  it('returns null for an unparseable string', () => {
+    expect(parseLastSeen('not-a-date')).toBeNull()
+  })
+})
+
+describe('formatLastSeenRelative', () => {
+  const now = new Date('2026-08-07T12:00:00Z')
+  const secondsAgo = (s: number) => new Date(now.getTime() - s * 1000)
+
+  it.each([
+    [30, 'just now'],
+    [5 * 60, '5 minutes ago'],
+    [3 * 3600, '3 hours ago'],
+    [3 * 24 * 3600, '3 days ago'],
+    [2 * 7 * 24 * 3600, '2 weeks ago'],
+    [65 * 24 * 3600, '2 months ago'],
+    [2 * 365 * 24 * 3600, '2 years ago'],
+  ])('%d seconds ago renders "%s"', (seconds, expected) => {
+    expect(formatLastSeenRelative(secondsAgo(seconds), now)).toBe(expected)
+  })
+
+  it('treats a slightly-ahead server clock as "just now"', () => {
+    expect(formatLastSeenRelative(secondsAgo(-10), now)).toBe('just now')
+  })
+})
+
+describe('formatLastSeenAbsolute', () => {
+  it('produces a locale date-time string containing the year', () => {
+    const out = formatLastSeenAbsolute(new Date('2026-08-04T11:52:20Z'))
+    expect(out).toContain('2026')
+  })
+})
+
+describe('compareLastSeen', () => {
+  const older = new Date('2026-01-01T00:00:00Z')
+  const newer = new Date('2026-08-01T00:00:00Z')
+
+  it('orders two dates chronologically under asc', () => {
+    expect(compareLastSeen(older, newer, 'asc')).toBeLessThan(0)
+    expect(compareLastSeen(newer, older, 'asc')).toBeGreaterThan(0)
+    expect(compareLastSeen(older, older, 'asc')).toBe(0)
+  })
+
+  it('sorts null after any date under asc', () => {
+    expect(compareLastSeen(null, older, 'asc')).toBeGreaterThan(0)
+    expect(compareLastSeen(older, null, 'asc')).toBeLessThan(0)
+  })
+
+  // The grid negates the comparator result when sorting desc, so the raw
+  // return values here are inverted relative to the final row order: -1 for
+  // (null, date) becomes +1 after negation, which still places null last.
+  it('pre-compensates under desc so null still lands last after negation', () => {
+    expect(compareLastSeen(null, older, 'desc')).toBeLessThan(0)
+    expect(compareLastSeen(older, null, 'desc')).toBeGreaterThan(0)
+  })
+
+  it('treats two nulls as equal in both directions', () => {
+    expect(compareLastSeen(null, null, 'asc')).toBe(0)
+    expect(compareLastSeen(undefined, null, 'desc')).toBe(0)
+  })
+
+  it('end-to-end: grid sort simulation keeps nulls last both ways', () => {
+    const rows: (Date | null)[] = [newer, null, older, null]
+    const asc = [...rows].sort((a, b) => compareLastSeen(a, b, 'asc'))
+    expect(asc).toEqual([older, newer, null, null])
+    // Desc mirrors the grid: it negates the comparator's result.
+    const desc = [...rows].sort((a, b) => -compareLastSeen(a, b, 'desc'))
+    expect(desc).toEqual([newer, older, null, null])
+  })
+})
+
+describe('LAST_SEEN_EMPTY_LABEL', () => {
+  // Tracking began 2026-08-06; for older accounts null means "nothing since
+  // tracking began", not "never signed in". Pin the neutral wording so it
+  // doesn't drift into something accusatory like "Never logged in".
+  it('is neutral about sign-in history', () => {
+    expect(LAST_SEEN_EMPTY_LABEL).toBe('No activity recorded')
+    expect(LAST_SEEN_EMPTY_LABEL.toLowerCase()).not.toContain('login')
+    expect(LAST_SEEN_EMPTY_LABEL.toLowerCase()).not.toContain('never')
+  })
+})

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -6,7 +6,11 @@
  * tracking began 2026-08-06, so a null for an older account means "no recorded
  * activity since tracking began", not "never signed in".
  */
-import type { GridFilterModel } from '@mui/x-data-grid'
+import type {
+  GridComparatorFn,
+  GridFilterModel,
+  GridSortItem,
+} from '@mui/x-data-grid'
 
 /** Neutral empty state - see the module note on why it isn't "Never logged in". */
 export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
@@ -106,4 +110,27 @@ export function compareLastSeen(
   if (aNull) return direction === 'desc' ? -1 : 1
   if (bNull) return direction === 'desc' ? 1 : -1
   return a.getTime() - b.getTime()
+}
+
+/**
+ * The column's comparator: reads the LIVE sort direction off the grid api at
+ * compare time (v6 commits the new sort model to state before applying the
+ * sort, so this sees the direction being applied, not the previous one) and
+ * hands it to compareLastSeen. Exported so the grid-level test can exercise
+ * this exact wiring - the getSortModel() read is the fragile part, not the
+ * pure comparison.
+ *
+ * TODO(x-data-grid v7): replace with getSortComparator(direction) on the
+ * column def and drop the direction plumbing here - a v7 upgrade that keeps
+ * this workaround would still work, but the native hook is the intended API.
+ */
+export const lastSeenSortComparator: GridComparatorFn<Date | null> = (
+  v1,
+  v2,
+  cellParams1
+) => {
+  const direction = (cellParams1.api.getSortModel() as GridSortItem[]).find(
+    (item) => item.field === cellParams1.field
+  )?.sort
+  return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
 }

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -1,0 +1,70 @@
+/**
+ * Sorting and formatting logic for the user grid's "Last seen" column,
+ * extracted so it can be tested without standing up the grid.
+ *
+ * The column is deliberately labeled "Last seen", not "Last login": activity
+ * tracking began 2026-08-06, so a null for an older account means "no recorded
+ * activity since tracking began", not "never signed in".
+ */
+
+/** Neutral empty state - see the module note on why it isn't "Never logged in". */
+export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
+
+/** Parse an ISO timestamp defensively; null for missing or unparseable input. */
+export function parseLastSeen(iso: string | null | undefined): Date | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  return isNaN(d.getTime()) ? null : d
+}
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ['year', 365 * 24 * 3600],
+  ['month', 30 * 24 * 3600],
+  ['week', 7 * 24 * 3600],
+  ['day', 24 * 3600],
+  ['hour', 3600],
+  ['minute', 60],
+]
+
+/**
+ * Relative rendering for the cell ("3 days ago"). Anything under a minute -
+ * including a slightly-ahead server clock - reads "just now".
+ */
+export function formatLastSeenRelative(value: Date, now: Date): string {
+  const diffSec = Math.round((now.getTime() - value.getTime()) / 1000)
+  if (diffSec < 60) return 'just now'
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always' })
+  for (const [unit, seconds] of RELATIVE_UNITS) {
+    if (diffSec >= seconds) {
+      return rtf.format(-Math.floor(diffSec / seconds), unit)
+    }
+  }
+  return 'just now'
+}
+
+/** Absolute timestamp for the hover tooltip, in the viewer's locale. */
+export function formatLastSeenAbsolute(value: Date): string {
+  return value.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+/**
+ * Comparator for the column, direction-aware so never-active rows sort LAST in
+ * both directions. The grid negates the comparator's result when sorting desc,
+ * so the null branches pre-compensate: returning -1 for a null under desc
+ * becomes +1 after negation, keeping the null at the bottom.
+ */
+export function compareLastSeen(
+  a: Date | null | undefined,
+  b: Date | null | undefined,
+  direction: 'asc' | 'desc'
+): number {
+  const aNull = a == null
+  const bNull = b == null
+  if (aNull && bNull) return 0
+  if (aNull) return direction === 'desc' ? -1 : 1
+  if (bNull) return direction === 'desc' ? 1 : -1
+  return a.getTime() - b.getTime()
+}

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -6,9 +6,48 @@
  * tracking began 2026-08-06, so a null for an older account means "no recorded
  * activity since tracking began", not "never signed in".
  */
+import type { GridFilterModel } from '@mui/x-data-grid'
 
 /** Neutral empty state - see the module note on why it isn't "Never logged in". */
 export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
+
+/** The filter item the "No Activity Only" toolbar switch injects. */
+export const NO_ACTIVITY_FILTER_ITEM = {
+  id: 'no-activity',
+  field: 'last_seen',
+  operator: 'isEmpty',
+}
+
+/** Whether the model currently carries the no-activity filter (drives the switch). */
+export function hasNoActivityFilter(model: GridFilterModel): boolean {
+  return model.items.some(
+    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
+  )
+}
+
+/**
+ * Toggle the no-activity filter on a filter model. The community DataGrid
+ * allows only ONE column-filter item (disableMultipleColumnsFiltering is
+ * hard-set); sanitizeFilterModel drops anything past the first and logs a
+ * console error. So switching ON must REPLACE the items array outright, not
+ * append - an appended item at index 1 would be silently discarded whenever
+ * the user already had a filter applied via the column filter panel. The
+ * spread preserves quickFilterValues, which live beside items and are not
+ * subject to the single-item limit.
+ */
+export function withNoActivityFilter(
+  model: GridFilterModel,
+  on: boolean
+): GridFilterModel {
+  return {
+    ...model,
+    items: on
+      ? [NO_ACTIVITY_FILTER_ITEM]
+      : model.items.filter(
+          (item) => !(item.field === 'last_seen' && item.operator === 'isEmpty')
+        ),
+  }
+}
 
 /** Parse an ISO timestamp defensively; null for missing or unparseable input. */
 export function parseLastSeen(iso: string | null | undefined): Date | null {

--- a/src/views/UserTable/lastSeenSortComparator.integration.test.tsx
+++ b/src/views/UserTable/lastSeenSortComparator.integration.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Grid-level test for the Last Seen sort wiring. The pure comparator is
+ * covered in lastSeen.test.ts with a simulated negation; this renders a real
+ * DataGrid and clicks the header so the fragile part - the live
+ * api.getSortModel() read inside lastSeenSortComparator while the grid
+ * applies a new sort - is exercised for real, in both directions.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
+import { lastSeenSortComparator, parseLastSeen } from './lastSeen'
+
+type Row = { id: number; name: string; last_seen: string | null }
+
+const rows: Row[] = [
+  { id: 1, name: 'Leia Organa', last_seen: '2026-08-01T00:00:00Z' },
+  { id: 2, name: 'Han Solo', last_seen: null },
+  { id: 3, name: 'Luke Skywalker', last_seen: '2026-06-01T00:00:00Z' },
+  { id: 4, name: 'Lando Calrissian', last_seen: null },
+]
+
+const columns: GridColDef[] = [
+  { field: 'name', headerName: 'Name' },
+  {
+    field: 'last_seen',
+    headerName: 'Last Seen',
+    type: 'dateTime',
+    valueGetter: (params) => parseLastSeen(params.row.last_seen),
+    sortComparator: lastSeenSortComparator,
+  },
+]
+
+function renderGrid() {
+  return render(
+    <div style={{ height: 500, width: 700 }}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        disableVirtualization
+        autoHeight
+      />
+    </div>
+  )
+}
+
+/** Names in on-screen row order (skips the header row). */
+function namesInOrder(): string[] {
+  return (
+    screen
+      .getAllByRole('row')
+      // Header row has columnheaders, not cells (v6 renders role="cell").
+      .filter((row) => within(row).queryAllByRole('cell').length > 0)
+      .map((row) => within(row).getAllByRole('cell')[0].textContent ?? '')
+  )
+}
+
+describe('lastSeenSortComparator in a real DataGrid', () => {
+  it('keeps never-active rows last under asc AND desc header sorts', () => {
+    renderGrid()
+    const header = screen.getByRole('columnheader', { name: 'Last Seen' })
+
+    // First click: ascending - oldest first, both nulls at the bottom.
+    fireEvent.click(within(header).getByText('Last Seen'))
+    expect(namesInOrder()).toEqual([
+      'Luke Skywalker',
+      'Leia Organa',
+      'Han Solo',
+      'Lando Calrissian',
+    ])
+
+    // Second click: descending - newest first, nulls STILL at the bottom
+    // (the grid negates the comparator; the live-direction read compensates).
+    fireEvent.click(within(header).getByText('Last Seen'))
+    expect(namesInOrder()).toEqual([
+      'Leia Organa',
+      'Luke Skywalker',
+      'Han Solo',
+      'Lando Calrissian',
+    ])
+  })
+})


### PR DESCRIPTION
Closes #675.

Adds a sortable "Last Seen" column to the user management grid, reading the `last_seen` field the backend now serves inline on `GET /users` - no new requests, the column rides the existing list response. Verified against the local prod clone: 1,269 users, 295 with timestamps, and the new "No Activity Only" toggle matches the remaining 974.

| | |
|---|---|
| Cell render | relative time ("18 hours ago"), absolute timestamp on hover and in a visually hidden span for screen readers |
| Never-active rows | italic "No activity recorded" - deliberately not blank, and deliberately not "never logged in" |
| Sorting | nulls last in both directions |
| Stretch (from the issue) | "No Activity Only" toolbar switch |

Two wording/mechanism choices worth knowing about:

**Why "Last Seen" and a neutral empty state.** Activity tracking began 2026-08-06, so for accounts created before that, null means "nothing since tracking began", not "never signed in". The label and empty state are worded so the column never accuses a user who simply predates tracking. A test pins the wording so it can't drift into "Never logged in".

**Why the sort comparator is direction-aware.** We're on x-data-grid v6.19.4, which has no `getSortComparator` (that's v7). The grid negates a plain comparator's result when sorting desc, which would flip "nulls last" into "nulls first" the moment someone sorts by most-recent. `compareLastSeen` reads the active sort direction and pre-compensates so never-active rows always sink to the bottom. Alternatives considered: a plain comparator (wrong under desc) and upgrading to v7 (out of scope for this change). The negation behavior is verified against the installed grid source and simulated end-to-end in a unit test.

The toggle drives a controlled filter model with an `isEmpty` filter on the column. The community DataGrid only keeps one column-filter item, so turning the toggle on replaces the items array rather than appending (an appended item is silently discarded when a filter panel filter already exists); quick-filter text lives beside the items and is preserved. That transform is extracted to `withNoActivityFilter` and unit-tested, including the pre-existing-filter case.

## Rider: InsightsPanel helper extraction

`severityStyle`, `rollupControls`, their types, `asText`, and `INFERRED_PASS_SOURCES` moved verbatim from `InsightsPanel.tsx` to a new `controlRollup.ts`. This clears the two long-standing `react-refresh/only-export-components` lint warnings (a component file must only export components). No behavior change - the move was line-diffed and the only deltas are `export` keywords, an import, and a docstring. Test imports updated to the new module.

## Testing

- 38 tests across `lastSeen.test.ts` / `LastSeenCell.test.tsx` / the untouched `cellEditGuards.test.ts`: ISO parsing (including the backend's microsecond timestamps), relative formatting, the direction-aware comparator with a grid-negation simulation, null render, the hidden-span a11y text, and the filter-model transform.
- Full suite: 866 passing. Typecheck and lint clean, zero warnings repo-wide.
- Verified live against a prod clone: render, both sort directions, and the toggle, as an OWNER account. OpDiv scoping needs no frontend work - `last_seen` is computed inside the same fail-closed OpDiv-scoped query as the rows themselves.
- Deliberately not needed: no new endpoints or hooks, no changes to `/users/current` (which intentionally returns null for this field), no edit-gate changes (the column is not editable).
<img width="576" height="632" alt="image" src="https://github.com/user-attachments/assets/30865d64-66d3-44b1-8ee2-f329d78004f5" />

The one judgment call to scrutinize: the toolbar switch wiring is covered by unit tests on the extracted filter-model transform rather than a grid-level component test, matching how the edit gates in this table are already tested.
