### PR TITLE
Fix questionnaire opening a different data call than the row's Data Call column

### DIFF
--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -55,7 +55,11 @@ import { scoreSortValue } from './scoreHelpers'
 import { isSystemSelectable } from './rowSelection'
 import { ProgressCell } from './progressColumn'
 import { progressSortValue } from './progressHelpers'
-import { resolveRowCallId, datacallNameComparator } from './rowCall'
+import {
+  resolveRowCallId,
+  resolveQuestionnaireCall,
+  datacallNameComparator,
+} from './rowCall'
 import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
@@ -973,8 +977,14 @@ export default function FismaTable({
                     openQuestionnaire(
                       params.row.fismasystemid,
                       params.row.fismaacronym,
-                      rowCallObjs[0] ??
-                        datacalls.find((d) => d.datacallid === activeDataCallId)
+                      resolveQuestionnaireCall(
+                        params.row.fismasystemid,
+                        chosenCallMap,
+                        systemCallMap,
+                        datacalls,
+                        activeDataCallId,
+                        activeDatacallIds
+                      )
                     )
                   }}
                   color="inherit"

--- a/src/views/FismaTable/rowCall.test.ts
+++ b/src/views/FismaTable/rowCall.test.ts
@@ -1,5 +1,9 @@
 import type { datacall } from '@/types'
