### PR TITLE
Hoist opdivs into the shared Outlet context (dedupe GET /opdivs)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -284,9 +284,10 @@ export type editSystemModalProps = {
   onClose: (data: FismaSystemType) => void
   system: FismaSystemType | null
   mode: string
-  // Datacenter-environment vocabulary for the dropdown. Passed from Title
-  // (the modal renders outside the outlet, so it can't read context).
+  // Datacenter-environment and OpDiv vocabularies for the dropdowns. Passed
+  // from Title because the modal renders outside the Outlet and can't read context.
   datacenterEnvironments: DataCenterEnvironment[]
+  opdivs: OpDiv[]
 }
 
 export type datacallModalProps = {

--- a/src/utils/opdivs.test.ts
+++ b/src/utils/opdivs.test.ts
@@ -1,0 +1,98 @@
+import MockAdapter from 'axios-mock-adapter'
+
+// Replace the app's axios instance with a bare one. The production module
+// reads import.meta.env at load time, which throws under @swc/jest.
+jest.mock('@/axiosConfig', () => {
+  const axios = require('axios').default
+  return { __esModule: true, default: axios.create({ baseURL: '/api/v1/' }) }
+})
+
+import axiosInstance from '@/axiosConfig'
+import { fetchOpDivs, createOpDiv, updateOpDiv } from './opdivs'
+import type { OpDiv } from '@/types'
+
+const mock = new MockAdapter(axiosInstance)
+afterEach(() => mock.reset())
+
+const ROWS: OpDiv[] = [
+  {
+    opdiv_id: 1,
+    code: 'CMS',
+    name: 'Centers for Medicare & Medicaid Services',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+  },
+  {
+    opdiv_id: 2,
+    code: 'RETIRED',
+    name: 'Deactivated OpDiv',
+    is_parent: false,
+    active: false,
+    system_delegate_enabled: false,
+  },
+]
+
+describe('fetchOpDivs', () => {
+  it('unwraps the { data: [...] } envelope', async () => {
+    mock.onGet('/opdivs').reply(200, { data: ROWS })
+    await expect(fetchOpDivs()).resolves.toEqual(ROWS)
+  })
+
+  it('defaults to active-only and sends active_only=false for the superset', async () => {
+    mock.onGet('/opdivs').reply(200, { data: ROWS })
+
+    await fetchOpDivs()
+    expect(mock.history.get[0].params).toBeUndefined()
+
+    await fetchOpDivs(true)
+    expect(mock.history.get[1].params).toEqual({ active_only: false })
+  })
+
+  it('coerces a null payload to an empty array', async () => {
+    mock.onGet('/opdivs').reply(200, { data: null })
+    await expect(fetchOpDivs(true)).resolves.toEqual([])
+  })
+
+  it('resolves an empty list as-is - empty is an answer, not a failure', async () => {
+    mock.onGet('/opdivs').reply(200, { data: [] })
+    await expect(fetchOpDivs(true)).resolves.toEqual([])
+  })
+
+  it('rejects on a server error', async () => {
+    mock.onGet('/opdivs').reply(500)
+    await expect(fetchOpDivs()).rejects.toBeDefined()
+  })
+
+  it('rejects on a network error', async () => {
+    mock.onGet('/opdivs').networkError()
+    await expect(fetchOpDivs()).rejects.toBeDefined()
+  })
+})
+
+describe('createOpDiv', () => {
+  it('posts the input and returns the created row', async () => {
+    mock.onPost('/opdivs').reply(201, { data: ROWS[0] })
+    await expect(createOpDiv({ code: 'CMS', name: 'CMS' })).resolves.toEqual(
+      ROWS[0]
+    )
+    expect(JSON.parse(mock.history.post[0].data)).toEqual({
+      code: 'CMS',
+      name: 'CMS',
+    })
+  })
+})
+
+describe('updateOpDiv', () => {
+  it('puts to the id-scoped path (204, no body)', async () => {
+    mock.onPut('/opdivs/2').reply(204)
+    await expect(
+      updateOpDiv(2, {
+        code: 'RETIRED',
+        name: 'Deactivated OpDiv',
+        active: false,
+      })
+    ).resolves.toBeUndefined()
+    expect(mock.history.put[0].url).toBe('/opdivs/2')
+  })
+})

--- a/src/utils/opdivs.ts
+++ b/src/utils/opdivs.ts
@@ -8,19 +8,22 @@ import type { OpDiv } from '@/types'
  * backend filters to active rows only; pass includeInactive to retrieve
  * deactivated rows as well (used by audit and historical-reference UI).
  *
- * Stage 1 publishes this helper so Stage 2+ work (OpDiv badges,
- * selectors, admin grant management) can consume it without each
- * caller hand-rolling the request. There is no production caller yet.
+ * Always resolves to an array: the backend serializes an empty result as JSON
+ * null on some endpoints (ztmf#346), and this response feeds the shared Outlet
+ * context, so a null would throw in every consumer at once.
  */
 export async function fetchOpDivs(
   includeInactive = false,
   signal?: AbortSignal
 ): Promise<OpDiv[]> {
-  const response = await axiosInstance.get<{ data: OpDiv[] }>('/opdivs', {
-    params: includeInactive ? { active_only: false } : undefined,
-    signal,
-  })
-  return response.data.data
+  const response = await axiosInstance.get<{ data: OpDiv[] | null }>(
+    '/opdivs',
+    {
+      params: includeInactive ? { active_only: false } : undefined,
+      signal,
+    }
+  )
+  return response.data.data ?? []
 }
 
 /**

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -20,15 +20,23 @@ import MockAdapter from 'axios-mock-adapter'
 import EditSystemModal from './EditSystemModal'
 import axiosInstance from '@/axiosConfig'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
-import type { FismaSystemType } from '@/types'
+import type { FismaSystemType, OpDiv } from '@/types'
 
 const mock = new MockAdapter(axiosInstance)
 afterEach(() => mock.reset())
-// The modal fetches the OpDiv reference list on open; a bare response keeps the
-// form out of its loading state.
-beforeEach(() =>
-  mock.onGet('/opdivs').reply(200, { data: [{ opdiv_id: 1, name: 'CMS' }] })
-)
+// The OpDiv reference list arrives as a prop from Title (the modal renders
+// outside the Outlet), so the dropdown needs no request mock.
+const OPDIVS: OpDiv[] = [
+  {
+    opdiv_id: 1,
+    code: 'CMS',
+    name: 'CMS',
+    is_parent: false,
+    active: true,
+    system_delegate_enabled: false,
+    insights_enabled: false,
+  },
+]
 
 const SYSTEM = {
   fismasystemid: 42,
@@ -85,6 +93,7 @@ test('clearing an enum select to None saves an empty string, not null', async ()
       system={SYSTEM}
       mode="edit"
       datacenterEnvironments={[]}
+      opdivs={OPDIVS}
     />
   )
 
@@ -127,6 +136,7 @@ test('an untouched extended field is omitted from the save (dirty-diff)', async 
       system={SYSTEM}
       mode="edit"
       datacenterEnvironments={[]}
+      opdivs={OPDIVS}
     />
   )
 
@@ -157,6 +167,7 @@ test('an edited ISSO Name is sent in the save payload', async () => {
       system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
       mode="edit"
       datacenterEnvironments={[]}
+      opdivs={OPDIVS}
     />
   )
 
@@ -186,6 +197,7 @@ test('clearing ISSO Name saves an empty string, which restores the derived name'
       system={{ ...SYSTEM, isso_name: 'Conan Antonio Motti' }}
       mode="edit"
       datacenterEnvironments={[]}
+      opdivs={OPDIVS}
     />
   )
 
@@ -215,6 +227,7 @@ test('clearing a free-text field saves an empty string, not null', async () => {
       system={{ ...SYSTEM, cloud_vendor: 'AWS' }}
       mode="edit"
       datacenterEnvironments={[]}
+      opdivs={OPDIVS}
     />
   )
 

--- a/src/views/EditSystemModal/EditSystemModal.test.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.test.tsx
@@ -24,8 +24,7 @@ import type { FismaSystemType, OpDiv } from '@/types'
 
 const mock = new MockAdapter(axiosInstance)
 afterEach(() => mock.reset())
-// The OpDiv reference list arrives as a prop from Title (the modal renders
-// outside the Outlet), so the dropdown needs no request mock.
+// Arrives as a prop from Title, so the dropdown needs no request mock.
 const OPDIVS: OpDiv[] = [
   {
     opdiv_id: 1,

--- a/src/views/EditSystemModal/EditSystemModal.tsx
+++ b/src/views/EditSystemModal/EditSystemModal.tsx
@@ -39,8 +39,6 @@ import {
 } from '@/constants'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
-import { fetchOpDivs } from '@/utils/opdivs'
-import type { OpDiv } from '@/types'
 import {
   getFieldsBySection,
   EXTENDED_METADATA_KEYS,
@@ -70,6 +68,7 @@ export default function EditSystemModal({
   system,
   mode,
   datacenterEnvironments,
+  opdivs: allOpdivs,
 }: editSystemModalProps) {
   const datacenterEnvironmentOptions = toDropdownOptionsWithCurrent(
     datacenterEnvironments,
@@ -87,7 +86,7 @@ export default function EditSystemModal({
     fismauid: false,
     opdiv_id: false,
   })
-  const [opdivs, setOpDivs] = React.useState<OpDiv[]>([])
+  const opdivs = allOpdivs.filter((o) => o.active)
   const isFormValid = (): boolean => {
     return Object.values(formValid).every((value) => value === true)
   }
@@ -120,23 +119,6 @@ export default function EditSystemModal({
       fismauid: TEXTFIELD_HELPER_TEXT,
       opdiv_id: TEXTFIELD_HELPER_TEXT,
     })
-  React.useEffect(() => {
-    if (!open) return
-    const controller = new AbortController()
-    fetchOpDivs(false, controller.signal)
-      .then(setOpDivs)
-      .catch((error) => {
-        // Ignore the abort fired by cleanup on close; surface real failures
-        // so an empty OpDiv list (which leaves Save stuck) isn't silent.
-        if (controller.signal.aborted || isAuthHandled(error)) return
-        const parsed = parseApiError(error)
-        notify(
-          parsed.message || 'Failed to load the OpDiv list. Please try again.',
-          'error'
-        )
-      })
-    return () => controller.abort()
-  }, [open])
 
   const handleConfirmReturn = (confirm: boolean) => {
     if (confirm) {

--- a/src/views/FismaTable/FismaTable.tsx
+++ b/src/views/FismaTable/FismaTable.tsx
@@ -60,11 +60,9 @@ import {
   resolveQuestionnaireCall,
   datacallNameComparator,
 } from './rowCall'
-import { fetchOpDivs } from '@/utils/opdivs'
 import { toCategoryMap } from '@/utils/dataCenterEnvironments'
 import { parseDatacallName } from '@/utils/datacallGrouping'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
-import type { OpDiv } from '@/types'
 import {
   applyDashboardFilters,
   hasNoActiveFilters,
@@ -542,6 +540,7 @@ export default function FismaTable({
     activeDatacallIds,
     userInfo,
     datacenterEnvironments,
+    opdivs,
   } = useContextProp()
   const activeDataCallId = selectedDatacall?.datacallid ?? latestDataCallId
   // "Latest by deadline" is not the same as "still open". Once the newest
@@ -608,7 +607,6 @@ export default function FismaTable({
   const [filters, setFilters] = useState<DashboardFilterState>(
     EMPTY_DASHBOARD_FILTERS
   )
-  const [opdivs, setOpDivs] = useState<OpDiv[]>([])
   const navigate = useNavigate()
 
   // When a system has scores in more than one active call, the questionnaire
@@ -633,20 +631,6 @@ export default function FismaTable({
       },
     })
   }
-
-  // OpDiv list is only needed to label the OpDiv filter. Include inactive
-  // OpDivs so a system tied to a since-deactivated OpDiv still shows a name,
-  // not a bare id. Fetched once; failure is non-fatal.
-  useEffect(() => {
-    const controller = new AbortController()
-    fetchOpDivs(true, controller.signal)
-      .then(setOpDivs)
-      .catch((error) => {
-        if (controller.signal.aborted) return
-        console.error('Fetch opdivs error:', error)
-      })
-    return () => controller.abort()
-  }, [])
 
   // Raw datacenterenvironment -> category label, from the vocabulary already in
   // context. Drives both the Environment filter options and row matching.

--- a/src/views/OpDivAdmin/OpDivAdmin.test.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.test.tsx
@@ -36,12 +36,16 @@ jest.mock('@mui/x-data-grid', () => {
       getRowId?: (row: Record<string, unknown>) => string | number
       slots?: { toolbar?: (p: unknown) => React.ReactNode }
       slotProps?: { toolbar?: Record<string, unknown> }
+      loading?: boolean
     }) => {
       const { rows = [], columns = [], getRowId, slots, slotProps } = props
       const Toolbar = slots?.toolbar
       return react.createElement(
         'div',
-        { 'data-testid': 'datagrid-mock' },
+        {
+          'data-testid': 'datagrid-mock',
+          'data-loading': String(!!props.loading),
+        },
         Toolbar
           ? react.createElement(Toolbar, {
               key: 'toolbar',
@@ -125,7 +129,7 @@ jest.mock('../Title/Context', () => ({
   },
 }))
 
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import OpDivAdmin from './OpDivAdmin'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
@@ -154,6 +158,7 @@ function ctx(role: UserRole) {
       role,
     } as userData,
     opdivs: [EMPIRE],
+    opdivsLoaded: true,
     refreshOpdivs: refreshOpdivsMock,
   }
 }
@@ -235,6 +240,23 @@ test('cancelling the toggle confirmation writes nothing', async () => {
   await user.click(screen.getByRole('button', { name: /^cancel$/i }))
 
   expect(setEnabledMock).not.toHaveBeenCalled()
+})
+
+test('the grid reads as loading until the shared OpDiv list settles', () => {
+  // Otherwise the empty grid's "No rows" overlay reads as "no OpDivs exist".
+  setMockCtx({ ...ctx('OWNER'), opdivs: [], opdivsLoaded: false })
+  renderWithProviders(<OpDivAdmin />)
+
+  expect(screen.getByTestId('datagrid-mock')).toHaveAttribute(
+    'data-loading',
+    'true'
+  )
+
+  act(() => setMockCtx(ctx('OWNER')))
+  expect(screen.getByTestId('datagrid-mock')).toHaveAttribute(
+    'data-loading',
+    'false'
+  )
 })
 
 test('an OPDIV_ADMIN is bounced - no Manage OpDivs grid renders', () => {

--- a/src/views/OpDivAdmin/OpDivAdmin.test.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.test.tsx
@@ -129,11 +129,9 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import OpDivAdmin from './OpDivAdmin'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
-import { fetchOpDivs } from '@/utils/opdivs'
 import { setOpDivDelegateEnabled } from '@/utils/delegates'
 import type { OpDiv, UserRole, userData } from '@/types'
 
-const fetchOpDivsMock = fetchOpDivs as jest.Mock
 const setEnabledMock = setOpDivDelegateEnabled as jest.Mock
 
 const EMPIRE: OpDiv = {
@@ -145,6 +143,8 @@ const EMPIRE: OpDiv = {
   system_delegate_enabled: false,
 }
 
+const refreshOpdivsMock = jest.fn()
+
 function ctx(role: UserRole) {
   return {
     userInfo: {
@@ -153,6 +153,8 @@ function ctx(role: UserRole) {
       fullname: 'Tester',
       role,
     } as userData,
+    opdivs: [EMPIRE],
+    refreshOpdivs: refreshOpdivsMock,
   }
 }
 
@@ -163,7 +165,6 @@ function renderAs(role: UserRole) {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  fetchOpDivsMock.mockResolvedValue([EMPIRE])
   setEnabledMock.mockResolvedValue({ ...EMPIRE, system_delegate_enabled: true })
 })
 
@@ -219,6 +220,8 @@ test('flipping the toggle confirms then calls the dedicated enable endpoint', as
   await waitFor(() => expect(setEnabledMock).toHaveBeenCalledTimes(1))
   // Toggled from false -> true for EMPIRE (opdiv_id 3).
   expect(setEnabledMock).toHaveBeenCalledWith(3, true)
+  // The grid reads the shared context list, so the write must refresh it.
+  await waitFor(() => expect(refreshOpdivsMock).toHaveBeenCalledTimes(1))
 })
 
 test('cancelling the toggle confirmation writes nothing', async () => {
@@ -239,5 +242,4 @@ test('an OPDIV_ADMIN is bounced - no Manage OpDivs grid renders', () => {
 
   expect(screen.queryByTestId('datagrid-mock')).not.toBeInTheDocument()
   expect(screen.queryByText(/manage opdivs/i)).not.toBeInTheDocument()
-  expect(fetchOpDivsMock).not.toHaveBeenCalled()
 })

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -68,7 +68,12 @@ function CreateToolbar({
 
 export default function OpDivAdmin() {
   const navigate = useNavigate()
-  const { userInfo, opdivs: rows, refreshOpdivs } = useContextProp()
+  const {
+    userInfo,
+    opdivs: rows,
+    opdivsLoaded,
+    refreshOpdivs,
+  } = useContextProp()
   // OWNER manages OpDivs fully (create / edit / activate). HHS admin reaches
   // the page only to flip the per-OpDiv System Delegate toggle - every other
   // control stays OWNER-only. The backend enforces both boundaries (OpDiv
@@ -297,6 +302,9 @@ export default function OpDivAdmin() {
           aria-label="Operating Divisions"
           rows={rows}
           columns={columns}
+          // Without this the grid's "No rows" overlay reads as "no OpDivs
+          // exist" while the shared list is still in flight.
+          loading={!opdivsLoaded}
           getRowId={(row) => row.opdiv_id}
           initialState={{
             sorting: { sortModel: [{ field: 'code', sort: 'asc' }] },

--- a/src/views/OpDivAdmin/OpDivAdmin.tsx
+++ b/src/views/OpDivAdmin/OpDivAdmin.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -29,12 +29,7 @@ import BreadCrumbs from '@/components/BreadCrumbs/BreadCrumbs'
 import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import { useContextProp } from '../Title/Context'
 import { Routes } from '@/router/constants'
-import {
-  createOpDiv,
-  fetchOpDivs,
-  updateOpDiv,
-  type OpDivInput,
-} from '@/utils/opdivs'
+import { createOpDiv, updateOpDiv, type OpDivInput } from '@/utils/opdivs'
 import { setOpDivDelegateEnabled } from '@/utils/delegates'
 import { isUnscopedWriteAdmin } from '@/utils/userRoles'
 import { parseApiError } from '@/utils/apiErrors'
@@ -73,7 +68,7 @@ function CreateToolbar({
 
 export default function OpDivAdmin() {
   const navigate = useNavigate()
-  const { userInfo } = useContextProp()
+  const { userInfo, opdivs: rows, refreshOpdivs } = useContextProp()
   // OWNER manages OpDivs fully (create / edit / activate). HHS admin reaches
   // the page only to flip the per-OpDiv System Delegate toggle - every other
   // control stays OWNER-only. The backend enforces both boundaries (OpDiv
@@ -83,7 +78,6 @@ export default function OpDivAdmin() {
   const canManage = isOwner
   const canToggleDelegate = canAccess
 
-  const [rows, setRows] = useState<OpDiv[]>([])
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editing, setEditing] = useState<OpDiv | null>(null)
   const [form, setForm] = useState<FormState>(EMPTY_FORM)
@@ -100,20 +94,6 @@ export default function OpDivAdmin() {
       navigate(Routes.ROOT, { replace: true })
     }
   }, [userInfo.role, canAccess, navigate])
-
-  const loadOpDivs = useCallback(() => {
-    fetchOpDivs(true)
-      .then(setRows)
-      .catch((error) => {
-        if (isAuthHandled(error)) return
-        const parsed = parseApiError(error)
-        notify(parsed.message, 'error')
-      })
-  }, [])
-
-  useEffect(() => {
-    if (canAccess) loadOpDivs()
-  }, [canAccess, loadOpDivs])
 
   const openCreate = () => {
     setEditing(null)
@@ -160,7 +140,7 @@ export default function OpDivAdmin() {
           'success'
         )
         setDialogOpen(false)
-        loadOpDivs()
+        refreshOpdivs()
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
@@ -191,7 +171,7 @@ export default function OpDivAdmin() {
             : 'Saved - OpDiv activated',
           'success'
         )
-        loadOpDivs()
+        refreshOpdivs()
       })
       .catch((error) => {
         if (isAuthHandled(error)) return
@@ -212,7 +192,7 @@ export default function OpDivAdmin() {
             : 'Saved - System Delegate enabled',
           'success'
         )
-        loadOpDivs()
+        refreshOpdivs()
       })
       .catch((error) => {
         if (isAuthHandled(error)) return

--- a/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.crossnav.test.tsx
@@ -112,6 +112,8 @@ function makeCtx(role: userData['role'] | undefined) {
     setShowDecommissioned: jest.fn(),
     fetchFismaSystems: jest.fn(),
     datacenterEnvironments: [],
+    opdivs: [],
+    opdivsLoaded: true,
   }
 }
 

--- a/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.deeplink.test.tsx
@@ -106,6 +106,8 @@ beforeEach(() => {
     setShowDecommissioned: jest.fn(),
     fetchFismaSystems: jest.fn(),
     datacenterEnvironments: [],
+    opdivs: [],
+    opdivsLoaded: true,
   }
 
   mockGet.mockImplementation((url: string) => {

--- a/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.saaspillars.test.tsx
@@ -153,6 +153,8 @@ function makeCtx(
         ordr: 60,
       },
     ],
+    opdivs: [],
+    opdivsLoaded: true,
   }
 }
 

--- a/src/views/QuestionnairePage/QuestionnairePage.test.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.test.tsx
@@ -192,6 +192,8 @@ function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
     setShowDecommissioned: jest.fn(),
     fetchFismaSystems: jest.fn(),
     datacenterEnvironments: [],
+    opdivs: [],
+    opdivsLoaded: true,
     ...overrides,
   }
 }
@@ -877,20 +879,19 @@ const OPDIV_ROWS = [
 describe('QuestionnairePage justification integration', () => {
   type InsightsResponse = { data: { data: unknown[] } }
 
+  // This block is the insights-enabled variant: SSD-EX's OpDiv (9) carries
+  // insights_enabled, so the layer is expected on unless a test says otherwise.
+  const insightsCtx = (overrides: Record<string, unknown> = {}) =>
+    makeCtx({ opdivs: OPDIV_ROWS, ...overrides })
+
   function installMocks({
     insightRows = [INSIGHT_ROW] as unknown[],
     insightsResponse,
-    opdivRows = OPDIV_ROWS as unknown[],
-    opdivsResponse,
   }: {
     insightRows?: unknown[]
     insightsResponse?: Promise<InsightsResponse>
-    opdivRows?: unknown[]
-    opdivsResponse?: Promise<InsightsResponse>
   } = {}) {
     axios.get.mockImplementation((url: string) => {
-      if (url === '/opdivs')
-        return opdivsResponse ?? Promise.resolve({ data: { data: opdivRows } })
       if (url === 'insights') {
         return (
           insightsResponse ?? Promise.resolve({ data: { data: insightRows } })
@@ -911,7 +912,7 @@ describe('QuestionnairePage justification integration', () => {
   it('keeps the insights layer on an HHS-named call for an insights-enabled OpDiv, and persists an accepted prior response', async () => {
     installMocks()
     setMockCtx(
-      makeCtx({
+      insightsCtx({
         latestDataCallId: 6,
         latestDatacall: 'FY25 ZTM',
         selectedDatacall: HHS_ZTM,
@@ -974,7 +975,7 @@ describe('QuestionnairePage justification integration', () => {
 
   it('shows the insights panel, option badges, and suggestion for a CMS data call', async () => {
     installMocks()
-    setMockCtx(makeCtx())
+    setMockCtx(insightsCtx())
 
     renderAt(DEEP_LINK)
 
@@ -991,10 +992,12 @@ describe('QuestionnairePage justification integration', () => {
   })
 
   it('hides the insights layer when the system belongs to an insights-disabled OpDiv', async () => {
-    installMocks({
-      opdivRows: [{ ...OPDIV_ROWS[0], insights_enabled: false }, OPDIV_ROWS[1]],
-    })
-    setMockCtx(makeCtx())
+    installMocks()
+    setMockCtx(
+      insightsCtx({
+        opdivs: [{ ...OPDIV_ROWS[0], insights_enabled: false }, OPDIV_ROWS[1]],
+      })
+    )
 
     renderAt(DEEP_LINK)
 
@@ -1013,12 +1016,8 @@ describe('QuestionnairePage justification integration', () => {
   })
 
   it('keeps the gate closed and submission blocked until the OpDiv lookup settles', async () => {
-    let resolveOpdivs: ((value: InsightsResponse) => void) | null = null
-    const opdivsResponse = new Promise<InsightsResponse>((resolve) => {
-      resolveOpdivs = resolve
-    })
-    installMocks({ opdivsResponse })
-    setMockCtx(makeCtx())
+    installMocks()
+    setMockCtx(insightsCtx({ opdivs: [], opdivsLoaded: false }))
 
     renderAt(DEEP_LINK)
 
@@ -1033,7 +1032,7 @@ describe('QuestionnairePage justification integration', () => {
     expect(screen.queryByText('ZTMF Insights panel')).not.toBeInTheDocument()
 
     await act(async () => {
-      resolveOpdivs?.({ data: { data: OPDIV_ROWS } })
+      setMockCtx(insightsCtx({ opdivsLoaded: true }))
     })
 
     expect(await screen.findByText('ZTMF Insights panel')).toBeInTheDocument()
@@ -1048,7 +1047,7 @@ describe('QuestionnairePage justification integration', () => {
       resolveInsights = resolve
     })
     installMocks({ insightsResponse })
-    setMockCtx(makeCtx())
+    setMockCtx(insightsCtx())
 
     renderAt(DEEP_LINK)
 
@@ -1072,7 +1071,7 @@ describe('QuestionnairePage justification integration', () => {
 
   it('keeps the plain four-row notes field when the question has no justification context', async () => {
     installMocks({ insightRows: [] })
-    setMockCtx(makeCtx())
+    setMockCtx(insightsCtx())
 
     renderAt(DEEP_LINK)
 
@@ -1164,15 +1163,10 @@ describe('carried-forward confirmation', () => {
   // variant); pass them to exercise the prior-response card.
   function installScoreMocks(
     scores: Array<{ scoreid: number }>,
-    {
-      insightRows = [] as unknown[],
-      opdivRows = [] as unknown[],
-    }: { insightRows?: unknown[]; opdivRows?: unknown[] } = {}
+    { insightRows = [] as unknown[] }: { insightRows?: unknown[] } = {}
   ) {
     let rows = scores
     axios.get.mockImplementation((url: string) => {
-      if (url === '/opdivs')
-        return Promise.resolve({ data: { data: opdivRows } })
       if (url === 'insights')
         return Promise.resolve({ data: { data: insightRows } })
       if (url.includes('/questions'))
@@ -1299,7 +1293,6 @@ describe('carried-forward confirmation', () => {
           },
         },
       ],
-      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
     })
 
     renderAt(DEEP_LINK)
@@ -1388,7 +1381,6 @@ describe('carried-forward confirmation', () => {
           },
         },
       ],
-      opdivRows: [{ opdiv_id: 9, code: 'CMS', insights_enabled: true }],
     })
 
     renderAt(DEEP_LINK)

--- a/src/views/QuestionnairePage/QuestionnairePage.tsx
+++ b/src/views/QuestionnairePage/QuestionnairePage.tsx
@@ -39,7 +39,6 @@ import {
   NOTES_UPDATE_REQUIRED_MSG,
 } from '@/constants'
 import { isAuthHandled, notify } from '@/utils/notify'
-import { fetchOpDivs } from '@/utils/opdivs'
 import { sortPillars } from '@/utils/sortPillars'
 import { sortFunctions } from '@/utils/sortFunctions'
 import Button from '@mui/material/Button'
@@ -141,6 +140,8 @@ export default function QuestionnarePage() {
     latestDeadline,
     fismaSystems,
     datacalls,
+    opdivs,
+    opdivsLoaded,
   } = useContextProp()
   const [isPastDeadline, setIsPastDeadline] = React.useState<boolean>(false)
   const [diffModalOpen, setDiffModalOpen] = React.useState(false)
@@ -342,37 +343,20 @@ export default function QuestionnarePage() {
     FismaSystemType[] | null
   >(null)
   // OpDivs whose systems surface the internal ZTMF Insights layer
-  // (opdivs.insights_enabled - CMS today). Fetched once per page mount. The
-  // insights gate keys on the SYSTEM's OpDiv, not the viewed data call's
-  // name: the FY23-25 era used call tenant (CMS-named vs ZTM-named calls) as
-  // a proxy, which broke when FY2026 unified every OpDiv into one HHS-named
-  // call and silently hid the insights layer for every insights-enabled
-  // system. null = not loaded yet; the gate stays closed until it resolves,
-  // so the panel can appear late but never flashes for a disabled OpDiv.
-  const [insightsOpdivIds, setInsightsOpdivIds] =
-    React.useState<Set<number> | null>(null)
-  React.useEffect(() => {
-    const controller = new AbortController()
-    // includeInactive: the backend serves insights rows for any
-    // insights-enabled OpDiv regardless of its active flag, so the UI gate
-    // must see inactive rows too or the two would diverge.
-    fetchOpDivs(true, controller.signal)
-      .then((rows) =>
-        setInsightsOpdivIds(
-          new Set(
-            rows
-              .filter((o) => o.insights_enabled === true)
-              .map((o) => o.opdiv_id)
-          )
-        )
-      )
-      .catch(() => {
-        // Insights are additive and optional; a failed lookup leaves the
-        // gate closed rather than surfacing an error.
-        if (!controller.signal.aborted) setInsightsOpdivIds(new Set())
-      })
-    return () => controller.abort()
-  }, [])
+  // (opdivs.insights_enabled - CMS today). The gate keys on the SYSTEM's OpDiv,
+  // not the viewed data call's name: the FY23-25 era used call tenant (CMS-named
+  // vs ZTM-named calls) as a proxy, which broke when FY2026 unified every OpDiv
+  // into one HHS-named call and silently hid the layer for every
+  // insights-enabled system. Derived from the shared context list, which carries
+  // inactive rows - the backend serves insights for an insights-enabled OpDiv
+  // regardless of its active flag, so the UI gate must match.
+  const insightsOpdivIds = React.useMemo(
+    () =>
+      new Set(
+        opdivs.filter((o) => o.insights_enabled === true).map((o) => o.opdiv_id)
+      ),
+    [opdivs]
+  )
   const resolvedDecommissioned = React.useMemo(
     () => resolveSystemIdByAcronym(decommissionedSystems ?? [], fismaacronym),
     [decommissionedSystems, fismaacronym]
@@ -546,7 +530,7 @@ export default function QuestionnarePage() {
     !!system &&
     (insightsLoadState.system !== system ||
       !insightsLoadState.settled ||
-      insightsOpdivIds === null)
+      !opdivsLoaded)
   const currentInsight =
     insightsLoadState.system === system && currentDatabaseQuestionId != null
       ? insightsByQuestion.get(currentDatabaseQuestionId)
@@ -560,7 +544,7 @@ export default function QuestionnarePage() {
   const systemOpdivId = systemInfo?.opdiv_id
   // Single source of truth for all internal insight UI gates.
   const showCmsInsights =
-    systemOpdivId != null && (insightsOpdivIds?.has(systemOpdivId) ?? false)
+    systemOpdivId != null && insightsOpdivIds.has(systemOpdivId)
   const showInsights = Boolean(currentInsight) && showCmsInsights
   const currentSuggestion = showCmsInsights
     ? buildInsightJustification(currentInsight)

--- a/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.issoName.test.tsx
@@ -81,21 +81,7 @@ const NON_WRITE_ROLES: UserRole[] = [
 
 beforeEach(() => {
   mock.reset()
-  mock
-    .onGet('/opdivs')
-    .reply(200, {
-      data: [
-        {
-          opdiv_id: 1,
-          code: 'CMS',
-          name: 'CMS',
-          active: true,
-          system_delegate_enabled: false,
-        },
-      ],
-    })
-    .onGet('/systemattributes')
-    .reply(200, { data: [] })
+  mock.onGet('/systemattributes').reply(200, { data: [] })
 })
 
 /**
@@ -113,6 +99,17 @@ function renderPage(role: UserRole, system: FismaSystemType = SYSTEM) {
       role,
     } as userData,
     datacenterEnvironments: [],
+    // OpDivs now arrive on the shared Outlet context instead of a per-page GET.
+    opdivs: [
+      {
+        opdiv_id: 1,
+        code: 'CMS',
+        name: 'CMS',
+        is_parent: false,
+        active: true,
+        system_delegate_enabled: false,
+      },
+    ],
     // The page refetches after a save instead of echoing its draft, so both of
     // these have to be present or the save path throws.
     fetchFismaSystems: jest.fn().mockResolvedValue(undefined),

--- a/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.requiredFields.test.tsx
@@ -60,21 +60,7 @@ const NON_CMS_SYSTEM = {
 
 beforeEach(() => {
   mock.reset()
-  mock
-    .onGet('/opdivs')
-    .reply(200, {
-      data: [
-        {
-          opdiv_id: 1,
-          code: 'CMS',
-          name: 'CMS',
-          active: true,
-          system_delegate_enabled: false,
-        },
-      ],
-    })
-    .onGet('/systemattributes')
-    .reply(200, { data: [] })
+  mock.onGet('/systemattributes').reply(200, { data: [] })
 })
 
 function renderPage(system: FismaSystemType = NON_CMS_SYSTEM) {
@@ -88,6 +74,17 @@ function renderPage(system: FismaSystemType = NON_CMS_SYSTEM) {
       role: 'OPDIV_ADMIN',
     } as userData,
     datacenterEnvironments: [],
+    // OpDivs now arrive on the shared Outlet context instead of a per-page GET.
+    opdivs: [
+      {
+        opdiv_id: 1,
+        code: 'CMS',
+        name: 'CMS',
+        is_parent: false,
+        active: true,
+        system_delegate_enabled: false,
+      },
+    ],
     fetchFismaSystems: jest.fn().mockResolvedValue(undefined),
     showDecommissioned: false,
   }

--- a/src/views/SystemDetailPage/SystemDetailPage.tsx
+++ b/src/views/SystemDetailPage/SystemDetailPage.tsx
@@ -3,13 +3,7 @@ import { useParams } from 'react-router-dom'
 import { Box, CircularProgress, Divider, Typography } from '@mui/material'
 import _ from 'lodash'
 
-import {
-  FismaSystemType,
-  FormValidType,
-  FormValidHelperText,
-  OpDiv,
-} from '@/types'
-import { fetchOpDivs } from '@/utils/opdivs'
+import { FismaSystemType, FormValidType, FormValidHelperText } from '@/types'
 import { useContextProp } from '@/views/Title/Context'
 import axiosInstance from '@/axiosConfig'
 import {
@@ -52,6 +46,7 @@ export default function SystemDetailPage() {
     datacenterEnvironments,
     fetchFismaSystems,
     showDecommissioned,
+    opdivs,
   } = useContextProp()
 
   const isAdmin = checkIsAdmin(userInfo)
@@ -100,21 +95,6 @@ export default function SystemDetailPage() {
       controller.abort()
     }
   }, [fismaSystems, system, systemId, setFismaSystems])
-
-  const [opdivs, setOpdivs] = useState<OpDiv[]>([])
-
-  useEffect(() => {
-    const controller = new AbortController()
-    fetchOpDivs(true, controller.signal)
-      .then(setOpdivs)
-      .catch((error) => {
-        if (controller.signal.aborted || isAuthHandled(error)) return
-        notify('Failed to load OpDiv list.', 'error')
-      })
-    return () => {
-      controller.abort()
-    }
-  }, [])
 
   const [isEditing, setIsEditing] = useState(false)
   const [editedSystem, setEditedSystem] = useState<FismaSystemType | null>(null)

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -30,6 +30,9 @@ type ContextType = {
   datacenterEnvironments: DataCenterEnvironment[]
   // OpDiv vocabulary incl. inactive; consumers needing active-only filter it.
   opdivs: OpDiv[]
+  // False until the initial fetch settles, so an empty list is distinguishable
+  // from a pending one. Stays true across later refreshes.
+  opdivsLoaded: boolean
   // Refetch after a mutation to keep the shared list fresh.
   refreshOpdivs: () => void
 }

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -5,6 +5,7 @@ import {
   userData,
   datacall,
   DataCenterEnvironment,
+  OpDiv,
 } from '@/types'
 
 type ContextType = {
@@ -27,6 +28,12 @@ type ContextType = {
   // Datacenter-environment vocabulary, fetched once at the layout level.
   // Empty until the fetch resolves; consumers fall back to raw values.
   datacenterEnvironments: DataCenterEnvironment[]
+  // OpDiv vocabulary (includeInactive=true), fetched once at the layout level.
+  // Consumers that need active-only filter client-side: opdivs.filter(o => o.active).
+  opdivs: OpDiv[]
+  // Call after any mutation (create/edit/activate/deactivate) to keep the
+  // shared list fresh without a full page reload.
+  refreshOpdivs: () => void
 }
 
 export function useContextProp() {

--- a/src/views/Title/Context.ts
+++ b/src/views/Title/Context.ts
@@ -28,11 +28,9 @@ type ContextType = {
   // Datacenter-environment vocabulary, fetched once at the layout level.
   // Empty until the fetch resolves; consumers fall back to raw values.
   datacenterEnvironments: DataCenterEnvironment[]
-  // OpDiv vocabulary (includeInactive=true), fetched once at the layout level.
-  // Consumers that need active-only filter client-side: opdivs.filter(o => o.active).
+  // OpDiv vocabulary incl. inactive; consumers needing active-only filter it.
   opdivs: OpDiv[]
-  // Call after any mutation (create/edit/activate/deactivate) to keep the
-  // shared list fresh without a full page reload.
+  // Refetch after a mutation to keep the shared list fresh.
   refreshOpdivs: () => void
 }
 

--- a/src/views/Title/Title.test.tsx
+++ b/src/views/Title/Title.test.tsx
@@ -30,6 +30,13 @@ jest.mock('@/utils/dataCenterEnvironments', () => ({
   fetchDataCenterEnvironments: jest.fn(),
 }))
 
+// Without this the axios stub above returns undefined from get(), so every test
+// here would silently run Title's OpDiv error path.
+jest.mock('@/utils/opdivs', () => ({
+  __esModule: true,
+  fetchOpDivs: jest.fn(),
+}))
+
 jest.mock('@/views/QuestionnairePage/draftStore', () => ({
   __esModule: true,
   clearOtherUserDrafts: jest.fn(),
@@ -91,6 +98,7 @@ jest.mock('@/assets/ztmf-logo-color.png', () => 'ztmf-logo-color.png', {
 import { useLoaderData, useLocation } from 'react-router-dom'
 import axiosInstance from '@/axiosConfig'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
+import { fetchOpDivs } from '@/utils/opdivs'
 import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
 import { notify } from '@/utils/notify'
 import { broadcastLogout } from '@/utils/sessionSync'
@@ -101,6 +109,7 @@ const mockedUseLocation = useLocation as jest.Mock
 const mockedGet = axiosInstance.get as jest.Mock
 const mockedPost = axiosInstance.post as jest.Mock
 const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
+const mockedFetchOpDivs = fetchOpDivs as jest.Mock
 const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
 const mockedNotify = notify as jest.Mock
 const mockedBroadcastLogout = broadcastLogout as jest.Mock
@@ -133,6 +142,7 @@ beforeEach(() => {
   mockedGet.mockResolvedValue({ data: { data: [] } })
   mockedPost.mockResolvedValue({ status: 204 })
   mockedFetchEnvs.mockResolvedValue([])
+  mockedFetchOpDivs.mockResolvedValue([])
   mockedClearDrafts.mockResolvedValue(undefined)
   // jsdom forbids assigning window.location.hash / calling reload on the real
   // object; swap in a writable stub so the logout redirect is observable.

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -12,7 +12,13 @@ import { UsaBanner } from '@cmsgov/design-system'
 import { Outlet, Link } from 'react-router-dom'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import 'core-js/stable/atob'
-import { userData, UserRole, datacall, DataCenterEnvironment } from '@/types'
+import {
+  userData,
+  UserRole,
+  datacall,
+  DataCenterEnvironment,
+  OpDiv,
+} from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead as checkHasAdminRead,
@@ -33,7 +39,8 @@ import { Routes } from '@/router/constants'
 import type { AuthLoaderData } from '@/router/authLoader'
 import EmailModal from '@/components/EmailModal/EmailModal'
 import axiosInstance from '@/axiosConfig'
-import { notify } from '@/utils/notify'
+import { notify, isAuthHandled } from '@/utils/notify'
+import { fetchOpDivs } from '@/utils/opdivs'
 import { broadcastLogout } from '@/utils/sessionSync'
 import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
 import { sortDatacallsByDeadline } from '@/utils/sortDatacallsByDeadline'
@@ -88,6 +95,7 @@ export default function Title() {
   const [datacenterEnvironments, setDatacenterEnvironments] = useState<
     DataCenterEnvironment[]
   >([])
+  const [opdivs, setOpdivs] = useState<OpDiv[]>([])
 
   const fetchFismaSystems = useCallback(
     async (decommissioned: boolean = false) => {
@@ -199,6 +207,29 @@ export default function Title() {
       controller.abort()
     }
   }, [loaderData.status])
+  // OpDiv reference data is read by five pages (systems table, system detail,
+  // user table, OpDiv admin, system form), so it is fetched once here and
+  // passed down via context. The full list (incl. inactive) is fetched so a
+  // system tied to a since-deactivated OpDiv still resolves its name;
+  // consumers that need active-only filter client-side.
+  const refreshOpdivs = useCallback((signal?: AbortSignal) => {
+    fetchOpDivs(true, signal)
+      .then(setOpdivs)
+      .catch((error) => {
+        if (signal?.aborted || isAuthHandled(error)) return
+        console.error('Fetch opdivs error:', error)
+      })
+  }, [])
+
+  useEffect(() => {
+    if (loaderData.status !== 200) return
+    const controller = new AbortController()
+    refreshOpdivs(controller.signal)
+    return () => {
+      controller.abort()
+    }
+  }, [loaderData.status, refreshOpdivs])
+
   const datacallsByYear = useMemo(
     () => groupDatacallsByYear(datacalls),
     [datacalls]
@@ -648,6 +679,8 @@ export default function Title() {
                   setShowDecommissioned,
                   fetchFismaSystems,
                   datacenterEnvironments,
+                  opdivs,
+                  refreshOpdivs,
                 }}
               />
             </Box>
@@ -661,6 +694,7 @@ export default function Title() {
           system={EMPTY_SYSTEM}
           mode={'create'}
           datacenterEnvironments={datacenterEnvironments}
+          opdivs={opdivs}
         />
         <EmailModal
           openModal={openEmailModal}

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -67,6 +67,11 @@ const emptyUser: userData = {
   assignedfismasystems: [],
 }
 
+// Fixed text, not parseApiError: this fires from the shell on any page, so a
+// generic "something went wrong" would give the user nothing to act on.
+const OPDIVS_LOAD_ERROR =
+  'Failed to load the OpDiv list. OpDiv names and pickers may be incomplete - please reload.'
+
 export default function Title() {
   const location = useLocation()
   const loaderData = useLoaderData() as AuthLoaderData
@@ -207,17 +212,17 @@ export default function Title() {
       controller.abort()
     }
   }, [loaderData.status])
-  // OpDiv reference data is read by five pages (systems table, system detail,
-  // user table, OpDiv admin, system form), so it is fetched once here and
-  // passed down via context. The full list (incl. inactive) is fetched so a
-  // system tied to a since-deactivated OpDiv still resolves its name;
-  // consumers that need active-only filter client-side.
+  // Fetched once for the five pages that read OpDivs, and re-invoked by OpDiv
+  // admin after a write. Includes inactive rows so a system tied to a
+  // deactivated OpDiv still resolves its name. Unlike the sibling fetches
+  // above this notifies rather than logs: it is the only fetch site, so an
+  // empty list persists for the session and leaves the system form's Save stuck.
   const refreshOpdivs = useCallback((signal?: AbortSignal) => {
     fetchOpDivs(true, signal)
       .then(setOpdivs)
       .catch((error) => {
         if (signal?.aborted || isAuthHandled(error)) return
-        console.error('Fetch opdivs error:', error)
+        notify(OPDIVS_LOAD_ERROR, 'error')
       })
   }, [])
 

--- a/src/views/Title/Title.tsx
+++ b/src/views/Title/Title.tsx
@@ -101,6 +101,9 @@ export default function Title() {
     DataCenterEnvironment[]
   >([])
   const [opdivs, setOpdivs] = useState<OpDiv[]>([])
+  // Distinguishes "not fetched yet" from "fetched, and there are none" - both
+  // are an empty list. The questionnaire's insights gate needs the difference.
+  const [opdivsLoaded, setOpdivsLoaded] = useState(false)
 
   const fetchFismaSystems = useCallback(
     async (decommissioned: boolean = false) => {
@@ -223,6 +226,11 @@ export default function Title() {
       .catch((error) => {
         if (signal?.aborted || isAuthHandled(error)) return
         notify(OPDIVS_LOAD_ERROR, 'error')
+      })
+      .finally(() => {
+        // Settled either way: a failure resolves to "no OpDivs" rather than
+        // leaving consumers blocked on a load that will never arrive.
+        if (!signal?.aborted) setOpdivsLoaded(true)
       })
   }, [])
 
@@ -685,6 +693,7 @@ export default function Title() {
                   fetchFismaSystems,
                   datacenterEnvironments,
                   opdivs,
+                  opdivsLoaded,
                   refreshOpdivs,
                 }}
               />

--- a/src/views/Title/TitleOpdivs.test.tsx
+++ b/src/views/Title/TitleOpdivs.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { userData, OpDiv } from '@/types'
+
+// Title-level coverage for #558. The consumer suites inject opdivs into a
+// mocked context, so none of them exercise the provide side - they would pass
+// even if Title never fetched. Renders the real Title and reads the context off
+// an Outlet harness, as TitleDecommissioned.test.tsx does.
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useLoaderData: jest.fn(),
+  useLocation: jest.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Outlet: ({
+    context,
+  }: {
+    context: { opdivs: OpDiv[]; refreshOpdivs: () => void }
+  }) => (
+    <div>
+      <button onClick={() => context.refreshOpdivs()}>refresh-opdivs</button>
+      <ul>
+        {context.opdivs.map((o) => (
+          <li key={o.opdiv_id}>{o.code}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}))
+
+jest.mock('@/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}))
+
+jest.mock('@/utils/dataCenterEnvironments', () => ({
+  __esModule: true,
+  fetchDataCenterEnvironments: jest.fn(),
+}))
+
+jest.mock('@/utils/opdivs', () => ({
+  __esModule: true,
+  fetchOpDivs: jest.fn(),
+}))
+
+jest.mock('@/views/QuestionnairePage/draftStore', () => ({
+  __esModule: true,
+  clearOtherUserDrafts: jest.fn(),
+}))
+
+jest.mock('@/utils/notify', () => ({
+  __esModule: true,
+  notify: jest.fn(),
+  isAuthHandled: jest.fn(),
+}))
+
+// Heavy children this test doesn't depend on (mirrors Title.test.tsx).
+jest.mock('@/components/EmailModal/EmailModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/EditSystemModal/EditSystemModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/DatacallModal/DataCallModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/Footer/Footer', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/components/DevEnvironmentBanner/DevEnvironmentBanner', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/views/LoginPage/LoginPage', () => ({
+  __esModule: true,
+  default: () => <div>LOGINPAGE</div>,
+}))
+jest.mock('@/views/ServerErrorPage/ServerErrorPage', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@/assets/ztmf-logo-color.png', () => 'ztmf-logo-color.png', {
+  virtual: true,
+})
+
+import { useLoaderData, useLocation } from 'react-router-dom'
+import axiosInstance from '@/axiosConfig'
+import { fetchDataCenterEnvironments } from '@/utils/dataCenterEnvironments'
+import { fetchOpDivs } from '@/utils/opdivs'
+import { clearOtherUserDrafts } from '@/views/QuestionnairePage/draftStore'
+import { notify } from '@/utils/notify'
+import Title from './Title'
+
+const mockedUseLoaderData = useLoaderData as jest.Mock
+const mockedUseLocation = useLocation as jest.Mock
+const mockedGet = axiosInstance.get as jest.Mock
+const mockedPost = axiosInstance.post as jest.Mock
+const mockedFetchEnvs = fetchDataCenterEnvironments as jest.Mock
+const mockedFetchOpDivs = fetchOpDivs as jest.Mock
+const mockedClearDrafts = clearOtherUserDrafts as jest.Mock
+const mockedNotify = notify as jest.Mock
+
+const USER: userData = {
+  userid: '11111111-1111-1111-1111-111111111111',
+  email: 'grand.moff@deathstar.empire',
+  fullname: 'Grand Moff Tarkin',
+  role: 'OWNER',
+  assignedfismasystems: [],
+}
+
+const CMS: OpDiv = {
+  opdiv_id: 1,
+  code: 'CMS',
+  name: 'Centers for Medicare & Medicaid Services',
+  is_parent: false,
+  active: true,
+  system_delegate_enabled: false,
+}
+// Inactive on purpose: the context holds the includeInactive superset.
+const RETIRED: OpDiv = {
+  opdiv_id: 2,
+  code: 'RETIRED',
+  name: 'Deactivated OpDiv',
+  is_parent: false,
+  active: false,
+  system_delegate_enabled: false,
+}
+
+const originalLocation = window.location
+
+beforeEach(() => {
+  mockedUseLoaderData.mockReset()
+  mockedUseLocation.mockReset()
+  mockedUseLoaderData.mockReturnValue({ status: 200, response: USER })
+  mockedUseLocation.mockReturnValue({ pathname: '/' })
+  mockedGet.mockResolvedValue({ data: { data: [] } })
+  mockedPost.mockResolvedValue({ status: 204 })
+  mockedFetchEnvs.mockResolvedValue([])
+  mockedFetchOpDivs.mockResolvedValue([CMS, RETIRED])
+  mockedClearDrafts.mockResolvedValue(undefined)
+
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { hash: '', reload: jest.fn() },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+})
+
+describe('Title — shared OpDiv context (#558)', () => {
+  it('fetches the inactive-inclusive list once and puts it on the Outlet context', async () => {
+    render(<Title />)
+
+    expect(await screen.findByText('CMS')).toBeInTheDocument()
+    expect(screen.getByText('RETIRED')).toBeInTheDocument()
+    // One fetch for the whole layout - the point of the issue.
+    expect(mockedFetchOpDivs).toHaveBeenCalledTimes(1)
+    expect(mockedFetchOpDivs).toHaveBeenCalledWith(true, expect.anything())
+  })
+
+  it('does not fetch when the session loader did not authenticate', () => {
+    mockedUseLoaderData.mockReturnValue({ status: 401, response: undefined })
+
+    render(<Title />)
+
+    expect(mockedFetchOpDivs).not.toHaveBeenCalled()
+  })
+
+  it('refreshOpdivs refetches so a mutation is reflected in the shared copy', async () => {
+    render(<Title />)
+    expect(await screen.findByText('CMS')).toBeInTheDocument()
+
+    mockedFetchOpDivs.mockResolvedValue([
+      CMS,
+      RETIRED,
+      { ...CMS, opdiv_id: 3, code: 'NEWLY_CREATED' },
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'refresh-opdivs' }))
+
+    expect(await screen.findByText('NEWLY_CREATED')).toBeInTheDocument()
+    expect(mockedFetchOpDivs).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a failed load rather than leaving consumers silently empty', async () => {
+    mockedFetchOpDivs.mockRejectedValue(new Error('network'))
+
+    render(<Title />)
+
+    // No second fetch site to recover on, so the user has to be told to reload.
+    await waitFor(() =>
+      expect(mockedNotify).toHaveBeenCalledWith(
+        expect.stringMatching(/opdiv/i),
+        'error'
+      )
+    )
+    expect(mockedFetchOpDivs).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/views/Title/TitleOpdivs.test.tsx
+++ b/src/views/Title/TitleOpdivs.test.tsx
@@ -13,10 +13,15 @@ jest.mock('react-router-dom', () => ({
   Outlet: ({
     context,
   }: {
-    context: { opdivs: OpDiv[]; refreshOpdivs: () => void }
+    context: {
+      opdivs: OpDiv[]
+      opdivsLoaded: boolean
+      refreshOpdivs: () => void
+    }
   }) => (
     <div>
       <button onClick={() => context.refreshOpdivs()}>refresh-opdivs</button>
+      <span>loaded:{String(context.opdivsLoaded)}</span>
       <ul>
         {context.opdivs.map((o) => (
           <li key={o.opdiv_id}>{o.code}</li>
@@ -203,5 +208,16 @@ describe('Title — shared OpDiv context (#558)', () => {
       )
     )
     expect(mockedFetchOpDivs).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks the list loaded once the fetch settles, including on failure', async () => {
+    // The questionnaire's insights gate blocks Next/Complete while this is
+    // false, so a failure has to settle it or the user is stuck for good.
+    mockedFetchOpDivs.mockRejectedValue(new Error('network'))
+
+    render(<Title />)
+
+    expect(screen.getByText('loaded:false')).toBeInTheDocument()
+    expect(await screen.findByText('loaded:true')).toBeInTheDocument()
   })
 })

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -30,12 +30,11 @@ import ConfirmDialog from '@/components/ConfirmDialog/ConfirmDialog'
 import Tooltip from '@mui/material/Tooltip'
 import './UserTable.css'
 import axiosInstance from '@/axiosConfig'
-import { users, OpDiv, FismaSystemType } from '@/types'
+import { users, FismaSystemType } from '@/types'
 import {
   isAdmin as checkIsAdmin,
   hasAdminRead,
   hasUnscopedRead,
-  isOpDivTier,
   isUnscopedWriteAdmin,
   selectableRoles,
 } from '@/utils/userRoles'
@@ -43,6 +42,12 @@ import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
 import { isUserCellEditable } from './cellEditGuards'
+import {
+  buildOpDivCodeMap,
+  buildOpDivLabelMap,
+  buildAssignableOpDivs,
+  narrowToCallerScope,
+} from './opdivDerivations'
 import { parseApiError } from '@/utils/apiErrors'
 import { isAuthHandled, notify } from '@/utils/notify'
 import { useContextProp } from '../Title/Context'
@@ -225,40 +230,18 @@ export default function UserTable() {
   const [openOpDivModal, setOpenOpDivModal] = useState<boolean>(false)
   const [opdivModalUserId, setOpDivModalUserId] = useState<GridRowId>('')
   const [opdivModalUserName, setOpDivModalUserName] = useState<string>('')
-  // opdiv_id -> code, for rendering the OpDivs membership column.
-  const opdivCodeMap = useMemo<Record<number, string>>(() => {
-    const map: Record<number, string> = {}
-    opdivs.forEach((od) => {
-      map[od.opdiv_id] = od.code
-    })
-    return map
-  }, [opdivs])
-  // opdiv_id -> { code, name }, a full label source (incl. parent/inactive) so
-  // the grant modal can label grants to non-assignable OpDivs, which are absent
-  // from its scoped options list.
-  const opdivLabelMap = useMemo<
-    Record<number, { code: string; name: string }>
-  >(() => {
-    const map: Record<number, { code: string; name: string }> = {}
-    opdivs.forEach((od) => {
-      map[od.opdiv_id] = { code: od.code, name: od.name }
-    })
-    return map
-  }, [opdivs])
-  // All assignable OpDivs (active, non-parent), NOT narrowed to the caller's
-  // scope. The grant modal narrows this against the caller's fresh grants
-  // itself, so it isn't fed the session-old scope that opdivOptions carries.
-  const allAssignableOpDivs = useMemo<OpDiv[]>(
-    () => (isAdmin ? opdivs.filter((od) => !od.is_parent && od.active) : []),
-    [isAdmin, opdivs]
+  // Four views of the shared OpDiv list; see opdivDerivations.ts for what each
+  // one is for and who narrows what.
+  const opdivCodeMap = useMemo(() => buildOpDivCodeMap(opdivs), [opdivs])
+  const opdivLabelMap = useMemo(() => buildOpDivLabelMap(opdivs), [opdivs])
+  const allAssignableOpDivs = useMemo(
+    () => buildAssignableOpDivs(opdivs, isAdmin),
+    [opdivs, isAdmin]
   )
-  // Caller-narrowed, for the inline EditOpDivCell only - the grant modal
-  // narrows the full set against fresh grants itself. Server enforces the same.
-  const opdivOptions = useMemo<OpDiv[]>(() => {
-    if (!isOpDivTier(userInfo)) return allAssignableOpDivs
-    const own = new Set(userInfo.assignedopdivids ?? [])
-    return allAssignableOpDivs.filter((od) => own.has(od.opdiv_id))
-  }, [allAssignableOpDivs, userInfo])
+  const opdivOptions = useMemo(
+    () => narrowToCallerScope(allAssignableOpDivs, userInfo),
+    [allAssignableOpDivs, userInfo]
+  )
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -252,11 +252,8 @@ export default function UserTable() {
     () => (isAdmin ? opdivs.filter((od) => !od.is_parent && od.active) : []),
     [isAdmin, opdivs]
   )
-  // opdivOptions stays caller-narrowed for the inline EditOpDivCell. The grant
-  // modal does NOT use this; it narrows the full set against the caller's fresh
-  // scope itself, so it isn't fed this session-old value. The HHS parent row is
-  // not a grantable tenant, and an OPDIV_ADMIN may only grant their own OpDivs;
-  // the server enforces the same rule.
+  // Caller-narrowed, for the inline EditOpDivCell only - the grant modal
+  // narrows the full set against fresh grants itself. Server enforces the same.
   const opdivOptions = useMemo<OpDiv[]>(() => {
     if (!isOpDivTier(userInfo)) return allAssignableOpDivs
     const own = new Set(userInfo.assignedopdivids ?? [])

--- a/src/views/UserTable/UserTable.tsx
+++ b/src/views/UserTable/UserTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
@@ -39,7 +39,6 @@ import {
   isUnscopedWriteAdmin,
   selectableRoles,
 } from '@/utils/userRoles'
-import { fetchOpDivs } from '@/utils/opdivs'
 import { fetchUserOpDivs, setUserOpDivs } from '@/utils/userOpdivs'
 import CONFIG from '@/utils/config'
 import EditOpDivCell from './EditOpDivCell'
@@ -175,7 +174,7 @@ function validateEmail(email: string) {
 export default function UserTable() {
   const apiRef = useGridApiRef()
   const navigate = useNavigate()
-  const { userInfo } = useContextProp()
+  const { userInfo, opdivs } = useContextProp()
   // Write-tier admins get the create/edit/delete/assign controls; read-only
   // admins may view the table but every mutating control is withheld. The
   // backend is the security boundary - this only governs which controls render.
@@ -226,19 +225,43 @@ export default function UserTable() {
   const [openOpDivModal, setOpenOpDivModal] = useState<boolean>(false)
   const [opdivModalUserId, setOpDivModalUserId] = useState<GridRowId>('')
   const [opdivModalUserName, setOpDivModalUserName] = useState<string>('')
-  const [opdivOptions, setOpDivOptions] = useState<OpDiv[]>([])
   // opdiv_id -> code, for rendering the OpDivs membership column.
-  const [opdivCodeMap, setOpDivCodeMap] = useState<Record<number, string>>({})
+  const opdivCodeMap = useMemo<Record<number, string>>(() => {
+    const map: Record<number, string> = {}
+    opdivs.forEach((od) => {
+      map[od.opdiv_id] = od.code
+    })
+    return map
+  }, [opdivs])
   // opdiv_id -> { code, name }, a full label source (incl. parent/inactive) so
   // the grant modal can label grants to non-assignable OpDivs, which are absent
   // from its scoped options list.
-  const [opdivLabelMap, setOpDivLabelMap] = useState<
+  const opdivLabelMap = useMemo<
     Record<number, { code: string; name: string }>
-  >({})
+  >(() => {
+    const map: Record<number, { code: string; name: string }> = {}
+    opdivs.forEach((od) => {
+      map[od.opdiv_id] = { code: od.code, name: od.name }
+    })
+    return map
+  }, [opdivs])
   // All assignable OpDivs (active, non-parent), NOT narrowed to the caller's
   // scope. The grant modal narrows this against the caller's fresh grants
   // itself, so it isn't fed the session-old scope that opdivOptions carries.
-  const [allAssignableOpDivs, setAllAssignableOpDivs] = useState<OpDiv[]>([])
+  const allAssignableOpDivs = useMemo<OpDiv[]>(
+    () => (isAdmin ? opdivs.filter((od) => !od.is_parent && od.active) : []),
+    [isAdmin, opdivs]
+  )
+  // opdivOptions stays caller-narrowed for the inline EditOpDivCell. The grant
+  // modal does NOT use this; it narrows the full set against the caller's fresh
+  // scope itself, so it isn't fed this session-old value. The HHS parent row is
+  // not a grantable tenant, and an OPDIV_ADMIN may only grant their own OpDivs;
+  // the server enforces the same rule.
+  const opdivOptions = useMemo<OpDiv[]>(() => {
+    if (!isOpDivTier(userInfo)) return allAssignableOpDivs
+    const own = new Set(userInfo.assignedopdivids ?? [])
+    return allAssignableOpDivs.filter((od) => own.has(od.opdiv_id))
+  }, [allAssignableOpDivs, userInfo])
   // userid -> granted opdiv ids, used as a refresh override after the grant modal
   // closes. The list now returns grants inline (assignedopdivids); this map only
   // holds rows refreshed since load, plus a one-time backfill against older
@@ -615,49 +638,6 @@ export default function UserTable() {
     }
   }, [isAdmin])
 
-  // OpDiv options for the grant modal: assignable children only (the HHS
-  // parent row is not a grantable tenant). An OPDIV_ADMIN may only grant their
-  // own OpDivs, so narrow the option set to their own grants; the server
-  // enforces the same rule.
-  useEffect(() => {
-    if (!isAdmin) return
-    // Pull the full list (incl. inactive/parent) so any granted id resolves to
-    // a code in the OpDivs column; derive the assignable subset from the same
-    // response for the grant modal.
-    async function loadOpDivs() {
-      try {
-        const all = await fetchOpDivs(true)
-        const codeMap: Record<number, string> = {}
-        const labelMap: Record<number, { code: string; name: string }> = {}
-        all.forEach((od) => {
-          codeMap[od.opdiv_id] = od.code
-          labelMap[od.opdiv_id] = { code: od.code, name: od.name }
-        })
-        setOpDivCodeMap(codeMap)
-        setOpDivLabelMap(labelMap)
-
-        const activeNonParent = all.filter((od) => !od.is_parent && od.active)
-        setAllAssignableOpDivs(activeNonParent)
-
-        // opdivOptions stays caller-narrowed for the inline EditOpDivCell. The
-        // grant modal does NOT use this; it narrows the full set against the
-        // caller's fresh scope itself, so it isn't fed this session-old value.
-        let assignable = activeNonParent
-        if (isOpDivTier(userInfo)) {
-          const own = new Set(userInfo.assignedopdivids ?? [])
-          assignable = assignable.filter((od) => own.has(od.opdiv_id))
-        }
-        setOpDivOptions(assignable)
-      } catch {
-        // Non-fatal: the grant modal simply shows no options if this fails.
-        setOpDivOptions([])
-        setAllAssignableOpDivs([])
-        setOpDivCodeMap({})
-        setOpDivLabelMap({})
-      }
-    }
-    loadOpDivs()
-  }, [isAdmin, userInfo])
   const columns: GridColDef[] = [
     {
       field: 'fullname',

--- a/src/views/UserTable/opdivDerivations.test.ts
+++ b/src/views/UserTable/opdivDerivations.test.ts
@@ -1,0 +1,114 @@
+// UserTable has no render coverage, so the OpDiv views it derives from the
+// shared context list (#558) are pinned here instead. The caller-scope
+// narrowing is the one that matters: it is a rule, not a transform.
+import {
+  buildOpDivCodeMap,
+  buildOpDivLabelMap,
+  buildAssignableOpDivs,
+  narrowToCallerScope,
+} from './opdivDerivations'
+import type { OpDiv, userData, UserRole } from '@/types'
+
+const opdiv = (over: Partial<OpDiv> & { opdiv_id: number }): OpDiv => ({
+  code: `OD${over.opdiv_id}`,
+  name: `OpDiv ${over.opdiv_id}`,
+  is_parent: false,
+  active: true,
+  system_delegate_enabled: false,
+  ...over,
+})
+
+const HHS = opdiv({ opdiv_id: 1, code: 'HHS', is_parent: true })
+const CMS = opdiv({ opdiv_id: 2, code: 'CMS' })
+const ACF = opdiv({ opdiv_id: 3, code: 'ACF' })
+const RETIRED = opdiv({ opdiv_id: 4, code: 'RETIRED', active: false })
+const ALL = [HHS, CMS, ACF, RETIRED]
+
+const user = (role: UserRole, assignedopdivids?: number[]): userData =>
+  ({
+    userid: 'u-1',
+    email: 'a@b.gov',
+    fullname: 'Tester',
+    role,
+    assignedopdivids,
+  }) as userData
+
+describe('buildOpDivCodeMap', () => {
+  it('maps every id to its code, including the parent and inactive rows', () => {
+    // The column falls back to a bare id for anything missing here, so a
+    // grant to a since-deactivated OpDiv still has to resolve.
+    expect(buildOpDivCodeMap(ALL)).toEqual({
+      1: 'HHS',
+      2: 'CMS',
+      3: 'ACF',
+      4: 'RETIRED',
+    })
+  })
+
+  it('returns an empty map for no rows', () => {
+    expect(buildOpDivCodeMap([])).toEqual({})
+  })
+})
+
+describe('buildOpDivLabelMap', () => {
+  it('carries code and name for every row', () => {
+    expect(buildOpDivLabelMap([CMS, RETIRED])).toEqual({
+      2: { code: 'CMS', name: 'OpDiv 2' },
+      4: { code: 'RETIRED', name: 'OpDiv 4' },
+    })
+  })
+})
+
+describe('buildAssignableOpDivs', () => {
+  it('drops the parent row and inactive rows', () => {
+    // HHS is not a grantable tenant; RETIRED cannot take new grants.
+    expect(buildAssignableOpDivs(ALL, true)).toEqual([CMS, ACF])
+  })
+
+  it('is empty for a non-write admin, who has no grant affordance', () => {
+    expect(buildAssignableOpDivs(ALL, false)).toEqual([])
+  })
+})
+
+describe('narrowToCallerScope', () => {
+  const assignable = [CMS, ACF]
+
+  it('narrows an OPDIV_ADMIN to the OpDivs they hold', () => {
+    expect(narrowToCallerScope(assignable, user('OPDIV_ADMIN', [3]))).toEqual([
+      ACF,
+    ])
+  })
+
+  it('gives an OPDIV_ADMIN with no grants nothing to assign', () => {
+    expect(narrowToCallerScope(assignable, user('OPDIV_ADMIN', []))).toEqual([])
+    expect(
+      narrowToCallerScope(assignable, user('OPDIV_ADMIN', undefined))
+    ).toEqual([])
+  })
+
+  it('leaves unscoped tiers the full assignable set', () => {
+    expect(narrowToCallerScope(assignable, user('OWNER'))).toEqual(assignable)
+    expect(narrowToCallerScope(assignable, user('HHS_ADMIN'))).toEqual(
+      assignable
+    )
+  })
+
+  it('cannot widen past what was assignable, even for a held parent OpDiv', () => {
+    // A grant on HHS must not resurrect the parent row as an option.
+    expect(
+      narrowToCallerScope(assignable, user('OPDIV_ADMIN', [1, 3]))
+    ).toEqual([ACF])
+  })
+})
+
+describe('the read-only admin labelling path', () => {
+  it('labels OpDivs for a read-only admin even though they get no options', () => {
+    // Pinning a deliberate change from #558: the fetch used to be gated on
+    // write-tier admin, so read-only admins saw bare ids in the OpDivs column.
+    const readOnly = user('HHS_READONLY_ADMIN')
+    expect(buildOpDivCodeMap(ALL)[2]).toBe('CMS')
+    expect(
+      narrowToCallerScope(buildAssignableOpDivs(ALL, false), readOnly)
+    ).toEqual([])
+  })
+})

--- a/src/views/UserTable/opdivDerivations.ts
+++ b/src/views/UserTable/opdivDerivations.ts
@@ -1,0 +1,61 @@
+// The four views UserTable derives from the shared OpDiv list (#558). Pure so
+// they can be tested without rendering the grid - UserTable itself has no
+// render coverage, and the caller-scope narrowing below is a rule, not a
+// transform, so it needs pinning.
+import { isOpDivTier } from '@/utils/userRoles'
+import type { OpDiv, userData } from '@/types'
+
+/**
+ * opdiv_id -> code, for the OpDivs membership column. Built from the full
+ * list (incl. parent/inactive) so any granted id resolves to a code rather
+ * than falling back to a bare number.
+ */
+export function buildOpDivCodeMap(opdivs: OpDiv[]): Record<number, string> {
+  const map: Record<number, string> = {}
+  opdivs.forEach((od) => {
+    map[od.opdiv_id] = od.code
+  })
+  return map
+}
+
+/**
+ * opdiv_id -> { code, name }, a full label source so the grant modal can label
+ * grants to non-assignable OpDivs, which are absent from its options list.
+ */
+export function buildOpDivLabelMap(
+  opdivs: OpDiv[]
+): Record<number, { code: string; name: string }> {
+  const map: Record<number, { code: string; name: string }> = {}
+  opdivs.forEach((od) => {
+    map[od.opdiv_id] = { code: od.code, name: od.name }
+  })
+  return map
+}
+
+/**
+ * Every grantable OpDiv: active and not the HHS parent row, which is not a
+ * tenant. NOT narrowed to the caller - the grant modal narrows this against
+ * the caller's fresh grants itself. Empty for non-write-admins, who have no
+ * grant affordance at all.
+ */
+export function buildAssignableOpDivs(
+  opdivs: OpDiv[],
+  isAdmin: boolean
+): OpDiv[] {
+  if (!isAdmin) return []
+  return opdivs.filter((od) => !od.is_parent && od.active)
+}
+
+/**
+ * Narrows the assignable set to the caller's own OpDivs for OPDIV-tier admins,
+ * who may only grant what they hold; unscoped tiers keep the full set. Display
+ * only - the server enforces the same rule on the write.
+ */
+export function narrowToCallerScope(
+  assignable: OpDiv[],
+  userInfo: userData
+): OpDiv[] {
+  if (!isOpDivTier(userInfo)) return assignable
+  const own = new Set(userInfo.assignedopdivids ?? [])
+  return assignable.filter((od) => own.has(od.opdiv_id))
+}


### PR DESCRIPTION
## Summary

Closes #558.

`fetchOpDivs` was called independently in six places, each firing a fresh `GET /opdivs` on mount with no shared cache. Fetches it once in `Title.tsx` and distributes it through `useContextProp()`, the pattern already used for `datacenterEnvironments` (#459) and `fismaSystems`. Not a defect fix — every per-mount fetch had correct abort/error/auth handling.

## Changes

* **`Title.tsx` / `Title/Context.ts`:** one `fetchOpDivs(true, signal)` gated on an active session; adds `opdivs`, `opdivsLoaded`, and `refreshOpdivs` to the context. `EditSystemModal` takes `opdivs` as a prop since it renders outside the Outlet.
* **Six consumers** drop their local fetch effect. `UserTable` loses four `useState`s and a 43-line effect.
* **`utils/opdivs.ts`:** `?? []` on the response — the backend serializes an empty result as JSON `null` on some endpoints (CMS-Enterprise/ztmf#346), and a `null` would now throw in every consumer at once.
* **`UserTable/opdivDerivations.ts` (new):** `UserTable`'s four OpDiv views moved out unchanged so they can be tested.

## The sixth call site, and `opdivsLoaded`

`QuestionnairePage` was added after #558 was filed so it isn't in the issue's table, but converting it is the difference between "deduped five sites" and "there is one fetch."

It needed one extra thing. Its insights gate keys on `null` meaning *not loaded yet* and blocks Next/Complete while pending, so the panel can't pop in after the user has advanced. Context `opdivs` starts `[]`, which is indistinguishable from loaded-and-empty — reading it directly would have opened the gate early. Hence `opdivsLoaded`, set in a `finally()` so a failed lookup resolves to "no insights OpDivs" rather than blocking forever, matching the old `.catch`.

## Re: the isolation-pattern comment (@jsos3-cms)

Applied, structurally rather than by copying #570's fix. The #532 poison needed a **mode-dependent** value: the Show Decommissioned toggle swaps the endpoint and replaces the shared `fismaSystems` array, so the picker inherited whatever the dashboard showed. `opdivs` can't do that — the context always holds the `includeInactive` superset, no consumer's UI state changes what is fetched, and no setter is exposed (only `refreshOpdivs`, which refetches the same superset). Each consumer narrows at point of use.

Worth recording: this branch was rebased off a stale WIP whose `UserTable` read `fismaSystems` from context and deleted the dedicated `/fismasystems` fetch — i.e. it would have reverted #570 and reopened #532. Resolving in `main`'s favour is what kept it out.

## Behaviour changes worth naming

* **Read-only admins now see OpDiv codes instead of raw ids.** Incidental, and a fix: `main` gated the fetch on `isAdmin` (write-tier) while `UserTable` admits `hasAdminRead`, so those roles hit the `?? id` fallback. Pinned by a test so it's deliberate.
* **A failed load is a toast, not a `console.error`.** With one fetch site there's no second mount to self-heal on, so an empty list persists for the session — Save stuck on the system form, OpDiv admin grid blank. Fixed text rather than `parseApiError`, which returns a generic message that tells the user nothing when fired from the shell. Cost: on the questionnaire route OpDivs feed only the insights gate, whose old catch deliberately failed silent. Accepted — the list is load-bearing on four other routes.
* **A cross-session OpDiv create no longer shows up without a reload.** `EditSystemModal` used to refetch on every open, so a newly created OpDiv appeared the next time you opened the form. Reading the shared list means it now appears on the next reload instead. Inherent to the dedupe, and narrow in practice: first-party creates are covered, since all three OpDiv-admin write paths call `refreshOpdivs`, which updates the list the modal reads. Only an OpDiv created in *another* session is affected. (Raised in review by @tarratsco.)

## Acceptance criteria

* [x] Fetched once in `Title.tsx`, added to the Outlet context value and to the context type
* [x] All five listed consumers drop their local `fetchOpDivs` effect (six deduped, not five)
* [x] The `includeInactive` superset is fetched; consumers needing active-only filter client-side
* [x] `EditSystemModal`'s active-only dropdown unchanged for the user
* [x] Exactly one `GET /opdivs` call site remains in `src/`
* [x] `yarn lint`, `yarn typecheck`, `yarn test` clean

## Testing

928 passed, 3 skipped (`main.test.tsx`, pre-existing). Three files had no coverage of the paths this touches, so they get it here:

| File | Pins |
| --- | --- |
| `Title/TitleOpdivs.test.tsx` (new, 5) | fetched **once** with `includeInactive` and reaching the context; skipped when unauthenticated; `refreshOpdivs` refetches; failure toasts; `opdivsLoaded` settles on failure |
| `utils/opdivs.test.ts` (new, 8) | envelope unwrap, the `active_only=false` param contract, `null` → `[]`, reject paths, `createOpDiv`/`updateOpDiv` |
| `UserTable/opdivDerivations.test.ts` (new, 10) | parent/inactive exclusion, OPDIV-tier narrowing, unscoped tiers keep the full set, read-only-admin labelling |

`Title.test.tsx` now mocks `fetchOpDivs` — the axios stub returned `undefined` from `get()`, so every test there was silently running the error path.

Two traps worth a reviewer's eye:

* The `QuestionnairePage` suites had **opposite** OpDiv defaults, and `OPDIV_ROWS[0]` is the fixture system's own OpDiv — putting it in the shared `makeCtx` default would have flipped the entire carried-forward suite to insights-enabled while still passing. Shared default is `[]`; the justification block opts in.
* `opdivDerivations.ts` is a move, not a rewrite. Verified with a throwaway differential test — previous inline bodies vs the new helpers over 5000 randomised inputs plus an edge matrix (empty lists, duplicate ids, every role × undefined/empty/matching/non-matching grants × both `isAdmin` values). Identical on every case.

## Out of scope

* **Dashboard datacall switch has no loading indicator.** `Home.tsx` initialises `loading` to `true` and never resets it when `activeDatacallIds` changes, so switching calls shows the previous call's scores until the refetch lands. Same symptom as the OpDiv grid overlay fixed here, unrelated cause. Filing separately.
* **Test-mock duplication.** The three `Title` suites now carry ~14 near-identical `jest.mock` calls each; this PR added the third. Extraction is awkward because `jest.mock` hoists per file.

