### PR TITLE
Scope the Scored / Systems tile to the selected call(s)

### DIFF
--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -103,7 +103,7 @@ export default function HomePageContainer() {
   }
   return (
     <Box>
-      <StatisticsBlocks scores={scoreMap} />
+      <StatisticsBlocks scores={scoreMap} progress={progressMap} />
       <BreadCrumbs />
       <FismaTable
         scores={scoreMap}

--- a/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import StatisticsBlocks from './StatisticsBlocks'
-import type { FismaSystemType, SystemScoreEntry } from '@/types'
+import type { FismaSystemType, ScoreProgress, SystemScoreEntry } from '@/types'
 
 // StatisticsBlocks reads the full active-system list from the outlet context and
 // the selection-scoped score map from props. The bug in ztmf-ui#633 was the
@@ -22,6 +22,18 @@ const score = (
   score: n,
   tier,
 })
+
+// A progress row for a system in the selected call(s). `expected` is the number
+// of applicable questions; > 0 means the system is part of the call.
+const prog = (id: number, expected: number): ScoreProgress =>
+  ({
+    fismasystemid: id,
+    questionsexpected: expected,
+    questionsanswered: 0,
+    questionsupdated: 0,
+    lastupdatedat: null,
+    updatedsincestart: false,
+  }) as ScoreProgress
 
 // Read the big numeral out of a tile located by its label. The high/low tiles
 // fold an acronym into the label element, so callers pass a regex for those.
@@ -49,15 +61,54 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     expect(tileValue('Average System Score')).toBe('3.5')
   })
 
-  it('shows the Scored / Total ratio scoped to the selection', () => {
-    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+  it('scopes the denominator to systems in the selected call(s), not the whole inventory', () => {
+    // Four active systems. 1, 2, 3 are in the selected call (progress rows); 1
+    // and 2 are scored, 3 is not started. System 4 is not in the call at all (no
+    // progress row). The tile reads 2 scored / 3 in-call - system 4 is excluded
+    // from the denominator instead of permanently counting as unscored.
+    mockFismaSystems = [
+      sys(1, 'AAA'),
+      sys(2, 'BBB'),
+      sys(3, 'CCC'),
+      sys(4, 'DDD'),
+    ]
     const scores: Record<number, SystemScoreEntry> = {
       1: score(2),
       2: score(5),
     }
-    render(<StatisticsBlocks scores={scores} />)
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 40),
+      3: prog(3, 40),
+    }
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
 
-    expect(tileValue('Scored / Total Systems')).toBe('2 / 3')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('2 / 3')
+  })
+
+  it('excludes a system whose questionnaire does not apply (0 expected)', () => {
+    // A 0/0 system carries a progress row but has no questions to answer, so it
+    // is not part of the call's population and must not inflate the denominator.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    const scores: Record<number, SystemScoreEntry> = { 1: score(3) }
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 0),
+    }
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
+
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('1 / 1')
+  })
+
+  it('does not read a false 100% when progress data is unavailable', () => {
+    // If the progress fetch fails entirely, the in-call population is unknown.
+    // The tile must not collapse to scored / scored (a false "all done"); it
+    // shows a 0 denominator so the missing data is visible rather than hidden.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    const scores: Record<number, SystemScoreEntry> = { 1: score(4) }
+    render(<StatisticsBlocks scores={scores} progress={{}} />)
+
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('1 / 0')
   })
 
   it('keeps the average between the lowest and highest displayed scores', () => {
@@ -78,14 +129,19 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     expect(high).toBe(4.82)
   })
 
-  it('handles a selection no system participated in without going below scale', () => {
-    // No scored systems: average is 0 (guarded), ratio is 0 / N, and the lowest
-    // tile falls back to 0.00 rather than rendering Infinity.
+  it('handles a call no system has started without going below scale', () => {
+    // Two systems in the call, none scored yet: average is 0 (guarded), ratio is
+    // 0 / 2 (both are in the call), and the lowest tile falls back to 0.00 rather
+    // than rendering Infinity.
     mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
-    render(<StatisticsBlocks scores={{}} />)
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 40),
+    }
+    render(<StatisticsBlocks scores={{}} progress={progress} />)
 
     expect(tileValue('Average System Score')).toBe('0')
-    expect(tileValue('Scored / Total Systems')).toBe('0 / 2')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('0 / 2')
     expect(tileValue('Lowest System Score:')).toBe('0.00')
   })
 
@@ -96,8 +152,14 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     const scores: Record<number, SystemScoreEntry> = {
       1: score(3.44),
     }
-    render(<StatisticsBlocks scores={scores} />)
+    // All 1342 systems are in the selected call, so the denominator is 1,342.
+    const progress: Record<number, ScoreProgress> = Object.fromEntries(
+      mockFismaSystems.map((s) => [s.fismasystemid, prog(s.fismasystemid, 40)])
+    )
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
 
-    expect(tileValue('Scored / Total Systems')).toBe('1 / 1,342')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe(
+      '1 / 1,342'
+    )
   })
 })

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper'
 import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { useContextProp } from '../Title/Context'
-import type { ScoreTier, SystemScoreEntry } from '@/types'
+import type { ScoreProgress, ScoreTier, SystemScoreEntry } from '@/types'
 import { TIERS } from '@/utils/tierStyles'
 const StatisticsPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(2),