-import { resolveRowCallId, datacallNameComparator } from './rowCall'
+import {
+  resolveRowCallId,
+  resolveQuestionnaireCall,
+  datacallNameComparator,
+} from './rowCall'
 
 const call = (datacallid: number, deadline: string): datacall => ({
   datacallid,
@@ -58,6 +62,62 @@ describe('last-resort call for a system with no data in the view', () => {
   it('still prefers real row data over the view', () => {
     expect(resolveRowCallId(7, { 7: 1 }, {}, DATACALLS, 2, [2, 3])).toBe(1)
     expect(resolveRowCallId(7, {}, { 7: [1] }, DATACALLS, 2, [2, 3])).toBe(1)
+  })
+})
+
+describe('resolveQuestionnaireCall', () => {
+  it('opens the column call for a score-less system, not the active call', () => {
+    // Past-year view: calls 1 and 3 are selected, the open call (2) is not. A
+    // score-less system is displayed against call 3. The icon must open call 3,
+    // the same call the column names - not the open call the old activeDataCallId
+    // fallback resolved to.
+    const call = resolveQuestionnaireCall(7, { 7: 3 }, {}, DATACALLS, 2, [1, 3])
+    expect(call?.datacallid).toBe(3)
+    expect(call?.datacallid).not.toBe(2)
+  })
+
+  it('opens the displayed call, not a hidden older scored call', () => {
+    // Scored in older call 1 but displayed against newer call 3 (a progress-only
+    // row updated more recently), so the row reads "Not scored" and its column
+    // names 3. The icon opens 3 to match the column, not the hidden score in 1.
+    const call = resolveQuestionnaireCall(
+      7,
+      { 7: 3 },
+      { 7: [1] },
+      DATACALLS,
+      2,
+      [1, 3]
+    )
+    expect(call?.datacallid).toBe(3)
+  })
+
+  it('matches the column newest-in-view fallback for a score-less system with no chosen call', () => {
+    // No chosen call and the active call is out of view: both the column and the
+    // icon resolve to the newest selected call (3), not the open call (2).
+    const call = resolveQuestionnaireCall(7, {}, {}, DATACALLS, 2, [1, 3])
+    expect(call?.datacallid).toBe(3)
+  })
+
+  it('keeps the active call when it is one of the selected calls (no regression)', () => {
+    const call = resolveQuestionnaireCall(7, {}, {}, DATACALLS, 1, [1, 3])
+    expect(call?.datacallid).toBe(1)
+  })
+
+  it('always names the same call as the Data Call column', () => {
+    // The icon and the column must never disagree: resolveQuestionnaireCall is
+    // resolveRowCallId plus a lookup, so it matches for every input shape.
+    const cases: Parameters<typeof resolveRowCallId>[] = [
+      [7, { 7: 3 }, {}, DATACALLS, 2, [1, 3]],
+      [7, { 7: 3 }, { 7: [1] }, DATACALLS, 2, [1, 3]],
+      [7, {}, { 7: [1, 2] }, DATACALLS, 3],
+      [7, {}, {}, DATACALLS, 2, [1, 3]],
+      [7, {}, {}, DATACALLS, 1, [1, 3]],
+    ]
+    for (const args of cases) {
+      expect(resolveQuestionnaireCall(...args)?.datacallid).toBe(
+        resolveRowCallId(...args)
+      )
+    }
   })
 })
 

--- a/src/views/FismaTable/rowCall.ts
+++ b/src/views/FismaTable/rowCall.ts
@@ -88,3 +88,39 @@ export function resolveRowCallId(
   }
   return activeDataCallId
 }
+
+/**
+ * The data call the questionnaire icon opens for a row, as a full datacall
+ * object. Resolves through resolveRowCallId - the exact path the Data Call
+ * column uses - so the column label and the call the icon opens always name the
+ * same call. This covers a score-less row (whose column used to disagree with
+ * the icon's active-call fallback) and a row scored in an older call but
+ * displayed against a newer one (which reads as "Not scored" and must open the
+ * call it is shown against, not the hidden older score). Systems scored in more
+ * than one active call open the call picker before this is reached.
+ * @param {number} fismasystemid - The row's system id.
+ * @param {Record<number, number>} chosenCallMap - System id -> displayed call id.
+ * @param {Record<number, number[]>} systemCallMap - System id -> call ids with scores.
+ * @param {datacall[]} datacalls - All known data calls.
+ * @param {number} activeDataCallId - The dashboard's active call id.
+ * @param {number[]} [activeDatacallIds] - Call ids selected in the year picker.
+ * @returns {datacall | undefined} The call to open, or undefined if none resolves.
+ */
+export function resolveQuestionnaireCall(
+  fismasystemid: number,
+  chosenCallMap: Record<number, number>,
+  systemCallMap: Record<number, number[]>,
+  datacalls: datacall[],
+  activeDataCallId: number,
+  activeDatacallIds?: number[]
+): datacall | undefined {
+  const id = resolveRowCallId(
+    fismasystemid,
+    chosenCallMap,
+    systemCallMap,
+    datacalls,
+    activeDataCallId,
+    activeDatacallIds
+  )
+  return datacalls.find((d) => d.datacallid === id)
+}


### PR DESCRIPTION
## Summary

Closes #662.

On the Home dashboard, the Data Call Progress column and the questionnaire icon could resolve to different data calls for a system with a progress row but no score in the selected call. The column labels one call, while clicking the questionnaire icon opens a different one: the exact failure `rowCall.ts`'s docstring warns about.

Root cause: the two surfaces resolved the row's call through different paths.
* **Column:** `resolveRowCallId` (`chosenCallMap`-first).
* **Icon:** read the score-derived `systemCallMap`, which is empty for a score-less system, then fell back to `activeDataCallId`.

`activeDataCallId` collapses to the newest (open) call whenever more than one call is toggled on, and selecting a year toggles all of its calls. So the two agree when the open call is the newest selected call, but diverge in a past-year view: the column names the past call while the icon opens the open call. Pre-existing on main; #657 only made these systems visible in more views.

## Changes

* **`rowCall.ts` (`resolveQuestionnaireCall` new):** resolves the questionnaire icon's target through the same `resolveRowCallId` path the column uses, then looks up the `datacall` object. The column label and the call the icon opens now always name the same call.
* **`FismaTable.tsx`:** the questionnaire icon's `onClick` calls `resolveQuestionnaireCall` instead of the old `rowCallObjs[0] ?? activeDataCallId` fallback. The multi-call picker gate (`rowCallObjs.length > 1`) is untouched, so multi-scored systems still get the picker. (`openQuestionnaire` already defaults to `activeDataCallId` only when the call is undefined.)
* **`rowCall.test.ts`:** tests for the past-year divergence and the fallback rungs, plus an invariant test that `resolveQuestionnaireCall` matches `resolveRowCallId` for every input shape.

## Scope note

Beyond the literal score-less case, this also aligns a related pre-existing edge (flagged in review): a system scored in an older call but displayed against a newer progress-only call reads "Not scored" and names the newer call in the column. The icon now opens that same call rather than the hidden older score. Both are the same bug, and the single fix resolves them together.

## Acceptance criteria

* [x] For a score-less system in a past-year view, the questionnaire icon opens the same call the Data Call column names.
* [x] No regression in the common case (open call is the newest selected call).
* [x] Test covering the past-year divergence.

## Testing

* **`rowCall.test.ts`:** score-less past-year case opens the column's call (not the active one); the scored-but-displayed-newer case opens the displayed call; newest-in-view fallback matches the column; active-call-in-view unregressed; and an invariant test pinning icon == column across all input shapes.
* Full `FismaTable` suite green (94 passed); `tsc --noEmit` and `eslint` clean.
* Manually verified in dev against a two-call FY25 past-year view: on main, `MOCK-GARRISON`'s row named "FY25 ZTM" but the questionnaire breadcrumb opened "FY26 ZTM"; on this branch both read "FY25 ZTM".
* Behavior-only; no visual change.