### PR TITLE
fix(#289): restore SaaS pillars on historical data calls

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -38,6 +38,7 @@ import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
 import { useContextProp } from '@/views/Title/Context'
+import { buildRadarData } from './radarData'
 
 interface PillarScoresModalProps {
   open: boolean
@@ -148,19 +149,13 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     (comparisonScoreEntry?.pillarscores?.length ?? 0) > 0
 
   // Prepare radar chart data
-  const radarData = useMemo(() => {
-    if (!hasValidData || !latestScore?.pillarscores) return []
-    return latestScore.pillarscores.map((pillar) => {
-      const comparisonPillarScore = comparisonScoreEntry?.pillarscores?.find(
-        (p) => p.pillarid === pillar.pillarid
-      )?.score
-      return {
-        pillar: pillar.pillar,
-        current: pillar.score ?? 0,
-        previous: comparisonPillarScore ?? 0,
-      }
-    })
-  }, [hasValidData, latestScore, comparisonScoreEntry])
+  const radarData = useMemo(
+    () =>
+      hasValidData
+        ? buildRadarData(latestScore?.pillarscores, comparisonScoreEntry)
+        : [],
+    [hasValidData, latestScore, comparisonScoreEntry]
+  )
 
   // Focus management for accessibility
   useEffect(() => {

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -38,7 +38,7 @@ import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
 import { useContextProp } from '@/views/Title/Context'
-import { buildRadarData } from './radarData'
+import { buildRadarData, findComparisonPillarScore } from './radarData'
 
 interface PillarScoresModalProps {
   open: boolean
@@ -489,10 +489,10 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
             </Typography>
             <Grid container spacing={2}>
               {(latestScore.pillarscores ?? []).map((pillar) => {
-                const previousPillarScore =
-                  comparisonScoreEntry?.pillarscores?.find(
-                    (p) => p.pillarid === pillar.pillarid
-                  )?.score
+                const previousPillarScore = findComparisonPillarScore(
+                  comparisonScoreEntry,
+                  pillar.pillarid
+                )
 
                 const currentScore = pillar.score ?? 0
                 const trendInfo = getTrendInfo(
@@ -839,10 +839,10 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       </TableHead>
                       <TableBody>
                         {latestScore?.pillarscores?.map((pillar) => {
-                          const previousPillarScore =
-                            comparisonScoreEntry?.pillarscores?.find(
-                              (p) => p.pillarid === pillar.pillarid
-                            )?.score
+                          const previousPillarScore = findComparisonPillarScore(
+                            comparisonScoreEntry,
+                            pillar.pillarid
+                          )
 
                           const currentScore = pillar.score ?? 0
                           const prevScore = previousPillarScore ?? 0

--- a/src/components/PillarScoresModal/radarData.test.ts
+++ b/src/components/PillarScoresModal/radarData.test.ts
@@ -1,0 +1,82 @@
+import { buildRadarData } from './radarData'
+import type { PillarScore, ScoreAggregate } from '@/types'
+
+// A pillar absent from the comparison call used to plot as previous = 0, which
+// drew the line into the centre of the chart.
+
+const ANCHOR: PillarScore[] = [
+  { pillarid: 1, pillar: 'Identity', score: 3.5 },
+  { pillarid: 2, pillar: 'Devices', score: 2.0 },
+]
+
+const comparison = (pillarscores: PillarScore[]): ScoreAggregate => ({
+  datacallid: 4,
+  fismasystemid: 1001,
+  systemscore: 3.0,
+  pillarscores,
+})
+
+describe('buildRadarData', () => {
+  it('carries the comparison score when the pillar exists in both calls', () => {
+    expect(
+      buildRadarData(
+        ANCHOR,
+        comparison([
+          { pillarid: 1, pillar: 'Identity', score: 2.5 },
+          { pillarid: 2, pillar: 'Devices', score: 1.5 },
+        ])
+      )
+    ).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: 2.5 },
+      { pillar: 'Devices', current: 2.0, previous: 1.5 },
+    ])
+  })
+
+  it('leaves previous undefined for a pillar the comparison call does not carry', () => {
+    const data = buildRadarData(
+      ANCHOR,
+      comparison([{ pillarid: 1, pillar: 'Identity', score: 2.5 }])
+    )
+
+    expect(data[1]).toEqual({
+      pillar: 'Devices',
+      current: 2.0,
+      previous: undefined,
+    })
+    expect(data[1].previous).not.toBe(0)
+  })
+
+  // A comparison missing an earlier pillar must not shift scores onto the wrong spoke.
+  it('matches on pillarid, not on position', () => {
+    const data = buildRadarData(
+      ANCHOR,
+      comparison([{ pillarid: 2, pillar: 'Devices', score: 1.5 }])
+    )
+
+    expect(data).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: undefined },
+      { pillar: 'Devices', current: 2.0, previous: 1.5 },
+    ])
+  })
+
+  it('leaves previous undefined for every pillar when there is no comparison', () => {
+    for (const entry of [null, undefined]) {
+      expect(buildRadarData(ANCHOR, entry)).toEqual([
+        { pillar: 'Identity', current: 3.5, previous: undefined },
+        { pillar: 'Devices', current: 2.0, previous: undefined },
+      ])
+    }
+  })
+
+  it('leaves previous undefined when the comparison call has an empty pillar list', () => {
+    expect(buildRadarData(ANCHOR, comparison([]))).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: undefined },
+      { pillar: 'Devices', current: 2.0, previous: undefined },
+    ])
+  })
+
+  it('returns an empty series when the anchor call has no pillar scores', () => {
+    expect(buildRadarData(undefined, null)).toEqual([])
+    expect(buildRadarData([], null)).toEqual([])
+  })
+})

--- a/src/components/PillarScoresModal/radarData.ts
+++ b/src/components/PillarScoresModal/radarData.ts
@@ -1,0 +1,33 @@
+import type { PillarScore, ScoreAggregate } from '@/types'
+
+export type RadarDatum = {
+  pillar: string
+  current: number
+  previous?: number
+}
+
+/**
+ * Builds the radar series from the anchor call's pillars, pairing each with the
+ * comparison call's score for the same pillarid.
+ *
+ * `previous` stays undefined - never 0 - when the comparison call has no row for
+ * that pillar. Scores are floored at 1.0, so 0 plotted a line into the centre of
+ * the chart and read as a collapse rather than "not measured that cycle".
+ * Reachable today for any system whose environment changed between cycles.
+ *
+ * Separate from the component so it can be tested; the rendered radar cannot be
+ * inspected under jsdom.
+ */
+export function buildRadarData(
+  anchorPillarScores: PillarScore[] | undefined,
+  comparisonScoreEntry: ScoreAggregate | null | undefined
+): RadarDatum[] {
+  if (!anchorPillarScores) return []
+  return anchorPillarScores.map((pillar) => ({
+    pillar: pillar.pillar,
+    current: pillar.score ?? 0,
+    previous: comparisonScoreEntry?.pillarscores?.find(
+      (p) => p.pillarid === pillar.pillarid
+    )?.score,
+  }))
+}

--- a/src/components/PillarScoresModal/radarData.ts
+++ b/src/components/PillarScoresModal/radarData.ts
@@ -7,6 +7,23 @@ export type RadarDatum = {
 }
 
 /**
+ * The comparison call's score for one pillar, matched on pillarid so a comparison
+ * missing an earlier pillar cannot shift scores onto the wrong row. undefined when
+ * that call has no row for the pillar.
+ *
+ * Shared by the chart and the accessible table that mirrors it, so the two cannot
+ * disagree about what "no comparison" means.
+ */
+export function findComparisonPillarScore(
+  comparisonScoreEntry: ScoreAggregate | null | undefined,
+  pillarid: number
+): number | undefined {
+  return comparisonScoreEntry?.pillarscores?.find(
+    (p) => p.pillarid === pillarid
+  )?.score
+}
+
+/**
  * Builds the radar series from the anchor call's pillars, pairing each with the
  * comparison call's score for the same pillarid.
  *
@@ -26,8 +43,6 @@ export function buildRadarData(
   return anchorPillarScores.map((pillar) => ({
     pillar: pillar.pillar,
     current: pillar.score ?? 0,
-    previous: comparisonScoreEntry?.pillarscores?.find(
-      (p) => p.pillarid === pillar.pillarid
-    )?.score,
+    previous: findComparisonPillarScore(comparisonScoreEntry, pillar.pillarid),
   }))
 }

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -1,0 +1,90 @@
+import { reducedPillarScopeApplies } from './reducedPillarScope'
+import type { datacall } from '@/types'
+
+const call = (
+  datacallid: number,
+  datacall: string,
+  deadline: string
+): datacall => ({ datacallid, datacall, datecreated: '', deadline })
+
+// Ids deliberately unordered relative to deadlines - the backfill carries the
+// highest id.
+const FY25 = call(3, 'FY2025 Q3', '2025-05-07T23:59:59Z')
+const FY26 = call(53, 'FY2026 ZTM', '2026-09-11T23:59:59Z')
+const FY27 = call(4, 'FY2027 ZTM', '2027-09-11T23:59:59Z')
+const FY23_BACKFILL = call(99, 'FY23 ZTM', '2023-09-30T23:59:59Z')
+
+const ALL = [FY23_BACKFILL, FY26, FY25, FY27]
+
+describe('reducedPillarScopeApplies', () => {
+  it('applies to the FY26 anchor cycle', () => {
+    expect(reducedPillarScopeApplies(ALL, FY26.datacallid)).toBe(true)
+  })
+
+  // Both true at once: a latest-only gate would flip FY26 back to the full set.
+  it('applies to every cycle after the anchor, not just the latest', () => {
+    expect(reducedPillarScopeApplies(ALL, FY27.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(ALL, FY26.datacallid)).toBe(true)
+  })
+
+  it('does not apply to cycles earlier than the anchor', () => {
+    expect(reducedPillarScopeApplies(ALL, FY25.datacallid)).toBe(false)
+  })
+
+  it('treats a late-loaded backfill as history despite its higher id', () => {
+    expect(reducedPillarScopeApplies(ALL, FY23_BACKFILL.datacallid)).toBe(false)
+  })
+
+  it('matches both the FY2026 and FY26 name prefixes', () => {
+    const shortName = call(60, 'FY26 ZTM', '2026-09-11T23:59:59Z')
+    expect(
+      reducedPillarScopeApplies([FY25, shortName], shortName.datacallid)
+    ).toBe(true)
+  })
+
+  it('is case-insensitive on the prefix match', () => {
+    const lower = call(61, 'fy2026 ztm', '2026-09-11T23:59:59Z')
+    expect(reducedPillarScopeApplies([FY25, lower], lower.datacallid)).toBe(
+      true
+    )
+  })
+
+  // Unknowable cases fall back to the full question set.
+  it('does not apply when there is no FY26 cycle at all', () => {
+    expect(
+      reducedPillarScopeApplies([FY25, FY23_BACKFILL], FY25.datacallid)
+    ).toBe(false)
+  })
+
+  it('does not apply for an unrecognized call id', () => {
+    expect(reducedPillarScopeApplies(ALL, 12345)).toBe(false)
+  })
+
+  it('does not apply while the data call list is still loading', () => {
+    expect(reducedPillarScopeApplies([], FY26.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(undefined, FY26.datacallid)).toBe(false)
+  })
+
+  it('does not apply without a call id', () => {
+    expect(reducedPillarScopeApplies(ALL, undefined)).toBe(false)
+    expect(reducedPillarScopeApplies(ALL, 0)).toBe(false)
+  })
+
+  it('does not apply when a deadline is unparseable', () => {
+    const broken = call(70, 'FY2026 Broken', 'not-a-date')
+    expect(reducedPillarScopeApplies([broken], broken.datacallid)).toBe(false)
+  })
+
+  it('picks the EARLIEST FY26 deadline as the anchor when there are several', () => {
+    const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
+    const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
+    const between = call(52, 'FY2025 Late', '2026-06-01T23:59:59Z')
+    const calls = [fy26Q4, fy26Q1, between, FY25]
+
+    expect(reducedPillarScopeApplies(calls, fy26Q1.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(calls, fy26Q4.datacallid)).toBe(true)
+    // The threshold is on time, not on the name.
+    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+  })
+})

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -77,13 +77,23 @@ describe('reducedPillarScopeApplies', () => {
     )
   })
 
-  // An FY26 name is authoritative, so a broken deadline on the cycle itself is
-  // still in scope; a non-FY26 call can only qualify by deadline, so it is not.
-  it('trusts the name over an unparseable deadline', () => {
+  // An FY26 name is authoritative, so a missing or unparseable deadline on the
+  // cycle itself is still in scope - matching the backend, which never consults
+  // the target's deadline for an FY26-named call. A non-FY26 call can only
+  // qualify by deadline, so it is not.
+  it('trusts the name over a bad deadline', () => {
     const brokenFY26 = call(70, 'FY2026 Broken', 'not-a-date')
     expect(reducedPillarScopeApplies([brokenFY26], brokenFY26.datacallid)).toBe(
       true
     )
+
+    const emptyDeadlineFY26 = call(73, 'FY26 ZTM', '')
+    expect(
+      reducedPillarScopeApplies(
+        [emptyDeadlineFY26],
+        emptyDeadlineFY26.datacallid
+      )
+    ).toBe(true)
 
     const brokenOther = call(72, 'Ad Hoc', 'not-a-date')
     expect(

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -70,21 +70,57 @@ describe('reducedPillarScopeApplies', () => {
     expect(reducedPillarScopeApplies(ALL, 0)).toBe(false)
   })
 
-  it('does not apply when a deadline is unparseable', () => {
-    const broken = call(70, 'FY2026 Broken', 'not-a-date')
-    expect(reducedPillarScopeApplies([broken], broken.datacallid)).toBe(false)
+  it('trims the name before matching, as the backend does', () => {
+    const padded = call(71, '  FY2026 ZTM', '2026-09-11T23:59:59Z')
+    expect(reducedPillarScopeApplies([FY25, padded], padded.datacallid)).toBe(
+      true
+    )
   })
 
-  it('picks the EARLIEST FY26 deadline as the anchor when there are several', () => {
+  // An FY26 name is authoritative, so a broken deadline on the cycle itself is
+  // still in scope; a non-FY26 call can only qualify by deadline, so it is not.
+  it('trusts the name over an unparseable deadline', () => {
+    const brokenFY26 = call(70, 'FY2026 Broken', 'not-a-date')
+    expect(reducedPillarScopeApplies([brokenFY26], brokenFY26.datacallid)).toBe(
+      true
+    )
+
+    const brokenOther = call(72, 'Ad Hoc', 'not-a-date')
+    expect(
+      reducedPillarScopeApplies([FY26, brokenOther], brokenOther.datacallid)
+    ).toBe(false)
+  })
+
+  it('applies to every FY26 cycle when there are several', () => {
     const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
     const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
-    const between = call(52, 'FY2025 Late', '2026-06-01T23:59:59Z')
-    const calls = [fy26Q4, fy26Q1, between, FY25]
+    const calls = [fy26Q4, fy26Q1, FY25]
 
     expect(reducedPillarScopeApplies(calls, fy26Q1.datacallid)).toBe(true)
     expect(reducedPillarScopeApplies(calls, fy26Q4.datacallid)).toBe(true)
-    // The threshold is on time, not on the name.
-    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(true)
     expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+  })
+
+  // A non-FY26 call qualifies only once it is past EVERY FY26 cycle, so a cycle
+  // interleaved between two FY26 calls stays out.
+  it('requires a later cycle to be past every FY26 deadline', () => {
+    const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
+    const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
+    const between = call(52, 'Ad Hoc', '2026-06-01T23:59:59Z')
+    const after = call(53, 'Ad Hoc Later', '2026-12-01T23:59:59Z')
+    const calls = [fy26Q4, fy26Q1, between, after]
+
+    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(calls, after.datacallid)).toBe(true)
+  })
+
+  // The regression the name check prevents: an FY26 call mis-dated before a
+  // closed cycle must not drag that closed cycle into scope and restate it.
+  it('does not pull a closed cycle into scope via a mis-dated FY26 call', () => {
+    const misdatedFY26 = call(54, 'FY2026 Q1', '2024-06-01T23:59:59Z')
+    const calls = [misdatedFY26, FY25, FY26]
+
+    expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(calls, misdatedFY26.datacallid)).toBe(true)
   })
 })

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -1,0 +1,45 @@
+import type { datacall } from '@/types'
+
+// Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
+export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
+
+/**
+ * Whether the reduced pillar scope (ztmf-misc#289) applies to a data call: true
+ * for the FY26 cycle and everything after it.
+ *
+ * A threshold, not "is this the latest call" - latest-only would flip FY26 back
+ * to the full question set once FY27 opened. Ordered by deadline, never by
+ * datacallid, since ids are not chronological.
+ *
+ * Returns false (the full set) whenever the answer is unknowable: showing an
+ * extra pillar only over-discloses to the form's author, while hiding one loses
+ * an answer.
+ *
+ * Interim - phase 2 moves this into the questions API.
+ */
+export function reducedPillarScopeApplies(
+  datacalls: datacall[] | undefined,
+  datacallid: number | undefined
+): boolean {
+  if (!datacalls?.length || !datacallid) return false
+
+  const viewed = datacalls.find((d) => d.datacallid === datacallid)
+  if (!viewed?.deadline) return false
+
+  const anchorDeadline = datacalls
+    .filter((d) =>
+      REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
+        d.datacall?.toUpperCase().startsWith(prefix)
+      )
+    )
+    .map((d) => new Date(d.deadline).getTime())
+    .filter((t) => !Number.isNaN(t))
+    .sort((a, b) => a - b)[0]
+
+  if (anchorDeadline === undefined) return false
+
+  const viewedDeadline = new Date(viewed.deadline).getTime()
+  if (Number.isNaN(viewedDeadline)) return false
+
+  return viewedDeadline >= anchorDeadline
+}

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -1,7 +1,7 @@
 import type { datacall } from '@/types'
 
 // Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
-export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
+const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
 
 const isFY26Named = (name: string | undefined) =>
   REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
@@ -32,8 +32,11 @@ export function reducedPillarScopeApplies(
   if (!datacalls?.length || !datacallid) return false
 
   const viewed = datacalls.find((d) => d.datacallid === datacallid)
-  if (!viewed?.deadline) return false
+  if (!viewed) return false
+  // Name first: an FY26 cycle is in scope on its name alone, matching the
+  // backend, which never consults the target's deadline in that case.
   if (isFY26Named(viewed.datacall)) return true
+  if (!viewed.deadline) return false
 
   const lastFY26Deadline = datacalls
     .filter((d) => isFY26Named(d.datacall))

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -3,19 +3,27 @@ import type { datacall } from '@/types'
 // Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
 export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
 
+const isFY26Named = (name: string | undefined) =>
+  REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
+    name?.trim().toUpperCase().startsWith(prefix)
+  )
+
 /**
  * Whether the reduced pillar scope (ztmf-misc#289) applies to a data call: true
- * for the FY26 cycle and everything after it.
+ * for the FY26 cycle and every cycle after it.
  *
  * A threshold, not "is this the latest call" - latest-only would flip FY26 back
- * to the full question set once FY27 opened. Ordered by deadline, never by
- * datacallid, since ids are not chronological.
+ * to the full question set once FY27 opened. Later cycles qualify by deadline,
+ * never by datacallid, since ids are not chronological. Deliberately NOT "at or
+ * after the earliest FY26 deadline": an FY26 call mis-dated before a closed cycle
+ * would drag that cycle into scope and restate it.
  *
  * Returns false (the full set) whenever the answer is unknowable: showing an
  * extra pillar only over-discloses to the form's author, while hiding one loses
  * an answer.
  *
- * Interim - phase 2 moves this into the questions API.
+ * Mirrors saasPillarScopeSQL in the backend. Interim - phase 2 moves this into
+ * the questions API.
  */
 export function reducedPillarScopeApplies(
   datacalls: datacall[] | undefined,
@@ -25,21 +33,18 @@ export function reducedPillarScopeApplies(
 
   const viewed = datacalls.find((d) => d.datacallid === datacallid)
   if (!viewed?.deadline) return false
+  if (isFY26Named(viewed.datacall)) return true
 
-  const anchorDeadline = datacalls
-    .filter((d) =>
-      REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
-        d.datacall?.toUpperCase().startsWith(prefix)
-      )
-    )
+  const lastFY26Deadline = datacalls
+    .filter((d) => isFY26Named(d.datacall))
     .map((d) => new Date(d.deadline).getTime())
     .filter((t) => !Number.isNaN(t))
-    .sort((a, b) => a - b)[0]
+    .sort((a, b) => b - a)[0]
 
-  if (anchorDeadline === undefined) return false
+  if (lastFY26Deadline === undefined) return false
 
   const viewedDeadline = new Date(viewed.deadline).getTime()
   if (Number.isNaN(viewedDeadline)) return false
 
-  return viewedDeadline >= anchorDeadline
+  return viewedDeadline > lastFY26Deadline
 }

--- a/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// ztmf-misc#289: the questionnaire hides Devices and Applications for SaaS, but
+// only from FY26 on. The filter used to run on every call, hiding answered
+// history from closed cycles. The sidebar uppercases pillar names and spells out
+// CrossCutting, so the assertions read what the ISSO sees.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const CURRENT_CALL = {
+  datacallid: 5,
+  datacall: 'FY2026 ZTM',
+  datecreated: '',
+  deadline: '2026-09-11T23:59:59Z',
+}
+
+// Later cycle, deliberately with a LOWER datacallid so an id-ordered threshold
+// would fail these tests too.
+const FUTURE_CALL = {
+  datacallid: 4,
+  datacall: 'FY2027 ZTM',
+  datecreated: '',
+  deadline: '2027-09-11T23:59:59Z',
+}
+
+const HISTORICAL_CALL = {
+  datacallid: 3,
+  datacall: 'FY2025 Q3',
+  datecreated: '',
+  deadline: '2025-05-07T23:59:59Z',
+}
+
+const PILLARS = [
+  'Identity',
+  'Devices',
+  'Networks',
+  'Applications',
+  'Data',
+  'CrossCutting',
+]
+
+const QUESTIONS = PILLARS.map((pillar, i) => ({
+  questionid: 900 + i,
+  question: `Question for ${pillar}`,
+  notesprompt: 'Notes',
+  pillar: { pillar },
+  function: {
+    functionid: 7000 + i,
+    function: `${pillar} Function`,
+    description: `${pillar} Function description`,
+    datacenterenvironment: 'SaaS',
+  },
+}))
+
+function makeCtx(
+  selectedDatacall: typeof CURRENT_CALL,
+  latest: typeof CURRENT_CALL = CURRENT_CALL
+) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'isso@example.hhs',
+      fullname: 'Test ISSO',
+      role: 'OWNER',
+    } as userData,
+    latestDataCallId: latest.datacallid,
+    latestDatacall: latest.datacall,
+    latestDeadline: latest.deadline,
+    selectedDatacall,
+    datacalls: [FUTURE_CALL, CURRENT_CALL, HISTORICAL_CALL],
+    activeDatacallIds: [latest.datacallid],
+    fismaSystems: [
+      {
+        fismasystemid: 2001,
+        fismaacronym: 'SAAS-EX',
+        fismaname: 'SaaS Example System',
+        datacenterenvironment: 'SaaS',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [
+      {
+        datacenterenvironment: 'SaaS',
+        category: 'SaaS',
+        scoring_key: 'SaaS',
+        selectable: true,
+        ordr: 60,
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [{ path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> }],
+    { initialEntries: ['/questionnaire/saas-ex'] }
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+it('hides Devices and Applications on the current cycle for a SaaS system', async () => {
+  mockCtx = makeCtx(CURRENT_CALL)
+  renderPage()
+
+  // The in-scope pillars prove the absences below are the filter, not a bad render.
+  await screen.findByText('IDENTITY')
+  expect(screen.getByText('NETWORKS')).toBeInTheDocument()
+  expect(screen.getByText('DATA')).toBeInTheDocument()
+  expect(screen.getByText('CROSS CUTTING')).toBeInTheDocument()
+
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})
+
+it('shows every pillar on a cycle earlier than FY26 for the same SaaS system', async () => {
+  mockCtx = makeCtx(HISTORICAL_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  await waitFor(() => {
+    expect(screen.getByText('DEVICES')).toBeInTheDocument()
+  })
+  expect(screen.getByText('APPLICATIONS')).toBeInTheDocument()
+})
+
+it('keeps filtering on cycles AFTER FY26, not just the latest one', async () => {
+  mockCtx = makeCtx(FUTURE_CALL, FUTURE_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})
+
+it('keeps filtering FY26 once a later cycle has opened', async () => {
+  // The regression a latest-only gate would cause.
+  mockCtx = makeCtx(CURRENT_CALL, FUTURE_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -42,6 +42,7 @@ import { isAuthHandled, notify } from '@/utils/notify'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
+import { reducedPillarScopeApplies } from '@/utils/reducedPillarScope'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
@@ -936,9 +937,14 @@ export default function QuestionnarePage() {
                 }
                 organizedData[question.pillar.pillar].push(question)
               })
+              // Cycles before FY26 collected the full question set and their
+              // answers still exist, so filtering them hid answered history
+              // (ztmf-misc#289). null short-circuits the filter.
               const sortedPillars = filterPillarsForSystem(
                 sortPillars(Object.keys(organizedData)),
-                systemCategory
+                reducedPillarScopeApplies(datacalls, activeDataCallId)
+                  ? systemCategory
+                  : null
               )
               const categoriesData: Category[] = sortedPillars.map((pillar) => {
                 const sortedSteps = sortFunctions(pillar, organizedData[pillar])

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -34,6 +34,7 @@ import { MAX_QUESTIONNAIRE_NOTES_LENGTH, STATUS_MESSAGES } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
+import { reducedPillarScopeApplies } from '@/utils/reducedPillarScope'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { sortFunctions } from '@/utils/sortFunctions'
 import { useContextProp } from '../Title/Context'
@@ -76,7 +77,7 @@ export default function QuestionnareModal({
   onClose,
   system,
 }: SystemDetailsModalProps) {
-  const { userInfo, datacenterEnvironments } = useContextProp()
+  const { userInfo, datacenterEnvironments, datacalls } = useContextProp()
   // Resolve the system's raw datacenter environment to its scoring category
   // for pillar filtering; fall back to the raw value until the vocabulary
   // loads or for any unmapped value.
@@ -294,9 +295,13 @@ export default function QuestionnareModal({
             }
             organizedData[question.pillar.pillar].push(question)
           })
+          // Same threshold as QuestionnairePage; this modal only ever shows the
+          // latest call, but one rule beats two.
           const sortedPillars = filterPillarsForSystem(
             sortPillars(Object.keys(organizedData)),
-            systemCategory
+            reducedPillarScopeApplies(datacalls, latestDataCallId)
+              ? systemCategory
+              : null
           )
           const categoriesData: Category[] = sortedPillars.map((pillar) => ({
             name: pillar,
@@ -327,7 +332,7 @@ export default function QuestionnareModal({
       fetchData()
       return () => controller.abort()
     }
-  }, [open, system, systemCategory])
+  }, [open, system, systemCategory, datacalls])
   React.useEffect(() => {
     if (questionId) {
       const controller = new AbortController()

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -77,7 +77,8 @@ export default function QuestionnareModal({
   onClose,
   system,
 }: SystemDetailsModalProps) {
-  const { userInfo, datacenterEnvironments, datacalls } = useContextProp()
+  const { userInfo, datacenterEnvironments, datacalls, latestDataCallId } =
+    useContextProp()
   // Resolve the system's raw datacenter environment to its scoring category
   // for pillar filtering; fall back to the raw value until the vocabulary
   // loads or for any unmapped value.
@@ -85,6 +86,13 @@ export default function QuestionnareModal({
     toCategoryMap(datacenterEnvironments)[
       system?.datacenterenvironment ?? ''
     ] ?? system?.datacenterenvironment
+  // Derived here, not inside the fetch effect: depending on the datacalls array
+  // would re-run that effect whenever the context refetches, resetting an open
+  // modal to question 1 and discarding unsaved notes. A boolean is stable.
+  const reducedPillarScope = React.useMemo(
+    () => reducedPillarScopeApplies(datacalls, latestDataCallId),
+    [datacalls, latestDataCallId]
+  )
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
@@ -299,9 +307,7 @@ export default function QuestionnareModal({
           // latest call, but one rule beats two.
           const sortedPillars = filterPillarsForSystem(
             sortPillars(Object.keys(organizedData)),
-            reducedPillarScopeApplies(datacalls, latestDataCallId)
-              ? systemCategory
-              : null
+            reducedPillarScope ? systemCategory : null
           )
           const categoriesData: Category[] = sortedPillars.map((pillar) => ({
             name: pillar,
@@ -332,7 +338,7 @@ export default function QuestionnareModal({
       fetchData()
       return () => controller.abort()
     }
-  }, [open, system, systemCategory, datacalls])
+  }, [open, system, systemCategory, reducedPillarScope])
   React.useEffect(() => {
     if (questionId) {
       const controller = new AbortController()


### PR DESCRIPTION
Part of CMS-Enterprise/ztmf-misc#289 — phase 1 of 2. Pairs with CMS-Enterprise/ztmf#546, **which must deploy first.**

## Problem

The SaaS pillar filter from #430 is not data-call-aware, so it hides Devices and Applications on **every** cycle, closed ones included. Those cycles collected all 40 questions and their answers still exist, so a historical SaaS questionnaire rendered 25 questions for a cycle that recorded 40, with no indication the other 15 existed — answered history the reader had no way to see.

## Change

**Filtering now starts at FY26 and applies to every cycle after it** (`src/utils/reducedPillarScope.ts`), gating the existing `filterPillarsForSystem` call in `QuestionnairePage` and `QuestionnareModal`.

A threshold, not "is this the latest call" — a latest-only gate would flip FY26 back to the full question set the moment FY27 opened, silently undoing the fix for a cycle already reported at 25. Later cycles qualify by deadline, never by `datacallid`, since ids are not chronological. Deliberately not "at or after the earliest FY26 deadline" either: an FY26 call mis-dated before a closed cycle would drag that cycle into scope. Mirrors `saasPillarScopeSQL` in #546. Every unknowable input falls back to the full set — showing an extra pillar only over-discloses to the form's author, while hiding one loses an answer.

**Also fixes the pillar-scores radar plotting a missing comparison pillar as `0`.** Scores are floored at 1.0, so 0 is not a reachable score: it drew the comparison line into the centre of the chart and read as a total collapse rather than "not measured that cycle". `previous` is now left undefined, which recharts renders as a gap, matching what the tiles and the comparison table already do. **This is already reachable on `main`** — any system whose environment changed between cycles has pillars in one call and not the other — and becomes unavoidable once phase 2 reduces SaaS scoring.

**Files:**
- `src/utils/reducedPillarScope.ts` (new) — `reducedPillarScopeApplies`
- `src/components/PillarScoresModal/radarData.ts` (new) — `buildRadarData`, `findComparisonPillarScore`; the chart, tiles and accessible table now share one pillarid pairing instead of each inlining it
- `QuestionnairePage.tsx`, `QuestionnareModal.tsx` — gate the filter; the modal derives the gate with `useMemo` outside its fetch effect, since depending on the `datacalls` array would re-run the effect on any context refetch and reset an open modal to question 1
- Tests for all three

## Acceptance criteria

- [x] Closed historical calls unchanged — **this is the criterion `main` violates**, and the reason for the PR. Historical cycles now show all six pillars with their recorded answers.
- [x] SaaS systems present exactly 25 questions, as seen by the ISSO, from FY26 onward. Still a client-side filter over an API that returns 40; CMS-Enterprise/ztmf#545 moves it into the questions endpoint, after which `filterPillarsForSystem` comes out.
- [x] All other environments unchanged (40) — `filterPillarsForSystem` short-circuits for any category but `SaaS`; this PR changes only *when* it is called.

The issue's remaining criteria are owned elsewhere: the `x/25` denominator by CMS-Enterprise/ztmf#546 (`progressColumn.tsx` renders what `/scores/progress` returns), and the API-side question set plus SaaS scoring by CMS-Enterprise/ztmf#545.

## Risk

Low. No API, schema, or data changes. The one behavior change outside the SaaS gate is the radar's missing-pillar rendering, which replaces a misleading zero with a gap.

## Verification

- `pnpm test` — 888 passing. `vite build` clean, lint clean, typecheck unchanged (2 pre-existing errors in `EmailModal.tsx` and the `ArrowIcon` JSX types, both untouched).
- `QuestionnairePage`: hidden on FY26; all six pillars on an earlier cycle; still hidden on a cycle *after* FY26; still hidden on FY26 once a later cycle has opened. The last two fixtures give the later cycle a **lower** `datacallid`, so an id-ordered threshold fails them too.
- `reducedPillarScopeApplies`: 16 cases — mis-dated FY26 call, name trimming, several FY26 cycles, and every unknowable input. `buildRadarData`: 6 cases including pillarid-not-position matching.
- Mutation-checked: reverting the page gate fails the historical-cycle test; restoring `?? 0` fails 4 radar cases; `>=`→`>` fails 5 helper cases; ordering by `datacallid` fails 3.
- Against a prod-shaped dev stack: a SaaS questionnaire shows 25 on FY2026 and all 40 on FY2025 Q3; a non-SaaS system is unchanged.

## UI

Screenshots are attached to CMS-Enterprise/ztmf-misc#289 rather than here, since they show live system data. What they cover:

- FY26 data call — SaaS systems show 25 questions.
- Historical data calls — SaaS systems show 40 questions total.
- A historical SaaS questionnaire — all 40 questions present, with the recorded answers.
- FY26 export of a SaaS system — only the 25 in-scope questions.

## Reviewer notes

- **CMS is deliberately not exempt.** This filter is OpDiv-blind and #546 does not exempt CMS either, so the two agree. When CMS confirms, both sides change together — exempting one alone would give CMS systems a 40 denominator with 15 questions their ISSOs cannot see.