@@ -21,8 +21,10 @@ const StatisticsPaper = styled(Paper)(({ theme }) => ({
 }))
 export default function StatisticsBlocks({
   scores,
+  progress,
 }: {
   scores: Record<number, SystemScoreEntry>
+  progress?: Record<number, ScoreProgress>
 }) {
   const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
@@ -41,12 +43,14 @@ export default function StatisticsBlocks({
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    // Count only the systems that actually contribute a score. The `scores` map
-    // is already scoped to the selected data call(s), so systems with no answers
-    // in the selection must not inflate the denominator (that dragged the average
-    // below the scale minimum — see ztmf-ui#633). Counted inside the loop so the
-    // numerator and denominator always cover the same systems.
+    // The average divides by the scored systems only: the scores map is scoped
+    // to the selected call(s), so unscored systems must not dilute it. The
+    // Scored / Systems tile pairs that scored count with a denominator scoped
+    // the same way - the systems actually in the selected call(s), taken from
+    // the progress map - instead of a call-scoped numerator over an all-systems
+    // denominator, which read as an order-of-magnitude larger backlog than real.
     let scoredCount: number = 0
+    let inCallCount: number = 0
     let maxScore: number = 0
     let maxScoreSystem: string = ''
     let maxScoreTier: ScoreTier | undefined
@@ -56,6 +60,22 @@ export default function StatisticsBlocks({
     let totalScores: number = 0
     for (const system of fismaSystems) {
       const entry = scores[system.fismasystemid]
+      // A system is in the selected call(s) if the progress map carries a row
+      // for it with questions to answer (questionsexpected > 0), a set that
+      // includes never-started systems. A scored system always has such a row
+      // when the progress fetch succeeds, so the ratio stays within 100% without
+      // a special case; if the whole progress fetch fails the denominator reads
+      // 0, which surfaces the outage instead of hiding it behind a false "all
+      // scored" (which counting scored systems here would produce).
+      const progressEntry = progress?.[system.fismasystemid]
+      if ((progressEntry?.questionsexpected ?? 0) > 0) {
+        inCallCount += 1
+      }
+      // Truthy check, not a null check, on purpose. Backend system scores are
+      // floored at 1.0 (each pillar averages the answer score plus one), so a
+      // real score is never 0. A 0 here only comes from an absent/null score
+      // being coalesced to 0 upstream, which must not count as scored. If
+      // scoring ever moves to a 0-based scale, this has to distinguish the two.
       if (entry && entry.score) {
         if (entry.score > maxScore) {
           maxScore = entry.score
@@ -79,7 +99,7 @@ export default function StatisticsBlocks({
       setMinSystemScore(minScore)
     }
     setAnsweredSystems(scoredCount)
-    setTotalSystems(fismaSystems.length)
+    setTotalSystems(inCallCount)
     setMaxSystemScore(maxScore)
     setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
@@ -87,7 +107,7 @@ export default function StatisticsBlocks({
     setMinSystemTier(minScoreTier)
     setMinSystemAcronym(minScoreSystem || '')
     setLoading(false)
-  }, [fismaSystems, scores])
+  }, [fismaSystems, scores, progress])
   if (loading) {
     return <p>Loading ...</p>
   }
@@ -114,7 +134,7 @@ export default function StatisticsBlocks({
           variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
-          Scored / Total Systems
+          Scored / Systems in selected data calls
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">


### PR DESCRIPTION
## Summary

Closes #658.

The dashboard's first stat tile, "Scored / Total Systems", put a call-scoped numerator over an all-systems denominator, so the ratio did not mean what it read as. The numerator (`answeredSystems`) counts systems with an entry in `scoreMap`, which `buildDashboardMaps` builds per selected call. The denominator was `fismaSystems.length` from `Title.tsx`, which takes no `datacallid` and represents every system the user can see across all calls and all time. A system that was never part of the selected call still landed in the denominator and could never reach the numerator, so the tile permanently reported it as unscored for a call it was never in. This overstated the outstanding work by roughly an order of magnitude in production, with no error state when it drifted.

## Changes

* **`StatisticsBlocks.tsx`:** added a `progress` prop and scoped the denominator to systems actually in the selected call(s): a progress row with `questionsexpected > 0`, the set that already includes never-started systems. Numerator, average, and high/low logic are unchanged. The stale "numerator and denominator always cover the same systems" comment is corrected. Label changed to "Scored / Systems in selected data calls", which reads correctly whether one call or a whole year is selected.
* **`Home.tsx`:** passes `progress={progressMap}` (already built there for the table).
* Documented why the numerator's truthy score guard is correct: backend system scores are floored at 1.0 (`AVG(answer + 1.0)` per pillar), so a falsey value only comes from an absent/null score coalesced upstream, which must not count as scored.

## Acceptance criteria

* [x] The tile's numerator and denominator cover the same population: systems in the selected data call(s).
* [x] A system not present in any selected call does not appear in the denominator.
* [x] The tile label names the population it measures.
* [x] Selecting a different year or call updates both halves consistently (both derive from `buildDashboardMaps`).
* [x] Unit tests cover a system outside the selected call and a call-scoped denominator.
* [x] The stale "same systems" comment is corrected.

## Testing

* **`StatisticsBlocks.test.tsx` (7 tests):** denominator scoped to system(s) in the selected call(s) with an out-of-call system excluded; a `questionsexpected: 0` (no-questionnaire) system excluded; a no-participation call reads 0 / 2 (not below scale); a total progress-fetch failure reads N / 0 rather than a false 100%; thousands separators intact.
* `tsc --noEmit` and `eslint` clean; Home suite (12) green.
* Behavior-only; the visible change is the corrected count and label.