### PR TITLE
Frontend batch 4: Last Seen column, SaaS pillar history, Scored/Systems tile scoping

### DIFF
--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -38,6 +38,7 @@ import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
 import { useContextProp } from '@/views/Title/Context'
+import { buildRadarData } from './radarData'
 
 interface PillarScoresModalProps {
   open: boolean
@@ -148,19 +149,13 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
     (comparisonScoreEntry?.pillarscores?.length ?? 0) > 0
 
   // Prepare radar chart data
-  const radarData = useMemo(() => {
-    if (!hasValidData || !latestScore?.pillarscores) return []
-    return latestScore.pillarscores.map((pillar) => {
-      const comparisonPillarScore = comparisonScoreEntry?.pillarscores?.find(
-        (p) => p.pillarid === pillar.pillarid
-      )?.score
-      return {
-        pillar: pillar.pillar,
-        current: pillar.score ?? 0,
-        previous: comparisonPillarScore ?? 0,
-      }
-    })
-  }, [hasValidData, latestScore, comparisonScoreEntry])
+  const radarData = useMemo(
+    () =>
+      hasValidData
+        ? buildRadarData(latestScore?.pillarscores, comparisonScoreEntry)
+        : [],
+    [hasValidData, latestScore, comparisonScoreEntry]
+  )
 
   // Focus management for accessibility
   useEffect(() => {

--- a/src/components/PillarScoresModal/PillarScoresModal.tsx
+++ b/src/components/PillarScoresModal/PillarScoresModal.tsx
@@ -38,7 +38,7 @@ import { tierStyle, TIERS } from '@/utils/tierStyles'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
 import { parseDatacallName } from '@/utils/datacallGrouping'
 import { useContextProp } from '@/views/Title/Context'
-import { buildRadarData } from './radarData'
+import { buildRadarData, findComparisonPillarScore } from './radarData'
 
 interface PillarScoresModalProps {
   open: boolean
@@ -489,10 +489,10 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
             </Typography>
             <Grid container spacing={2}>
               {(latestScore.pillarscores ?? []).map((pillar) => {
-                const previousPillarScore =
-                  comparisonScoreEntry?.pillarscores?.find(
-                    (p) => p.pillarid === pillar.pillarid
-                  )?.score
+                const previousPillarScore = findComparisonPillarScore(
+                  comparisonScoreEntry,
+                  pillar.pillarid
+                )
 
                 const currentScore = pillar.score ?? 0
                 const trendInfo = getTrendInfo(
@@ -839,10 +839,10 @@ const PillarScoresModal: React.FC<PillarScoresModalProps> = ({
                       </TableHead>
                       <TableBody>
                         {latestScore?.pillarscores?.map((pillar) => {
-                          const previousPillarScore =
-                            comparisonScoreEntry?.pillarscores?.find(
-                              (p) => p.pillarid === pillar.pillarid
-                            )?.score
+                          const previousPillarScore = findComparisonPillarScore(
+                            comparisonScoreEntry,
+                            pillar.pillarid
+                          )
 
                           const currentScore = pillar.score ?? 0
                           const prevScore = previousPillarScore ?? 0

--- a/src/components/PillarScoresModal/radarData.test.ts
+++ b/src/components/PillarScoresModal/radarData.test.ts
@@ -1,0 +1,82 @@
+import { buildRadarData } from './radarData'
+import type { PillarScore, ScoreAggregate } from '@/types'
+
+// A pillar absent from the comparison call used to plot as previous = 0, which
+// drew the line into the centre of the chart.
+
+const ANCHOR: PillarScore[] = [
+  { pillarid: 1, pillar: 'Identity', score: 3.5 },
+  { pillarid: 2, pillar: 'Devices', score: 2.0 },
+]
+
+const comparison = (pillarscores: PillarScore[]): ScoreAggregate => ({
+  datacallid: 4,
+  fismasystemid: 1001,
+  systemscore: 3.0,
+  pillarscores,
+})
+
+describe('buildRadarData', () => {
+  it('carries the comparison score when the pillar exists in both calls', () => {
+    expect(
+      buildRadarData(
+        ANCHOR,
+        comparison([
+          { pillarid: 1, pillar: 'Identity', score: 2.5 },
+          { pillarid: 2, pillar: 'Devices', score: 1.5 },
+        ])
+      )
+    ).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: 2.5 },
+      { pillar: 'Devices', current: 2.0, previous: 1.5 },
+    ])
+  })
+
+  it('leaves previous undefined for a pillar the comparison call does not carry', () => {
+    const data = buildRadarData(
+      ANCHOR,
+      comparison([{ pillarid: 1, pillar: 'Identity', score: 2.5 }])
+    )
+
+    expect(data[1]).toEqual({
+      pillar: 'Devices',
+      current: 2.0,
+      previous: undefined,
+    })
+    expect(data[1].previous).not.toBe(0)
+  })
+
+  // A comparison missing an earlier pillar must not shift scores onto the wrong spoke.
+  it('matches on pillarid, not on position', () => {
+    const data = buildRadarData(
+      ANCHOR,
+      comparison([{ pillarid: 2, pillar: 'Devices', score: 1.5 }])
+    )
+
+    expect(data).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: undefined },
+      { pillar: 'Devices', current: 2.0, previous: 1.5 },
+    ])
+  })
+
+  it('leaves previous undefined for every pillar when there is no comparison', () => {
+    for (const entry of [null, undefined]) {
+      expect(buildRadarData(ANCHOR, entry)).toEqual([
+        { pillar: 'Identity', current: 3.5, previous: undefined },
+        { pillar: 'Devices', current: 2.0, previous: undefined },
+      ])
+    }
+  })
+
+  it('leaves previous undefined when the comparison call has an empty pillar list', () => {
+    expect(buildRadarData(ANCHOR, comparison([]))).toEqual([
+      { pillar: 'Identity', current: 3.5, previous: undefined },
+      { pillar: 'Devices', current: 2.0, previous: undefined },
+    ])
+  })
+
+  it('returns an empty series when the anchor call has no pillar scores', () => {
+    expect(buildRadarData(undefined, null)).toEqual([])
+    expect(buildRadarData([], null)).toEqual([])
+  })
+})

--- a/src/components/PillarScoresModal/radarData.ts
+++ b/src/components/PillarScoresModal/radarData.ts
@@ -1,0 +1,33 @@
+import type { PillarScore, ScoreAggregate } from '@/types'
+
+export type RadarDatum = {
+  pillar: string
+  current: number
+  previous?: number
+}
+
+/**
+ * Builds the radar series from the anchor call's pillars, pairing each with the
+ * comparison call's score for the same pillarid.
+ *
+ * `previous` stays undefined - never 0 - when the comparison call has no row for
+ * that pillar. Scores are floored at 1.0, so 0 plotted a line into the centre of
+ * the chart and read as a collapse rather than "not measured that cycle".
+ * Reachable today for any system whose environment changed between cycles.
+ *
+ * Separate from the component so it can be tested; the rendered radar cannot be
+ * inspected under jsdom.
+ */
+export function buildRadarData(
+  anchorPillarScores: PillarScore[] | undefined,
+  comparisonScoreEntry: ScoreAggregate | null | undefined
+): RadarDatum[] {
+  if (!anchorPillarScores) return []
+  return anchorPillarScores.map((pillar) => ({
+    pillar: pillar.pillar,
+    current: pillar.score ?? 0,
+    previous: comparisonScoreEntry?.pillarscores?.find(
+      (p) => p.pillarid === pillar.pillarid
+    )?.score,
+  }))
+}

--- a/src/components/PillarScoresModal/radarData.ts
+++ b/src/components/PillarScoresModal/radarData.ts
@@ -7,6 +7,23 @@ export type RadarDatum = {
 }
 
 /**
+ * The comparison call's score for one pillar, matched on pillarid so a comparison
+ * missing an earlier pillar cannot shift scores onto the wrong row. undefined when
+ * that call has no row for the pillar.
+ *
+ * Shared by the chart and the accessible table that mirrors it, so the two cannot
+ * disagree about what "no comparison" means.
+ */
+export function findComparisonPillarScore(
+  comparisonScoreEntry: ScoreAggregate | null | undefined,
+  pillarid: number
+): number | undefined {
+  return comparisonScoreEntry?.pillarscores?.find(
+    (p) => p.pillarid === pillarid
+  )?.score
+}
+
+/**
  * Builds the radar series from the anchor call's pillars, pairing each with the
  * comparison call's score for the same pillarid.
  *
@@ -26,8 +43,6 @@ export function buildRadarData(
   return anchorPillarScores.map((pillar) => ({
     pillar: pillar.pillar,
     current: pillar.score ?? 0,
-    previous: comparisonScoreEntry?.pillarscores?.find(
-      (p) => p.pillarid === pillar.pillarid
-    )?.score,
+    previous: findComparisonPillarScore(comparisonScoreEntry, pillar.pillarid),
   }))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -371,6 +371,11 @@ export type users = {
   deleted?: boolean
   isNew?: boolean
   identity_provider?: 'okta' | 'entra'
+  // Most recent recorded activity (incl. sign-ins), list endpoint only.
+  // null = no activity recorded since tracking began (2026-08-06), which for
+  // older accounts is NOT the same as "never signed in" - keep any empty-state
+  // wording neutral. /users/current always returns null for this field.
+  last_seen?: string | null
 }
 
 export type datacall = {

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -1,0 +1,90 @@
+import { reducedPillarScopeApplies } from './reducedPillarScope'
+import type { datacall } from '@/types'
+
+const call = (
+  datacallid: number,
+  datacall: string,
+  deadline: string
+): datacall => ({ datacallid, datacall, datecreated: '', deadline })
+
+// Ids deliberately unordered relative to deadlines - the backfill carries the
+// highest id.
+const FY25 = call(3, 'FY2025 Q3', '2025-05-07T23:59:59Z')
+const FY26 = call(53, 'FY2026 ZTM', '2026-09-11T23:59:59Z')
+const FY27 = call(4, 'FY2027 ZTM', '2027-09-11T23:59:59Z')
+const FY23_BACKFILL = call(99, 'FY23 ZTM', '2023-09-30T23:59:59Z')
+
+const ALL = [FY23_BACKFILL, FY26, FY25, FY27]
+
+describe('reducedPillarScopeApplies', () => {
+  it('applies to the FY26 anchor cycle', () => {
+    expect(reducedPillarScopeApplies(ALL, FY26.datacallid)).toBe(true)
+  })
+
+  // Both true at once: a latest-only gate would flip FY26 back to the full set.
+  it('applies to every cycle after the anchor, not just the latest', () => {
+    expect(reducedPillarScopeApplies(ALL, FY27.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(ALL, FY26.datacallid)).toBe(true)
+  })
+
+  it('does not apply to cycles earlier than the anchor', () => {
+    expect(reducedPillarScopeApplies(ALL, FY25.datacallid)).toBe(false)
+  })
+
+  it('treats a late-loaded backfill as history despite its higher id', () => {
+    expect(reducedPillarScopeApplies(ALL, FY23_BACKFILL.datacallid)).toBe(false)
+  })
+
+  it('matches both the FY2026 and FY26 name prefixes', () => {
+    const shortName = call(60, 'FY26 ZTM', '2026-09-11T23:59:59Z')
+    expect(
+      reducedPillarScopeApplies([FY25, shortName], shortName.datacallid)
+    ).toBe(true)
+  })
+
+  it('is case-insensitive on the prefix match', () => {
+    const lower = call(61, 'fy2026 ztm', '2026-09-11T23:59:59Z')
+    expect(reducedPillarScopeApplies([FY25, lower], lower.datacallid)).toBe(
+      true
+    )
+  })
+
+  // Unknowable cases fall back to the full question set.
+  it('does not apply when there is no FY26 cycle at all', () => {
+    expect(
+      reducedPillarScopeApplies([FY25, FY23_BACKFILL], FY25.datacallid)
+    ).toBe(false)
+  })
+
+  it('does not apply for an unrecognized call id', () => {
+    expect(reducedPillarScopeApplies(ALL, 12345)).toBe(false)
+  })
+
+  it('does not apply while the data call list is still loading', () => {
+    expect(reducedPillarScopeApplies([], FY26.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(undefined, FY26.datacallid)).toBe(false)
+  })
+
+  it('does not apply without a call id', () => {
+    expect(reducedPillarScopeApplies(ALL, undefined)).toBe(false)
+    expect(reducedPillarScopeApplies(ALL, 0)).toBe(false)
+  })
+
+  it('does not apply when a deadline is unparseable', () => {
+    const broken = call(70, 'FY2026 Broken', 'not-a-date')
+    expect(reducedPillarScopeApplies([broken], broken.datacallid)).toBe(false)
+  })
+
+  it('picks the EARLIEST FY26 deadline as the anchor when there are several', () => {
+    const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
+    const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
+    const between = call(52, 'FY2025 Late', '2026-06-01T23:59:59Z')
+    const calls = [fy26Q4, fy26Q1, between, FY25]
+
+    expect(reducedPillarScopeApplies(calls, fy26Q1.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(calls, fy26Q4.datacallid)).toBe(true)
+    // The threshold is on time, not on the name.
+    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(true)
+    expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+  })
+})

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -77,13 +77,23 @@ describe('reducedPillarScopeApplies', () => {
     )
   })
 
-  // An FY26 name is authoritative, so a broken deadline on the cycle itself is
-  // still in scope; a non-FY26 call can only qualify by deadline, so it is not.
-  it('trusts the name over an unparseable deadline', () => {
+  // An FY26 name is authoritative, so a missing or unparseable deadline on the
+  // cycle itself is still in scope - matching the backend, which never consults
+  // the target's deadline for an FY26-named call. A non-FY26 call can only
+  // qualify by deadline, so it is not.
+  it('trusts the name over a bad deadline', () => {
     const brokenFY26 = call(70, 'FY2026 Broken', 'not-a-date')
     expect(reducedPillarScopeApplies([brokenFY26], brokenFY26.datacallid)).toBe(
       true
     )
+
+    const emptyDeadlineFY26 = call(73, 'FY26 ZTM', '')
+    expect(
+      reducedPillarScopeApplies(
+        [emptyDeadlineFY26],
+        emptyDeadlineFY26.datacallid
+      )
+    ).toBe(true)
 
     const brokenOther = call(72, 'Ad Hoc', 'not-a-date')
     expect(

--- a/src/utils/reducedPillarScope.test.ts
+++ b/src/utils/reducedPillarScope.test.ts
@@ -70,21 +70,57 @@ describe('reducedPillarScopeApplies', () => {
     expect(reducedPillarScopeApplies(ALL, 0)).toBe(false)
   })
 
-  it('does not apply when a deadline is unparseable', () => {
-    const broken = call(70, 'FY2026 Broken', 'not-a-date')
-    expect(reducedPillarScopeApplies([broken], broken.datacallid)).toBe(false)
+  it('trims the name before matching, as the backend does', () => {
+    const padded = call(71, '  FY2026 ZTM', '2026-09-11T23:59:59Z')
+    expect(reducedPillarScopeApplies([FY25, padded], padded.datacallid)).toBe(
+      true
+    )
   })
 
-  it('picks the EARLIEST FY26 deadline as the anchor when there are several', () => {
+  // An FY26 name is authoritative, so a broken deadline on the cycle itself is
+  // still in scope; a non-FY26 call can only qualify by deadline, so it is not.
+  it('trusts the name over an unparseable deadline', () => {
+    const brokenFY26 = call(70, 'FY2026 Broken', 'not-a-date')
+    expect(reducedPillarScopeApplies([brokenFY26], brokenFY26.datacallid)).toBe(
+      true
+    )
+
+    const brokenOther = call(72, 'Ad Hoc', 'not-a-date')
+    expect(
+      reducedPillarScopeApplies([FY26, brokenOther], brokenOther.datacallid)
+    ).toBe(false)
+  })
+
+  it('applies to every FY26 cycle when there are several', () => {
     const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
     const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
-    const between = call(52, 'FY2025 Late', '2026-06-01T23:59:59Z')
-    const calls = [fy26Q4, fy26Q1, between, FY25]
+    const calls = [fy26Q4, fy26Q1, FY25]
 
     expect(reducedPillarScopeApplies(calls, fy26Q1.datacallid)).toBe(true)
     expect(reducedPillarScopeApplies(calls, fy26Q4.datacallid)).toBe(true)
-    // The threshold is on time, not on the name.
-    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(true)
     expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+  })
+
+  // A non-FY26 call qualifies only once it is past EVERY FY26 cycle, so a cycle
+  // interleaved between two FY26 calls stays out.
+  it('requires a later cycle to be past every FY26 deadline', () => {
+    const fy26Q1 = call(50, 'FY2026 Q1', '2026-01-31T23:59:59Z')
+    const fy26Q4 = call(51, 'FY2026 Q4', '2026-09-30T23:59:59Z')
+    const between = call(52, 'Ad Hoc', '2026-06-01T23:59:59Z')
+    const after = call(53, 'Ad Hoc Later', '2026-12-01T23:59:59Z')
+    const calls = [fy26Q4, fy26Q1, between, after]
+
+    expect(reducedPillarScopeApplies(calls, between.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(calls, after.datacallid)).toBe(true)
+  })
+
+  // The regression the name check prevents: an FY26 call mis-dated before a
+  // closed cycle must not drag that closed cycle into scope and restate it.
+  it('does not pull a closed cycle into scope via a mis-dated FY26 call', () => {
+    const misdatedFY26 = call(54, 'FY2026 Q1', '2024-06-01T23:59:59Z')
+    const calls = [misdatedFY26, FY25, FY26]
+
+    expect(reducedPillarScopeApplies(calls, FY25.datacallid)).toBe(false)
+    expect(reducedPillarScopeApplies(calls, misdatedFY26.datacallid)).toBe(true)
   })
 })

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -1,0 +1,45 @@
+import type { datacall } from '@/types'
+
+// Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
+export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
+
+/**
+ * Whether the reduced pillar scope (ztmf-misc#289) applies to a data call: true
+ * for the FY26 cycle and everything after it.
+ *
+ * A threshold, not "is this the latest call" - latest-only would flip FY26 back
+ * to the full question set once FY27 opened. Ordered by deadline, never by
+ * datacallid, since ids are not chronological.
+ *
+ * Returns false (the full set) whenever the answer is unknowable: showing an
+ * extra pillar only over-discloses to the form's author, while hiding one loses
+ * an answer.
+ *
+ * Interim - phase 2 moves this into the questions API.
+ */
+export function reducedPillarScopeApplies(
+  datacalls: datacall[] | undefined,
+  datacallid: number | undefined
+): boolean {
+  if (!datacalls?.length || !datacallid) return false
+
+  const viewed = datacalls.find((d) => d.datacallid === datacallid)
+  if (!viewed?.deadline) return false
+
+  const anchorDeadline = datacalls
+    .filter((d) =>
+      REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
+        d.datacall?.toUpperCase().startsWith(prefix)
+      )
+    )
+    .map((d) => new Date(d.deadline).getTime())
+    .filter((t) => !Number.isNaN(t))
+    .sort((a, b) => a - b)[0]
+
+  if (anchorDeadline === undefined) return false
+
+  const viewedDeadline = new Date(viewed.deadline).getTime()
+  if (Number.isNaN(viewedDeadline)) return false
+
+  return viewedDeadline >= anchorDeadline
+}

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -1,7 +1,7 @@
 import type { datacall } from '@/types'
 
 // Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
-export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
+const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
 
 const isFY26Named = (name: string | undefined) =>
   REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
@@ -32,8 +32,11 @@ export function reducedPillarScopeApplies(
   if (!datacalls?.length || !datacallid) return false
 
   const viewed = datacalls.find((d) => d.datacallid === datacallid)
-  if (!viewed?.deadline) return false
+  if (!viewed) return false
+  // Name first: an FY26 cycle is in scope on its name alone, matching the
+  // backend, which never consults the target's deadline in that case.
   if (isFY26Named(viewed.datacall)) return true
+  if (!viewed.deadline) return false
 
   const lastFY26Deadline = datacalls
     .filter((d) => isFY26Named(d.datacall))

--- a/src/utils/reducedPillarScope.ts
+++ b/src/utils/reducedPillarScope.ts
@@ -3,19 +3,27 @@ import type { datacall } from '@/types'
 // Mirrors rolloverHardcodeTargetPrefixes in the backend's scores.go.
 export const REDUCED_PILLAR_SCOPE_PREFIXES = ['FY2026', 'FY26'] as const
 
+const isFY26Named = (name: string | undefined) =>
+  REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
+    name?.trim().toUpperCase().startsWith(prefix)
+  )
+
 /**
  * Whether the reduced pillar scope (ztmf-misc#289) applies to a data call: true
- * for the FY26 cycle and everything after it.
+ * for the FY26 cycle and every cycle after it.
  *
  * A threshold, not "is this the latest call" - latest-only would flip FY26 back
- * to the full question set once FY27 opened. Ordered by deadline, never by
- * datacallid, since ids are not chronological.
+ * to the full question set once FY27 opened. Later cycles qualify by deadline,
+ * never by datacallid, since ids are not chronological. Deliberately NOT "at or
+ * after the earliest FY26 deadline": an FY26 call mis-dated before a closed cycle
+ * would drag that cycle into scope and restate it.
  *
  * Returns false (the full set) whenever the answer is unknowable: showing an
  * extra pillar only over-discloses to the form's author, while hiding one loses
  * an answer.
  *
- * Interim - phase 2 moves this into the questions API.
+ * Mirrors saasPillarScopeSQL in the backend. Interim - phase 2 moves this into
+ * the questions API.
  */
 export function reducedPillarScopeApplies(
   datacalls: datacall[] | undefined,
@@ -25,21 +33,18 @@ export function reducedPillarScopeApplies(
 
   const viewed = datacalls.find((d) => d.datacallid === datacallid)
   if (!viewed?.deadline) return false
+  if (isFY26Named(viewed.datacall)) return true
 
-  const anchorDeadline = datacalls
-    .filter((d) =>
-      REDUCED_PILLAR_SCOPE_PREFIXES.some((prefix) =>
-        d.datacall?.toUpperCase().startsWith(prefix)
-      )
-    )
+  const lastFY26Deadline = datacalls
+    .filter((d) => isFY26Named(d.datacall))
     .map((d) => new Date(d.deadline).getTime())
     .filter((t) => !Number.isNaN(t))
-    .sort((a, b) => a - b)[0]
+    .sort((a, b) => b - a)[0]
 
-  if (anchorDeadline === undefined) return false
+  if (lastFY26Deadline === undefined) return false
 
   const viewedDeadline = new Date(viewed.deadline).getTime()
   if (Number.isNaN(viewedDeadline)) return false
 
-  return viewedDeadline >= anchorDeadline
+  return viewedDeadline > lastFY26Deadline
 }

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -103,7 +103,7 @@ export default function HomePageContainer() {
   }
   return (
     <Box>
-      <StatisticsBlocks scores={scoreMap} />
+      <StatisticsBlocks scores={scoreMap} progress={progressMap} />
       <BreadCrumbs />
       <FismaTable
         scores={scoreMap}

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import InsightsPanel, {
   OptionInsightBadges,
-  severityStyle,
-  rollupControls,
   ISSO_DETERMINATION_DISCLAIMER,
 } from './InsightsPanel'
+import { severityStyle, rollupControls } from './controlRollup'
 import type { InsightPayload } from '@/types'
 import CONFIG from '@/utils/config'
 

--- a/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
+++ b/src/views/QuestionnairePage/InsightsPanel/InsightsPanel.tsx
@@ -14,6 +14,15 @@ import {
   asImpactLevel,
   FIPS_GOLD,
 } from '../fipsBaseline'
+import {
+  asText,
+  severityStyle,
+  rollupControls,
+  INFERRED_PASS_SOURCES,
+  type ControlRollup,
+  type ControlRollupState,
+  type ControlEvidence,
+} from './controlRollup'
 
 type Props = {
   payload: InsightPayload
@@ -1169,17 +1178,6 @@ function FeedCheckBlock({
   )
 }
 
-// Coerce an opaque payload value to renderable text. The payload is untrusted
-// JSON, so a field the type declares as a string could arrive as an object or
-// array; rendering that directly throws "Objects are not valid as a React
-// child" and (via the error boundary) blanks the whole panel. Coercing to a
-// string degrades gracefully instead. Returns undefined for nullish/empty so
-// existing truthiness guards still hide the element.
-function asText(v: unknown): string | undefined {
-  if (v == null || v === '') return undefined
-  return typeof v === 'string' ? v : String(v)
-}
-
 // Hardenize instance `detail` is inconsistent — a stringified JSON object
 // ({"Error message":"..."}), plain text ("Dangling DNS record: ..."), or empty
 // ({}). Surface something readable: JSON objects → their values joined; plain
@@ -1197,17 +1195,6 @@ function formatHardenizeDetail(detail?: string): string | undefined {
     /* not JSON — fall through to raw text */
   }
   return t
-}
-
-// Severity → chip color. error/high/critical = red, warning/medium = amber,
-// everything else (low, powerup, unknown) = neutral.
-export function severityStyle(sev?: string): { bg: string; fg: string } {
-  const s = (sev ?? '').toLowerCase()
-  if (s === 'error' || s === 'high' || s === 'critical')
-    return { bg: '#fdecec', fg: '#b02a37' }
-  if (s === 'warning' || s === 'warn' || s === 'medium')
-    return { bg: '#fff4e5', fg: '#b26a00' }
-  return { bg: '#f0f0f0', fg: '#666' }
 }
 
 // TEMPORARY stopgap severity glossary shown on hover when a finding has no
@@ -1233,182 +1220,6 @@ const SEVERITY_HELP: Record<string, string> = {
 }
 function severityHelp(sev?: string): string | undefined {
   return SEVERITY_HELP[(sev ?? '').toLowerCase()]
-}
-
-// The state of one control in the ARS Controls rollup. `unsatisfied` = CFACTS says
-// the control applies here but nothing has confirmed it satisfied (may be
-// unassessed) — informational, not an alarm.
-export type ControlRollupState = 'satisfied' | 'unsatisfied' | 'failing'
-
-// One piece of evidence behind a control's state: which source spoke to it, the
-// specific check (when the evidence is a finding-source check rather than a CFACTS
-// coverage flag), and what that evidence said.
-export type ControlEvidence = {
-  source: string
-  check?: string
-  state: ControlRollupState
-  // The check's human sentence, carried alongside the slug. A control chip is
-  // labeled with the control id, so without this its hover would name the check
-  // only by slug (`account-without-compliant-password-policy`) and the reader
-  // would have to decode it — the check chips have shown this sentence since
-  // they were introduced.
-  description?: string
-}
-
-// A control after the cross-source rollup: its net (weakest-link) state, whether
-// its sources disagree, and the full evidence list so the UI can name every source
-// and show how a conflict resolved.
-export type ControlRollup = {
-  id: string
-  state: ControlRollupState
-  conflict: boolean
-  evidence: ControlEvidence[]
-}
-
-// Weakest-link precedence for a control's NET state: failing beats satisfied beats
-// unsatisfied. So a control is failing if ANY source fails it, else satisfied if
-// ANY source passes it, else unsatisfied. Matches the zero-trust scoring principle
-// (lowest signal wins).
-const CONTROL_RANK: Record<ControlRollupState, number> = {
-  failing: 3,
-  satisfied: 2,
-  unsatisfied: 1,
-}
-
-// The ARS Controls total is the UNION of every ARS control any evidence source
-// touches — CFACTS applicable/failing controls PLUS the NIST control each Kion,
-// SecurityHub, and Hardenize check maps to. Each control keeps its full evidence
-// list, nets to a weakest-link state, and is flagged `conflict` when at least one
-// source passes it AND at least one source fails it (e.g. SC-12: Kion passes
-// key-rotation but fails cross-account-access). This is why a control Kion passes
-// appears here even though CFACTS never assessed it, and why a conflicted control
-// can net to failing. The payload is opaque, so every value is coerced and
-// guarded; a malformed element is skipped, never thrown.
-// Sources whose "passing" entries are inferred from the absence of a finding
-// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
-// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
-// as "mapped control with no active failure". That cannot distinguish "evaluated
-// and passed" from "never scanned", so on a partially scanned system it would
-// otherwise assert controls are met on the strength of checks that never ran.
-// Consequently these entries still render as ✓ chips (the check is not failing)
-// but are read as an absence of findings, and are withheld from the control
-// rollup rather than counted as affirmative `satisfied` evidence.
-//
-// Remove a source from this set once its feed emits real passes; nothing else
-// needs to change. Used by both the feed blocks and rollupControls below.
-const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
-
-export function rollupControls(
-  payload: Partial<InsightPayload>
-): ControlRollup[] {
-  const map = new Map<string, ControlEvidence[]>()
-  const add = (
-    raw: unknown,
-    source: string,
-    state: ControlRollupState,
-    check?: string,
-    description?: string
-  ) => {
-    const text = asText(raw)
-    if (!text) return
-    // One check can map to several controls, e.g. "AC-2, AC-3".
-    for (const part of text.split(',')) {
-      const id = part.trim()
-      if (!id) continue
-      const list = map.get(id) ?? []
-      list.push({
-        source,
-        state,
-        check,
-        // A title-only finding (no id, no description) resolves both the check
-        // and the sentence to that same title. Drop the duplicate rather than
-        // printing it twice in the hover and announcing it twice to AT.
-        description: description === check ? undefined : description,
-      })
-      map.set(id, list)
-    }
-  }
-  const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
-  const finding = (f: unknown) =>
-    f && typeof f === 'object'
-      ? (f as {
-          nist_controls?: unknown
-          id?: unknown
-          title?: unknown
-          description?: unknown
-        })
-      : null
-  // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
-  // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
-  // control catalog, not a source — CFACTS is the source of this coverage. These
-  // arrays are plain control-id strings (unlike nist_controls, which may arrive as
-  // an array and needs asText coercion), so filter to strings: a non-string
-  // element would otherwise coerce to a junk chip ("42", "[object Object]").
-  const isStr = (v: unknown): v is string => typeof v === 'string'
-  // ars_not_satisfied is a SUPERSET of ars_failing — a failing control appears in
-  // both. Subtract the failing ids so the control isn't listed twice in the hover
-  // (once "not assessed", once "failed"); the net state is failing either way.
-  const arsFailingIds = new Set(arr(payload.ars_failing_controls).filter(isStr))
-  arr(payload.ars_satisfied_controls)
-    .filter(isStr)
-    .forEach((c) => add(c, 'CFACTS', 'satisfied'))
-  arr(payload.ars_not_satisfied_controls)
-    .filter(isStr)
-    .filter((c) => !arsFailingIds.has(c))
-    .forEach((c) => add(c, 'CFACTS', 'unsatisfied'))
-  arr(payload.ars_failing_controls)
-    .filter(isStr)
-    .forEach((c) => add(c, 'CFACTS', 'failing'))
-  // Finding-source checks: a passing check satisfies its control, a failing one (a
-  // finding) fails it. Carry the check id/title so the hover can name it.
-  const findings = (payload.findings ?? {}) as Record<string, unknown>
-  const SRC_LABEL: Record<string, string> = {
-    kion: 'Kion',
-    sechub: 'SecurityHub',
-    hardenize: 'Hardenize',
-  }
-  for (const src of ['kion', 'sechub', 'hardenize'] as const) {
-    const label = SRC_LABEL[src]
-    // An inferred pass is the absence of a finding, not evidence the control is
-    // met — counting it as `satisfied` would flip a control from "not assessed"
-    // to green on the strength of a check that may never have run.
-    if (!INFERRED_PASS_SOURCES.has(src)) {
-      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
-        (f) => {
-          const o = finding(f)
-          add(
-            o?.nist_controls,
-            label,
-            'satisfied',
-            asText(o?.id) ?? asText(o?.title),
-            // Kion puts the sentence in `description`, SecurityHub in `title` —
-            // same fallback CheckTooltip uses, so both hovers read alike.
-            asText(o?.description) ?? asText(o?.title)
-          )
-        }
-      )
-    }
-    arr(findings[src]).forEach((f) => {
-      const o = finding(f)
-      add(
-        o?.nist_controls,
-        label,
-        'failing',
-        asText(o?.id) ?? asText(o?.title),
-        asText(o?.description) ?? asText(o?.title)
-      )
-    })
-  }
-  return [...map.entries()].map(([id, evidence]) => {
-    const state = evidence.reduce<ControlRollupState>(
-      (net, e) => (CONTROL_RANK[e.state] > CONTROL_RANK[net] ? e.state : net),
-      'unsatisfied'
-    )
-    const conflict =
-      evidence.some((e) => e.state === 'satisfied') &&
-      evidence.some((e) => e.state === 'failing')
-    return { id, state, conflict, evidence }
-  })
 }
 
 // Plain-text words for a control's net state and each evidence line — shared by the

--- a/src/views/QuestionnairePage/InsightsPanel/controlRollup.ts
+++ b/src/views/QuestionnairePage/InsightsPanel/controlRollup.ts
@@ -1,0 +1,205 @@
+/**
+ * Non-component logic shared by the Insights panel and its tests: payload text
+ * coercion, severity chip styling, and the cross-source ARS control rollup.
+ * Lives in its own module (not InsightsPanel.tsx) so the panel file only
+ * exports components and Vite fast refresh keeps working.
+ */
+import type { InsightPayload } from '@/types'
+
+// Coerce an opaque payload value to renderable text. The payload is untrusted
+// JSON, so a field the type declares as a string could arrive as an object or
+// array; rendering that directly throws "Objects are not valid as a React
+// child" and (via the error boundary) blanks the whole panel. Coercing to a
+// string degrades gracefully instead. Returns undefined for nullish/empty so
+// existing truthiness guards still hide the element.
+export function asText(v: unknown): string | undefined {
+  if (v == null || v === '') return undefined
+  return typeof v === 'string' ? v : String(v)
+}
+
+// Severity → chip color. error/high/critical = red, warning/medium = amber,
+// everything else (low, powerup, unknown) = neutral.
+export function severityStyle(sev?: string): { bg: string; fg: string } {
+  const s = (sev ?? '').toLowerCase()
+  if (s === 'error' || s === 'high' || s === 'critical')
+    return { bg: '#fdecec', fg: '#b02a37' }
+  if (s === 'warning' || s === 'warn' || s === 'medium')
+    return { bg: '#fff4e5', fg: '#b26a00' }
+  return { bg: '#f0f0f0', fg: '#666' }
+}
+
+// The state of one control in the ARS Controls rollup. `unsatisfied` = CFACTS says
+// the control applies here but nothing has confirmed it satisfied (may be
+// unassessed) — informational, not an alarm.
+export type ControlRollupState = 'satisfied' | 'unsatisfied' | 'failing'
+
+// One piece of evidence behind a control's state: which source spoke to it, the
+// specific check (when the evidence is a finding-source check rather than a CFACTS
+// coverage flag), and what that evidence said.
+export type ControlEvidence = {
+  source: string
+  check?: string
+  state: ControlRollupState
+  // The check's human sentence, carried alongside the slug. A control chip is
+  // labeled with the control id, so without this its hover would name the check
+  // only by slug (`account-without-compliant-password-policy`) and the reader
+  // would have to decode it — the check chips have shown this sentence since
+  // they were introduced.
+  description?: string
+}
+
+// A control after the cross-source rollup: its net (weakest-link) state, whether
+// its sources disagree, and the full evidence list so the UI can name every source
+// and show how a conflict resolved.
+export type ControlRollup = {
+  id: string
+  state: ControlRollupState
+  conflict: boolean
+  evidence: ControlEvidence[]
+}
+
+// Weakest-link precedence for a control's NET state: failing beats satisfied beats
+// unsatisfied. So a control is failing if ANY source fails it, else satisfied if
+// ANY source passes it, else unsatisfied. Matches the zero-trust scoring principle
+// (lowest signal wins).
+const CONTROL_RANK: Record<ControlRollupState, number> = {
+  failing: 3,
+  satisfied: 2,
+  unsatisfied: 1,
+}
+
+// Sources whose "passing" entries are inferred from the absence of a finding
+// rather than observed as a pass. SecurityHub's vendor feed carries only FAILED
+// records — it never emits a PASSED one — so `sechub_passing` is derived upstream
+// as "mapped control with no active failure". That cannot distinguish "evaluated
+// and passed" from "never scanned", so on a partially scanned system it would
+// otherwise assert controls are met on the strength of checks that never ran.
+// Consequently these entries still render as ✓ chips (the check is not failing)
+// but are read as an absence of findings, and are withheld from the control
+// rollup rather than counted as affirmative `satisfied` evidence.
+//
+// Remove a source from this set once its feed emits real passes; nothing else
+// needs to change. Used by both the panel's feed blocks and rollupControls below.
+export const INFERRED_PASS_SOURCES: ReadonlySet<string> = new Set(['sechub'])
+
+// The ARS Controls total is the UNION of every ARS control any evidence source
+// touches — CFACTS applicable/failing controls PLUS the NIST control each Kion,
+// SecurityHub, and Hardenize check maps to. Each control keeps its full evidence
+// list, nets to a weakest-link state, and is flagged `conflict` when at least one
+// source passes it AND at least one source fails it (e.g. SC-12: Kion passes
+// key-rotation but fails cross-account-access). This is why a control Kion passes
+// appears here even though CFACTS never assessed it, and why a conflicted control
+// can net to failing. The payload is opaque, so every value is coerced and
+// guarded; a malformed element is skipped, never thrown.
+export function rollupControls(
+  payload: Partial<InsightPayload>
+): ControlRollup[] {
+  const map = new Map<string, ControlEvidence[]>()
+  const add = (
+    raw: unknown,
+    source: string,
+    state: ControlRollupState,
+    check?: string,
+    description?: string
+  ) => {
+    const text = asText(raw)
+    if (!text) return
+    // One check can map to several controls, e.g. "AC-2, AC-3".
+    for (const part of text.split(',')) {
+      const id = part.trim()
+      if (!id) continue
+      const list = map.get(id) ?? []
+      list.push({
+        source,
+        state,
+        check,
+        // A title-only finding (no id, no description) resolves both the check
+        // and the sentence to that same title. Drop the duplicate rather than
+        // printing it twice in the hover and announcing it twice to AT.
+        description: description === check ? undefined : description,
+      })
+      map.set(id, list)
+    }
+  }
+  const arr = (v: unknown): unknown[] => (Array.isArray(v) ? v : [])
+  const finding = (f: unknown) =>
+    f && typeof f === 'object'
+      ? (f as {
+          nist_controls?: unknown
+          id?: unknown
+          title?: unknown
+          description?: unknown
+        })
+      : null
+  // CFACTS assesses the ARS-framework controls (the ars_* fields carry CFACTS's
+  // satisfied / applicable-but-not-satisfied / failing coverage). ARS is the
+  // control catalog, not a source — CFACTS is the source of this coverage. These
+  // arrays are plain control-id strings (unlike nist_controls, which may arrive as
+  // an array and needs asText coercion), so filter to strings: a non-string
+  // element would otherwise coerce to a junk chip ("42", "[object Object]").
+  const isStr = (v: unknown): v is string => typeof v === 'string'
+  // ars_not_satisfied is a SUPERSET of ars_failing — a failing control appears in
+  // both. Subtract the failing ids so the control isn't listed twice in the hover
+  // (once "not assessed", once "failed"); the net state is failing either way.
+  const arsFailingIds = new Set(arr(payload.ars_failing_controls).filter(isStr))
+  arr(payload.ars_satisfied_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'satisfied'))
+  arr(payload.ars_not_satisfied_controls)
+    .filter(isStr)
+    .filter((c) => !arsFailingIds.has(c))
+    .forEach((c) => add(c, 'CFACTS', 'unsatisfied'))
+  arr(payload.ars_failing_controls)
+    .filter(isStr)
+    .forEach((c) => add(c, 'CFACTS', 'failing'))
+  // Finding-source checks: a passing check satisfies its control, a failing one (a
+  // finding) fails it. Carry the check id/title so the hover can name it.
+  const findings = (payload.findings ?? {}) as Record<string, unknown>
+  const SRC_LABEL: Record<string, string> = {
+    kion: 'Kion',
+    sechub: 'SecurityHub',
+    hardenize: 'Hardenize',
+  }
+  for (const src of ['kion', 'sechub', 'hardenize'] as const) {
+    const label = SRC_LABEL[src]
+    // An inferred pass is the absence of a finding, not evidence the control is
+    // met — counting it as `satisfied` would flip a control from "not assessed"
+    // to green on the strength of a check that may never have run.
+    if (!INFERRED_PASS_SOURCES.has(src)) {
+      arr((payload as Record<string, unknown>)[`${src}_passing`]).forEach(
+        (f) => {
+          const o = finding(f)
+          add(
+            o?.nist_controls,
+            label,
+            'satisfied',
+            asText(o?.id) ?? asText(o?.title),
+            // Kion puts the sentence in `description`, SecurityHub in `title` —
+            // same fallback CheckTooltip uses, so both hovers read alike.
+            asText(o?.description) ?? asText(o?.title)
+          )
+        }
+      )
+    }
+    arr(findings[src]).forEach((f) => {
+      const o = finding(f)
+      add(
+        o?.nist_controls,
+        label,
+        'failing',
+        asText(o?.id) ?? asText(o?.title),
+        asText(o?.description) ?? asText(o?.title)
+      )
+    })
+  }
+  return [...map.entries()].map(([id, evidence]) => {
+    const state = evidence.reduce<ControlRollupState>(
+      (net, e) => (CONTROL_RANK[e.state] > CONTROL_RANK[net] ? e.state : net),
+      'unsatisfied'
+    )
+    const conflict =
+      evidence.some((e) => e.state === 'satisfied') &&
+      evidence.some((e) => e.state === 'failing')
+    return { id, state, conflict, evidence }
+  })
+}

--- a/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Routes as AppRoutes } from '@/router/constants'
+import QuestionnairePage from './QuestionnairePage'
+import type { userData } from '@/types'
+
+// ztmf-misc#289: the questionnaire hides Devices and Applications for SaaS, but
+// only from FY26 on. The filter used to run on every call, hiding answered
+// history from closed cycles. The sidebar uppercases pillar names and spells out
+// CrossCutting, so the assertions read what the ISSO sees.
+
+jest.mock('@/utils/config', () => ({
+  __esModule: true,
+  default: { INSIGHTS_SUGGEST_FIX_ENABLED: false },
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+}))
+const mockGet = require('@/axiosConfig').default.get as jest.Mock
+
+jest.mock('./draftStore', () => ({
+  saveDraft: jest.fn().mockResolvedValue(true),
+  loadDraft: jest.fn().mockResolvedValue(null),
+  clearDraft: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/utils/notify', () => {
+  const actual = jest.requireActual('@/utils/notify')
+  return { ...actual, notify: jest.fn() }
+})
+
+let mockCtx: Record<string, unknown>
+jest.mock('../Title/Context', () => ({
+  useContextProp: () => mockCtx,
+}))
+
+const CURRENT_CALL = {
+  datacallid: 5,
+  datacall: 'FY2026 ZTM',
+  datecreated: '',
+  deadline: '2026-09-11T23:59:59Z',
+}
+
+// Later cycle, deliberately with a LOWER datacallid so an id-ordered threshold
+// would fail these tests too.
+const FUTURE_CALL = {
+  datacallid: 4,
+  datacall: 'FY2027 ZTM',
+  datecreated: '',
+  deadline: '2027-09-11T23:59:59Z',
+}
+
+const HISTORICAL_CALL = {
+  datacallid: 3,
+  datacall: 'FY2025 Q3',
+  datecreated: '',
+  deadline: '2025-05-07T23:59:59Z',
+}
+
+const PILLARS = [
+  'Identity',
+  'Devices',
+  'Networks',
+  'Applications',
+  'Data',
+  'CrossCutting',
+]
+
+const QUESTIONS = PILLARS.map((pillar, i) => ({
+  questionid: 900 + i,
+  question: `Question for ${pillar}`,
+  notesprompt: 'Notes',
+  pillar: { pillar },
+  function: {
+    functionid: 7000 + i,
+    function: `${pillar} Function`,
+    description: `${pillar} Function description`,
+    datacenterenvironment: 'SaaS',
+  },
+}))
+
+function makeCtx(
+  selectedDatacall: typeof CURRENT_CALL,
+  latest: typeof CURRENT_CALL = CURRENT_CALL
+) {
+  return {
+    userInfo: {
+      userid: '1',
+      email: 'isso@example.hhs',
+      fullname: 'Test ISSO',
+      role: 'OWNER',
+    } as userData,
+    latestDataCallId: latest.datacallid,
+    latestDatacall: latest.datacall,
+    latestDeadline: latest.deadline,
+    selectedDatacall,
+    datacalls: [FUTURE_CALL, CURRENT_CALL, HISTORICAL_CALL],
+    activeDatacallIds: [latest.datacallid],
+    fismaSystems: [
+      {
+        fismasystemid: 2001,
+        fismaacronym: 'SAAS-EX',
+        fismaname: 'SaaS Example System',
+        datacenterenvironment: 'SaaS',
+      },
+    ],
+    setFismaSystems: jest.fn(),
+    showDecommissioned: false,
+    setShowDecommissioned: jest.fn(),
+    fetchFismaSystems: jest.fn(),
+    datacenterEnvironments: [
+      {
+        datacenterenvironment: 'SaaS',
+        category: 'SaaS',
+        scoring_key: 'SaaS',
+        selectable: true,
+        ordr: 60,
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGet.mockImplementation((url: string) => {
+    if (url.includes('/questions'))
+      return Promise.resolve({ data: { data: QUESTIONS } })
+    if (url.startsWith('scores')) return Promise.resolve({ data: { data: [] } })
+    return Promise.resolve({ data: { data: [] } })
+  })
+})
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [{ path: AppRoutes.QUESTIONNAIRE, element: <QuestionnairePage /> }],
+    { initialEntries: ['/questionnaire/saas-ex'] }
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+it('hides Devices and Applications on the current cycle for a SaaS system', async () => {
+  mockCtx = makeCtx(CURRENT_CALL)
+  renderPage()
+
+  // The in-scope pillars prove the absences below are the filter, not a bad render.
+  await screen.findByText('IDENTITY')
+  expect(screen.getByText('NETWORKS')).toBeInTheDocument()
+  expect(screen.getByText('DATA')).toBeInTheDocument()
+  expect(screen.getByText('CROSS CUTTING')).toBeInTheDocument()
+
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})
+
+it('shows every pillar on a cycle earlier than FY26 for the same SaaS system', async () => {
+  mockCtx = makeCtx(HISTORICAL_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  await waitFor(() => {
+    expect(screen.getByText('DEVICES')).toBeInTheDocument()
+  })
+  expect(screen.getByText('APPLICATIONS')).toBeInTheDocument()
+})
+
+it('keeps filtering on cycles AFTER FY26, not just the latest one', async () => {
+  mockCtx = makeCtx(FUTURE_CALL, FUTURE_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})
+
+it('keeps filtering FY26 once a later cycle has opened', async () => {
+  // The regression a latest-only gate would cause.
+  mockCtx = makeCtx(CURRENT_CALL, FUTURE_CALL)
+  renderPage()
+
+  await screen.findByText('IDENTITY')
+  expect(screen.queryByText('DEVICES')).not.toBeInTheDocument()
+  expect(screen.queryByText('APPLICATIONS')).not.toBeInTheDocument()
+})

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -42,6 +42,7 @@ import { isAuthHandled, notify } from '@/utils/notify'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
+import { reducedPillarScopeApplies } from '@/utils/reducedPillarScope'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
@@ -936,9 +937,14 @@ export default function QuestionnarePage() {
                 }
                 organizedData[question.pillar.pillar].push(question)
               })
+              // Cycles before FY26 collected the full question set and their
+              // answers still exist, so filtering them hid answered history
+              // (ztmf-misc#289). null short-circuits the filter.
               const sortedPillars = filterPillarsForSystem(
                 sortPillars(Object.keys(organizedData)),
-                systemCategory
+                reducedPillarScopeApplies(datacalls, activeDataCallId)
+                  ? systemCategory
+                  : null
               )
               const categoriesData: Category[] = sortedPillars.map((pillar) => {
                 const sortedSteps = sortFunctions(pillar, organizedData[pillar])

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -34,6 +34,7 @@ import { MAX_QUESTIONNAIRE_NOTES_LENGTH, STATUS_MESSAGES } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { sortPillars } from '@/utils/sortPillars'
 import { filterPillarsForSystem } from '@/utils/filterPillarsForSystem'
+import { reducedPillarScopeApplies } from '@/utils/reducedPillarScope'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { sortFunctions } from '@/utils/sortFunctions'
 import { useContextProp } from '../Title/Context'
@@ -76,7 +77,7 @@ export default function QuestionnareModal({
   onClose,
   system,
 }: SystemDetailsModalProps) {
-  const { userInfo, datacenterEnvironments } = useContextProp()
+  const { userInfo, datacenterEnvironments, datacalls } = useContextProp()
   // Resolve the system's raw datacenter environment to its scoring category
   // for pillar filtering; fall back to the raw value until the vocabulary
   // loads or for any unmapped value.
@@ -294,9 +295,13 @@ export default function QuestionnareModal({
             }
             organizedData[question.pillar.pillar].push(question)
           })
+          // Same threshold as QuestionnairePage; this modal only ever shows the
+          // latest call, but one rule beats two.
           const sortedPillars = filterPillarsForSystem(
             sortPillars(Object.keys(organizedData)),
-            systemCategory
+            reducedPillarScopeApplies(datacalls, latestDataCallId)
+              ? systemCategory
+              : null
           )
           const categoriesData: Category[] = sortedPillars.map((pillar) => ({
             name: pillar,
@@ -327,7 +332,7 @@ export default function QuestionnareModal({
       fetchData()
       return () => controller.abort()
     }
-  }, [open, system, systemCategory])
+  }, [open, system, systemCategory, datacalls])
   React.useEffect(() => {
     if (questionId) {
       const controller = new AbortController()

--- a/src/views/QuestionnareModal/QuestionnareModal.tsx
+++ b/src/views/QuestionnareModal/QuestionnareModal.tsx
@@ -77,7 +77,8 @@ export default function QuestionnareModal({
   onClose,
   system,
 }: SystemDetailsModalProps) {
-  const { userInfo, datacenterEnvironments, datacalls } = useContextProp()
+  const { userInfo, datacenterEnvironments, datacalls, latestDataCallId } =
+    useContextProp()
   // Resolve the system's raw datacenter environment to its scoring category
   // for pillar filtering; fall back to the raw value until the vocabulary
   // loads or for any unmapped value.
@@ -85,6 +86,13 @@ export default function QuestionnareModal({
     toCategoryMap(datacenterEnvironments)[
       system?.datacenterenvironment ?? ''
     ] ?? system?.datacenterenvironment
+  // Derived here, not inside the fetch effect: depending on the datacalls array
+  // would re-run that effect whenever the context refetches, resetting an open
+  // modal to question 1 and discarding unsaved notes. A boolean is stable.
+  const reducedPillarScope = React.useMemo(
+    () => reducedPillarScopeApplies(datacalls, latestDataCallId),
+    [datacalls, latestDataCallId]
+  )
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const isReadOnly =
     isReadOnlyAdmin(userInfo) || (isPastDeadline && !isAdmin(userInfo))
@@ -299,9 +307,7 @@ export default function QuestionnareModal({
           // latest call, but one rule beats two.
           const sortedPillars = filterPillarsForSystem(
             sortPillars(Object.keys(organizedData)),
-            reducedPillarScopeApplies(datacalls, latestDataCallId)
-              ? systemCategory
-              : null
+            reducedPillarScope ? systemCategory : null
           )
           const categoriesData: Category[] = sortedPillars.map((pillar) => ({
             name: pillar,
@@ -332,7 +338,7 @@ export default function QuestionnareModal({
       fetchData()
       return () => controller.abort()
     }
-  }, [open, system, systemCategory, datacalls])
+  }, [open, system, systemCategory, reducedPillarScope])
   React.useEffect(() => {
     if (questionId) {
       const controller = new AbortController()

--- a/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import StatisticsBlocks from './StatisticsBlocks'
-import type { FismaSystemType, SystemScoreEntry } from '@/types'
+import type { FismaSystemType, ScoreProgress, SystemScoreEntry } from '@/types'
 
 // StatisticsBlocks reads the full active-system list from the outlet context and
 // the selection-scoped score map from props. The bug in ztmf-ui#633 was the
@@ -22,6 +22,18 @@ const score = (
   score: n,
   tier,
 })
+
+// A progress row for a system in the selected call(s). `expected` is the number
+// of applicable questions; > 0 means the system is part of the call.
+const prog = (id: number, expected: number): ScoreProgress =>
+  ({
+    fismasystemid: id,
+    questionsexpected: expected,
+    questionsanswered: 0,
+    questionsupdated: 0,
+    lastupdatedat: null,
+    updatedsincestart: false,
+  }) as ScoreProgress
 
 // Read the big numeral out of a tile located by its label. The high/low tiles
 // fold an acronym into the label element, so callers pass a regex for those.
@@ -49,15 +61,54 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     expect(tileValue('Average System Score')).toBe('3.5')
   })
 
-  it('shows the Scored / Total ratio scoped to the selection', () => {
-    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB'), sys(3, 'CCC')]
+  it('scopes the denominator to systems in the selected call(s), not the whole inventory', () => {
+    // Four active systems. 1, 2, 3 are in the selected call (progress rows); 1
+    // and 2 are scored, 3 is not started. System 4 is not in the call at all (no
+    // progress row). The tile reads 2 scored / 3 in-call - system 4 is excluded
+    // from the denominator instead of permanently counting as unscored.
+    mockFismaSystems = [
+      sys(1, 'AAA'),
+      sys(2, 'BBB'),
+      sys(3, 'CCC'),
+      sys(4, 'DDD'),
+    ]
     const scores: Record<number, SystemScoreEntry> = {
       1: score(2),
       2: score(5),
     }
-    render(<StatisticsBlocks scores={scores} />)
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 40),
+      3: prog(3, 40),
+    }
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
 
-    expect(tileValue('Scored / Total Systems')).toBe('2 / 3')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('2 / 3')
+  })
+
+  it('excludes a system whose questionnaire does not apply (0 expected)', () => {
+    // A 0/0 system carries a progress row but has no questions to answer, so it
+    // is not part of the call's population and must not inflate the denominator.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    const scores: Record<number, SystemScoreEntry> = { 1: score(3) }
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 0),
+    }
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
+
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('1 / 1')
+  })
+
+  it('does not read a false 100% when progress data is unavailable', () => {
+    // If the progress fetch fails entirely, the in-call population is unknown.
+    // The tile must not collapse to scored / scored (a false "all done"); it
+    // shows a 0 denominator so the missing data is visible rather than hidden.
+    mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
+    const scores: Record<number, SystemScoreEntry> = { 1: score(4) }
+    render(<StatisticsBlocks scores={scores} progress={{}} />)
+
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('1 / 0')
   })
 
   it('keeps the average between the lowest and highest displayed scores', () => {
@@ -78,14 +129,19 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     expect(high).toBe(4.82)
   })
 
-  it('handles a selection no system participated in without going below scale', () => {
-    // No scored systems: average is 0 (guarded), ratio is 0 / N, and the lowest
-    // tile falls back to 0.00 rather than rendering Infinity.
+  it('handles a call no system has started without going below scale', () => {
+    // Two systems in the call, none scored yet: average is 0 (guarded), ratio is
+    // 0 / 2 (both are in the call), and the lowest tile falls back to 0.00 rather
+    // than rendering Infinity.
     mockFismaSystems = [sys(1, 'AAA'), sys(2, 'BBB')]
-    render(<StatisticsBlocks scores={{}} />)
+    const progress: Record<number, ScoreProgress> = {
+      1: prog(1, 40),
+      2: prog(2, 40),
+    }
+    render(<StatisticsBlocks scores={{}} progress={progress} />)
 
     expect(tileValue('Average System Score')).toBe('0')
-    expect(tileValue('Scored / Total Systems')).toBe('0 / 2')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe('0 / 2')
     expect(tileValue('Lowest System Score:')).toBe('0.00')
   })
 
@@ -96,8 +152,14 @@ describe('StatisticsBlocks — ztmf-ui#633 selection-scoped scoring', () => {
     const scores: Record<number, SystemScoreEntry> = {
       1: score(3.44),
     }
-    render(<StatisticsBlocks scores={scores} />)
+    // All 1342 systems are in the selected call, so the denominator is 1,342.
+    const progress: Record<number, ScoreProgress> = Object.fromEntries(
+      mockFismaSystems.map((s) => [s.fismasystemid, prog(s.fismasystemid, 40)])
+    )
+    render(<StatisticsBlocks scores={scores} progress={progress} />)
 
-    expect(tileValue('Scored / Total Systems')).toBe('1 / 1,342')
+    expect(tileValue('Scored / Systems in selected data calls')).toBe(
+      '1 / 1,342'
+    )
   })
 })

--- a/src/views/StatisticBlocks/StatisticsBlocks.tsx
+++ b/src/views/StatisticBlocks/StatisticsBlocks.tsx
@@ -4,7 +4,7 @@ import Paper from '@mui/material/Paper'
 import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { useContextProp } from '../Title/Context'
-import type { ScoreTier, SystemScoreEntry } from '@/types'
+import type { ScoreProgress, ScoreTier, SystemScoreEntry } from '@/types'
 import { TIERS } from '@/utils/tierStyles'
 const StatisticsPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(2),
@@ -21,8 +21,10 @@ const StatisticsPaper = styled(Paper)(({ theme }) => ({
 }))
 export default function StatisticsBlocks({
   scores,
+  progress,
 }: {
   scores: Record<number, SystemScoreEntry>
+  progress?: Record<number, ScoreProgress>
 }) {
   const { fismaSystems } = useContextProp()
   const [totalSystems, setTotalSystems] = useState<number>(0)
@@ -41,12 +43,14 @@ export default function StatisticsBlocks({
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
-    // Count only the systems that actually contribute a score. The `scores` map
-    // is already scoped to the selected data call(s), so systems with no answers
-    // in the selection must not inflate the denominator (that dragged the average
-    // below the scale minimum — see ztmf-ui#633). Counted inside the loop so the
-    // numerator and denominator always cover the same systems.
+    // The average divides by the scored systems only: the scores map is scoped
+    // to the selected call(s), so unscored systems must not dilute it. The
+    // Scored / Systems tile pairs that scored count with a denominator scoped
+    // the same way - the systems actually in the selected call(s), taken from
+    // the progress map - instead of a call-scoped numerator over an all-systems
+    // denominator, which read as an order-of-magnitude larger backlog than real.
     let scoredCount: number = 0
+    let inCallCount: number = 0
     let maxScore: number = 0
     let maxScoreSystem: string = ''
     let maxScoreTier: ScoreTier | undefined
@@ -56,6 +60,22 @@ export default function StatisticsBlocks({
     let totalScores: number = 0
     for (const system of fismaSystems) {
       const entry = scores[system.fismasystemid]
+      // A system is in the selected call(s) if the progress map carries a row
+      // for it with questions to answer (questionsexpected > 0), a set that
+      // includes never-started systems. A scored system always has such a row
+      // when the progress fetch succeeds, so the ratio stays within 100% without
+      // a special case; if the whole progress fetch fails the denominator reads
+      // 0, which surfaces the outage instead of hiding it behind a false "all
+      // scored" (which counting scored systems here would produce).
+      const progressEntry = progress?.[system.fismasystemid]
+      if ((progressEntry?.questionsexpected ?? 0) > 0) {
+        inCallCount += 1
+      }
+      // Truthy check, not a null check, on purpose. Backend system scores are
+      // floored at 1.0 (each pillar averages the answer score plus one), so a
+      // real score is never 0. A 0 here only comes from an absent/null score
+      // being coalesced to 0 upstream, which must not count as scored. If
+      // scoring ever moves to a 0-based scale, this has to distinguish the two.
       if (entry && entry.score) {
         if (entry.score > maxScore) {
           maxScore = entry.score
@@ -79,7 +99,7 @@ export default function StatisticsBlocks({
       setMinSystemScore(minScore)
     }
     setAnsweredSystems(scoredCount)
-    setTotalSystems(fismaSystems.length)
+    setTotalSystems(inCallCount)
     setMaxSystemScore(maxScore)
     setMaxSystemTier(maxScoreTier)
     setMaxSystemAcronym(maxScoreSystem || '')
@@ -87,7 +107,7 @@ export default function StatisticsBlocks({
     setMinSystemTier(minScoreTier)
     setMinSystemAcronym(minScoreSystem || '')
     setLoading(false)
-  }, [fismaSystems, scores])
+  }, [fismaSystems, scores, progress])
   if (loading) {
     return <p>Loading ...</p>
   }
@@ -114,7 +134,7 @@ export default function StatisticsBlocks({
           variant="body1"
           sx={{ fontSize: '16px', overflowWrap: 'break-word' }}
         >
-          Scored / Total Systems
+          Scored / Systems in selected data calls
         </Typography>
       </StatisticsPaper>
       <StatisticsPaper variant="outlined">

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -24,4 +24,13 @@ describe('LastSeenCell', () => {
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent('2026')
   })
+
+  it('carries the absolute timestamp in the accessible name (tooltip is hover-only)', () => {
+    render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
+    const el = screen.getByText('3 days ago')
+    expect(el).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/^3 days ago \(.*2026.*\)$/)
+    )
+  })
 })

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LastSeenCell from './LastSeenCell'
+import { LAST_SEEN_EMPTY_LABEL } from './lastSeen'
+
+describe('LastSeenCell', () => {
+  const now = new Date('2026-08-07T12:00:00Z')
+
+  it('renders the neutral empty state for null (never blank)', () => {
+    render(<LastSeenCell value={null} now={now} />)
+    expect(screen.getByText(LAST_SEEN_EMPTY_LABEL)).toBeInTheDocument()
+  })
+
+  it('renders relative time for a recorded timestamp', () => {
+    render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
+    expect(screen.getByText('3 days ago')).toBeInTheDocument()
+  })
+
+  it('exposes the absolute timestamp as a tooltip on hover', async () => {
+    const user = userEvent.setup()
+    const value = new Date('2026-08-04T12:00:00Z')
+    render(<LastSeenCell value={value} now={now} />)
+    await user.hover(screen.getByText('3 days ago'))
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip).toHaveTextContent('2026')
+  })
+})

--- a/src/views/UserTable/LastSeenCell.test.tsx
+++ b/src/views/UserTable/LastSeenCell.test.tsx
@@ -13,24 +13,25 @@ describe('LastSeenCell', () => {
 
   it('renders relative time for a recorded timestamp', () => {
     render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
-    expect(screen.getByText('3 days ago')).toBeInTheDocument()
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument()
   })
 
   it('exposes the absolute timestamp as a tooltip on hover', async () => {
     const user = userEvent.setup()
     const value = new Date('2026-08-04T12:00:00Z')
     render(<LastSeenCell value={value} now={now} />)
-    await user.hover(screen.getByText('3 days ago'))
+    await user.hover(screen.getByText(/3 days ago/))
     const tooltip = await screen.findByRole('tooltip')
     expect(tooltip).toHaveTextContent('2026')
   })
 
-  it('carries the absolute timestamp in the accessible name (tooltip is hover-only)', () => {
+  it('carries the absolute timestamp in a visually hidden span (tooltip is hover-only)', () => {
     render(<LastSeenCell value={new Date('2026-08-04T12:00:00Z')} now={now} />)
-    const el = screen.getByText('3 days ago')
-    expect(el).toHaveAttribute(
-      'aria-label',
-      expect.stringMatching(/^3 days ago \(.*2026.*\)$/)
-    )
+    // Full spoken text = relative phrase plus the parenthesized absolute.
+    const cell = screen.getByText(/3 days ago/)
+    expect(cell).toHaveTextContent(/3 days ago \(.*2026.*\)/)
+    // The absolute part is present for AT but visually clipped, not displayed.
+    const hidden = screen.getByText(/\(.*2026.*\)/)
+    expect(hidden).toHaveStyle({ position: 'absolute', width: '1px' })
   })
 })

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -30,10 +30,15 @@ export default function LastSeenCell({ value, now }: Props) {
       </Typography>
     )
   }
+  const absolute = formatLastSeenAbsolute(value)
+  const relative = formatLastSeenRelative(value, now ?? new Date())
   return (
-    <Tooltip title={formatLastSeenAbsolute(value)} placement="top">
-      <Typography variant="body2">
-        {formatLastSeenRelative(value, now ?? new Date())}
+    <Tooltip title={absolute} placement="top">
+      {/* The tooltip is hover-only, so the absolute timestamp rides in the
+          accessible name too - a screen reader hears both, not just the
+          relative phrase (508). */}
+      <Typography variant="body2" aria-label={`${relative} (${absolute})`}>
+        {relative}
       </Typography>
     </Tooltip>
   )

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -1,0 +1,40 @@
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import {
+  LAST_SEEN_EMPTY_LABEL,
+  formatLastSeenAbsolute,
+  formatLastSeenRelative,
+} from './lastSeen'
+
+type Props = {
+  value: Date | null
+  /** Injectable clock for tests; defaults to the real current time. */
+  now?: Date
+}
+
+/**
+ * View cell for the "Last seen" column: relative time with the absolute
+ * timestamp on hover, or a neutral empty state for rows with no recorded
+ * activity (deliberately not blank, so "never seen" is a visible, scannable
+ * state rather than an ambiguous hole in the grid).
+ */
+export default function LastSeenCell({ value, now }: Props) {
+  if (!value) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ fontStyle: 'italic' }}
+      >
+        {LAST_SEEN_EMPTY_LABEL}
+      </Typography>
+    )
+  }
+  return (
+    <Tooltip title={formatLastSeenAbsolute(value)} placement="top">
+      <Typography variant="body2">
+        {formatLastSeenRelative(value, now ?? new Date())}
+      </Typography>
+    </Tooltip>
+  )
+}

--- a/src/views/UserTable/LastSeenCell.tsx
+++ b/src/views/UserTable/LastSeenCell.tsx
@@ -1,5 +1,7 @@
+import Box from '@mui/material/Box'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import { visuallyHidden } from '@mui/utils'
 import {
   LAST_SEEN_EMPTY_LABEL,
   formatLastSeenAbsolute,
@@ -34,11 +36,13 @@ export default function LastSeenCell({ value, now }: Props) {
   const relative = formatLastSeenRelative(value, now ?? new Date())
   return (
     <Tooltip title={absolute} placement="top">
-      {/* The tooltip is hover-only, so the absolute timestamp rides in the
-          accessible name too - a screen reader hears both, not just the
-          relative phrase (508). */}
-      <Typography variant="body2" aria-label={`${relative} (${absolute})`}>
+      <Typography variant="body2">
         {relative}
+        {/* The tooltip is hover-only, so the absolute timestamp also rides
+            along visually hidden - a screen reader hears both, not just the
+            relative phrase (508). A hidden span rather than aria-label
+            because ARIA-in-HTML doesn't permit aria-label on a paragraph. */}
+        <Box component="span" sx={visuallyHidden}>{` (${absolute})`}</Box>
       </Typography>
     </Tooltip>
   )

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -23,7 +23,6 @@ import {
   GridRowEditStopReasons,
   GridToolbarQuickFilter,
   GridFilterModel,
-  GridSortItem,
   useGridApiRef,
 } from '@mui/x-data-grid'
 import { Chip, FormControlLabel, Switch, Typography } from '@mui/material'
@@ -58,7 +57,7 @@ import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import LastSeenCell from './LastSeenCell'
 import {
-  compareLastSeen,
+  lastSeenSortComparator,
   parseLastSeen,
   hasNoActivityFilter,
   withNoActivityFilter,
@@ -765,14 +764,9 @@ export default function UserTable() {
       valueGetter: (params) => parseLastSeen(params.row.last_seen),
       // Direction-aware so never-active rows sort last under BOTH asc and
       // desc; see compareLastSeen for how it pre-compensates the grid's
-      // negation on desc.
-      sortComparator: (v1, v2, cellParams1) => {
-        const direction =
-          (cellParams1.api.getSortModel() as GridSortItem[]).find(
-            (item) => item.field === cellParams1.field
-          )?.sort ?? 'asc'
-        return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
-      },
+      // negation on desc, and lastSeenSortComparator for the live-direction
+      // read (and the TODO for the v7 getSortComparator migration).
+      sortComparator: lastSeenSortComparator,
       renderCell: (params) => <LastSeenCell value={params.value ?? null} />,
     },
     {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -22,6 +22,8 @@ import {
   GridRenderEditCellParams,
   GridRowEditStopReasons,
   GridToolbarQuickFilter,
+  GridFilterModel,
+  GridSortItem,
   useGridApiRef,
 } from '@mui/x-data-grid'
 import { Chip, FormControlLabel, Switch, Typography } from '@mui/material'
@@ -54,6 +56,8 @@ import { useNavigate } from 'react-router-dom'
 import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
+import LastSeenCell from './LastSeenCell'
+import { compareLastSeen, parseLastSeen } from './lastSeen'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
   setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void
@@ -63,11 +67,20 @@ interface EditToolbarProps {
   isAdmin?: boolean
   showDeleted: boolean
   setShowDeleted: (value: boolean) => void
+  noActivityOnly: boolean
+  setNoActivityOnly: (value: boolean) => void
 }
 
 function EditToolbar(props: EditToolbarProps) {
-  const { setRows, setRowModesModel, isAdmin, showDeleted, setShowDeleted } =
-    props
+  const {
+    setRows,
+    setRowModesModel,
+    isAdmin,
+    showDeleted,
+    setShowDeleted,
+    noActivityOnly,
+    setNoActivityOnly,
+  } = props
   const addUserRow = () => {
     const userid = Math.floor(Math.random() * 1000) + 1
     setRows((oldRows) => [
@@ -103,6 +116,23 @@ function EditToolbar(props: EditToolbarProps) {
         }}
       />
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={noActivityOnly}
+              onChange={(e) => setNoActivityOnly(e.target.checked)}
+              sx={{
+                '& .MuiSwitch-switchBase.Mui-checked': {
+                  color: '#004297',
+                },
+                '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                  backgroundColor: '#004297',
+                },
+              }}
+            />
+          }
+          label="No Activity Only"
+        />
         <FormControlLabel
           control={
             <Switch
@@ -174,6 +204,28 @@ export default function UserTable() {
     assignedfismasystems: [],
   })
   const [showDeleted, setShowDeleted] = useState<boolean>(false)
+  // Controlled so the "No Activity Only" toolbar switch can inject/remove an
+  // isEmpty filter on last_seen while quick-filter text (which also lives in
+  // this model) keeps working. The switch state is DERIVED from the model, so
+  // removing the filter via the column filter panel un-checks the switch too.
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({ items: [] })
+  const noActivityOnly = filterModel.items.some(
+    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
+  )
+  const setNoActivityOnly = (value: boolean) => {
+    setFilterModel((prev) => ({
+      ...prev,
+      items: value
+        ? [
+            ...prev.items.filter((item) => item.field !== 'last_seen'),
+            { id: 'no-activity', field: 'last_seen', operator: 'isEmpty' },
+          ]
+        : prev.items.filter(
+            (item) =>
+              !(item.field === 'last_seen' && item.operator === 'isEmpty')
+          ),
+    }))
+  }
   const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
   const [pendingRestoreRow, setPendingRestoreRow] = useState<users | null>(null)
   const [assignModalUserName, setAssignModalUserName] = useState<string>('')
@@ -708,6 +760,27 @@ export default function UserTable() {
       renderCell: (params) => params.row.identity_provider || '—',
     },
     {
+      field: 'last_seen',
+      headerName: 'Last Seen',
+      flex: 0.75,
+      type: 'dateTime',
+      // valueGetter (not just renderCell) so sorting, the isEmpty filter
+      // operator, and the toolbar's No Activity switch all see a real
+      // Date-or-null instead of the raw ISO string.
+      valueGetter: (params) => parseLastSeen(params.row.last_seen),
+      // Direction-aware so never-active rows sort last under BOTH asc and
+      // desc; see compareLastSeen for how it pre-compensates the grid's
+      // negation on desc.
+      sortComparator: (v1, v2, cellParams1) => {
+        const direction =
+          (cellParams1.api.getSortModel() as GridSortItem[]).find(
+            (item) => item.field === cellParams1.field
+          )?.sort ?? 'asc'
+        return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
+      },
+      renderCell: (params) => <LastSeenCell value={params.value ?? null} />,
+    },
+    {
       field: 'actions',
       type: 'actions',
       headerName: 'Actions',
@@ -861,6 +934,8 @@ export default function UserTable() {
               sortModel: [{ field: 'role', sort: 'asc' }],
             },
           }}
+          filterModel={filterModel}
+          onFilterModelChange={setFilterModel}
           rowModesModel={rowModesModel}
           onRowModesModelChange={handleRowModesModelChange}
           onProcessRowUpdateError={handleProcessRowUpdateError}
@@ -876,6 +951,8 @@ export default function UserTable() {
               isAdmin,
               showDeleted,
               setShowDeleted,
+              noActivityOnly,
+              setNoActivityOnly,
             },
             filterPanel: {
               sx: {

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -57,7 +57,12 @@ import { Routes } from '@/router/constants'
 import { ERROR_MESSAGES, STATUS_MESSAGES } from '@/constants'
 import EditInputCell from './EditInputCell'
 import LastSeenCell from './LastSeenCell'
-import { compareLastSeen, parseLastSeen } from './lastSeen'
+import {
+  compareLastSeen,
+  parseLastSeen,
+  hasNoActivityFilter,
+  withNoActivityFilter,
+} from './lastSeen'
 import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 interface EditToolbarProps {
   setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void
@@ -208,23 +213,13 @@ export default function UserTable() {
   // isEmpty filter on last_seen while quick-filter text (which also lives in
   // this model) keeps working. The switch state is DERIVED from the model, so
   // removing the filter via the column filter panel un-checks the switch too.
+  // The toggle logic lives in lastSeen.ts (withNoActivityFilter) because the
+  // community grid's single-filter-item limit makes it subtle enough to pin
+  // with tests.
   const [filterModel, setFilterModel] = useState<GridFilterModel>({ items: [] })
-  const noActivityOnly = filterModel.items.some(
-    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
-  )
+  const noActivityOnly = hasNoActivityFilter(filterModel)
   const setNoActivityOnly = (value: boolean) => {
-    setFilterModel((prev) => ({
-      ...prev,
-      items: value
-        ? [
-            ...prev.items.filter((item) => item.field !== 'last_seen'),
-            { id: 'no-activity', field: 'last_seen', operator: 'isEmpty' },
-          ]
-        : prev.items.filter(
-            (item) =>
-              !(item.field === 'last_seen' && item.operator === 'isEmpty')
-          ),
-    }))
+    setFilterModel((prev) => withNoActivityFilter(prev, value))
   }
   const [pendingDeleteRow, setPendingDeleteRow] = useState<users | null>(null)
   const [pendingRestoreRow, setPendingRestoreRow] = useState<users | null>(null)

--- a/src/views/UserTable/lastSeen.test.ts
+++ b/src/views/UserTable/lastSeen.test.ts
@@ -1,9 +1,12 @@
 import {
   LAST_SEEN_EMPTY_LABEL,
+  NO_ACTIVITY_FILTER_ITEM,
   compareLastSeen,
   formatLastSeenAbsolute,
   formatLastSeenRelative,
+  hasNoActivityFilter,
   parseLastSeen,
+  withNoActivityFilter,
 } from './lastSeen'
 
 describe('parseLastSeen', () => {
@@ -87,6 +90,58 @@ describe('compareLastSeen', () => {
     // Desc mirrors the grid: it negates the comparator's result.
     const desc = [...rows].sort((a, b) => -compareLastSeen(a, b, 'desc'))
     expect(desc).toEqual([newer, older, null, null])
+  })
+})
+
+describe('withNoActivityFilter / hasNoActivityFilter', () => {
+  it('turning ON injects the isEmpty item and reports active', () => {
+    const next = withNoActivityFilter({ items: [] }, true)
+    expect(next.items).toEqual([NO_ACTIVITY_FILTER_ITEM])
+    expect(hasNoActivityFilter(next)).toBe(true)
+  })
+
+  // The community DataGrid keeps only ONE column-filter item
+  // (disableMultipleColumnsFiltering is hard-set) and silently discards the
+  // rest. An implementation that APPENDS after an existing panel filter puts
+  // the no-activity item at index 1, where the grid throws it away and the
+  // toggle does nothing - so ON must replace the items outright.
+  it('turning ON replaces a pre-existing column filter instead of appending', () => {
+    const withPanelFilter = {
+      items: [{ id: 1, field: 'role', operator: 'is', value: 'ISSO' }],
+    }
+    const next = withNoActivityFilter(withPanelFilter, true)
+    expect(next.items).toEqual([NO_ACTIVITY_FILTER_ITEM])
+  })
+
+  it('preserves quick-filter text across both transitions', () => {
+    const quick = { items: [], quickFilterValues: ['skywalker'] }
+    const on = withNoActivityFilter(quick, true)
+    expect(on.quickFilterValues).toEqual(['skywalker'])
+    const off = withNoActivityFilter(on, false)
+    expect(off.quickFilterValues).toEqual(['skywalker'])
+    expect(off.items).toEqual([])
+  })
+
+  it('turning OFF removes only the no-activity item', () => {
+    const model = {
+      items: [
+        { id: 1, field: 'role', operator: 'is', value: 'ISSO' },
+        NO_ACTIVITY_FILTER_ITEM,
+      ],
+    }
+    const off = withNoActivityFilter(model, false)
+    expect(off.items).toEqual([
+      { id: 1, field: 'role', operator: 'is', value: 'ISSO' },
+    ])
+    expect(hasNoActivityFilter(off)).toBe(false)
+  })
+
+  it('hasNoActivityFilter is false for an unrelated last_seen filter', () => {
+    expect(
+      hasNoActivityFilter({
+        items: [{ id: 2, field: 'last_seen', operator: 'after', value: 'x' }],
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/views/UserTable/lastSeen.test.ts
+++ b/src/views/UserTable/lastSeen.test.ts
@@ -1,0 +1,102 @@
+import {
+  LAST_SEEN_EMPTY_LABEL,
+  compareLastSeen,
+  formatLastSeenAbsolute,
+  formatLastSeenRelative,
+  parseLastSeen,
+} from './lastSeen'
+
+describe('parseLastSeen', () => {
+  it('parses a backend ISO timestamp (microseconds + Z)', () => {
+    const d = parseLastSeen('2026-08-04T11:52:20.090616Z')
+    expect(d).toBeInstanceOf(Date)
+    expect(d!.toISOString()).toBe('2026-08-04T11:52:20.090Z')
+  })
+
+  it('returns null for null, undefined, and empty string', () => {
+    expect(parseLastSeen(null)).toBeNull()
+    expect(parseLastSeen(undefined)).toBeNull()
+    expect(parseLastSeen('')).toBeNull()
+  })
+
+  it('returns null for an unparseable string', () => {
+    expect(parseLastSeen('not-a-date')).toBeNull()
+  })
+})
+
+describe('formatLastSeenRelative', () => {
+  const now = new Date('2026-08-07T12:00:00Z')
+  const secondsAgo = (s: number) => new Date(now.getTime() - s * 1000)
+
+  it.each([
+    [30, 'just now'],
+    [5 * 60, '5 minutes ago'],
+    [3 * 3600, '3 hours ago'],
+    [3 * 24 * 3600, '3 days ago'],
+    [2 * 7 * 24 * 3600, '2 weeks ago'],
+    [65 * 24 * 3600, '2 months ago'],
+    [2 * 365 * 24 * 3600, '2 years ago'],
+  ])('%d seconds ago renders "%s"', (seconds, expected) => {
+    expect(formatLastSeenRelative(secondsAgo(seconds), now)).toBe(expected)
+  })
+
+  it('treats a slightly-ahead server clock as "just now"', () => {
+    expect(formatLastSeenRelative(secondsAgo(-10), now)).toBe('just now')
+  })
+})
+
+describe('formatLastSeenAbsolute', () => {
+  it('produces a locale date-time string containing the year', () => {
+    const out = formatLastSeenAbsolute(new Date('2026-08-04T11:52:20Z'))
+    expect(out).toContain('2026')
+  })
+})
+
+describe('compareLastSeen', () => {
+  const older = new Date('2026-01-01T00:00:00Z')
+  const newer = new Date('2026-08-01T00:00:00Z')
+
+  it('orders two dates chronologically under asc', () => {
+    expect(compareLastSeen(older, newer, 'asc')).toBeLessThan(0)
+    expect(compareLastSeen(newer, older, 'asc')).toBeGreaterThan(0)
+    expect(compareLastSeen(older, older, 'asc')).toBe(0)
+  })
+
+  it('sorts null after any date under asc', () => {
+    expect(compareLastSeen(null, older, 'asc')).toBeGreaterThan(0)
+    expect(compareLastSeen(older, null, 'asc')).toBeLessThan(0)
+  })
+
+  // The grid negates the comparator result when sorting desc, so the raw
+  // return values here are inverted relative to the final row order: -1 for
+  // (null, date) becomes +1 after negation, which still places null last.
+  it('pre-compensates under desc so null still lands last after negation', () => {
+    expect(compareLastSeen(null, older, 'desc')).toBeLessThan(0)
+    expect(compareLastSeen(older, null, 'desc')).toBeGreaterThan(0)
+  })
+
+  it('treats two nulls as equal in both directions', () => {
+    expect(compareLastSeen(null, null, 'asc')).toBe(0)
+    expect(compareLastSeen(undefined, null, 'desc')).toBe(0)
+  })
+
+  it('end-to-end: grid sort simulation keeps nulls last both ways', () => {
+    const rows: (Date | null)[] = [newer, null, older, null]
+    const asc = [...rows].sort((a, b) => compareLastSeen(a, b, 'asc'))
+    expect(asc).toEqual([older, newer, null, null])
+    // Desc mirrors the grid: it negates the comparator's result.
+    const desc = [...rows].sort((a, b) => -compareLastSeen(a, b, 'desc'))
+    expect(desc).toEqual([newer, older, null, null])
+  })
+})
+
+describe('LAST_SEEN_EMPTY_LABEL', () => {
+  // Tracking began 2026-08-06; for older accounts null means "nothing since
+  // tracking began", not "never signed in". Pin the neutral wording so it
+  // doesn't drift into something accusatory like "Never logged in".
+  it('is neutral about sign-in history', () => {
+    expect(LAST_SEEN_EMPTY_LABEL).toBe('No activity recorded')
+    expect(LAST_SEEN_EMPTY_LABEL.toLowerCase()).not.toContain('login')
+    expect(LAST_SEEN_EMPTY_LABEL.toLowerCase()).not.toContain('never')
+  })
+})

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -6,7 +6,11 @@
  * tracking began 2026-08-06, so a null for an older account means "no recorded
  * activity since tracking began", not "never signed in".
  */
-import type { GridFilterModel } from '@mui/x-data-grid'
+import type {
+  GridComparatorFn,
+  GridFilterModel,
+  GridSortItem,
+} from '@mui/x-data-grid'
 
 /** Neutral empty state - see the module note on why it isn't "Never logged in". */
 export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
@@ -106,4 +110,27 @@ export function compareLastSeen(
   if (aNull) return direction === 'desc' ? -1 : 1
   if (bNull) return direction === 'desc' ? 1 : -1
   return a.getTime() - b.getTime()
+}
+
+/**
+ * The column's comparator: reads the LIVE sort direction off the grid api at
+ * compare time (v6 commits the new sort model to state before applying the
+ * sort, so this sees the direction being applied, not the previous one) and
+ * hands it to compareLastSeen. Exported so the grid-level test can exercise
+ * this exact wiring - the getSortModel() read is the fragile part, not the
+ * pure comparison.
+ *
+ * TODO(x-data-grid v7): replace with getSortComparator(direction) on the
+ * column def and drop the direction plumbing here - a v7 upgrade that keeps
+ * this workaround would still work, but the native hook is the intended API.
+ */
+export const lastSeenSortComparator: GridComparatorFn<Date | null> = (
+  v1,
+  v2,
+  cellParams1
+) => {
+  const direction = (cellParams1.api.getSortModel() as GridSortItem[]).find(
+    (item) => item.field === cellParams1.field
+  )?.sort
+  return compareLastSeen(v1, v2, direction === 'desc' ? 'desc' : 'asc')
 }

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -1,0 +1,70 @@
+/**
+ * Sorting and formatting logic for the user grid's "Last seen" column,
+ * extracted so it can be tested without standing up the grid.
+ *
+ * The column is deliberately labeled "Last seen", not "Last login": activity
+ * tracking began 2026-08-06, so a null for an older account means "no recorded
+ * activity since tracking began", not "never signed in".
+ */
+
+/** Neutral empty state - see the module note on why it isn't "Never logged in". */
+export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
+
+/** Parse an ISO timestamp defensively; null for missing or unparseable input. */
+export function parseLastSeen(iso: string | null | undefined): Date | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  return isNaN(d.getTime()) ? null : d
+}
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ['year', 365 * 24 * 3600],
+  ['month', 30 * 24 * 3600],
+  ['week', 7 * 24 * 3600],
+  ['day', 24 * 3600],
+  ['hour', 3600],
+  ['minute', 60],
+]
+
+/**
+ * Relative rendering for the cell ("3 days ago"). Anything under a minute -
+ * including a slightly-ahead server clock - reads "just now".
+ */
+export function formatLastSeenRelative(value: Date, now: Date): string {
+  const diffSec = Math.round((now.getTime() - value.getTime()) / 1000)
+  if (diffSec < 60) return 'just now'
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always' })
+  for (const [unit, seconds] of RELATIVE_UNITS) {
+    if (diffSec >= seconds) {
+      return rtf.format(-Math.floor(diffSec / seconds), unit)
+    }
+  }
+  return 'just now'
+}
+
+/** Absolute timestamp for the hover tooltip, in the viewer's locale. */
+export function formatLastSeenAbsolute(value: Date): string {
+  return value.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+/**
+ * Comparator for the column, direction-aware so never-active rows sort LAST in
+ * both directions. The grid negates the comparator's result when sorting desc,
+ * so the null branches pre-compensate: returning -1 for a null under desc
+ * becomes +1 after negation, keeping the null at the bottom.
+ */
+export function compareLastSeen(
+  a: Date | null | undefined,
+  b: Date | null | undefined,
+  direction: 'asc' | 'desc'
+): number {
+  const aNull = a == null
+  const bNull = b == null
+  if (aNull && bNull) return 0
+  if (aNull) return direction === 'desc' ? -1 : 1
+  if (bNull) return direction === 'desc' ? 1 : -1
+  return a.getTime() - b.getTime()
+}

--- a/src/views/UserTable/lastSeen.ts
+++ b/src/views/UserTable/lastSeen.ts
@@ -6,9 +6,48 @@
  * tracking began 2026-08-06, so a null for an older account means "no recorded
  * activity since tracking began", not "never signed in".
  */
+import type { GridFilterModel } from '@mui/x-data-grid'
 
 /** Neutral empty state - see the module note on why it isn't "Never logged in". */
 export const LAST_SEEN_EMPTY_LABEL = 'No activity recorded'
+
+/** The filter item the "No Activity Only" toolbar switch injects. */
+export const NO_ACTIVITY_FILTER_ITEM = {
+  id: 'no-activity',
+  field: 'last_seen',
+  operator: 'isEmpty',
+}
+
+/** Whether the model currently carries the no-activity filter (drives the switch). */
+export function hasNoActivityFilter(model: GridFilterModel): boolean {
+  return model.items.some(
+    (item) => item.field === 'last_seen' && item.operator === 'isEmpty'
+  )
+}
+
+/**
+ * Toggle the no-activity filter on a filter model. The community DataGrid
+ * allows only ONE column-filter item (disableMultipleColumnsFiltering is
+ * hard-set); sanitizeFilterModel drops anything past the first and logs a
+ * console error. So switching ON must REPLACE the items array outright, not
+ * append - an appended item at index 1 would be silently discarded whenever
+ * the user already had a filter applied via the column filter panel. The
+ * spread preserves quickFilterValues, which live beside items and are not
+ * subject to the single-item limit.
+ */
+export function withNoActivityFilter(
+  model: GridFilterModel,
+  on: boolean
+): GridFilterModel {
+  return {
+    ...model,
+    items: on
+      ? [NO_ACTIVITY_FILTER_ITEM]
+      : model.items.filter(
+          (item) => !(item.field === 'last_seen' && item.operator === 'isEmpty')
+        ),
+  }
+}
 
 /** Parse an ISO timestamp defensively; null for missing or unparseable input. */
 export function parseLastSeen(iso: string | null | undefined): Date | null {

--- a/src/views/UserTable/lastSeenSortComparator.integration.test.tsx
+++ b/src/views/UserTable/lastSeenSortComparator.integration.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Grid-level test for the Last Seen sort wiring. The pure comparator is
+ * covered in lastSeen.test.ts with a simulated negation; this renders a real
+ * DataGrid and clicks the header so the fragile part - the live
+ * api.getSortModel() read inside lastSeenSortComparator while the grid
+ * applies a new sort - is exercised for real, in both directions.
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { DataGrid, GridColDef } from '@mui/x-data-grid'
+import { lastSeenSortComparator, parseLastSeen } from './lastSeen'
+
+type Row = { id: number; name: string; last_seen: string | null }
+
+const rows: Row[] = [
+  { id: 1, name: 'Leia Organa', last_seen: '2026-08-01T00:00:00Z' },
+  { id: 2, name: 'Han Solo', last_seen: null },
+  { id: 3, name: 'Luke Skywalker', last_seen: '2026-06-01T00:00:00Z' },
+  { id: 4, name: 'Lando Calrissian', last_seen: null },
+]
+
+const columns: GridColDef[] = [
+  { field: 'name', headerName: 'Name' },
+  {
+    field: 'last_seen',
+    headerName: 'Last Seen',
+    type: 'dateTime',
+    valueGetter: (params) => parseLastSeen(params.row.last_seen),
+    sortComparator: lastSeenSortComparator,
+  },
+]
+
+function renderGrid() {
+  return render(
+    <div style={{ height: 500, width: 700 }}>
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        disableVirtualization
+        autoHeight
+      />
+    </div>
+  )
+}
+
+/** Names in on-screen row order (skips the header row). */
+function namesInOrder(): string[] {
+  return (
+    screen
+      .getAllByRole('row')
+      // Header row has columnheaders, not cells (v6 renders role="cell").
+      .filter((row) => within(row).queryAllByRole('cell').length > 0)
+      .map((row) => within(row).getAllByRole('cell')[0].textContent ?? '')
+  )
+}
+
+describe('lastSeenSortComparator in a real DataGrid', () => {
+  it('keeps never-active rows last under asc AND desc header sorts', () => {
+    renderGrid()
+    const header = screen.getByRole('columnheader', { name: 'Last Seen' })
+
+    // First click: ascending - oldest first, both nulls at the bottom.
+    fireEvent.click(within(header).getByText('Last Seen'))
+    expect(namesInOrder()).toEqual([
+      'Luke Skywalker',
+      'Leia Organa',
+      'Han Solo',
+      'Lando Calrissian',
+    ])
+
+    // Second click: descending - newest first, nulls STILL at the bottom
+    // (the grid negates the comparator; the live-direction read compensates).
+    fireEvent.click(within(header).getByText('Last Seen'))
+    expect(namesInOrder()).toEqual([
+      'Leia Organa',
+      'Luke Skywalker',
+      'Han Solo',
+      'Lando Calrissian',
+    ])
+  })
+})


### PR DESCRIPTION
One batch carrying tonight's approved frontend work so it takes a single dev deploy and a single prod deploy instead of three. The dev lane serialises and a newer deployment marks the previous one inactive, so three separate merges would have raced each other.

## Ordering dependency, read this before merging

**This must land after CMS-Enterprise/ztmf#546.** #690 is the frontend half of a pair and both halves say the backend deploys first. Backend-first means FY26 SaaS systems immediately get a denominator of 25 they can actually complete, which is the active data call. Frontend-first would instead fix the historical display and leave FY26 stuck at a permanent 25/40. Nothing here breaks in the other order, but it fixes the less urgent half first.

## What is folded in

| PR | Author | Approved by |
| --- | --- | --- |
| #687 Last Seen column in the user management grid | Daniel Bowne | MackOverflow, 2026-08-07 |
| #690 restore SaaS pillars on historical data calls | Calvin Costa | MackOverflow, 2026-08-10 |
| #688 scope the Scored / Systems tile to the selected call(s) | Onix Tarrats Calderon | jsos3-cms, 2026-08-10 |

Appended in approval order and nothing reordered, so the record of what joined when survives. Every constituent was approved before being folded.

Closing keywords are deliberately not re-declared for #690. It is phase 1 of 2 against CMS-Enterprise/ztmf-misc#289, which stays open for #545, and cross-repository keywords do not fire anyway. #688 closes #658 and that is re-declared below, since a folded PR closes unmerged and its own keyword never fires.

Closes #658
Closes #675

## Verification

The three changes touch **entirely disjoint files**, confirmed by comparing every path across all three: #687 in `UserTable`, `InsightsPanel` and `types.ts`, #690 in `PillarScoresModal`, `utils/reducedPillarScope` and the questionnaire views, #688 in `Home` and `StatisticBlocks`. No file is written by two of them.

Checked on the combined branch rather than trusting the individual runs:

- `tsc --noEmit` clean
- `eslint ./src` clean
- Jest: **918 passed**, 3 skipped, 68 of 69 suites, zero failures
- `yarn build:prod` succeeds

No API, schema, or data changes anywhere in this batch, so a rollback is a redeploy with nothing to undo.

## Risk

Low, and lower than it looks for a batch this size. The disjoint-file property means the combination cannot produce an interaction the individual PRs did not already cover, and the suite run above is the first place all three met. The one behavioural change outside its own feature is #690 rendering a missing comparison pillar as a gap in the radar rather than plotting it as zero, which replaces a misleading total-collapse line with an honest absence.
